### PR TITLE
Fix test errors:`rw db ...` commands using new --schema flag

### DIFF
--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -1,7 +1,7 @@
 jest.mock('@redwoodjs/internal')
 jest.mock('src/lib')
 
-import { runCommandTask } from 'src/lib'
+import { runCommandTask, generateTempSchema } from 'src/lib'
 
 import * as up from '../up'
 import * as down from '../down'
@@ -19,22 +19,24 @@ describe('db commands', () => {
   it('runs the command as expected', async () => {
     await up.handler({})
     expect(runCommandTask.mock.results[0].value).toEqual([
-      'prisma2 migrate up --experimental --create-db',
-      'prisma2 generate',
+      `prisma2 migrate up --experimental --create-db --schema=${generateTempSchema}`,
+      `prisma2 generate --schema=${generateTempSchema}`,
     ])
 
     await down.handler({})
     expect(runCommandTask.mock.results[1].value).toEqual([
-      'prisma2 migrate down --experimental',
+      `prisma2 migrate down --experimental --schema=${generateTempSchema}`,
     ])
 
     await save.handler({ name: 'my-migration' })
     expect(runCommandTask.mock.results[2].value).toEqual([
-      'prisma2 migrate save --name my-migration --experimental',
+      `prisma2 migrate save --name my-migration --experimental --schema=${generateTempSchema}`,
     ])
 
     await generate.handler({})
-    expect(runCommandTask.mock.results[3].value).toEqual(['prisma2 generate'])
+    expect(runCommandTask.mock.results[3].value).toEqual([
+      `prisma2 generate --schema=${generateTempSchema}`,
+    ])
 
     await seed.handler({})
     expect(runCommandTask.mock.results[4].value).toEqual(['node seeds.js'])

--- a/packages/cli/src/commands/dbCommands/down.js
+++ b/packages/cli/src/commands/dbCommands/down.js
@@ -6,7 +6,7 @@ export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
 }
 export const handler = async ({ verbose }) => {
-  const tempSchemaPath = generateTempSchema()
+  const tempSchemaPath = generateTempSchema
 
   await runCommandTask(
     [

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -6,7 +6,7 @@ export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
 }
 export const handler = async ({ verbose }) => {
-  const tempSchemaPath = generateTempSchema()
+  const tempSchemaPath = generateTempSchema
 
   return await runCommandTask(
     [

--- a/packages/cli/src/commands/dbCommands/save.js
+++ b/packages/cli/src/commands/dbCommands/save.js
@@ -6,7 +6,7 @@ export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
 }
 export const handler = async ({ name, verbose }) => {
-  const tempSchemaPath = generateTempSchema()
+  const tempSchemaPath = generateTempSchema
 
   await runCommandTask(
     [

--- a/packages/cli/src/commands/dbCommands/up.js
+++ b/packages/cli/src/commands/dbCommands/up.js
@@ -7,7 +7,7 @@ export const builder = {
 }
 
 export const handler = async ({ verbose }) => {
-  const tempSchemaPath = generateTempSchema()
+  const tempSchemaPath = generateTempSchema
 
   await runCommandTask(
     [


### PR DESCRIPTION
@cannikin Could you take a look at the following and see if my fixes make sense? 

`yarn test` was resulting in following error:
```terminal
FAIL  src/commands/dbCommands/__tests__/dbCommands.test.js
  db commands
    ✓ some commands have a verbose flag (5ms)
    ✕ runs the command as expected (2ms)

  ● db commands › runs the command as expected

    TypeError: (0 , _lib.generateTempSchema) is not a function

       8 | 
       9 | export const handler = async ({ verbose }) => {
    > 10 |   const tempSchemaPath = generateTempSchema()
         |                          ^
      11 | 
      12 |   await runCommandTask(
      13 |     [

      at Object.handler (src/commands/dbCommands/up.js:10:26)
      at Object.<anonymous> (src/commands/dbCommands/__tests__/dbCommands.test.js:20:14)
```

After fixing the `generateTempSchema` Type Error, I added the `--schema=...` flags to the expected output for each of the commands.

The tests pass with these fixes. 