### PR TITLE
Automatic withCell for cells.

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -154,6 +154,18 @@ module.exports = (webpackEnv) => {
             ),
           },
         },
+        {
+          test: /web\/src\/components\/.+Cell.js$/,
+          use: {
+            loader: path.resolve(
+              __dirname,
+              '..',
+              'dist',
+              'loaders',
+              'cell-loader'
+            ),
+          },
+        },
       ],
     },
     optimization: {

--- a/packages/scripts/src/loaders/cell-loader.js
+++ b/packages/scripts/src/loaders/cell-loader.js
@@ -1,0 +1,24 @@
+export default function(source) {
+  const exports = []
+
+  const names = [
+    'QUERY',
+    'Loading',
+    'Success',
+    'Error',
+    'Empty',
+    'beforeQuery',
+    'afterQuery',
+  ]
+
+  names.forEach((name) => {
+    source.match(`export const ${name}`) && exports.push(name)
+  })
+
+  const newSource = `import { withCell } from '@redwoodjs/web'
+${source}
+export default withCell({ ${exports.join(', ')} })`
+
+  // Give 'em what they want!
+  return newSource
+}


### PR DESCRIPTION
This PR shows a Webpack-loader approach to eliminating the need for the `index.js` file in cells. It looks in the cell file for the various possible exports and then default exports `withCell` with just the exports that exist. This should be identical in functionality to the `index.js` file that we currently use in the example apps.

Closes #30.