### PR TITLE
Add development tool that copies packages/* to a redwood project

### DIFF
--- a/scripts/copy-builds-to-dest.js
+++ b/scripts/copy-builds-to-dest.js
@@ -21,7 +21,7 @@ const removeFileFromDest = (file, source, destination) => {}
 // Watch the source directory for changes to files
 // and copy those to the destination's `node_modules/@redwoodjs/*`
 const start = ({ destination }) => {
-  const source = path.resolve('./packages/api')
+  const source = path.resolve('./packages')
   destination = path.resolve(
     process.cwd(),
     destination,
@@ -39,7 +39,6 @@ const start = ({ destination }) => {
   const watcher = chokidar.watch(source, {
     cwd: process.cwd(),
     persistent: true,
-    followSymlinks: false,
     awaitWriteFinish: true,
   })
   watcher

--- a/scripts/copy-builds-to-dest.js
+++ b/scripts/copy-builds-to-dest.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const path = require('path')
+
+const chokidar = require('chokidar')
+const yargs = require('yargs')
+
+const copyBuildToDest = (file, source, destination) => {
+  destination = path.join(destination, file.replace(source, '.'))
+  source = path.resolve(process.cwd(), file)
+
+  console.log(file)
+
+  fs.mkdirSync(destination.replace(path.basename(destination), ''), {
+    recursive: true,
+  })
+  fs.copyFileSync(source, destination)
+}
+
+const removeFileFromDest = (file, source, destination) => {}
+
+// Watch the source directory for changes to files
+// and copy those to the destination's `node_modules/@redwoodjs/*`
+const start = ({ destination }) => {
+  const source = path.resolve('./packages/api')
+  destination = path.resolve(
+    process.cwd(),
+    destination,
+    'node_modules/@redwoodjs/'
+  )
+
+  // check that the destination folders exist.
+  if (!fs.existsSync(destination)) {
+    console.log(`${destination} doesn't exist`)
+    process.exit(1)
+  }
+
+  console.log(`Copying files from '${source}'\nto '${destination}'`)
+
+  const watcher = chokidar.watch(source, {
+    cwd: process.cwd(),
+    persistent: true,
+    followSymlinks: false,
+    awaitWriteFinish: true,
+  })
+  watcher
+    .on('add', (file) => copyBuildToDest(file, source, destination))
+    .on('change', (file) => copyBuildToDest(file, source, destination))
+    .on('unlink', (file) => removeFileFromDest(file, source, destination))
+}
+
+const { destination } = yargs
+  .usage('Usage: $0 [destination]')
+  .demandOption(['destination']).argv
+
+start({ destination })


### PR DESCRIPTION
This tool can be used by core contributors of Redwood to watch `redwood.git/packages/*` for changes and to copy them into a Redwood project.

A contributor would run 
```bash
cd redwood/
yarn build:watch
[opens a new tab]
yarn copy-build-to-dest <path/to/redwood/project/>
```

The intention is to replace `yarn link @redwoodjs/<packagename>`

- [ ] One of the problems we have during development is that if you install a node_module in Redwood that it isn't available in the project.
- [ ] An alternative, more complete solution is to install a npm proxy (verdaccio) and to stream changes to this proxy instead: https://github.com/verdaccio/verdaccio#override-public-packages