### PR TITLE
- Drop requirement for ID field to be labeled "id"

### DIFF
--- a/packages/cli/src/commands/generate/commands/scaffold.js
+++ b/packages/cli/src/commands/generate/commands/scaffold.js
@@ -32,7 +32,7 @@ const COMPONENTS = fs.readdirSync(
 const SCAFFOLD_STYLE_PATH = './scaffold.css'
 
 const getIdType = (model) => {
-  return model.fields.find((field) => field.name === 'id')?.type
+  return model.fields.find((field) => field.isId)?.type
 }
 
 export const files = async ({ model: name }) => {

--- a/packages/cli/src/commands/generate/commands/sdl.js
+++ b/packages/cli/src/commands/generate/commands/sdl.js
@@ -34,7 +34,7 @@ const inputSDL = (model, types = {}) => {
 }
 
 const idType = (model) => {
-  const idField = model.fields.find((field) => field.name === 'id')
+  const idField = model.fields.find((field) => field.isId)
   if (!idField) {
     throw new Error('Cannot generate SDL without an `id` database column')
   }


### PR DESCRIPTION
Addresses issue #235 

Redwood currently doesn't support [composite ids](https://github.com/prisma/prisma2/blob/master/docs/data-modeling.md#ids) and expects a single id