### PR TITLE
Support spaces in directory names for yarn rw dev command.

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -13,7 +13,7 @@ export const builder = {
 }
 
 export const handler = async ({ app = ['db', 'api', 'web'] }) => {
-  // Replaces ` ` with `\ `. Damn.here has got to be a better
+  // Replaces ` ` with `\ `. Damn, there has got to be a better
   // way to sanitize paths?!
   const BASE_DIR = getPaths().base.replace(' ', '\\ ')
 

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -13,9 +13,11 @@ export const builder = {
 }
 
 export const handler = async ({ app = ['db', 'api', 'web'] }) => {
-  const { base: BASE_DIR } = getPaths()
+  // Replaces ` ` with `\ `. Damn.here has got to be a better
+  // way to sanitize paths?!
+  const BASE_DIR = getPaths().base.replace(' ', '\\ ')
 
-  // Generate the prisma client if it doesn't exist.
+  // Generate the Prisma client if it doesn't exist.
   await generatePrismaClient({ verbose: false, force: false })
 
   const jobs = {

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -89,16 +89,16 @@ const createProjectTasks = ({ newAppDir }) => {
       title: 'Clean up',
       task: () => {
         try {
-          fs.unlinkSync(path.join(newAppDir, './README.md'))
+          fs.unlinkSync(path.join(newAppDir, 'README.md'))
           fs.renameSync(
-            path.join(newAppDir, './README_APP.md'),
-            path.join(newAppDir, './README.md')
+            path.join(newAppDir, 'README_APP.md'),
+            path.join(newAppDir, 'README.md')
           )
 
-          fs.unlinkSync(path.join(newAppDir, './.gitignore'))
+          fs.unlinkSync(path.join(newAppDir, '.gitignore'))
           fs.renameSync(
-            path.join(newAppDir, './.gitignore.app'),
-            path.join(newAppDir, './.gitignore')
+            path.join(newAppDir, '.gitignore.app'),
+            path.join(newAppDir, '.gitignore')
           )
         } catch (e) {
           throw new Error('Could not move project files')

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -131,7 +131,7 @@ const installNodeModulesTasks = ({ newAppDir }) => {
       },
     },
     {
-      title: 'Running `yarn install`... (Could take a while)',
+      title: 'Running `yarn install`... (This could take a while)',
       task: () => {
         return execa('yarn install', {
           shell: true,

--- a/packages/dev-server/src/main.ts
+++ b/packages/dev-server/src/main.ts
@@ -194,7 +194,9 @@ const server = startServer()
 server.setTimeout(10 * 1000)
 
 const watcher = chokidar.watch(API_DIR, {
-  ignored: (path: string) => path.includes('node_modules') || ['.db', '.sqlite', '-journal'].some((ext) => path.endsWith(ext)),
+  ignored: (path: string) =>
+    path.includes('node_modules') ||
+    ['.db', '.sqlite', '-journal'].some((ext) => path.endsWith(ext)),
 })
 
 watcher.on('ready', () => {


### PR DESCRIPTION
We use concurrently to run the web and api dev server commands. It does not allow us to specify the path where the command should be executed so we do something like this:

`cd /Users/my username/to/api && yarn dev-server`, which does not work if you have a space in your path because those need to be escaped with a backslash `\ `.

Fixes #222 

I've asked concurrently if it's possible to supply a cwd for commands: https://github.com/kimmobrunfeldt/concurrently/issues/216