### PR TITLE
update sdl.js to use scalar datatypes in input types

### DIFF
--- a/packages/cli/src/commands/generate/commands/sdl.js
+++ b/packages/cli/src/commands/generate/commands/sdl.js
@@ -42,7 +42,6 @@ const idType = (model) => {
 }
 
 const sdlFromSchemaModel = async (name) => {
-  console.log('FRED')
   const model = await getSchema(name)
 
   if (model) {

--- a/packages/cli/src/commands/generate/commands/sdl.js
+++ b/packages/cli/src/commands/generate/commands/sdl.js
@@ -14,15 +14,7 @@ const IGNORE_FIELDS = ['id', 'createdAt']
 
 const modelFieldToSDL = (field, required = true, types = {}) => {
   if (Object.entries(types).length) {
-    if (field.kind === "object") {
-      if (!(field.type in types)) {
-        throw new Error(
-          `"${field.type}" model not found, check if it exists in "./api/prisma/schema.prisma"`
-        )
-      } else {
-        field.type = field.kind === 'object' ? idType(types[field.type]) : field.type
-      }
-    }
+    field.type = field.kind === 'object' ? idType(types[field.type]) : field.type
   }
   return `${field.name}: ${field.type}${
     field.isRequired && required ? '!' : ''


### PR DESCRIPTION
Resolves the problem cited in [#210](https://github.com/redwoodjs/redwood/issues/210)

Per See https://graphql.org/graphql-js/mutations-and-input-types: "Input types can't have fields that are other objects, only basic scalar types, list types, and other input types".

In `generate scaffold`, identify custom types referenced by the model. Load model definitions for those types. Pass definitions to the `modelFieldToSDL` function. Identify the scalar data type used as the `@id` field in the referenced type and use that as the field type for the Input.

This changes the SDL for ___Input types only.  No change to base type, query or mutations.