### PR TITLE
Set README within create-redwood-app based on context

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -41,6 +41,7 @@ const tmpDownloadPath = tmp.tmpNameSync({
   postfix: '.zip',
 })
 
+// To run any commands, use these to set path for the working dir
 const targetDir = String(process.argv.slice(2)).replace(/,/g, '-')
 const newAppDir = path.resolve(process.cwd(), targetDir)
 
@@ -128,6 +129,28 @@ const tasks = new Listr(
               }
             },
           },
+          {
+            title: 'Set Local App Development README.md',
+            task: (_ctx, task) => {
+              try {
+                fs.unlinkSync(path.join(newAppDir, './README.md'))
+              } catch (e) {
+                task.skip(
+                  'Could not replace source README.md with a local copy'
+                )
+              }
+              try {
+                fs.renameSync(
+                  path.join(newAppDir, './README_APP.md'),
+                  path.join(newAppDir, './README.md')
+                )
+              } catch (e) {
+                task.skip(
+                  'Could not replace source README.md with a local copy'
+                )
+              }
+            },
+          },
         ])
       },
     },
@@ -148,7 +171,7 @@ const tasks = new Listr(
     {
       title: '...Redwood planting in progress...',
       task: (_ctx, task) => {
-        task.title = 'Success: Your Redwood is Ready to Grow!'
+        task.title = 'SUCCESS: Your Redwood is Ready to Grow!'
         console.log('')
       },
     },

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -151,6 +151,34 @@ const tasks = new Listr(
               }
             },
           },
+          {
+            title: 'Initialize Git and Add First Commit',
+            task: (_ctx, task) => {
+              try {
+                execa.commandSync('git init', {
+                  shell: true,
+                  cwd: `${targetDir}`,
+                })
+              } catch (e) {
+                task.skip(
+                  'Git not installed. Recommend initializing this directory using `git init`.'
+                )
+              }
+              try {
+                execa.commandSync(
+                  'git add . && git commit -m "Initialized with Create Readwood App"',
+                  {
+                    shell: true,
+                    cwd: `${targetDir}`,
+                  }
+                )
+              } catch (e) {
+                task.skip(
+                  'Initial git commit failed. Recommend running `git add .` and `git commit -m` '
+                )
+              }
+            },
+          },
         ])
       },
     },


### PR DESCRIPTION
Provides a way to effectively have separate READMEs for 'create-redwood-app':
1. Repo: content is contributing developer focused, has instructions and link to tutorial for people who are really looking to install and build via `yarn create`
2. Local App: has setup instructions and helpful links to tutorial, website, etc.

Thoughts about this one @peterp ? 

Has a dependent PR in tutorial repo here: redwoodjs/create-redwood-app/pull/26