### PR TITLE
Fix typo and add an hyperlink

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,4 +58,4 @@ export const commandProps = {
 
 ## Publishing
 
-This is a monorepo and is published via LearnaJS. See the root README for instructions.
+This is a monorepo and is published via [LernaJS](https://lerna.js.org/). See the root README for instructions.


### PR DESCRIPTION
While reading the documentation I noticed there was a typo. This PR fixes is and adds an hyperlink to the tool.