### PR TITLE
Better Prisma client generation in build and dev commands

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -14,11 +14,15 @@ export const builder = {
   stats: { type: 'boolean', default: false },
 }
 
-export const handler = async ({ app, verbose, stats }) => {
+export const handler = async ({
+  app = ['api', 'web'],
+  verbose = false,
+  stats = false,
+}) => {
   const { base: BASE_DIR } = getPaths()
 
   if (app.includes('api')) {
-    await generatePrismaClient({ verbose: false, force: true })
+    await generatePrismaClient({ verbose, force: true })
   }
 
   const execCommandsForApps = {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -4,6 +4,7 @@ import VerboseRenderer from 'listr-verbose-renderer'
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
+import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
 export const command = 'build [app..]'
 export const desc = 'Build for production.'
@@ -15,6 +16,11 @@ export const builder = {
 
 export const handler = async ({ app, verbose, stats }) => {
   const { base: BASE_DIR } = getPaths()
+
+  if (app.includes('api')) {
+    await generatePrismaClient({ verbose: false, force: true })
+  }
+
   const execCommandsForApps = {
     api: {
       cwd: `${BASE_DIR}/api`,

--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -17,26 +17,26 @@ describe('db commands', () => {
   })
 
   it('runs the command as expected', async () => {
-    await up.handler({})
+    await up.handler({ dbClient: true })
     expect(runCommandTask.mock.results[0].value).toEqual([
       'prisma2 migrate up --experimental --create-db',
-      'prisma2 generate',
     ])
+    expect(runCommandTask.mock.results[1].value).toEqual(['prisma2 generate'])
 
     await down.handler({})
-    expect(runCommandTask.mock.results[1].value).toEqual([
+    expect(runCommandTask.mock.results[2].value).toEqual([
       'prisma2 migrate down --experimental',
     ])
 
     await save.handler({ name: 'my-migration' })
-    expect(runCommandTask.mock.results[2].value).toEqual([
+    expect(runCommandTask.mock.results[3].value).toEqual([
       'prisma2 migrate save --name my-migration --experimental',
     ])
 
     await generate.handler({})
-    expect(runCommandTask.mock.results[3].value).toEqual(['prisma2 generate'])
+    expect(runCommandTask.mock.results[4].value).toEqual(['prisma2 generate'])
 
     await seed.handler({})
-    expect(runCommandTask.mock.results[4].value).toEqual(['node seeds.js'])
+    expect(runCommandTask.mock.results[5].value).toEqual(['node seeds.js'])
   })
 })

--- a/packages/cli/src/commands/dbCommands/down.js
+++ b/packages/cli/src/commands/dbCommands/down.js
@@ -5,7 +5,7 @@ export const desc = 'Migrate your database down.'
 export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
 }
-export const handler = async ({ verbose }) => {
+export const handler = async ({ verbose = true }) => {
   await runCommandTask(
     [
       {

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -9,9 +9,9 @@ export const builder = {
   force: { type: 'boolean', default: true, alias: ['f'] },
 }
 export const handler = async ({ verbose, force }) => {
-  // Do not generate the prisma client if it exists exist. The
-  // Prisma client throws when it's not generated.
+  // Do not generate the Prisma client if it exists.
   if (!force) {
+    // The Prisma client throws if it is not generated.
     try {
       // Import the client from the redwood apps node_modules path.
       const { PrismaClient } = require(path.join(
@@ -22,7 +22,7 @@ export const handler = async ({ verbose, force }) => {
       new PrismaClient()
       return undefined
     } catch (e) {
-      // Do nothing, the client already exists and we're not forcing generation.
+      // Swallow your pain.
     }
   }
 

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -1,11 +1,31 @@
-import { runCommandTask } from 'src/lib'
+import path from 'path'
+
+import { runCommandTask, getPaths } from 'src/lib'
 
 export const command = 'generate'
 export const desc = 'Generate the Prisma client.'
 export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
+  force: { type: 'boolean', default: true, alias: ['f'] },
 }
-export const handler = async ({ verbose }) => {
+export const handler = async ({ verbose, force }) => {
+  // Do not generate the prisma client if it exists exist. The
+  // Prisma client throws when it's not generated.
+  if (!force) {
+    // We have to import from the redwood apps node_modules path.
+    try {
+      const { PrismaClient } = require(path.join(
+        getPaths().base,
+        'node_modules/@prisma/client'
+      ))
+      // eslint-disable-next-line no-new
+      new PrismaClient()
+      return undefined
+    } catch (e) {
+      // do nothing, the client already exists and we're not forcing generation.
+    }
+  }
+
   return await runCommandTask(
     [
       {

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -8,7 +8,7 @@ export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
   force: { type: 'boolean', default: true, alias: ['f'] },
 }
-export const handler = async ({ verbose, force }) => {
+export const handler = async ({ verbose = true, force = true }) => {
   // Do not generate the Prisma client if it exists.
   if (!force) {
     // The Prisma client throws if it is not generated.

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -12,17 +12,17 @@ export const handler = async ({ verbose, force }) => {
   // Do not generate the prisma client if it exists exist. The
   // Prisma client throws when it's not generated.
   if (!force) {
-    // We have to import from the redwood apps node_modules path.
     try {
+      // Import the client from the redwood apps node_modules path.
       const { PrismaClient } = require(path.join(
         getPaths().base,
         'node_modules/@prisma/client'
       ))
-      // eslint-disable-next-line no-new
+      // eslint-disable-next-line
       new PrismaClient()
       return undefined
     } catch (e) {
-      // do nothing, the client already exists and we're not forcing generation.
+      // Do nothing, the client already exists and we're not forcing generation.
     }
   }
 

--- a/packages/cli/src/commands/dbCommands/save.js
+++ b/packages/cli/src/commands/dbCommands/save.js
@@ -5,7 +5,7 @@ export const desc = 'Create a new migration.'
 export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
 }
-export const handler = async ({ name, verbose }) => {
+export const handler = async ({ name, verbose = true }) => {
   await runCommandTask(
     [
       {

--- a/packages/cli/src/commands/dbCommands/up.js
+++ b/packages/cli/src/commands/dbCommands/up.js
@@ -1,23 +1,24 @@
 import { runCommandTask } from 'src/lib'
+import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
 export const command = 'up'
 export const desc = 'Generate the Prisma client and apply migrations.'
 export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
+  dbClient: { type: 'boolean', default: true },
 }
 
-export const handler = async ({ verbose }) => {
+export const handler = async ({ verbose, dbClient }) => {
+  if (dbClient) {
+    await generatePrismaClient({ force: true, verbose: true })
+  }
+
   await runCommandTask(
     [
       {
         title: 'Migrate database up...',
         cmd: 'prisma2',
         args: ['migrate up', '--experimental', '--create-db'],
-      },
-      {
-        title: 'Generating the Prisma client...',
-        cmd: 'prisma2',
-        args: ['generate'],
       },
     ],
     { verbose }

--- a/packages/cli/src/commands/dbCommands/up.js
+++ b/packages/cli/src/commands/dbCommands/up.js
@@ -8,11 +8,7 @@ export const builder = {
   dbClient: { type: 'boolean', default: true },
 }
 
-export const handler = async ({ verbose, dbClient }) => {
-  if (dbClient) {
-    await generatePrismaClient({ force: true, verbose: true })
-  }
-
+export const handler = async ({ verbose = true, dbClient = true }) => {
   await runCommandTask(
     [
       {
@@ -23,4 +19,8 @@ export const handler = async ({ verbose, dbClient }) => {
     ],
     { verbose }
   )
+
+  if (dbClient) {
+    await generatePrismaClient({ force: true, verbose })
+  }
 }

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -25,7 +25,7 @@ export const handler = async ({ app }) => {
       prefixColor: 'cyan',
     },
     db: {
-      name: ' db', // prefixed with ` ` to match indentation.
+      name: ' db', // prefixed with ` ` to match output indentation.
       command: `cd ${path.join(
         BASE_DIR,
         'api'

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -15,9 +15,15 @@ export const builder = {
 export const handler = async ({ app }) => {
   const { base: BASE_DIR } = getPaths()
 
-  // The Redwood API needs the Prisma client to be created before it is started,
-  // because it throws when it cannot import the Prisma client.
-  await generatePrismaClient({ verbose: false })
+  // Generate the prisma client if it doesn't exist. The Prisma client
+  // throws when it's not generated.
+  try {
+    const { PrismaClient } = require('@prisma/client')
+    // eslint-disable-next-line no-new
+    new PrismaClient()
+  } catch (e) {
+    await generatePrismaClient({ verbose: false })
+  }
 
   const jobs = {
     api: {
@@ -26,7 +32,7 @@ export const handler = async ({ app }) => {
       prefixColor: 'cyan',
     },
     db: {
-      name: ' db',
+      name: ' db', // prefixed with ` ` to match indentation.
       command: `cd ${path.join(
         BASE_DIR,
         'api'

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -12,7 +12,7 @@ export const builder = {
   app: { choices: ['db', 'api', 'web'], default: ['db', 'api', 'web'] },
 }
 
-export const handler = async ({ app }) => {
+export const handler = async ({ app = ['db', 'api', 'web'] }) => {
   const { base: BASE_DIR } = getPaths()
 
   // Generate the prisma client if it doesn't exist.

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -15,15 +15,8 @@ export const builder = {
 export const handler = async ({ app }) => {
   const { base: BASE_DIR } = getPaths()
 
-  // Generate the prisma client if it doesn't exist. The Prisma client
-  // throws when it's not generated.
-  try {
-    const { PrismaClient } = require('@prisma/client')
-    // eslint-disable-next-line no-new
-    new PrismaClient()
-  } catch (e) {
-    await generatePrismaClient({ verbose: false })
-  }
+  // Generate the prisma client if it doesn't exist.
+  await generatePrismaClient({ verbose: false, force: false })
 
   const jobs = {
     api: {

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -3,11 +3,13 @@ import path from 'path'
 
 import yargs from 'yargs'
 import { getPaths } from '@redwoodjs/internal'
+import { config } from 'dotenv-defaults'
 
-require(`dotenv-defaults`).config({
+config({
   path: path.join(getPaths().base, '.env'),
   encoding: 'utf8',
   defaults: path.join(getPaths().base, '.env.defaults'),
 })
+
 // eslint-disable-next-line no-unused-expressions
 yargs.commandDir('./commands').demandCommand().argv


### PR DESCRIPTION
- Generate the Prisma client during the build step.
- Conditionally generate the Prisma client for dev commands.
- Add option to not generate the Prisma client when running `yarn rw up`

Closes #189