### PR TITLE
[bug fix] fix case-sensitive generate directory

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
     "@types/node-fetch": "^2.5.5"
   },
   "scripts": {
-    "build": "yarn clean && babel src --out-dir dist && rm -rf ./dist/commands/Generate/templates && cp -r ./src/commands/Generate/templates ./dist/commands/Generate/templates",
+    "build": "yarn clean && babel src --out-dir dist && rm -rf ./dist/commands/generate/templates && cp -r ./src/commands/Generate/templates ./dist/commands/Generate/templates",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",
     "clean": "rm -rf dist",
     "prepublishOnly": "yarn clean && yarn build",

--- a/packages/cli/src/commands/generate/README.md
+++ b/packages/cli/src/commands/generate/README.md
@@ -21,7 +21,7 @@ A typicall generator writes files.
 
 Templates for the files created by generators go in `src/commands/Generate/templates` and should be named after the command that invokes your generator. The files inside should end in `.template` to avoid being compiled by Babel.
 
-    src/commands/Generate/
+    src/commands/generate/
     ├── generators
     │   ├── component.js
     │   └── page.js

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -75,7 +75,7 @@ const nameVariants = (name) => {
 
 export const templateRoot = path.resolve(
   __dirname,
-  '../commands/Generate/templates'
+  '../commands/generate/templates'
 )
 
 export const generateTemplate = (templateFilename, { name, ...rest }) => {


### PR DESCRIPTION
the cli directory that contains templates is alternately named `Generate` and `generate` in the source.  This fails on case-sensitive file systems, but would not fail on case-preserving/case-insensitive file systems.

This fix updates the code and docs to use all lower-case `generate`.