### PR TITLE
Allow creating app in existing empty dir

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -57,6 +57,11 @@ if (!targetDir) {
 }
 
 const newAppDir = path.resolve(process.cwd(), targetDir)
+const appDirExists = fs.existsSync(newAppDir)
+
+if (appDirExists && fs.readdirSync(newAppDir).length > 0) {
+  throw new Error(`'${newAppDir}' already exists and is not empty.`)
+}
 
 const createProjectTasks = ({ newAppDir }) => {
   const tmpDownloadPath = tmp.tmpNameSync({
@@ -66,11 +71,8 @@ const createProjectTasks = ({ newAppDir }) => {
 
   return [
     {
-      title: `Creating directory '${newAppDir}'`,
+      title: `${appDirExists ? 'Using' : 'Creating'} directory '${newAppDir}'`,
       task: () => {
-        if (fs.existsSync(newAppDir)) {
-          throw new Error(`'${newAppDir}' already exists.`)
-        }
         fs.mkdirSync(newAppDir, { recursive: true })
       },
     },
@@ -159,7 +161,7 @@ new Listr(
   .then(() => {
     // TODO: show helpful out for next steps.
     console.log()
-    console.log(`Thanks for trying out Redwood! We've created '${newAppDir}'`)
+    console.log(`Thanks for trying out Redwood! We've created your app in '${newAppDir}'`)
     console.log()
     console.log(
       'Inside that directory you can run `yarn rw dev` to start the development server.'

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -60,7 +60,8 @@ const newAppDir = path.resolve(process.cwd(), targetDir)
 const appDirExists = fs.existsSync(newAppDir)
 
 if (appDirExists && fs.readdirSync(newAppDir).length > 0) {
-  throw new Error(`'${newAppDir}' already exists and is not empty.`)
+  console.error(`'${newAppDir}' already exists and is not empty.`)
+  process.exit(1)
 }
 
 const createProjectTasks = ({ newAppDir }) => {


### PR DESCRIPTION
I tried `yarn create redwood-app .` in an empty directory where I wanted the files generated, and got an error saying the dir already exists.  
I think it should be OK to use an existing directory if it's empty 🙂 

I have also moved the error out of the Listr task itself, because it seems Listr is not actually stopping execution of the following tasks. At least, it continues outputting the next tasks' titles, which is confusing:
![image](https://user-images.githubusercontent.com/314079/77251173-2a871980-6c4d-11ea-9ef7-80c87efd0335.png)

I'd say an early exit for this particular error is acceptable?