### PR TITLE
Fixed order of routes

### DIFF
--- a/packages/cli/src/commands/generate/commands/scaffold.js
+++ b/packages/cli/src/commands/generate/commands/scaffold.js
@@ -159,8 +159,8 @@ const routes = async ({ model: name }) => {
   const idRouteParam = getIdType(model) === 'Int' ? ':Int' : ''
 
   return [
-    `<Route path="/${pluralCamelName}/{id${idRouteParam}}/edit" page={Edit${singularPascalName}Page} name="edit${singularPascalName}" />`,
     `<Route path="/${pluralCamelName}/new" page={New${singularPascalName}Page} name="new${singularPascalName}" />`,
+    `<Route path="/${pluralCamelName}/{id${idRouteParam}}/edit" page={Edit${singularPascalName}Page} name="edit${singularPascalName}" />`,
     `<Route path="/${pluralCamelName}/{id${idRouteParam}}" page={${singularPascalName}Page} name="${singularCamelName}" />`,
     `<Route path="/${pluralCamelName}" page={${pluralPascalName}Page} name="${pluralCamelName}" />`,
   ]


### PR DESCRIPTION
I was following the [tutorial](https://redwoodjs.com/tutorial/getting-dynamic) and the order of routes was wrong. Here is a simple fix:

Make sure the `/new` route is above the `/{id}` route.