### PR TITLE
Allow users to generate components with plural names

### DIFF
--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -2,7 +2,6 @@ import path from 'path'
 
 import Listr from 'listr'
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 
 import { generateTemplate, getPaths, writeFilesTask } from 'src/lib'
 
@@ -21,7 +20,7 @@ export const templateForComponentFile = ({
   templateVars,
 }) => {
   const basePath = getPaths().web[webPathSection]
-  const componentName = pascalcase(pluralize.singular(name)) + suffix
+  const componentName = pascalcase(name) + suffix
   const outputPath = path.join(
     basePath,
     componentName,


### PR DESCRIPTION
Generator was forcing component file names to be singular. E.g.

`$ yarn rw generate cell blog-posts` generated the files:
-  `./web/src/components/BlogPostsCell/BlogPostCell.js`
This blocked the user from generating `…cell blog-post`.

Removed `pluralize.singular()` to allow user full control over file name plural/singular.

Fixes #125 required for tutorial to work as written. 