### PR TITLE
Fixing a typo

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -131,7 +131,7 @@ const installNodeModulesTasks = ({ newAppDir }) => {
       },
     },
     {
-      title: 'Running `yarn install`... (Could take awhile)',
+      title: 'Running `yarn install`... (Could take a while)',
       task: () => {
         return execa('yarn install', {
           shell: true,


### PR DESCRIPTION
Hi there,

Here's a fix for a small typo in `create-redwood-app`.

Kind regards,
Hampus Kraft.