### PR TITLE
Run `db generate` before starting dev servers

### DIFF
--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -6,7 +6,7 @@ export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
 }
 export const handler = async ({ verbose }) => {
-  await runCommandTask(
+  return await runCommandTask(
     [
       {
         title: 'Generating the Prisma client...',

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -15,7 +15,8 @@ export const builder = {
 export const handler = async ({ app }) => {
   const { base: BASE_DIR } = getPaths()
 
-  // The Redwood API needs the Prisma client to be created before it is started.
+  // The Redwood API needs the Prisma client to be created before it is started,
+  // because it throws when it cannot import the Prisma client.
   await generatePrismaClient({ verbose: false })
 
   const jobs = {

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -4,6 +4,7 @@ import concurrently from 'concurrently'
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
+import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
 export const command = 'dev [app..]'
 export const desc = 'Run development servers.'
@@ -11,8 +12,11 @@ export const builder = {
   app: { choices: ['db', 'api', 'web'], default: ['db', 'api', 'web'] },
 }
 
-export const handler = ({ app }) => {
+export const handler = async ({ app }) => {
   const { base: BASE_DIR } = getPaths()
+
+  // The Redwood API needs the Prisma client to be created before it is started.
+  await generatePrismaClient({ verbose: false })
 
   const jobs = {
     api: {


### PR DESCRIPTION
Not generating the client causes the dev-server to crash because of the missing package.