### PR TITLE
Improves Yargs --help output on Windows

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -12,4 +12,11 @@ config({
 })
 
 // eslint-disable-next-line no-unused-expressions
-yargs.commandDir('./commands').demandCommand().argv
+yargs
+  .commandDir('./commands')
+  .scriptName('rw')
+  .example(
+    'yarn rw g page home /',
+    "\"Create a page component named 'Home' at path '/'\""
+  )
+  .demandCommand().argv


### PR DESCRIPTION
Addresses an issue for Windows users mentioned here:
https://github.com/redwoodjs/redwood/issues/322#issuecomment-602849062

I spend quite a bit of time looking for other ways to improve help text below. Unfortunately, I couldn't find more helpful options (e.g. provide an alias for main command, main command help text, etc.)

- This will "fix" the command display to be `rw`. Previously on Mac it would display whichever you used to output help (either `redwood` or `rw`). With this change it will _always_ be `rw`
- I added the example, which displays at the bottom. Is this useful to keep? Thoughts about how/if to improve? (Note: this example _only_ displays when help is called on the `rw` command.)


```shell
rw <command>

Commands:
  rw build [app..]    Build for production.
  rw db <command>     Database tools.                        [aliases: database]
  rw dev [app..]      Run development servers.
  rw generate <type>  Save time by generating boilerplate code.     [aliases: g]
  rw lint             Lint your files.
  rw open             Open your project in your browser.
  rw test [app..]     Run Jest tests for api and web.

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]

Examples:
  yarn rw g page home /  "Create a page component named 'Home' at path '/'"
```