### PR TITLE
Make context handler asynchronous

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,7 +29,8 @@
   },
   "jest": {
     "testPathIgnorePatterns": [
-      "/fixtures/"
+      "/fixtures/",
+      "/dist/"
     ]
   },
   "scripts": {

--- a/packages/api/src/__tests__/graphQLServer.test.js
+++ b/packages/api/src/__tests__/graphQLServer.test.js
@@ -1,9 +1,9 @@
 import { handleContext, context } from '../main'
 
 describe('graphQLServer handleContext', () => {
-  it('merges the context correctly', () => {
+  it('merges the context correctly', async () => {
     const handler = handleContext({ context: { a: 1 } })
-    expect(handler({ context: { b: 2 } })).toEqual({
+    expect(await handler({ context: { b: 2 } })).toEqual({
       a: 1,
       b: 2,
       callbackWaitsForEmptyEventLoop: false,
@@ -15,17 +15,28 @@ describe('graphQLServer handleContext', () => {
     })
   })
 
-  it('deals with undefined contexts properly', () => {
+  it('deals with undefined contexts properly', async () => {
     const handler1 = handleContext()
-    expect(handler1({ context: { b: 2 } })).toEqual({
+    expect(await handler1({ context: { b: 2 } })).toEqual({
       b: 2,
       callbackWaitsForEmptyEventLoop: false,
     })
   })
 
-  it('also accepts a function', () => {
+  it('also accepts a function', async () => {
     const handler = handleContext({ context: () => ({ c: 3 }) })
-    expect(handler({ context: { d: 4 } })).toEqual({
+    expect(await handler({ context: { d: 4 } })).toEqual({
+      c: 3,
+      d: 4,
+      callbackWaitsForEmptyEventLoop: false,
+    })
+  })
+
+  it('also accepts a promise', async () => {
+    const handler = handleContext({
+      context: async () => Promise.resolve({ c: 3 }),
+    })
+    expect(await handler({ context: { d: 4 } })).toEqual({
       c: 3,
       d: 4,
       callbackWaitsForEmptyEventLoop: false,

--- a/packages/api/src/graphQLServer.ts
+++ b/packages/api/src/graphQLServer.ts
@@ -1,11 +1,12 @@
-import { ApolloServer, Config } from 'apollo-server-lambda'
 import { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
+
+import { ApolloServer, Config } from 'apollo-server-lambda'
 
 import { setContext } from './globalContext'
 
 export const handleContext = (options: Config) => {
   // Returns a function that deals with the context per request.
-  return ({
+  return async ({
     context,
     event,
   }: {
@@ -21,7 +22,7 @@ export const handleContext = (options: Config) => {
     // initialize the handler.
     let userContext = options?.context || {}
     if (typeof userContext === 'function') {
-      userContext = userContext({ context, event })
+      userContext = await userContext({ context, event })
     }
 
     // The context object returned from this function is passed to


### PR DESCRIPTION
This makes `handleContext` return a Promise, which `ApolloServer` handles automatically.

This enables users to write asynchronous context functions, e.g. to fetch user data for authentication.