### PR TITLE
Convert PageLoader to React class.

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -207,7 +207,7 @@ const SomeLayout = () => {
 }
 ```
 
-When the lazy-loaded page is loading, `PageLoadingContext.Consumer` will pass `true` to the render function, or false otherwise. You can use this context wherever you like in your application!
+When the lazy-loaded page is loading, `PageLoadingContext.Consumer` will pass `{ loading: true }` to the render function, or false otherwise. You can use this context wherever you like in your application!
 
 After adding this to your app you will probably not see it when navigating between pages. This is because having a loading indicator is nice, but can get annoying when it shows up every single time you navigate to a new page. In fact, this behavior makes it feel like your pages take even longer to load than they actually do! RR takes this into account and, by default, will only show the loader when it takes more than 1000 milliseconds for the page to load. You can change this to whatever you like with the `pageLoadingDelay` prop on `Router`:
 

--- a/packages/router/src/page-loader.js
+++ b/packages/router/src/page-loader.js
@@ -30,15 +30,16 @@ export class PageLoader extends React.Component {
 
   startPageLoadTransition = async () => {
     const { spec, delay } = this.props
-    // This spec is the page where the user has navigated., we'll kick of an async
-    // request to import the page's module.
     const { loader, name } = spec
 
-    // If loading the page is taking too long (> `this.props.delay`) then update
-    // the context. Consumers of the context can display a loading interstitial.
-    this.loadingTimeout = setTimeout(() => {
-      this.setState({ slowModuleImport: true })
-    }, delay)
+    // Update the context if importing the page is taking longer
+    // than `delay`.
+    // Consumers of the context can show a loading indicator
+    // to signal to the user that something is happening.
+    this.loadingTimeout = setTimeout(
+      () => this.setState({ slowModuleImport: true }),
+      delay
+    )
 
     const module = await loader()
 


### PR DESCRIPTION
A React class made this feel easier to reason about. 

This fixes the issue of clearing the`loadingTimeout`, removes the cache, and the "noop" branch whilst the component is "loading."