### PR TITLE
Remove core-js as a direct dep

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@redwoodjs/core": "^0.0.1-alpha.21",
     "apollo-server-lambda": "2.9.9",
-    "core-js": "3.6.0",
     "graphql": "^14.5.8",
     "graphql-iso-date": "^3.6.1",
     "graphql-tools": "4.0.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,6 @@
     "@redwoodjs/core": "^0.0.1-alpha.21",
     "camelcase": "^5.3.1",
     "concurrently": "^5.0.0",
-    "core-js": "3.6.0",
     "ink": "^2.2.0",
     "lodash": "^4.17.15",
     "param-case": "^3.0.2",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -6,9 +6,6 @@
   ],
   "main": "dist/index.js",
   "license": "MIT",
-  "dependencies": {
-    "core-js": "3.6.0"
-  },
   "scripts": {
     "build": "yarn clean && babel src -d dist",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -24,7 +24,6 @@
     "@types/react-dom": "^16.9.4",
     "babel-loader": "^8.0.6",
     "babel-plugin-module-resolver": "^3.2.0",
-    "core-js": "3.6.0",
     "css-loader": "^3.2.0",
     "directory-named-webpack-plugin": "^4.0.1",
     "dotenv-webpack": "^1.7.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,7 +15,6 @@
     "apollo-client": "^2.6.8",
     "apollo-link": "^1.2.13",
     "apollo-utilities": "^1.3.3",
-    "core-js": "3.6.0",
     "graphql": "^14.5.8",
     "proptypes": "^1.1.0",
     "react-hook-form": "^4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,11 +5312,6 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.1.tgz#59acfb71caf2fb495aae4c1a0b2a7f2c1b65267e"
   integrity sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA==
 
-core-js@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.0.tgz#2b854e451de1967d1e29896025cdc13a2518d9ea"
-  integrity sha512-AHPTNKzyB+YwgDWoSOCaid9PUSEF6781vsfiK8qUz62zRR448/XgK2NtCbpiUGizbep8Lrpt0Du19PpGGZvw3Q==
-
 core-js@^3.0.1, core-js@^3.2.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.1.tgz#39d5e2e346258cc01eb7d44345b1c3c014ca3f05"


### PR DESCRIPTION
@peterp I could be mistaken, but I don't think we need `core-js` as a direct dependency of any of these do we? It doesn't change anything regarding build size, but it seems like best-practice not to have unnecessary deps. Or am I uninformed about why it's a dep?