### PR TITLE
more explicit where the scheme should be

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -40,7 +40,7 @@ export const getSchema = async (name) => {
     if (model) {
       return model
     } else {
-      throw `No schema definition found for \`${name}\``
+      throw `No schema definition found for \`${name}\` in schema.prisma file`
     }
   }
 


### PR DESCRIPTION
I wanted to change this a bit more but figured I'd start with a small change. Alternatives.

"Schema definition for Post not found in schema.prism file"