### PR TITLE
Prevent dev-server refreshes when mutating SQLite DB

### DIFF
--- a/packages/dev-server/src/main.ts
+++ b/packages/dev-server/src/main.ts
@@ -194,7 +194,7 @@ const server = startServer()
 server.setTimeout(10 * 1000)
 
 const watcher = chokidar.watch(API_DIR, {
-  ignored: (path: string) => path.includes('node_modules'),
+  ignored: (path: string) => path.includes('node_modules') || ['.db', '.sqlite', '-journal'].some((ext) => path.endsWith(ext)),
 })
 
 watcher.on('ready', () => {


### PR DESCRIPTION
Resolution for issue  #220 

Files ending with '.db', '.sqlite', and '-journal' should no longer trigger dev-server refreshes when saved. This will speed up mutations when using SQLite dbs.