### PR TITLE
Swap mergeSchemas with makeExecutableSchema

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,8 @@
     "graphql-iso-date": "^3.6.1",
     "graphql-tools": "4.0.7",
     "lodash.merge": "^4.6.2",
-    "lodash.omitby": "^4.6.0"
+    "lodash.omitby": "^4.6.0",
+    "merge-graphql-schemas": "^1.7.6"
   },
   "devDependencies": {
     "@types/graphql-iso-date": "^3.3.3",
@@ -29,7 +30,8 @@
   },
   "jest": {
     "testPathIgnorePatterns": [
-      "/fixtures/"
+      "/fixtures/",
+      "/dist/"
     ]
   },
   "scripts": {

--- a/packages/api/src/makeMergedSchema/makeMergedSchema.js
+++ b/packages/api/src/makeMergedSchema/makeMergedSchema.js
@@ -1,4 +1,8 @@
-import { mergeSchemas, addResolveFunctionsToSchema } from 'apollo-server-lambda'
+import {
+  addResolveFunctionsToSchema,
+  makeExecutableSchema,
+} from 'apollo-server-lambda'
+import { mergeTypes } from 'merge-graphql-schemas'
 import merge from 'lodash.merge'
 import omitBy from 'lodash.omitby'
 
@@ -103,12 +107,15 @@ const mergeResolvers = (schemas) =>
  * })
  * ```
  */
-export const makeMergedSchema = ({ schemas, services }) => {
-  const schema = mergeSchemas({
-    schemas: [
-      rootSchema.schema,
-      ...Object.values(schemas).map(({ schema }) => schema),
-    ],
+export const makeMergedSchema = ({ schemas, services, schemaDirectives }) => {
+  const typeDefs = mergeTypes(
+    [rootSchema.schema, ...Object.values(schemas).map(({ schema }) => schema)],
+    { all: true }
+  )
+
+  const schema = makeExecutableSchema({
+    typeDefs,
+    schemaDirectives,
   })
 
   const resolvers = mergeResolversWithServices({


### PR DESCRIPTION
Basically the title says it all!

Motivation in #333 

Unfortunately what @peterp mentioned in https://github.com/redwoodjs/redwood/issues/333#issuecomment-604070287 didn't fly; just swapping out `apollo-server-lambda` for `graphql-tools-fork` didn't work. It seems like `graph-tools-fork` is improving on the seemingly abandoned `graphql-tools`, but not (yet) on custom directive support for `mergeSchemas`.

What _does_ however support custom directives is `makeExecutableSchema`. In order to use this I needed to merge the `typeDefs`, and the only/quickest/cleanest way I could find to do this is using `merge-graphql-schemas`, the second package mentioned by @peterp.  

Using this PR you can pass `schemaDirectives` in `makeMergedSchemas` like so:
```javascript
schema: makeMergedSchema({
  schemas,
  services: makeServices({ services }),
  schemaDirectives: {
    auth: AuthDirective,
  },
}),
```