### PR TITLE
Adds ability to override generated component filename/path

### DIFF
--- a/packages/cli/src/commands/generate/commands/service.js
+++ b/packages/cli/src/commands/generate/commands/service.js
@@ -1,18 +1,23 @@
+import camelcase from 'camelcase'
+import pluralize from 'pluralize'
+
 import {
   templateForComponentFile,
   createYargsForComponentGeneration,
 } from '../helpers'
 
 export const files = async ({ name, ...rest }) => {
-  console.info(rest)
+  const componentName = camelcase(pluralize(name))
   const serviceFile = templateForComponentFile({
     name,
+    componentName: componentName,
     apiPathSection: 'services',
     templatePath: 'service/service.js.template',
     templateVars: { ...rest },
   })
   const testFile = templateForComponentFile({
     name,
+    componentName: componentName,
     extension: '.test.js',
     apiPathSection: 'services',
     templatePath: 'service/test.js.template',

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -19,15 +19,16 @@ export const templateForComponentFile = ({
   apiPathSection,
   templatePath,
   templateVars,
+  componentName,
 }) => {
   const basePath = webPathSection
     ? getPaths().web[webPathSection]
     : getPaths().api[apiPathSection]
-  const componentName = pascalcase(name) + suffix
+  const outputComponentName = componentName || pascalcase(name) + suffix
   const outputPath = path.join(
     basePath,
-    componentName,
-    componentName + extension
+    outputComponentName,
+    outputComponentName + extension
   )
   const content = generateTemplate(templatePath, {
     name,


### PR DESCRIPTION
All components we create are PascalCase for their filename (like `components/BlogPost/BlogPost.js`), but services should not be (like `services/posts/posts.js`). 

This code change adds an option to the generator to let you say what directory/name the created file should have.