### PR TITLE
Make generators adhere to `prettier.config.js`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "param-case": "^3.0.3",
     "pascalcase": "^1.0.0",
     "pluralize": "^8.0.0",
+    "prettier": "^2.0.2",
     "react": "16.13.0",
     "yargs": "^15.1.0"
   },

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -81,11 +81,13 @@ export const templateRoot = path.resolve(
 export const generateTemplate = (templateFilename, { name, ...rest }) => {
   const templatePath = path.join(templateRoot, templateFilename)
   const template = lodash.template(readFile(templatePath).toString())
-  return template({
-    name,
-    ...nameVariants(name),
-    ...rest,
-  })
+  return formatTemplate(
+    template({
+      name,
+      ...nameVariants(name),
+      ...rest,
+    })
+  )
 }
 
 export const readFile = (target) => fs.readFileSync(target)

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -11,7 +11,7 @@ import { getPaths as getRedwoodPaths } from '@redwoodjs/internal'
 import execa from 'execa'
 import Listr from 'listr'
 import VerboseRenderer from 'listr-verbose-renderer'
-
+import { format } from 'prettier'
 import c from 'src/lib/colors'
 
 export const asyncForEach = async (array, callback) => {
@@ -114,6 +114,23 @@ export const bytes = (contents) => Buffer.byteLength(contents, 'utf8')
 export const getPaths = () => {
   try {
     return getRedwoodPaths()
+  } catch (e) {
+    console.log(c.error(e.message))
+    process.exit(0)
+  }
+}
+
+/**
+ * Format a given string using the config provided in `prettier.config.js`
+ * of a Redwood project.
+ *
+ * @param {string} content - generated content.
+ */
+export const formatTemplate = (content) => {
+  try {
+    const { base: BASE_DIR } = getPaths()
+    const prettierConfig = require(path.join(BASE_DIR, 'prettier.config.js'))
+    return format(content, prettierConfig)
   } catch (e) {
     console.log(c.error(e.message))
     process.exit(0)

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -81,12 +81,13 @@ export const templateRoot = path.resolve(
 export const generateTemplate = (templateFilename, { name, ...rest }) => {
   const templatePath = path.join(templateRoot, templateFilename)
   const template = lodash.template(readFile(templatePath).toString())
-  return formatTemplate(
+  return format(
     template({
       name,
       ...nameVariants(name),
       ...rest,
-    })
+    }),
+    prettierOptions()
   )
 }
 
@@ -123,19 +124,13 @@ export const getPaths = () => {
 }
 
 /**
- * Format a given string using the config provided in `prettier.config.js`
- * of a Redwood project.
- *
- * @param {string} content - generated content.
+ * This returns the config present in `prettier.config.js` of a Redwood project.
  */
-export const formatTemplate = (content) => {
+export const prettierOptions = () => {
   try {
-    const { base: BASE_DIR } = getPaths()
-    const prettierConfig = require(path.join(BASE_DIR, 'prettier.config.js'))
-    return format(content, prettierConfig)
+    return require(path.join(getPaths().base, 'prettier.config.js'))
   } catch (e) {
-    console.log(c.error(e.message))
-    process.exit(0)
+    return undefined
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,7 +1173,7 @@
   integrity sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
   dependencies:
     exec-sh "^0.3.2"
-    minimist "^1.2.5"
+    minimist "^1.2.0"
 
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
@@ -3187,7 +3187,7 @@ acorn-globals@^4.3.2:
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
   integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
   dependencies:
-    acorn "^6.4.1"
+    acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
 acorn-jsx@^5.1.0:
@@ -3200,12 +3200,12 @@ acorn-walk@^6.0.1, acorn-walk@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
-acorn@^6.4.1:
+acorn@^6.0.1, acorn@^6.0.7, acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.1:
+acorn@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -4562,7 +4562,7 @@ check-node-version@^4.0.2:
   dependencies:
     chalk "^3.0.0"
     map-values "^1.0.1"
-    minimist "^1.2.5"
+    minimist "^1.2.0"
     object-filter "^1.0.2"
     run-parallel "^1.1.4"
     semver "^6.3.0"
@@ -6284,7 +6284,7 @@ espree@^6.1.2:
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d"
   integrity sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
   dependencies:
-    acorn "^7.1.1"
+    acorn "^7.1.0"
     acorn-jsx "^5.1.0"
     eslint-visitor-keys "^1.1.0"
 
@@ -8745,7 +8745,7 @@ jsdom@^15.1.1:
   integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
   dependencies:
     abab "^2.0.0"
-    acorn "^7.1.1"
+    acorn "^7.1.0"
     acorn-globals "^4.3.2"
     array-equal "^1.0.0"
     cssom "^0.4.1"
@@ -8826,14 +8826,14 @@ json5@^1.0.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
-    minimist "^1.2.5"
+    minimist "^1.2.0"
 
 json5@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
   integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
-    minimist "^1.2.5"
+    minimist "^1.2.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -9484,7 +9484,7 @@ meow@^3.3.0:
     decamelize "^1.1.2"
     loud-rejection "^1.0.0"
     map-obj "^1.0.1"
-    minimist "^1.2.5"
+    minimist "^1.1.3"
     normalize-package-data "^2.3.4"
     object-assign "^4.0.1"
     read-pkg-up "^1.0.1"
@@ -9499,7 +9499,7 @@ meow@^4.0.0:
     camelcase-keys "^4.0.0"
     decamelize-keys "^1.0.0"
     loud-rejection "^1.0.0"
-    minimist "^1.2.5"
+    minimist "^1.1.3"
     minimist-options "^3.0.1"
     normalize-package-data "^2.3.4"
     read-pkg-up "^3.0.0"
@@ -9653,15 +9653,20 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.2.1, minimist@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
-  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.3.5, minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"
@@ -9734,7 +9739,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
-    minimist "0.2.1"
+    minimist "0.0.8"
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -10325,7 +10330,7 @@ optimist@^0.6.1:
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
   dependencies:
-    minimist "~0.2.1"
+    minimist "~0.0.1"
     wordwrap "~0.0.2"
 
 optionator@^0.8.1, optionator@^0.8.3:
@@ -10945,6 +10950,11 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
+
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -11232,7 +11242,7 @@ rc@^1.0.1, rc@^1.1.6:
   dependencies:
     deep-extend "^0.6.0"
     ini "~1.3.0"
-    minimist "^1.2.5"
+    minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
 react-hook-form@^4.10.1:
@@ -11803,7 +11813,7 @@ rollup@1.29.0:
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"
-    acorn "^7.1.1"
+    acorn "^7.1.0"
 
 rsvp@^4.8.4:
   version "4.8.5"
@@ -11875,7 +11885,7 @@ sane@^4.0.3:
     execa "^1.0.0"
     fb-watchman "^2.0.0"
     micromatch "^3.1.4"
-    minimist "^1.2.5"
+    minimist "^1.1.1"
     walker "~1.0.5"
 
 sax@>=0.6.0:
@@ -12614,7 +12624,7 @@ strong-log-transformer@^2.0.0:
   integrity sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==
   dependencies:
     duplexer "^0.1.1"
-    minimist "^1.2.5"
+    minimist "^1.2.0"
     through "^2.3.4"
 
 style-loader@^1.1.3:
@@ -13549,7 +13559,7 @@ webpack-bundle-analyzer@^3.6.0:
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz#39b3a8f829ca044682bc6f9e011c95deb554aefd"
   integrity sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==
   dependencies:
-    acorn "^6.4.1"
+    acorn "^6.0.7"
     acorn-walk "^6.1.1"
     bfj "^6.1.1"
     chalk "^2.4.1"
@@ -13662,7 +13672,7 @@ webpack@^4.42.0:
     "@webassemblyjs/helper-module-context" "1.8.5"
     "@webassemblyjs/wasm-edit" "1.8.5"
     "@webassemblyjs/wasm-parser" "1.8.5"
-    acorn "^6.4.1"
+    acorn "^6.2.1"
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"


### PR DESCRIPTION
![](https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/200w_d.gif)

This PR helps us format the generated code using the configuration provided in `prettier.config.js` of a Redwood project.

Closes #339 