### PR TITLE
Generate temp schema with `redwood dev`

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -2,7 +2,7 @@ import path from 'path'
 
 import concurrently from 'concurrently'
 
-import { getPaths } from 'src/lib'
+import { getPaths, generateTempSchema } from 'src/lib'
 import c from 'src/lib/colors'
 import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
@@ -14,6 +14,7 @@ export const builder = {
 
 export const handler = async ({ app }) => {
   const { base: BASE_DIR } = getPaths()
+  const tempSchemaPath = generateTempSchema()
 
   // The Redwood API needs the Prisma client to be created before it is started,
   // because it throws when it cannot import the Prisma client.
@@ -30,7 +31,7 @@ export const handler = async ({ app }) => {
       command: `cd ${path.join(
         BASE_DIR,
         'api'
-      )} && yarn prisma2 generate --watch`,
+      )} && yarn prisma2 generate --watch --schema=${tempSchemaPath}`,
       prefixColor: 'magenta',
     },
     web: {

--- a/packages/cli/src/lib/generateTempSchema.js
+++ b/packages/cli/src/lib/generateTempSchema.js
@@ -30,29 +30,43 @@ const getProvider = (host) => {
   return protocol ? PROTOCOL_TO_PROVIDER_MAP[protocol] : null
 }
 
+const hasRedwoodProvider = (schema) => {
+  return !!schema.match(/provider *= *['"]redwood['"]/)
+}
+
 // reads api/prisma/schema.prisma and dynamically sets the provider based on what you have set in
 // your ENV, then writes out the schema to a tmp file, returning the path to said file
 export const generateTempSchema = () => {
-  const tempSchemaPath = tmp.tmpNameSync({
-    prefix: 'schema',
-    postfix: '.prisma',
-  })
   let schema = fs.readFileSync(getPaths().api.dbSchema).toString()
+
+  // no need to continue if the schema doesn't have the "redwood" provider,
+  // just return the path to the default schema in the app
+  if (!hasRedwoodProvider(schema)) {
+    return getPaths().api.dbSchema
+  }
+
   const host = getConnectionString(schema)
 
   if (host) {
     const provider = getProvider(host)
 
     if (provider) {
-      schema = schema.replace('redwood', provider)
+      const tempSchemaPath = tmp.tmpNameSync({
+        prefix: 'schema',
+        postfix: '.prisma',
+      })
+
+      fs.writeFileSync(
+        tempSchemaPath,
+        schema.replace(/(['"])redwood['"]/, `$1${provider}$1`)
+      )
       console.info(`Using ${provider} provider as set in DB_HOST`)
+
+      return tempSchemaPath
     } else {
       throw new Error(
-        `Unable to determine provider from host "${host}".\nMake sure your db host protocol (the part before ://) is one of: [file, postgres, mysql]`
+        `Unable to determine provider from host "${host}".\nMake sure your db host protocol (the part before :) is one of: [file, postgres, mysql]`
       )
     }
   }
-  fs.writeFileSync(tempSchemaPath, schema)
-
-  return tempSchemaPath
 }


### PR DESCRIPTION
This also checks to see if the `"redwood"` provider is even set before making a temp schema. If not then it just returns the path to the default schema in the app.

@peterp See #165 for a weird issue with double console logging.

