### PR TITLE
Copies .gitignore.app to .gitignore

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -104,6 +104,51 @@ const tasks = new Listr(
             },
           },
           {
+            title: 'Set Local App Development README.md',
+            task: (_ctx, task) => {
+              try {
+                fs.unlinkSync(path.join(newAppDir, './README.md'))
+              } catch (e) {
+                task.skip(
+                  'Could not replace source README.md with a local copy'
+                )
+              }
+              try {
+                fs.renameSync(
+                  path.join(newAppDir, './README_APP.md'),
+                  path.join(newAppDir, './README.md')
+                )
+              } catch (e) {
+                task.skip(
+                  'Could not replace source README.md with a local copy'
+                )
+              }
+            },
+          },
+          {
+            title: 'Set Local App Development .gitignore',
+            task: (_ctx, task) => {
+              try {
+                fs.unlinkSync(path.join(newAppDir, './.gitignore'))
+              } catch (e) {
+                task.skip(
+                  'Could not replace source .gitignore with a local copy'
+                )
+              }
+              try {
+                fs.renameSync(
+                  path.join(newAppDir, './.gitignore.app'),
+                  path.join(newAppDir, './.gitignore')
+                )
+              } catch (e) {
+                task.skip(
+                  'Could not replace source .gitignore with a local copy'
+                )
+              }
+            },
+          },
+
+          {
             title: 'Renaming index.html Meta Title',
             task: (_ctx, task) => {
               try {

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -147,7 +147,6 @@ const tasks = new Listr(
               }
             },
           },
-
           {
             title: 'Renaming index.html Meta Title',
             task: (_ctx, task) => {


### PR DESCRIPTION
Restores @thedavidprice copying of README_APP.md to README.md

Setting `.gitignore` in `create-redwood-app` is the actual one that git is using to figure out what to ignore in the codebase. But we want a different `.gitignore` for the app that's actually created by `create-redwood-app`. So we have a `.gitignore.app` that is the one that the app will use, and this PR updates the install scripts to replace `.gitignore` with `.gitignore.app`.

See https://github.com/redwoodjs/create-redwood-app/commit/699e6f56469698804ded142d1fb9f25acabb9f79