### PR TITLE
Use host configuration provided in redwood configuration file (so that VM/container users can set it to "0.0.0.0")

### DIFF
--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -13,6 +13,7 @@ module.exports = merge(webpackConfig('development'), {
     compress: true,
     quiet: true,
     historyApiFallback: true,
+    host: redwoodConfig.web.host || 'localhost',
     port: redwoodConfig.web.port,
     proxy: {
       [redwoodConfig.web.apiProxyPath]: {

--- a/packages/dev-server/src/main.ts
+++ b/packages/dev-server/src/main.ts
@@ -29,14 +29,15 @@ babelRegister({
 
 // TODO: Convert to yargs.
 args
+  .option('host', '', redwoodConfig.api.host || 'localhost')
   .option('port', '', redwoodConfig.api.port)
   .option(
     'path',
     'The path to your lambda functions',
     redwoodPaths.api.functions
   )
-const { port: PORT, path: PATH } = args.parse(process.argv)
-const HOSTNAME = `http://localhost:${PORT}`
+const { host: HOST, port: PORT, path: PATH } = args.parse(process.argv)
+const HOSTNAME = `http://${HOST}:${PORT}`
 
 const showHeader = (lambdas: Record<string, any>) => {
   console.log(`Listening on ${HOSTNAME}`)

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -1,9 +1,11 @@
 export type Config = {
   web: {
+    host: string
     port: number
     apiProxyPath: string
   }
   api: {
+    host: string
     port: number
   }
   browser: {


### PR DESCRIPTION
Instead of hardcoding/assuming development host to be `localhost`,
make it configurable so that redwood servers being run inside a
container/VM can still be accessed setting host to "0.0.0.0"

The accompanying PR for create-redwood-app is at : https://github.com/redwoodjs/create-redwood-app/pull/32