### PR TITLE
Fix check for nodejs and yarn versions

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -69,6 +69,7 @@ module.exports = (webpackEnv) => {
         }),
       !isEnvProduction && new webpack.HotModuleReplacementPlugin(),
       new HtmlWebpackPlugin({
+        title: path.basename(redwoodPaths.base),
         template: path.resolve(redwoodPaths.base, 'web/src/index.html'),
         inject: true,
         chunks: 'all',

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -10,6 +10,7 @@
     "@babel/runtime-corejs3": "^7.8.4",
     "@redwoodjs/internal": "^0.0.1-alpha.35",
     "axios": "^0.19.2",
+    "chalk": "^3.0.0",
     "check-node-version": "^4.0.2",
     "decompress": "^4.2.0",
     "execa": "^4.0.0",


### PR DESCRIPTION
@thedavidprice The task to check for node and yarn versions was not working properly. I decided to use the programmatic API instead.

Listr swallows a bunch of the output so I also decided to split out the functionality into individual functions which made it easier to test during development.

I also removed the bit of code that set the title in the html template and used the functionality that's included in html webpack plugin.

Closes #114 

