### PR TITLE
[Router] fixes `validatePath` duplicate params & reject spaces in routes

### DIFF
--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -95,6 +95,18 @@ describe('validatePath', () => {
   ])('rejects path "%s" with duplicate params', (path) => {
     expect(validatePath.bind(null, path)).toThrowError(`Route path contains duplicate parameter: "${path}"`)
   })
+
+  it.each([
+    '/users/{id:Int}/photos/{photo_id:Int}',
+    '/users/{id}/photos/{photo_id}',
+    '/users/{id}/photos/{photo_id}?format=jpg&w=400&h=400',
+    '/',
+    '/404',
+    '/about',
+    '/about/redwood',
+  ])('validates correct path "%s"', (path) => {
+    expect(validatePath.bind(null, path)).not.toThrow();
+  })
 })
 
 describe('parseSearch', () => {

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -73,6 +73,21 @@ describe('validatePath', () => {
   })
 
   it.each([
+    '/path/to/user profile',
+    '/path/ to/userprofile',
+    '/path/to /userprofile',
+    '/path/to/users/{id: Int}',
+    '/path/to/users/{id :Int}',
+    '/path/to/users/{id : Int}',
+    '/path/to/users/{ id:Int}',
+    '/path/to/users/{id:Int }',
+    '/path/to/users/{ id:Int }',
+    '/path/to/users/{ id : Int }',
+  ])('rejects paths with spaces: "%s"', (path) => {
+    expect(validatePath.bind(null, path)).toThrowError(`Route path contains spaces: "${path}"`)
+  })
+
+  it.each([
     '/users/{id}/photos/{id}',
     '/users/{id}/photos/{id:Int}',
     '/users/{id:Int}/photos/{id}',

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -1,53 +1,31 @@
 import {matchPath, parseSearch, validatePath} from '../util'
 
 describe('matchPath', () => {
-  it('matches paths correctly', () => {
+  it.each([
+    ['/post/{id:Int}', '/post/notAnInt'],
+    ['/post/{id:Int}', '/post/2.0'],
+    ['/post/{id:Int}', '/post/.1'],
+    ['/post/{id:Int}', '/post/0.1'],
+    ['/post/{id:Int}', '/post/123abcd'],
+    ['/post/{id:Int}', '/post/abcd123'],
+    ['/blog/{year}/{month:Int}/{day}', '/blog/2019/december/07'],
+    ['/blog/{year}/{month}/{day}', '/blog/2019/07'],
+    ['/posts/{id}/edit', '/posts//edit'],
+    ['/about', '/']
+  ])('does not match route "%s" with path "%s"',
+    (route, pathname) => {
+    expect(matchPath(route, pathname)).toEqual({ match: false })
+  })
+
+  it('matches valid paths and extracts params correctly', () => {
     expect(matchPath('/post/{id:Int}', '/post/7')).toEqual({
       match: true,
       params: { id: 7 },
     })
 
-    expect(matchPath('/post/{id:Int}', '/post/notAnInt')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/post/{id:Int}', '/post/2.0')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/post/{id:Int}', '/post/.1')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/post/{id:Int}', '/post/0.1')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/post/{id:Int}', '/post/123abcd')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/post/{id:Int}', '/post/abcd123')).toEqual({
-      match: false,
-    })
-
     expect(
       matchPath('/blog/{year}/{month}/{day}', '/blog/2019/12/07')
     ).toEqual({ match: true, params: { day: '07', month: '12', year: '2019' } })
-
-    expect(
-      matchPath('/blog/{year}/{month:Int}/{day}', '/blog/2019/december/07')
-    ).toEqual({ match: false })
-
-    expect(matchPath('/blog/{year}/{month}/{day}', '/blog/2019/07')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/posts/{id}/edit', '/posts//edit')).toEqual({
-      match: false,
-    })
-
-    expect(matchPath('/about', '/')).toEqual({ match: false })
   })
 
   it('transforms a param based on the specified transform', () => {

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -1,4 +1,4 @@
-import {matchPath, parseSearch, validatePath} from '../util'
+import { matchPath, parseSearch, validatePath } from '../util'
 
 describe('matchPath', () => {
   it.each([
@@ -11,9 +11,8 @@ describe('matchPath', () => {
     ['/blog/{year}/{month:Int}/{day}', '/blog/2019/december/07'],
     ['/blog/{year}/{month}/{day}', '/blog/2019/07'],
     ['/posts/{id}/edit', '/posts//edit'],
-    ['/about', '/']
-  ])('does not match route "%s" with path "%s"',
-    (route, pathname) => {
+    ['/about', '/'],
+  ])('does not match route "%s" with path "%s"', (route, pathname) => {
     expect(matchPath(route, pathname)).toEqual({ match: false })
   })
 
@@ -42,13 +41,14 @@ describe('matchPath', () => {
 })
 
 describe('validatePath', () => {
-  it.each([
-    'invalid/route',
-    '{id}/invalid/route',
-    ' /invalid/route',
-  ])('rejects "%s" path that does not begin with a slash', (path) => {
-    expect(validatePath.bind(null, path)).toThrowError(`Route path does not begin with a slash: "${path}"`)
-  })
+  it.each(['invalid/route', '{id}/invalid/route', ' /invalid/route'])(
+    'rejects "%s" path that does not begin with a slash',
+    (path) => {
+      expect(validatePath.bind(null, path)).toThrowError(
+        `Route path does not begin with a slash: "${path}"`
+      )
+    }
+  )
 
   it.each([
     '/path/to/user profile',
@@ -62,7 +62,9 @@ describe('validatePath', () => {
     '/path/to/users/{ id:Int }',
     '/path/to/users/{ id : Int }',
   ])('rejects paths with spaces: "%s"', (path) => {
-    expect(validatePath.bind(null, path)).toThrowError(`Route path contains spaces: "${path}"`)
+    expect(validatePath.bind(null, path)).toThrowError(
+      `Route path contains spaces: "${path}"`
+    )
   })
 
   it.each([
@@ -71,7 +73,9 @@ describe('validatePath', () => {
     '/users/{id:Int}/photos/{id}',
     '/users/{id:Int}/photos/{id:Int}',
   ])('rejects path "%s" with duplicate params', (path) => {
-    expect(validatePath.bind(null, path)).toThrowError(`Route path contains duplicate parameter: "${path}"`)
+    expect(validatePath.bind(null, path)).toThrowError(
+      `Route path contains duplicate parameter: "${path}"`
+    )
   })
 
   it.each([
@@ -83,7 +87,7 @@ describe('validatePath', () => {
     '/about',
     '/about/redwood',
   ])('validates correct path "%s"', (path) => {
-    expect(validatePath.bind(null, path)).not.toThrow();
+    expect(validatePath.bind(null, path)).not.toThrow()
   })
 })
 

--- a/packages/router/src/__tests__/util.test.js
+++ b/packages/router/src/__tests__/util.test.js
@@ -1,4 +1,4 @@
-import { matchPath, parseSearch } from '../util'
+import {matchPath, parseSearch, validatePath} from '../util'
 
 describe('matchPath', () => {
   it('matches paths correctly', () => {
@@ -60,6 +60,25 @@ describe('matchPath', () => {
       match: true,
       params: { id: 1337 },
     })
+  })
+})
+
+describe('validatePath', () => {
+  it.each([
+    'invalid/route',
+    '{id}/invalid/route',
+    ' /invalid/route',
+  ])('rejects "%s" path that does not begin with a slash', (path) => {
+    expect(validatePath.bind(null, path)).toThrowError(`Route path does not begin with a slash: "${path}"`)
+  })
+
+  it.each([
+    '/users/{id}/photos/{id}',
+    '/users/{id}/photos/{id:Int}',
+    '/users/{id:Int}/photos/{id}',
+    '/users/{id:Int}/photos/{id:Int}',
+  ])('rejects path "%s" with duplicate params', (path) => {
+    expect(validatePath.bind(null, path)).toThrowError(`Route path contains duplicate parameter: "${path}"`)
   })
 })
 

--- a/packages/router/src/util.js
+++ b/packages/router/src/util.js
@@ -131,6 +131,10 @@ const validatePath = (path) => {
     throw new Error(`Route path does not begin with a slash: "${path}"`)
   }
 
+  if (path.indexOf(' ') >= 0) {
+    throw new Error(`Route path contains spaces: "${path}"`)
+  }
+
   // Check for duplicate named params.
   const matches = path.matchAll(/\{([^}]+)\}/g)
   let memo = {}

--- a/packages/router/src/util.js
+++ b/packages/router/src/util.js
@@ -128,18 +128,19 @@ const parseSearch = (search) => {
 const validatePath = (path) => {
   // Check that path begins with a slash.
   if (!path.startsWith('/')) {
-    throw new Error('Route path does not begin with a slash: "' + path + '"')
+    throw new Error(`Route path does not begin with a slash: "${path}"`)
   }
 
   // Check for duplicate named params.
   const matches = path.matchAll(/\{([^}]+)\}/g)
   let memo = {}
   for (const match of matches) {
-    const param = match[0]
+    // Extract the param's name to make sure there aren't any duplicates
+    const param = match[1].split(':')[0]
     if (memo[param]) {
-      throw new Error('Route path contains duplicate parameter: "' + path + '"')
+      throw new Error(`Route path contains duplicate parameter: "${path}"`)
     } else {
-      memo[match[0]] = true
+      memo[param] = true
     }
   }
 }


### PR DESCRIPTION
Closes #382 

This PR makes `validatePath` throw an error when a route's provided path contains at least one space character.
It's only looking for `' '`; I figured other whitespace characters such as `'\t'`, `'\n'`, ... would make so little sense that it does not warrant "complicating" the code & tests with that.

Super easy to change if you'd rather reject everything though!

I also took the opportunity to fix the duplicate params detection, which was broken when only one of two duplicates used a type, and to refactor the router's utils tests a little 🙂 

**Question:** I intentionally added a test case that validates `'/users/{id}/photos/{photo_id}?format=jpg&w=400&h=400'` as a valid route.
I don't see why not, but I wanted to make sure we actually allow query strings in routes paths?