### PR TITLE
add babel auto import to jest test section of config

### DIFF
--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -111,6 +111,28 @@ module.exports = () => ({
             },
           },
         ],
+        [
+          'babel-plugin-auto-import',
+          {
+            declarations: [
+              {
+                // import { React } from 'react'
+                default: 'React',
+                path: 'react',
+              },
+              {
+                // import { PropTypes } from 'prop-types'
+                default: 'PropTypes',
+                path: 'prop-types',
+              },
+              {
+                // import gql from 'graphql-tag'
+                default: 'gql',
+                path: 'graphql-tag',
+              },
+            ],
+          },
+        ],
       ],
     },
   ],


### PR DESCRIPTION
@peterp Continuing the work from #152 which I thought was working when testing locally (I think my yarn lock was keeping packages I had removed).

Previously, I tried to move the auto-import from Webpack to Babel, which worked for Jest but did not work for running the development environment. When I read your recent doc about where/how we build, it seems that Webpack only is how we're building the web/ side, and **not** our file `core/config/babel-preset.js`. Researching a bit further about babel, I think I now understand this code:
```
overrides: [
    // ** API **
    {
      test: './api/',
      presets: [
        [
          '@babel/preset-env',
          {
            targets: {
              node: TARGETS_NODE,
...
```
and this
```
 // ** WEB **
    {
      test: './web',
...
```
is effectively a switch to use the included settings **only** to transpile in the case Jest is being run.

Am I correct?

If so, the changes in this PR include adding the auto-import to the "Web" section of the babel config file. I've kept the auto-import settings in Webpack.

My local testing confirms the `yarn rw test` command now runs correctly (and passes) using the updated test templates in master redwood branch, which do _not_ import React and gql implicitly. And the command `yarn rw dev` also runs as expected with no browser errors.

Are we there? Finally?!?