### PR TITLE
Fix service generator

### DIFF
--- a/packages/cli/src/commands/generate/commands/service.js
+++ b/packages/cli/src/commands/generate/commands/service.js
@@ -7,7 +7,6 @@ import {
 } from '../helpers'
 
 export const files = async ({ name, ...rest }) => {
-  console.info(rest)
   const componentName = camelcase(pluralize(name))
   const serviceFile = templateForComponentFile({
     name,

--- a/packages/cli/src/commands/generate/commands/service.js
+++ b/packages/cli/src/commands/generate/commands/service.js
@@ -7,6 +7,7 @@ import {
 } from '../helpers'
 
 export const files = async ({ name, ...rest }) => {
+  console.info(rest)
   const componentName = camelcase(pluralize(name))
   const serviceFile = templateForComponentFile({
     name,
@@ -37,12 +38,12 @@ export const files = async ({ name, ...rest }) => {
   }, {})
 }
 
-export const {
-  command,
-  desc,
-  builder,
-  handler,
-} = createYargsForComponentGeneration({
+export const builder = {
+  crud: { type: 'boolean', default: false, desc: 'Create CRUD functions' },
+  force: { type: 'boolean', default: false },
+}
+
+export const { command, desc, handler } = createYargsForComponentGeneration({
   componentName: 'service',
   filesFn: files,
 })


### PR DESCRIPTION
@thedavidprice found that you couldn't run the `service` generator on its own as it expected a `crud` argument to exist that wasn't an option when called from the command line. The tutorial only uses the `scaffold` and `sdl` generators which call to the `service` generator behind the scenes and send in the `crud` argument themselves, so this wasn't exposed for the majority of early adopters.