### PR TITLE
Make redwood's build and dev commands reference our internal webpack and babel configs.

### DIFF
--- a/packages/api/__mocks__/@redwoodjs/core.js
+++ b/packages/api/__mocks__/@redwoodjs/core.js
@@ -3,7 +3,9 @@ import path from 'path'
 const BASE_PATH = path.resolve(__dirname, '../../src/__tests__/fixtures')
 
 export const getPaths = () => ({
+  base: BASE_PATH,
   api: {
+    src: path.resolve(BASE_PATH, './api/src'),
     services: path.resolve(BASE_PATH, './api/src/services'),
     graphql: path.resolve(BASE_PATH, './api/src/graphql'),
   },

--- a/packages/api/src/__tests__/__snapshots__/importAll.macro.test.js.snap
+++ b/packages/api/src/__tests__/__snapshots__/importAll.macro.test.js.snap
@@ -7,11 +7,11 @@ const graphQLImports = importAll('api', 'graphql')
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import * as _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcGraphqlPostsSdlTs from '/Users/peterp/Personal/redwoodjs/redwood/packages/api/src/__tests__/fixtures/api/src/graphql/posts.sdl.ts'
-import * as _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcGraphqlUsersSdlJs from '/Users/peterp/Personal/redwoodjs/redwood/packages/api/src/__tests__/fixtures/api/src/graphql/users.sdl.js'
+import * as _fixturesApiSrcGraphqlPostsSdlTs from './fixtures/api/src/graphql/posts.sdl.ts'
+import * as _fixturesApiSrcGraphqlUsersSdlJs from './fixtures/api/src/graphql/users.sdl.js'
 const graphQLImports = {
-  posts: _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcGraphqlPostsSdlTs,
-  users: _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcGraphqlUsersSdlJs,
+  posts: _fixturesApiSrcGraphqlPostsSdlTs,
+  users: _fixturesApiSrcGraphqlUsersSdlJs,
 }
 
 
@@ -24,11 +24,11 @@ const serviceImports = importAll('api', 'services')
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import * as _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcServicesPostsTs from '/Users/peterp/Personal/redwoodjs/redwood/packages/api/src/__tests__/fixtures/api/src/services/posts.ts'
-import * as _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcServicesUsersJs from '/Users/peterp/Personal/redwoodjs/redwood/packages/api/src/__tests__/fixtures/api/src/services/users.js'
+import * as _fixturesApiSrcServicesPostsTs from './fixtures/api/src/services/posts.ts'
+import * as _fixturesApiSrcServicesUsersJs from './fixtures/api/src/services/users.js'
 const serviceImports = {
-  posts: _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcServicesPostsTs,
-  users: _UsersPeterpPersonalRedwoodjsRedwoodPackagesApiSrc__tests__FixturesApiSrcServicesUsersJs,
+  posts: _fixturesApiSrcServicesPostsTs,
+  users: _fixturesApiSrcServicesUsersJs,
 }
 
 

--- a/packages/api/src/importAll.macro.js
+++ b/packages/api/src/importAll.macro.js
@@ -29,19 +29,24 @@ function prevalMacros({ references, state, babel }) {
   })
 }
 
-const getGlobPattern = (callExpressionPath) => {
-  const redwoodPaths = getPaths()
+const getGlobPattern = (callExpressionPath, cwd) => {
   const args = callExpressionPath.parentPath.get('arguments')
   const target = args[0].evaluate().value
   const dir = args[1].evaluate().value
-  return `${redwoodPaths[target][dir]}/*.{ts,js}`
+
+  const redwoodPaths = getPaths()
+  const relativePaths = path.relative(cwd, redwoodPaths[target][dir])
+  return `./${relativePaths}/*.{ts,js}`
 }
 
 function importAll({ referencePath, state, babel }) {
   const t = babel.types
-  const globPattern = getGlobPattern(referencePath)
+  const { filename } = state.file.opts
+  const cwd = path.dirname(filename)
+  const globPattern = getGlobPattern(referencePath, cwd)
+
   // Grab a list of the files
-  const importSources = glob.sync(globPattern)
+  const importSources = glob.sync(globPattern, { cwd })
 
   const { importNodes, objectProperties } = importSources.reduce(
     (all, source) => {

--- a/packages/cli/src/commands/Build/Build.js
+++ b/packages/cli/src/commands/Build/Build.js
@@ -9,7 +9,7 @@ export default ({ args }) => {
   const { base } = getPaths()
   const availableWatchers = {
     api: `cd ${base}/api && NODE_ENV=production yarn babel src --out-dir dist`,
-    web: `cd ${base}/web && yarn webpack --config config/webpack.prod.js`,
+    web: `cd ${base}/web && yarn webpack --config ../node_modules/@redwoodjs/scripts/config/webpack.production.js`,
   }
 
   // The user can do something like `$ yarn rw build api,web` or just `yarn rw build`

--- a/packages/cli/src/commands/Dev/Dev.js
+++ b/packages/cli/src/commands/Dev/Dev.js
@@ -15,7 +15,7 @@ export default ({ args }) => {
       const availableWatchers = {
         db: `cd ${base}/api && yarn prisma2 generate --watch`,
         api: `cd ${base}/api && yarn dev-server`,
-        web: `cd ${base}/web && yarn webpack-dev-server --config ./config/webpack.dev.js`,
+        web: `cd ${base}/web && yarn webpack-dev-server --config ../node_modules/@redwoodjs/scripts/config/webpack.development.js`,
       }
 
       // The user can do something like `$ yarn rw dev api,web` or just `yarn rw dev`

--- a/packages/scripts/config/babel-preset.js
+++ b/packages/scripts/config/babel-preset.js
@@ -4,13 +4,14 @@
 
 const { getPaths } = require('@redwoodjs/core')
 
+const CORE_JS_VERSION = '3.6.4'
+
 module.exports = () => ({
   presets: ['@babel/preset-react', '@babel/typescript'],
   plugins: [
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     'babel-plugin-macros',
   ],
-
   overrides: [
     {
       test: './api/',
@@ -21,8 +22,11 @@ module.exports = () => ({
             targets: {
               node: '8.10.0',
             },
-            useBuiltIns: 'entry',
-            corejs: 3,
+            useBuiltIns: 'usage',
+            corejs: {
+              version: CORE_JS_VERSION,
+              proposals: true,
+            },
           },
         ],
       ],
@@ -35,6 +39,7 @@ module.exports = () => ({
             },
           },
         ],
+        '@babel/plugin-proposal-optional-chaining',
       ],
     },
     {
@@ -43,9 +48,8 @@ module.exports = () => ({
         [
           '@babel/preset-env',
           {
-            targets: '> 0.25%, not dead',
+            // the targets are set in web/package.json
             useBuiltIns: 'usage',
-            corejs: 3,
           },
         ],
       ],
@@ -59,7 +63,6 @@ module.exports = () => ({
             },
           },
         ],
-        'babel-plugin-styled-components',
       ],
     },
   ],

--- a/packages/scripts/config/babel-preset.js
+++ b/packages/scripts/config/babel-preset.js
@@ -1,0 +1,66 @@
+// TODO: Determine what to do different during development, test, and production
+// TODO: Get core js version
+// TODO: Take a look at create-react-app. They've dropped a ton of knowledge.
+
+const { getPaths } = require('@redwoodjs/core')
+
+module.exports = () => ({
+  presets: ['@babel/preset-react', '@babel/typescript'],
+  plugins: [
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
+    'babel-plugin-macros',
+  ],
+
+  overrides: [
+    {
+      test: './api/',
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: {
+              node: '8.10.0',
+            },
+            useBuiltIns: 'entry',
+            corejs: 3,
+          },
+        ],
+      ],
+      plugins: [
+        [
+          'babel-plugin-module-resolver',
+          {
+            alias: {
+              src: getPaths().api.src,
+            },
+          },
+        ],
+      ],
+    },
+    {
+      test: './web',
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            targets: '> 0.25%, not dead',
+            useBuiltIns: 'usage',
+            corejs: 3,
+          },
+        ],
+      ],
+      plugins: [
+        '@babel/plugin-transform-runtime',
+        [
+          'babel-plugin-module-resolver',
+          {
+            alias: {
+              src: './src',
+            },
+          },
+        ],
+        'babel-plugin-styled-components',
+      ],
+    },
+  ],
+})

--- a/packages/scripts/config/webpack.development.js
+++ b/packages/scripts/config/webpack.development.js
@@ -3,7 +3,7 @@ const merge = require('webpack-merge')
 const escapeRegExp = require('lodash.escaperegexp')
 const { getConfig } = require('@redwoodjs/core')
 
-const webpackConfig = require('./webpack.config.js')
+const webpackConfig = require('./webpackConfig.js')
 
 const redwoodConfig = getConfig()
 

--- a/packages/scripts/config/webpack.production.js
+++ b/packages/scripts/config/webpack.production.js
@@ -1,0 +1,3 @@
+const webpackConfig = require('./webpackConfig.js')
+
+module.exports = webpackConfig('production')

--- a/packages/scripts/config/webpackConfig.js
+++ b/packages/scripts/config/webpackConfig.js
@@ -62,10 +62,10 @@ module.exports = (webpackEnv) => {
     },
     plugins: [
       isEnvProduction &&
-        new MiniCssExtractPlugin({
-          filename: '[name].[contenthash:8].css',
-          chunkFilename: '[name].[contenthash:8].css',
-        }),
+      new MiniCssExtractPlugin({
+        filename: '[name].[contenthash:8].css',
+        chunkFilename: '[name].[contenthash:8].css',
+      }),
       !isEnvProduction && new webpack.HotModuleReplacementPlugin(),
       new HtmlWebpackPlugin({
         template: path.resolve(redwoodPaths.base, 'web/src/index.html'),
@@ -185,9 +185,9 @@ module.exports = (webpackEnv) => {
       publicPath: '/',
       devtoolModuleFilenameTemplate: isEnvProduction
         ? (info) =>
-            path
-              .relative(redwoodPaths.web.src, info.absoluteResourcePath)
-              .replace(/\\/g, '/')
+          path
+            .relative(redwoodPaths.web.src, info.absoluteResourcePath)
+            .replace(/\\/g, '/')
         : (info) => path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
     },
   }

--- a/packages/scripts/config/webpackConfig.js
+++ b/packages/scripts/config/webpackConfig.js
@@ -69,6 +69,8 @@ module.exports = (webpackEnv) => {
       !isEnvProduction && new webpack.HotModuleReplacementPlugin(),
       new HtmlWebpackPlugin({
         template: path.resolve(redwoodPaths.base, 'web/src/index.html'),
+        inject: true,
+        chunks: 'all',
       }),
       new webpack.ProvidePlugin({
         React: 'react',
@@ -119,7 +121,6 @@ module.exports = (webpackEnv) => {
               use: {
                 loader: 'babel-loader',
                 options: {
-                  presets: ['@babel/preset-env'],
                   cacheDirectory: true,
                 },
               },
@@ -167,7 +168,7 @@ module.exports = (webpackEnv) => {
     optimization: {
       splitChunks: {
         chunks: 'all',
-        name: false,
+        name: 'vendors',
       },
       runtimeChunk: {
         name: (entrypoint) => `runtime-${entrypoint.name}`,

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -3,15 +3,15 @@
   "version": "0.0.1-alpha.24",
   "license": "MIT",
   "files": [
-    "config/*",
-    "dist/*"
+    "./config",
+    "./dist",
+    "babel-preset.js"
   ],
   "dependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.8.4",
     "@babel/node": "^7.8.4",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-export-default-from": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.8.3",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.8.4",
     "@babel/node": "^7.8.4",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.8.3",


### PR DESCRIPTION
We exported config entry points in `web/config/webpack.<prod|dev>.js`, and whilst this allowed user's to modify their webpack configs easily it also makes it more difficult for us to upgrade redwood, and to be "zero config."

- [x] Reference internal webpack configs rather than in `web/config/`
- [x] Move babel configs into scripts
- [x] [Update `example-todo`](https://github.com/redwoodjs/example-todo/pull/18): Change babel and delete webpack configs. 
- [x] [Update `example-blog`](https://github.com/redwoodjs/example-blog/pull/19): Change babel and delete webpack configs.
- [x] [Update `create-react-app`](https://github.com/redwoodjs/create-redwood-app/pull/19): Change babel and  delete webpack configs.

Closes #76 

