### PR TITLE
path.join does not work for import statements on windows

### DIFF
--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -87,7 +87,8 @@ export const processPagesDir = (
         // onto the deps array.
         const basename = path.posix.basename(entry.name, '.js')
         const importName = prefix.join() + basename
-        const importFile = path.join('src', 'pages', ...prefix, basename)
+        // `src/pages/<PageName>`
+        const importFile = ['src', 'pages', ...prefix, basename].join('/')
         deps.push({
           const: importName,
           path: path.join(webPagesDir, entry.name),


### PR DESCRIPTION
`path.join` caused the auto-imported statements to look like this:

```javascript
const FatalErrorPage = { name: 'FatalErrorPage', loader: () => import('src\\pages\\FatalErrorPage') }
```

They now look like this:

```javascript
importStatement: "const NotFoundPage = { name: 'NotFoundPage', loader: () => import('src/pages/NotFoundPage') }"
```


Fixes #219 