### PR TITLE
First try at a Routes auto-loader

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -29,6 +29,12 @@ module.exports = {
         'prettier/@typescript-eslint',
       ],
     },
+    {
+      files: ['web/src/Routes.js', 'web/src/Routes.ts'],
+      rules: {
+        'no-undef': 'off',
+      },
+    },
   ],
   settings: {
     'import/resolver': {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -12,7 +12,15 @@
 
 module.exports = {
   parser: 'babel-eslint',
-  plugins: ['prettier', 'babel', 'import', 'jsx-a11y', 'react', 'react-hooks'],
+  plugins: [
+    'prettier',
+    'babel',
+    'import',
+    'jsx-a11y',
+    'react',
+    'react-hooks',
+    '@redwoodjs/redwood',
+  ],
   ignorePatterns: ['node_modules'],
   extends: [
     'eslint:recommended',
@@ -33,6 +41,7 @@ module.exports = {
       files: ['web/src/Routes.js', 'web/src/Routes.ts'],
       rules: {
         'no-undef': 'off',
+        '@redwoodjs/redwood/no-unavailable-pages': 'error',
       },
     },
   ],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@redwoodjs/eslint-plugin-redwood": "file:../eslint-plugin-redwood",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "babel-eslint": "^10.0.3",

--- a/packages/eslint-plugin-redwood/index.js
+++ b/packages/eslint-plugin-redwood/index.js
@@ -1,0 +1,7 @@
+const noUnavailablePages = require('./src/no-unavailable-pages')
+
+module.exports = {
+  rules: {
+    'no-unavailable-pages': noUnavailablePages,
+  },
+}

--- a/packages/eslint-plugin-redwood/package.json
+++ b/packages/eslint-plugin-redwood/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@redwoodjs/eslint-plugin-redwood",
+  "version": "0.0.1",
+  "description": "eslint plugin for Redwood rules.",
+  "main": "index.js",
+  "repository": "https://github.com/redwoodjs/redwood",
+  "author": "Tom Preston-Werner",
+  "license": "MIT",
+  "private": false
+}

--- a/packages/eslint-plugin-redwood/src/no-unavailable-pages.js
+++ b/packages/eslint-plugin-redwood/src/no-unavailable-pages.js
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview Rule to flag references to non-existent Pages.
+ * @author Tom Preston-Werner
+ *
+ * Check to make sure that all referenced Pages exist in the `/web/src/pages`
+ * directory. Thanks to eslint/undef upon which this code is based.
+ */
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const { flattenDeep } = require('lodash')
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+function processDir(dir, prefix = []) {
+  const deps = []
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  // Iterate over a dir's entries, recursing as necessary into
+  // subdirectories.
+  entries.forEach((entry) => {
+    if (entry.isDirectory()) {
+      // Actual JS files reside in a directory of the same name, so let's
+      // construct the filename of the actual Page file.
+      const testFile = path.join(dir, entry.name, entry.name + '.js')
+
+      if (fs.existsSync(testFile)) {
+        // If the Page exists, then construct the dependency object and push it
+        // onto the deps array.
+        const basename = path.posix.basename(entry.name, '.js')
+        const importName = prefix.join() + basename
+        const importFile = path.join('src', 'pages', basename)
+        deps.push({
+          const: entry.name,
+          path: path.join(dir, entry.name),
+          importStatement: `import ${importName} from '${importFile}'`,
+        })
+      } else {
+        // If the Page doesn't exist then we are in a directory of Page
+        // directories, so let's recurse into it and do the whole thing over
+        // again.
+        const newPrefix = prefix.concat(entry.name)
+        deps.push(processDir(path.join(dir, entry.name), newPrefix))
+      }
+    }
+  })
+
+  // We may have nested arrays because of the recursion, so flatten the deps
+  // into a list.
+  return flattenDeep(deps)
+}
+
+/**
+ * Checks if the given node is the argument of a typeof operator.
+ * @param {ASTNode} node The AST node being checked.
+ * @returns {boolean} Whether or not the node is the argument of a typeof operator.
+ */
+function hasTypeOfOperator(node) {
+  const parent = node.parent
+
+  return parent.type === 'UnaryExpression' && parent.operator === 'typeof'
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+
+    docs: {
+      description: 'disallow the use of non-existent Pages in Routes file',
+      category: 'Variables',
+      recommended: true,
+    },
+
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          typeof: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      undef: "'{{name}}' can not be found in '/web/src/pages'.",
+    },
+  },
+
+  create(context) {
+    const options = context.options[0]
+    const considerTypeOf = (options && options.typeof === true) || false
+
+    const deps = processDir(path.join(context.getCwd(), 'web', 'src', 'pages'))
+    const pageConsts = deps.map((dep) => dep.const)
+
+    return {
+      'Program:exit'(/* node */) {
+        const globalScope = context.getScope()
+
+        globalScope.through.forEach((ref) => {
+          const identifier = ref.identifier
+
+          if (!considerTypeOf && hasTypeOfOperator(identifier)) {
+            return
+          }
+
+          if (!pageConsts.includes(identifier.name)) {
+            context.report({
+              node: identifier,
+              messageId: 'undef',
+              data: identifier,
+            })
+          }
+        })
+      },
+    }
+  },
+}

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -137,6 +137,20 @@ module.exports = (webpackEnv) => {
             },
           ],
         },
+        {
+          test: path.resolve(BASE_DIR, 'web', 'src', 'Routes.js'),
+          use: {
+            loader: path.resolve(
+              __dirname,
+              '..',
+              'loaders',
+              'routes-auto-loader'
+            ),
+            options: {
+              dir: path.resolve(BASE_DIR, 'web', 'src', 'pages'),
+            },
+          },
+        },
       ],
     },
     optimization: {

--- a/packages/scripts/loaders/routes-auto-loader.js
+++ b/packages/scripts/loaders/routes-auto-loader.js
@@ -1,0 +1,64 @@
+const fs = require('fs')
+const path = require('path')
+
+const { getOptions } = require('loader-utils')
+
+function processDir(dir, prefix = []) {
+  const deps = []
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  // Iterate over a dir's entries, recursing as necessary into
+  // subdirectories.
+  entries.forEach((entry) => {
+    if (entry.isDirectory()) {
+      // Actual JS files reside in a directory of the same name, so let's
+      // construct the filename of the actual Page file.
+      const testFile = path.join(dir, entry.name, entry.name + '.js')
+
+      if (fs.existsSync(testFile)) {
+        // If the Page exists, then construct the dependency object and push it
+        // onto the deps array.
+        const basename = path.posix.basename(entry.name, '.js')
+        const importName = prefix.join() + basename
+        const importFile = path.join('src', 'pages', basename)
+        deps.push({
+          path: path.join(dir, entry.name),
+          importStatement: `import ${importName} from '${importFile}'`,
+        })
+      } else {
+        // If the Page doesn't exist then we are in a directory of Page
+        // directories, so let's recurse into it and do the whole thing over
+        // again.
+        const newPrefix = prefix.concat(entry.name)
+        deps.push(processDir(path.join(dir, entry.name), newPrefix))
+      }
+    }
+  })
+
+  // We may have nested arrays because of the recursion, so flatten the deps
+  // into a list.
+  return [].concat.apply([], deps)
+}
+
+function routesAutoLoader(source) {
+  // Get the top level directory from the Webpack config options.
+  const { dir } = getOptions(this)
+
+  // Process the dir to find all Page dependencies.
+  const deps = processDir(dir)
+
+  // Inform Webpack that we're pulling external dependencies so it can do the
+  // right thing with watched files, etc.
+  deps.forEach((entry) => {
+    this.addDependency(entry.path)
+  })
+
+  // Grab the import strings from the deps and get them ready to be appended
+  // onto the Routes file.
+  const importString = deps.map((x) => x.importStatement).join('\n')
+
+  // Give 'em what they want!
+  return importString + '\n' + source
+}
+
+module.exports = routesAutoLoader

--- a/packages/scripts/loaders/routes-auto-loader.js
+++ b/packages/scripts/loaders/routes-auto-loader.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
+const { flattenDeep } = require('lodash')
 const { getOptions } = require('loader-utils')
 
 function processDir(dir, prefix = []) {
@@ -37,7 +38,7 @@ function processDir(dir, prefix = []) {
 
   // We may have nested arrays because of the recursion, so flatten the deps
   // into a list.
-  return [].concat.apply([], deps)
+  return flattenDeep(deps)
 }
 
 function routesAutoLoader(source) {
@@ -58,7 +59,7 @@ function routesAutoLoader(source) {
   const importString = deps.map((x) => x.importStatement).join('\n')
 
   // Give 'em what they want!
-  return importString + '\n' + source
+  return importString + '\n\n' + source
 }
 
 module.exports = routesAutoLoader

--- a/yarn.lock
+++ b/yarn.lock
@@ -2309,6 +2309,9 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@redwoodjs/eslint-plugin-redwood@file:packages/eslint-plugin-redwood":
+  version "0.0.1"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"


### PR DESCRIPTION
This Webpack loader will add import statements for all pages from `web/src/pages` onto the top of the `web/src/Routes.js` file. This was the easiest approach I could find to make this work, and wanted to give it a try. It works for nested Pages too:

```
'src/pages/HomePage/HomePage.js'         -> HomePage
'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
```