### PR TITLE
Change the way a path is matched against a route

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,6 +16,8 @@
     "build": "yarn clean && babel src -d dist",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",
     "prepublishOnly": "yarn clean && yarn build",
+    "test": "yarn jest src",
+    "test:watch": "yarn test --watch",
     "clean": "rm -rf dist"
   },
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649"

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -15,6 +15,11 @@ describe('matchPath', () => {
   })
 
   it('transforms a param based on the specified transform', () => {
+    expect(matchPath('/post/{id}', '/post/1337')).toEqual({
+      match: true,
+      params: { id: '1337' },
+    })
+
     expect(matchPath('/post/{id:Int}', '/post/1337')).toEqual({
       match: true,
       params: { id: 1337 },

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -1,0 +1,27 @@
+import { matchPath } from '../util'
+
+const coreParamTypes = {
+  Int: {
+    constraint: /\d+/,
+    transform: Number,
+  },
+}
+
+describe('matchPath', () => {
+  it('matches paths correctly', () => {
+    expect(matchPath('/post/{id:Int}', '/post/7', coreParamTypes)).toEqual({
+      match: true,
+      params: { id: 7 },
+    })
+
+    expect(
+      matchPath(
+        '/blog/{year}/{month}/{day}',
+        '/blog/2019/12/07',
+        coreParamTypes
+      )
+    ).toEqual({ match: true, params: { day: '07', month: '12', year: '2019' } })
+
+    expect(matchPath('/about', '/', coreParamTypes)).toEqual({ match: false })
+  })
+})

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -24,4 +24,11 @@ describe('matchPath', () => {
 
     expect(matchPath('/about', '/', coreParamTypes)).toEqual({ match: false })
   })
+
+  it('transforms a param based on the specified transform', () => {
+    expect(matchPath('/post/{id:Int}', '/post/1337', coreParamTypes)).toEqual({
+      match: true,
+      params: { id: 1337 },
+    })
+  })
 })

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -1,32 +1,21 @@
 import { matchPath } from '../util'
 
-const coreParamTypes = {
-  Int: {
-    constraint: /\d+/,
-    transform: Number,
-  },
-}
-
 describe('matchPath', () => {
   it('matches paths correctly', () => {
-    expect(matchPath('/post/{id:Int}', '/post/7', coreParamTypes)).toEqual({
+    expect(matchPath('/post/{id:Int}', '/post/7')).toEqual({
       match: true,
       params: { id: 7 },
     })
 
     expect(
-      matchPath(
-        '/blog/{year}/{month}/{day}',
-        '/blog/2019/12/07',
-        coreParamTypes
-      )
+      matchPath('/blog/{year}/{month}/{day}', '/blog/2019/12/07')
     ).toEqual({ match: true, params: { day: '07', month: '12', year: '2019' } })
 
-    expect(matchPath('/about', '/', coreParamTypes)).toEqual({ match: false })
+    expect(matchPath('/about', '/')).toEqual({ match: false })
   })
 
   it('transforms a param based on the specified transform', () => {
-    expect(matchPath('/post/{id:Int}', '/post/1337', coreParamTypes)).toEqual({
+    expect(matchPath('/post/{id:Int}', '/post/1337')).toEqual({
       match: true,
       params: { id: 1337 },
     })

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -12,15 +12,6 @@ import {
   PageLoader,
 } from './internal'
 
-// Definitions of the core param types.
-// TODO: Move these to utils, and merge them with the "paramtypes" that a user defines.
-const coreParamTypes = {
-  Int: {
-    constraint: /\d+/,
-    transform: Number,
-  },
-}
-
 const Route = () => {
   return null
 }
@@ -73,7 +64,6 @@ const RouterImpl = ({
   mapNamedRoutes(routes)
 
   let NotFoundPage
-  const allParamTypes = { ...coreParamTypes, ...paramTypes }
 
   for (let route of routes) {
     const { path, page: Page, redirect, notfound } = route.props
@@ -83,11 +73,7 @@ const RouterImpl = ({
       continue
     }
 
-    const { match, params: pathParams } = matchPath(
-      path,
-      pathname,
-      allParamTypes
-    )
+    const { match, params: pathParams } = matchPath(path, pathname, paramTypes)
 
     if (match) {
       const searchParams = parseSearch(search)

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -13,6 +13,7 @@ import {
 } from './internal'
 
 // Definitions of the core param types.
+// TODO: Move these to utils, and merge them with the "paramtypes" that a user defines.
 const coreParamTypes = {
   Int: {
     constraint: /\d+/,

--- a/packages/router/src/util.js
+++ b/packages/router/src/util.js
@@ -9,15 +9,21 @@ const createNamedContext = (name, defaultValue) => {
 //
 // '/blog/{year}/{month}/{day:Int}' => [['year'], ['month'], ['day', 'Int']]
 const paramsForType = (route) => {
+  // Match the strings between `{` and `}`.
   const params = [...route.matchAll(/\{([^}]+)\}/g)]
-  return (
-    params
-      .map((match) => match[1])
-      // remove the param type part
-      .map((match) => {
-        return match.split(':')
-      })
-  )
+  return params
+    .map((match) => match[1])
+    .map((match) => {
+      return match.split(':')
+    })
+}
+
+// Definitions of the core param types.
+const coreParamTypes = {
+  Int: {
+    constraint: /\d+/,
+    transform: Number,
+  },
 }
 
 // Determine if the given route is a match for the given pathname. If so,
@@ -37,14 +43,19 @@ const paramsForType = (route) => {
 //
 //   matchPath('/post/{id:Int}', '/post/7')
 //   => { match: true, params: { id: 7 }}
-const matchPath = (route, pathname, allParamTypes) => {
+const matchPath = (route, pathname, paramTypes) => {
+  // Does the `pathname` match the `route`?
   const matches = [
     ...pathname.matchAll(`^${route.replace(/\{([^}]+)\}/g, '([^/]+)')}$`),
   ]
+
   if (matches.length === 0) {
     return { match: false }
   }
 
+  const allParamTypes = { ...coreParamTypes, ...paramTypes }
+
+  // Get the names and the transform types for the given route.
   const paramInfo = paramsForType(route)
   const params = matches[0].slice(1).reduce((acc, value, index) => {
     const [name, transformName] = paramInfo[index]

--- a/packages/router/src/util.js
+++ b/packages/router/src/util.js
@@ -5,38 +5,19 @@ const createNamedContext = (name, defaultValue) => {
   return Ctx
 }
 
-// Separator token used during param type recognition.
-const separator = '__redwood_param_type__'
-
-// Convert the given path (from the path specified in the Route) into a regular
-// expression that will match any named parameters. Param types are handled here
-// as well.
+// Get param name and type tranform for a route
 //
-// path          - The path as specified in the <Route ... />.
-// allParamTypes - The object containing all param type definitions.
-//
-// Examples:
-//
-//   reRoute('/blog/{year}/{month}/{day}', { ... })
-//   reRoute('/post/{id:Int}', { Int: { ... }})
-const reRoute = (path, allParamTypes) => {
-  let pathWithCaptures = path
-
-  Object.keys(allParamTypes).forEach((pType) => {
-    const { constraint: pConstraint } = allParamTypes[pType]
-    const regex = new RegExp(`\{([^}]+):${pType}\}`, 'g')
-    const constraintString = pConstraint.toString()
-    const constraint = constraintString.substring(
-      1,
-      constraintString.length - 1
-    )
-    const capture = `(?<$1${separator}${pType}>${constraint})`
-    pathWithCaptures = pathWithCaptures.replace(regex, capture)
-  })
-
-  pathWithCaptures = pathWithCaptures.replace(/\{([^}]+)\}/g, '(?<$1>[^/]+)')
-
-  return `^${pathWithCaptures}$`
+// '/blog/{year}/{month}/{day:Int}' => [['year'], ['month'], ['day', 'Int']]
+const paramsForType = (route) => {
+  const params = [...route.matchAll(/\{([^}]+)\}/g)]
+  return (
+    params
+      .map((match) => match[1])
+      // remove the param type part
+      .map((match) => {
+        return match.split(':')
+      })
+  )
 }
 
 // Determine if the given route is a match for the given pathname. If so,
@@ -57,28 +38,28 @@ const reRoute = (path, allParamTypes) => {
 //   matchPath('/post/{id:Int}', '/post/7')
 //   => { match: true, params: { id: 7 }}
 const matchPath = (route, pathname, allParamTypes) => {
-  const matches = Array.from(pathname.matchAll(reRoute(route, allParamTypes)))
-  if (matches.length > 0) {
-    const params = matches[0].groups || {}
-
-    // Handle param types.
-    const transformedParams = Object.keys(params).reduce((acc, key) => {
-      const pMatches = key.match(`^(\\w+)${separator}(\\w+)$`)
-
-      if (pMatches && pMatches.length > 0) {
-        const [_, pName, pType] = pMatches
-        acc[pName] = allParamTypes[pType].transform(params[key])
-      } else {
-        acc[key] = params[key]
-      }
-
-      return acc
-    }, {})
-
-    return { match: true, params: transformedParams }
-  } else {
+  const matches = [
+    ...pathname.matchAll(`^${route.replace(/\{([^}]+)\}/g, '([^/]+)')}$`),
+  ]
+  if (matches.length === 0) {
     return { match: false }
   }
+
+  const paramInfo = paramsForType(route)
+  const params = matches[0].slice(1).reduce((acc, value, index) => {
+    const [name, transformName] = paramInfo[index]
+
+    if (transformName) {
+      value = allParamTypes[transformName].transform(value)
+    }
+
+    return {
+      ...acc,
+      [name]: value,
+    }
+  }, {})
+
+  return { match: true, params }
 }
 
 // Parse the given search string into key/value pairs and return them in an
@@ -166,7 +147,6 @@ const replaceParams = (path, args = {}) => {
 
 export {
   createNamedContext,
-  reRoute,
   matchPath,
   parseSearch,
   validatePath,


### PR DESCRIPTION
Regex named capture routes aren't supported in Firefox (and some other browsers), since we generate the regex during runtime we couldn't use the babel-tranform that adds support for them.

This pull requests changes the way that routes are matched:
1. It matches the URL to the route: `'/blog/{year}/{month}/{day}'` matches `'/blog/2019/12/07'`
2. It extracts the strings between `{}`: `'/blog/{year}/{month}/{day:Int}'` => `[['year'], ['month'], ['day', 'Int']]`
3. And applies the transformation if specified.

The data structure returned from `matchPath` remains unchanged: https://github.com/redwoodjs/redwood/blob/9b72f136f30cefaad58876b4aa6d4ced51934643/packages/router/src/util.js#L46

Fixes #205