### PR TITLE
(fix) typo "Appened" -> "Appended"

### DIFF
--- a/packages/cli/src/commands/Generate/Generate.js
+++ b/packages/cli/src/commands/Generate/Generate.js
@@ -131,7 +131,7 @@ const Generate = ({
 
     results.push(
       <Text key="route">
-        <Color green>Appened route</Color>
+        <Color green>Appended routes</Color>
       </Text>
     )
   }


### PR DESCRIPTION
(fix) typo "Appened" -> "Appended"