### PR TITLE
Fix route insertion order

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -144,7 +144,7 @@ export const writeFilesTask = (files, options) => {
 export const addRoutesToRouterTask = (routes) => {
   const redwoodPaths = getPaths()
   const routesContent = readFile(redwoodPaths.web.routes).toString()
-  const newRoutesContent = routes.reduce((content, route) => {
+  const newRoutesContent = routes.reverse().reduce((content, route) => {
     if (content.includes(route)) {
       return content
     }


### PR DESCRIPTION
The `addRoutesToRouterTask` function searches the routes file for `<Router>` and inserts a new route (1-by-1) directly below this line:
```jsx
<Router>
   <NewRoute />
```

Since they're always added to the top, the order of `routes` is reversed. We switch it around since users of this function might expect routes to be inserted in the order that they are defined.

https://github.com/redwoodjs/redwood/blob/04f137d149eee5b9bae0a5876e1685c83ec0cb4a/packages/cli/src/lib/index.js#L144-L156

Fixes #211 