### PR TITLE
Add self commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,8 +26,8 @@
     "yargs-parser": "^13.1.1"
   },
   "devDependencies": {
-    "@types/react": "^16.9.19",
     "@types/node-fetch": "^2.5.4",
+    "@types/react": "^16.9.19",
     "ink-testing-library": "^1.0.2"
   },
   "scripts": {

--- a/packages/cli/src/commands/Self/Self.js
+++ b/packages/cli/src/commands/Self/Self.js
@@ -1,0 +1,31 @@
+import { getPaths } from '@redwoodjs/core'
+
+const installedPackages = (pattern = '@redwoodjs') => {
+  //➜ yarn list --pattern "@redwoodjs" --depth=0
+  // ├─ @redwoodjs/api@0.0.1-alpha.22
+  // ├─ @redwoodjs/cli@0.0.1-alpha.22
+  // ├─ @redwoodjs/core@0.0.1-alpha.22
+  // ├─ @redwoodjs/dev-server@0.0.1-alpha.22
+  // ├─ @redwoodjs/eslint-config@0.0.1-alpha.22
+  // ├─ @redwoodjs/eslint-plugin-redwood@0.0.1-alpha.22
+  // ├─ @redwoodjs/router@0.0.1-alpha.22
+  // ├─ @redwoodjs/scripts@0.0.1-alpha.22
+  // └─ @redwoodjs/web@0.0.1-alpha.22
+}
+
+/**
+ * The self commands are used during development of the RedwoodJS project.
+ *
+ * `self link`    - Links all of the redwood packages to the current project folder.
+ */
+export default ({ args }) => {
+  const redwoodPaths = getPaths()
+
+  return null
+}
+
+export const commandProps = {
+  name: 'self',
+  hidden: true,
+  description: 'Commands that are helful when developing Redwood itself',
+}

--- a/packages/cli/src/commands/Self/Self.js
+++ b/packages/cli/src/commands/Self/Self.js
@@ -1,6 +1,8 @@
 import { promisify } from 'util'
 import { exec } from 'child_process'
 
+import { getPaths } from '@redwoodjs/core'
+
 const asyncExec = promisify(exec)
 
 const installedPackages = async (pattern = '@redwoodjs') => {
@@ -11,19 +13,26 @@ const installedPackages = async (pattern = '@redwoodjs') => {
 const link = async () => {
   const redwoodPackages = await installedPackages()
   redwoodPackages.forEach(async (pkgName) => {
-    const { stdout, stderr } = await asyncExec(`yarn link '${pkgName}'`)
-    console.log(stdout, stderr)
+    console.log(`Linking ${pkgName}`)
+    const { stderr } = await asyncExec(`yarn link '${pkgName}'`)
+    if (stderr) {
+      console.error(stderr)
+    }
   })
 }
+
+const build = async () => { }
 
 /**
  * The self commands are used during development of the RedwoodJS project.
  *
- * `self link` - Links all of the redwood packages to the current project folder.
+ * `self link`  - Links all of the Redwood packages to the current project folder.
+ * `self build` - Builds all of the Redwood packages when a change is detected.
  */
 export default ({ args }) => {
   const commands = {
     link,
+    build,
   }
 
   const subcommandToRun = args?.[0]?.[1]

--- a/packages/cli/src/components/CommandList.js
+++ b/packages/cli/src/components/CommandList.js
@@ -7,7 +7,13 @@ const CommandList = ({ commands }) => {
       <Box marginBottom={1}>
         <Text bold>Commands</Text>
       </Box>
-      {commands.map(({ commandProps: { name, description } }) => {
+      {commands.map(({ commandProps: { name, description, hidden } }) => {
+        // Redwood has some commands that are not exposed in the menu. We use this
+        // to hide commands that are used by developers that are working on Redwood.
+        if (hidden) {
+          return null
+        }
+
         return (
           <Box key={`command-${name}`}>
             <Box justifyContent="flex-end" marginX={2}>

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -17,11 +17,11 @@ const Router = ({ commands, args = [[], {}] }) => {
       {command ? (
         command.default({ args })
       ) : (
-        <>
-          <Header marginBottom={1} />
-          <CommandList commands={commands} />
-        </>
-      )}
+          <>
+            <Header marginBottom={1} />
+            <CommandList commands={commands} />
+          </>
+        )}
     </Box>
   )
 }

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -112,7 +112,7 @@ const validateCommandExports = ({ commandProps, ...rest }) => {
 
   const { description } = commandProps
   if (!description) {
-    throw 'you must add a `description` to  your `commandProps`'
+    throw 'you must add a `description` to your `commandProps`'
   }
 }
 


### PR DESCRIPTION
This adds commands that are useful for redwoodjs project developers:

`yarn rw self build ../path/to/redwood/library` will build and watch all the redwood packages.

`yarn rw self link` will create a symlink using `yarn link "@redwoodjs/*"` for all the redwood packages in your current project.

Closes #58 