### PR TITLE
Add current CLI commands to `packages/cli/README.md`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ Additionally, you can use `rw` as shorthand for `redwood`. For example, `yarn rw
 ### Get Help
 
 ```terminal
-yarn redwood --help
+$ yarn redwood --help
 ```
 
 You can see the list of available CLI commands directly from the terminal. The output will be similar to:
@@ -38,7 +38,7 @@ The `--help` flag can be passed after any of the Redwood CLI commands described 
 ### Create a New Redwood Project
 
 ```terminal
-yarn create redwood-app <project-dir>
+$ yarn create redwood-app <project-dir>
 ```
 
 OK, OK, so this isn't really part of the RedwoodJS CLI, per se. But we felt it belonged here anyway!

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,16 +1,41 @@
 # The Redwood Command Line Interface
 
-The Redwood CLI comes with RedwoodJS (which means no extra software to install!).
+The Redwood CLI comes with RedwoodJS (which means no extra software to install!). It is made with [yargs](https://yargs.js.org/).
 
 ## Usage
 
 The [`yarn`](https://classic.yarnpkg.com/en/docs/install) package is required to use the Redwood CLI.
 
-Be sure to prefix all Redwood CLI commands with `yarn `. For example, `yarn redwood new`.
+Be sure to prefix all Redwood CLI commands with `yarn`. For example, `yarn redwood new`.
 
 Additionally, you can use `rw` as shorthand for `redwood`. For example, `yarn rw new`.
 
 ## Command line basics
+
+### Get Help
+
+```terminal
+yarn redwood --help
+```
+
+You can see the list of available CLI commands directly from the terminal. The output will be similar to:
+
+```terminal
+rw <command>
+
+Commands:
+  rw build [app..]    Build for production.
+  rw db <command>     Database tools.                        [aliases: database]
+  rw dev [app..]      Run development servers.
+  rw generate <type>  Save time by generating boilerplate code.     [aliases: g]
+  rw lint             Lint your files.
+  rw open [port]      Open your project in your browser.
+  rw test [app..]     Run Jest tests for api and web.
+```
+
+The `--help` flag can be passed after any of the Redwood CLI commands described above. For example, `yarn redwood open --help` displays the documentation for the `redwood open` command.
+
+### Create a New Redwood Project
 
 ```terminal
 yarn create redwood-app <project-dir>
@@ -25,6 +50,64 @@ For example:
 ```terminal
 $ yarn create redwood-app ~/myprojects/todo
 ```
+
+### Database Tools
+
+```terminal
+$ yarn redwood database <command>
+```
+
+or
+
+```terminal
+$ yarn redwood db <command>
+```
+
+This command exposes the various database commands.
+
+#### Create a New Migration
+
+```terminal
+$ yarn redwood db save [name..]
+```
+
+This command creates and saves new migrations in a new folder based on current data model changes.
+
+It takes an optional parameter, `name`, that, if present, will be used as a name for the new migration.
+
+#### Generate Prisma Client and Apply Migrations
+
+```terminal
+$ yarn redwood db up
+```
+
+This command generates the Prisma Client and applies any unapplied migrations.
+
+#### Undo Migrations
+
+```terminal
+$ yarn redwood db down
+```
+
+This command undoes any migrations that were applied to the database.
+
+#### Generate Prisma Client
+
+```terminal
+$ yarn redwood db generate
+```
+
+This command generates the Prisma Client (more specifially, it invokes the generators specific in the Prisma project file).
+
+#### Seed Database
+
+```terminal
+$ yarn redwood db seed
+```
+
+This command seeds the database with test data.
+
+More specifically, it runs the `api/prisma/seeds.js` file which must be filled with seed code to seed the database with initial test data.
 
 ## Development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -200,4 +200,4 @@ export const commandProps = {
 
 ## Publishing
 
-This is a monorepo and is published via [LernaJS](https://lerna.js.org/). See the root README for instructions.
+This is a monorepo and is published via [LernaJS](https://lerna.js.org/). See the [root README](/README.md) for instructions.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -117,6 +117,24 @@ $ yarn redwood lint
 
 This command runs the linter in all projects.
 
+### Run Tests
+
+```terminal
+$ yarn redwood test [app..]
+```
+
+This command runs tests in the specified projects.
+
+It takes an optional parameter, `app`, which is an array of strings, each which identifies the project to be run.
+
+By default, it runs the tests of all projects (`api` and `web`).
+
+For example, if you'd like to _only_ run the `api` project tests, run:
+
+```terminal
+$ yarn redwood test api
+```
+
 ### Run Development Server(s)
 
 ```terminal
@@ -125,9 +143,11 @@ $ yarn redwood dev [app..]
 
 This command runs the development servers.
 
-It takes an optional parameter, `app`, which is an array of strings, each which identifies the project to be run. This defaults to run all projects (`api` and `web`).
+It takes an optional parameter, `app`, which is an array of strings, each which identifies the project to be run.
 
-For example, if you'd like to _only_ run the `api` project, you can run:
+By default, it runs the development servers of all projects (`api` and `web`).
+
+For example, if you'd like to _only_ run the `api` project development server, run:
 
 ```terminal
 $ yarn redwood dev api

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,9 +6,9 @@ The Redwood CLI comes with RedwoodJS (which means no extra software to install!)
 
 The [`yarn`](https://classic.yarnpkg.com/en/docs/install) package is required to use the Redwood CLI.
 
-Be sure to prefix all Redwood CLI commands with `yarn`. For example, `yarn redwood new`.
+Be sure to prefix all Redwood CLI commands with `yarn`. For example, `yarn redwood lint`.
 
-Additionally, you can use `rw` as shorthand for `redwood`. For example, `yarn rw new`.
+Additionally, you can use `rw` as shorthand for `redwood`. For example, `yarn rw lint`.
 
 ## Command line basics
 
@@ -108,6 +108,48 @@ $ yarn redwood db seed
 This command seeds the database with test data.
 
 More specifically, it runs the `api/prisma/seeds.js` file which must be filled with seed code to seed the database with initial test data.
+
+### Generate
+
+```terminal
+yarn redwood generate <type>
+```
+
+This command exposes various generators that generate boilerplate code for a module type. For example, `yarn redwood generate component todo` generates boilerplate code for a `Todo`.
+
+The various module types are described below.
+
+#### Genreate Cell
+
+```terminal
+yarn redwood generate cell <name>
+```
+
+This command generates boilerplate code for a Redwood cell.
+
+It requires a `name` parameter which is the name of the cell. The cell component and test file are saved to the `/web/src/components/NameCell` (where _"Name"_ is replaced with the `name` parameter) directory.
+
+For example,
+
+```terminal
+yarn redwood generate cell todo
+```
+
+generates a cell component and a test file in the `/web/src/components/TodoCell` directory.
+
+#### Generate Component
+
+This command generates boilerplate code for a React component.
+
+It requires a `name` parameter which is the name of the component. The component and test file are saved to the `/web/src/components/Name` (where _"Name"_ is replaced with the `name` parameter) directory.
+
+For example,
+
+```terminal
+yarn redwood generate component todo
+```
+
+generates a component and a test file in the `/web/src/components/Todo` directory.
 
 ### Run Linter
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -109,6 +109,40 @@ This command seeds the database with test data.
 
 More specifically, it runs the `api/prisma/seeds.js` file which must be filled with seed code to seed the database with initial test data.
 
+### Run Linter
+
+```terminal
+$ yarn redwood lint
+```
+
+This command runs the linter in all projects.
+
+### Run Development Server(s)
+
+```terminal
+$ yarn redwood dev [app..]
+```
+
+This command runs the development servers.
+
+It takes an optional parameter, `app`, which is an array of strings, each which identifies the project to be run. This defaults to run all projects (`api` and `web`).
+
+For example, if you'd like to _only_ run the `api` project, you can run:
+
+```terminal
+$ yarn redwood dev api
+```
+
+### Open Project
+
+```terminal
+$ yarn redwood open
+```
+
+This command opens the browser to the local port in which the web development server is running. This port is defined and can be modified in your project's `redwood.toml` file (found in the root).
+
+Please note that this command _does not_ run the development server. It simply opens the browser.
+
 ## Development
 
 Commands require a "redwood project structure" to be effectively tested.

--- a/packages/cli/src/commands/generate/README.md
+++ b/packages/cli/src/commands/generate/README.md
@@ -15,7 +15,7 @@ The generator must export the following:
   `builder`: A function that describes the arguments for the command.
   `handler`: The function that's invoked by the command.
 
-A typicall generator writes files.
+A typical generator writes files.
 
 ## Templates
 

--- a/packages/cli/src/commands/open.js
+++ b/packages/cli/src/commands/open.js
@@ -1,7 +1,7 @@
 import execa from 'execa'
 import { getConfig } from '@redwoodjs/internal'
 
-export const command = 'open [port]'
+export const command = 'open'
 export const desc = 'Open your project in your browser.'
 export const handler = () => {
   execa(`open http://localhost:${getConfig().web.port}`, { shell: true })


### PR DESCRIPTION
This pull request is a work in progress. I will mark it ready to review as soon as I can.

I opened this pull request to get comments on the documentation I have written so far. Great documentation requires some iteration so I thought I'd start that process as early as possible.

**List of CLI Commands**
- [x] redwood build
- [x] redwood db
  - [x] redwood db down
  - [x] redwood db generate
  - [x] redwood db save
  - [x] redwood db seed
  - [x] redwood db up
- [x] redwood dev
- [ ] redwood generate
  - [ ] redwood generate cell
  - [ ] redwood generate component
  - [ ] redwood generate layout
  - [ ] redwood generate page
  - [ ] redwood generate scaffold
  - [ ] redwood generate sdl
  - [ ] redwood generate service
- [x] redwood lint
- [x] redwood open
- [x] redwood test

I am yet to get around to those commands without the check.

Closes #301