### PR TITLE
Fix a layout issue with scaffolded forms

### DIFF
--- a/packages/cli/src/commands/generate/templates/scaffold/assets/scaffold.css.template
+++ b/packages/cli/src/commands/generate/templates/scaffold/assets/scaffold.css.template
@@ -122,6 +122,7 @@
 .rw-scaffold .whitespace-no-wrap{white-space:nowrap}
 .rw-scaffold .truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .rw-scaffold .w-full{width:100%}
+.rw-scaffold .box-border{box-sizing:border-box}
 @media (min-width:768px) {
   .rw-scaffold .md\:w-1\/5{width:20%}
 }

--- a/packages/cli/src/commands/generate/templates/scaffold/assets/scaffold.css.template
+++ b/packages/cli/src/commands/generate/templates/scaffold/assets/scaffold.css.template
@@ -76,6 +76,7 @@
 .rw-scaffold .ml-1{margin-left:.25rem}
 .rw-scaffold .mt-2{margin-top:.5rem}
 .rw-scaffold .ml-2{margin-left:.5rem}
+.rw-scaffold .mt-4{margin-top:1rem}
 .rw-scaffold .mb-4{margin-bottom:1rem}
 .rw-scaffold .mt-6{margin-top:1.5rem}
 .rw-scaffold .mt-8{margin-top:2rem}

--- a/packages/cli/src/commands/generate/templates/scaffold/assets/scaffold.css.template
+++ b/packages/cli/src/commands/generate/templates/scaffold/assets/scaffold.css.template
@@ -72,6 +72,7 @@
 .rw-scaffold .mx-2{margin-left:.5rem;margin-right:.5rem}
 .rw-scaffold .my-4{margin-top:1rem;margin-bottom:1rem}
 .rw-scaffold .mx-4{margin-left:1rem;margin-right:1rem}
+.rw-scaffold .mt-0{margin-top:0}
 .rw-scaffold .mt-1{margin-top:.25rem}
 .rw-scaffold .ml-1{margin-left:.25rem}
 .rw-scaffold .mt-2{margin-top:.5rem}

--- a/packages/cli/src/commands/generate/templates/scaffold/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/templates/scaffold/components/NameForm.js.template
@@ -27,7 +27,7 @@ const ${singularPascalName}Form = (props) => {
       <Form onSubmit={onSubmit} error={props.error}>
         <FormError
           error={props.error}
-          wrapperClassName="p-4 bg-red-100 text-red-700 border border-red-300 rounded mb-4"
+          wrapperClassName="p-4 bg-red-100 text-red-700 border border-red-300 rounded mt-4 mb-4"
           titleClassName="font-semibold"
           listClassName="mt-2 list-disc list-inside"
         />

--- a/packages/cli/src/commands/generate/templates/scaffold/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/templates/scaffold/components/NameForm.js.template
@@ -23,7 +23,7 @@ const ${singularPascalName}Form = (props) => {
   }
 
   return (
-    <div className="text-sm -mt-4">
+    <div className="box-border text-sm -mt-4">
       <Form onSubmit={onSubmit} error={props.error}>
         <FormError
           error={props.error}

--- a/packages/cli/src/commands/generate/templates/scaffold/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/templates/scaffold/components/NameForm.js.template
@@ -28,7 +28,7 @@ const ${singularPascalName}Form = (props) => {
         <FormError
           error={props.error}
           wrapperClassName="p-4 bg-red-100 text-red-700 border border-red-300 rounded mt-4 mb-4"
-          titleClassName="font-semibold"
+          titleClassName="mt-0 font-semibold"
           listClassName="mt-2 list-disc list-inside"
         />
 <% editableColumns.forEach(column => { %>


### PR DESCRIPTION
Scaffolded form input fields have their width set to 100%, but since their parent has a padding and its box-sizing is set to `inherit`, the field gets cut off.

This commit adds an extra class from Tailwind CSS and applies it to the form container to ensure that the entire inputs are visible.

I wasn’t sure where in the CSS template file to put the new selector since they seem to be grouped by function (rather than alphabetically) and I didn’t find any related selectors, so I stuck it at the end of the list. Let me know if I should move it.

**Before**
![form_layout_before](https://user-images.githubusercontent.com/3891/78457062-eca3df80-76a7-11ea-9030-1809ce97b9b9.png)

**After**
![form_layout_after](https://user-images.githubusercontent.com/3891/78457068-f0cffd00-76a7-11ea-802d-820f8707a2c4.png)

----

**Edit**: added other commits to add consistency to error messages’ margins, see screenshots below:

**Before**
![Screen Shot 1](https://user-images.githubusercontent.com/3891/78501919-862dc880-775e-11ea-8e70-ae9f7844c834.png)


**After**
![Screen Shot](https://user-images.githubusercontent.com/3891/78501921-89c14f80-775e-11ea-98e6-b0278dbb9f5f.png)