### PR TITLE
add browser open:true to webpack config

### DIFF
--- a/docs/redwood.toml.md
+++ b/docs/redwood.toml.md
@@ -1,0 +1,31 @@
+# Redwood App Configuration
+
+Develompment environment settings can be adjusted using `redwood.toml`.
+
+## web
+
+TODO
+
+### web.port
+
+TODO
+
+### web.apiProxyPaths
+
+TODO
+
+## api.port
+
+TODO
+
+## browser.open
+
+```
+boolean = true string
+```
+
+Tells the dev server to open the browser after server start. Defaults to true in Redwood App.
+
+Can also provide a browser name to use instead of the default, e.g. `open = 'Firefox'`
+
+Uses Webpack. For more details see [Webpack devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen)

--- a/docs/redwood.toml.md
+++ b/docs/redwood.toml.md
@@ -24,8 +24,8 @@ TODO
 boolean = true string
 ```
 
-Tells the dev server to open the browser after server start. Defaults to true in Redwood App.
+Tells the dev server to open the browser after server start. Defaults to false if config missing.
 
-Can also provide a browser name to use instead of the default, e.g. `open = 'Firefox'`
+Can instead provide a browser name to use instead of system default. E.g. `open = 'Firefox'` will auto-open in Firefox regardless of which browser is default.
 
 Uses Webpack. For more details see [Webpack devServer.open](https://webpack.js.org/configuration/dev-server/#devserveropen)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,9 @@ export type Config = {
   api: {
     port: number
   }
+  browser: {
+    open: boolean | string
+  }
 }
 
 export type Paths = {

--- a/packages/scripts/config/webpack.development.js
+++ b/packages/scripts/config/webpack.development.js
@@ -26,6 +26,7 @@ module.exports = merge(webpackConfig('development'), {
     },
     inline: true,
     overlay: true,
+    open: true,
   },
   optimization: {
     removeAvailableModules: false,

--- a/packages/scripts/config/webpack.development.js
+++ b/packages/scripts/config/webpack.development.js
@@ -29,7 +29,7 @@ module.exports = merge(webpackConfig('development'), {
     inline: true,
     overlay: true,
     // checks for override in redwood.toml, defaults to true
-    open: redwoodConfig?.browser?.open ? redwoodConfig.browser.open : true,
+    open: redwoodConfig.browser ? redwoodConfig.browser.open : false,
   },
   optimization: {
     removeAvailableModules: false,

--- a/packages/scripts/config/webpack.development.js
+++ b/packages/scripts/config/webpack.development.js
@@ -5,6 +5,7 @@ const { getConfig } = require('@redwoodjs/core')
 
 const webpackConfig = require('./webpackConfig.js')
 
+// this is the parsed redwood.toml
 const redwoodConfig = getConfig()
 
 module.exports = merge(webpackConfig('development'), {
@@ -26,7 +27,8 @@ module.exports = merge(webpackConfig('development'), {
     },
     inline: true,
     overlay: true,
-    open: true,
+    // checks for override in redwood.toml, defaults to true
+    open: !redwoodConfig.browser || redwoodConfig.browser.open,
   },
   optimization: {
     removeAvailableModules: false,

--- a/packages/scripts/config/webpack.development.js
+++ b/packages/scripts/config/webpack.development.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 /* eslint-disable import/no-extraneous-dependencies */
 const merge = require('webpack-merge')
 const escapeRegExp = require('lodash.escaperegexp')
@@ -28,7 +29,7 @@ module.exports = merge(webpackConfig('development'), {
     inline: true,
     overlay: true,
     // checks for override in redwood.toml, defaults to true
-    open: !redwoodConfig.browser || redwoodConfig.browser.open,
+    open: redwoodConfig?.browser?.open ? redwoodConfig.browser.open : true,
   },
   optimization: {
     removeAvailableModules: false,


### PR DESCRIPTION
Fixes /redwoodjs/redwood/#55

The google said to do this: https://webpack.js.org/configuration/dev-server/#devserveropen

I agree this is the best setting for our getting started tutorial. But this will continually open new browser windows each time we go through a dev server stop/start cycle. In the future this may get annoying and we’ll possibly want to provide a config override on the app side. TBD
