### PR TITLE
Remove auto import of `db`

### DIFF
--- a/packages/cli/src/commands/generate/templates/service/service.js.template
+++ b/packages/cli/src/commands/generate/templates/service/service.js.template
@@ -1,3 +1,5 @@
+import { db } from 'src/lib/db'
+
 export const ${pluralCamelName} = () => {
   return db.${singularCamelName}.findMany()
 }<% if (crud) { %>

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -69,11 +69,6 @@ module.exports = () => ({
           {
             declarations: [
               {
-                // import { db } from '<base-dir>/api/config/db'
-                members: ['db'],
-                path: path.join(getPaths().api.config, 'db'),
-              },
-              {
                 // import { context } from '@redwoodjs/api'
                 members: ['context'],
                 path: '@redwoodjs/api',

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -4,8 +4,6 @@
 
 // TODO: Determine what to do different during development, test, and production
 // TODO: Take a look at create-react-app. They've dropped a ton of knowledge.
-const path = require('path')
-
 const { getPaths } = require('@redwoodjs/internal')
 
 const TARGETS_NODE = '12.16.1'


### PR DESCRIPTION
This removes some of the magic.

We feel that having the import visible in the services will help people understand that services are a layer where you can connect your schema to a database, but can also be a request to an API, to Redis, or anything else... the possibilities are endless.