### PR TITLE
Add iniital yarn build to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You'll want to run a local redwood app sandbox using your local @redwoodjs packa
 
 ### Example Setup: Package `@redwoodjs/cli` Local Dev
 
-Assuming you've already cloned `redwoodjs/redwood` locally and run `yarn install`, navigate to the `packages/cli` directory and run the following command:
+Assuming you've already cloned `redwoodjs/redwood` locally and run `yarn install` and `yarn build`, navigate to the `packages/cli` directory and run the following command:
 
 ```
 yarn link


### PR DESCRIPTION
CONTRIBUTING.md didn't explicitly say to run `yarn build` after cloning `redwoodjs/redwood` and running `yarn install`, causing files necessary for using the cli locally, such as `main.js` in `redwood/internal`, to not exist. This PR stems from a discussion on discourse: https://community.redwoodjs.com/t/guide-on-redwood-package-development/135/3?u=dom.