### PR TITLE
Check for local app's copy of dbInstance before resorting to @redwoodjs/api copy

### DIFF
--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -16,7 +16,7 @@ const TARGETS_NODE = '12.16.1'
 // instead of corejs: 3, since with corejs: 3 will not be injected modules which
 // were added in minor core-js releases.
 const CORE_JS_VERSION = '3.6'
-const DB_INITIALIZER_PATH = path.join(getPaths().api.init, 'dbInstance')
+const DB_INITIALIZER_PATH = path.join(getPaths().api.config, 'dbInstance')
 
 // Whether a given file path is a Javascript or Typescript file
 const isScript = (filePath) => {

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -5,6 +5,9 @@
 // TODO: Determine what to do different during development, test, and production
 // TODO: Take a look at create-react-app. They've dropped a ton of knowledge.
 
+const fs = require('fs')
+const path = require('path')
+
 const { getPaths } = require('@redwoodjs/internal')
 
 const TARGETS_NODE = '12.16.1'
@@ -13,6 +16,21 @@ const TARGETS_NODE = '12.16.1'
 // instead of corejs: 3, since with corejs: 3 will not be injected modules which
 // were added in minor core-js releases.
 const CORE_JS_VERSION = '3.6'
+const DB_INITIALIZER_PATH = path.join(getPaths().api.config, 'dbInstance')
+
+// Whether a given file path is a Javascript or Typescript file
+const isScript = (filePath) => {
+  return !!path.extname(filePath).match(/^[jt]s$/)
+}
+// Filters a list of files to only return Javascript or Typescripts
+const scriptsOnly = (files) => {
+  return files.filter(isScript)
+}
+// Given a path like 'src/config/dbInstance' will return the path to the actual
+// filename like 'src/config/dbInstance.ts' (or .js) or will return null
+const pathIfScriptExists = (path) => {
+  return scriptsOnly(fs.readdirSync(path)).length !== 0 ? path : null
+}
 
 module.exports = () => ({
   presets: ['@babel/preset-react', '@babel/typescript'],
@@ -70,7 +88,9 @@ module.exports = () => ({
               {
                 // import { db } from '@redwoodjs/api/dist/dbInstance'
                 members: ['db'],
-                path: '@redwoodjs/api/dist/dbInstance',
+                path:
+                  pathIfScriptExists(DB_INITIALIZER_PATH) ||
+                  '@redwoodjs/api/dist/dbInstance',
               },
               {
                 // import { context } from '@redwoodjs/api'

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -16,7 +16,7 @@ const TARGETS_NODE = '12.16.1'
 // instead of corejs: 3, since with corejs: 3 will not be injected modules which
 // were added in minor core-js releases.
 const CORE_JS_VERSION = '3.6'
-const DB_INITIALIZER_PATH = path.join(getPaths().api.config, 'dbInstance')
+const DB_INITIALIZER_PATH = path.join(getPaths().api.init, 'dbInstance')
 
 // Whether a given file path is a Javascript or Typescript file
 const isScript = (filePath) => {

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -11,7 +11,7 @@ const PATH_API_DIR_FUNCTIONS = 'api/src/functions'
 const PATH_API_DIR_GRAPHQL = 'api/src/graphql'
 const PATH_API_DIR_DB = 'api/prisma'
 const PATH_API_DIR_DB_SCHEMA = 'api/prisma/schema.prisma'
-const PATH_API_DIR_INIT = 'api/config'
+const PATH_API_DIR_CONFIG = 'api/src/config'
 const PATH_API_DIR_SERVICES = 'api/src/services'
 const PATH_API_DIR_SRC = 'api/src'
 const PATH_WEB_ROUTES = 'web/src/Routes.js'
@@ -51,7 +51,7 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       dbSchema: path.join(BASE_DIR, PATH_API_DIR_DB_SCHEMA),
       functions: path.join(BASE_DIR, PATH_API_DIR_FUNCTIONS),
       graphql: path.join(BASE_DIR, PATH_API_DIR_GRAPHQL),
-      init: path.join(BASE_DIR, PATH_API_DIR_INIT),
+      config: path.join(BASE_DIR, PATH_API_DIR_CONFIG),
       services: path.join(BASE_DIR, PATH_API_DIR_SERVICES),
       src: path.join(BASE_DIR, PATH_API_DIR_SRC),
     },

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -9,6 +9,7 @@ const CONFIG_FILE_NAME = 'redwood.toml'
 
 const PATH_API_DIR_FUNCTIONS = 'api/src/functions'
 const PATH_API_DIR_GRAPHQL = 'api/src/graphql'
+const PATH_API_DIR_CONFIG = 'api/config'
 const PATH_API_DIR_DB = 'api/prisma'
 const PATH_API_DIR_DB_SCHEMA = 'api/prisma/schema.prisma'
 const PATH_API_DIR_SERVICES = 'api/src/services'
@@ -46,6 +47,7 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
   return {
     base: BASE_DIR,
     api: {
+      config: path.join(BASE_DIR, PATH_API_DIR_CONFIG),
       db: path.join(BASE_DIR, PATH_API_DIR_DB),
       dbSchema: path.join(BASE_DIR, PATH_API_DIR_DB_SCHEMA),
       functions: path.join(BASE_DIR, PATH_API_DIR_FUNCTIONS),

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -9,9 +9,9 @@ const CONFIG_FILE_NAME = 'redwood.toml'
 
 const PATH_API_DIR_FUNCTIONS = 'api/src/functions'
 const PATH_API_DIR_GRAPHQL = 'api/src/graphql'
-const PATH_API_DIR_CONFIG = 'api/config'
 const PATH_API_DIR_DB = 'api/prisma'
 const PATH_API_DIR_DB_SCHEMA = 'api/prisma/schema.prisma'
+const PATH_API_DIR_INIT = 'api/config'
 const PATH_API_DIR_SERVICES = 'api/src/services'
 const PATH_API_DIR_SRC = 'api/src'
 const PATH_WEB_ROUTES = 'web/src/Routes.js'
@@ -47,11 +47,11 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
   return {
     base: BASE_DIR,
     api: {
-      config: path.join(BASE_DIR, PATH_API_DIR_CONFIG),
       db: path.join(BASE_DIR, PATH_API_DIR_DB),
       dbSchema: path.join(BASE_DIR, PATH_API_DIR_DB_SCHEMA),
       functions: path.join(BASE_DIR, PATH_API_DIR_FUNCTIONS),
       graphql: path.join(BASE_DIR, PATH_API_DIR_GRAPHQL),
+      init: path.join(BASE_DIR, PATH_API_DIR_INIT),
       services: path.join(BASE_DIR, PATH_API_DIR_SERVICES),
       src: path.join(BASE_DIR, PATH_API_DIR_SRC),
     },

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -23,6 +23,7 @@ export type Paths = {
     src: string
   }
   api: {
+    config: string
     db: string
     dbSchema: string
     functions: string

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -23,11 +23,11 @@ export type Paths = {
     src: string
   }
   api: {
-    config: string
     db: string
     dbSchema: string
     functions: string
     graphql: string
+    init: string
     services: string
     src: string
   }

--- a/packages/internal/src/types.ts
+++ b/packages/internal/src/types.ts
@@ -23,11 +23,11 @@ export type Paths = {
     src: string
   }
   api: {
+    config: string
     db: string
     dbSchema: string
     functions: string
     graphql: string
-    init: string
     services: string
     src: string
   }


### PR DESCRIPTION
Added support in create-redwood-app: https://github.com/redwoodjs/create-redwood-app/pull/40

Building off the discussion in https://github.com/redwoodjs/redwood/issues/286 this looks for a local app `dbInstance` config file before resorting to the one in `@redwoodjs/api`. I like the idea of always including this file with a new app so that it's easy for people to change if needed (and we can include comments about how to use it).

Maybe this could be the beginning of a convention to allow configuration files to be put in their own home, `api/config`? And so we need a `web/config` as well? What do you think @mojombo?

### Questions

* Will hot reloading work if changes are made to this file?

Closes #286 