### PR TITLE
Support for App yarn rw build on Windows

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -28,7 +28,7 @@ export const handler = async ({
   const execCommandsForApps = {
     api: {
       cwd: `${BASE_DIR}/api`,
-      cmd: 'NODE_ENV=production babel src --out-dir dist',
+      cmd: 'yarn cross-env NODE_ENV=production babel src --out-dir dist',
     },
     web: {
       cwd: `${BASE_DIR}/web`,


### PR DESCRIPTION
yarn rw build api script was not working due to setting the NODE_ENV. Using cross-env fixes the problem.