### PR TITLE
Add docs for local Postgres and connection pooling.

### DIFF
--- a/docs/connectionPooling.md
+++ b/docs/connectionPooling.md
@@ -1,0 +1,29 @@
+# Connection Pooling
+
+Production Redwood apps should enable connection pooling in order to properly scale with your Serverless functions.
+
+## Heroku
+For Postgres, see [Postgres Connection Pooling](https://devcenter.heroku.com/articles/postgres-connection-pooling).
+
+Heroku does not officially support MySQL.
+
+
+## Digital Ocean
+For Postgres, see [How to Manage Connection Pools](https://www.digitalocean.com/docs/databases/postgresql/how-to/manage-connection-pools)
+
+Connection Pooling for MySQL is not yet supported.
+
+## AWS
+Use [Amazon RDS Proxy] https://aws.amazon.com/rds/proxy for MySQL or RDS PostgreSQL.
+
+
+## Why Connection Pooling?
+
+Relational databases have a maximum number of concurrent client connections.
+
+* Postgres allows 100 by default
+* MySQL allows 151 by default
+
+In a traditional server environment, you would need a large amount of traffic (and therefore web servers) to exhaust these connections, since each web server instance typically leverages a single connection.
+
+In a Serverless environment, each function connects directly to the database, which can exhaust limits quickly. To prevent connection errors, you should add a connection pooling service in front of your database. Think of it as a load balancer.

--- a/docs/localPostgresSetup.md
+++ b/docs/localPostgresSetup.md
@@ -1,0 +1,57 @@
+# Local Postgres Setup
+
+RedwoodJS uses a SQLite database by default. While SQLite makes local development easy, you're
+likely going to want to run the same database setup you use on production. Here's how to setup
+Postgres.
+
+## Install Postgres
+
+Ensure you have Postgres installed and running on your machine. If you're on a Mac, we recommend
+Homebrew:
+
+```bash
+brew install postgres
+```
+
+Follow the instructions provided. If you're using another platform, See
+[postgresql.org/download](https://www.postgresql.org/download/).
+
+## Update the Prisma Schema
+
+Tell Prisma to use a Postgres database instead of SQLite by updating the `provider` attribute in your
+`schema.prisma` file:
+
+```prisma
+// prisma/schema.prisma
+datasource DS {
+  provider = "postgres"
+  url = env("DATABASE_URL")
+}
+```
+
+Add a `DATABASE_URL` to your `.env` file with the URL of the database you'd like to use locally. The
+following example uses `redwoodblog_dev` for the database. It also has `postgres` setup as a
+superuser for ease of use.
+
+```env
+# .env
+DATABASE_URL="postgresql://postgres@localhost/redwoodblog_dev?connection_limit=1"
+```
+
+Note the `connection_limit` parameter. This is [recommended by Prisma](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/deployment#recommended-connection-limit) when working with
+relational databases in a Serverless context. You should also append this parameter to your production
+`DATABASE_URL` when configuring your deployments.
+
+If you've already created migrations using SQLite, you just need to run migrations again:
+
+```bash
+yarn rw db up
+```
+
+If you haven't created migrations yet, use `save`:
+
+```bash
+yarn rw db save
+```
+
+Both commands will create and migrate the Postres database you specified in your `.env`.


### PR DESCRIPTION
Based on discussion in redwoodjs/redwoodjs.com#87, I've added two docs to the `docs` section.

The first gives more information around Connection Pools, and includes relevant links to recommended providers. ([Rendered](https://github.com/redwoodjs/redwood/blob/ed0eb079ff9f7a67ae7f2ff49d4aef0649a1510e/docs/connectionPooling.md))

The second documents how to setup Postgres locally, and how to have Redwood create/migrate the new database. ([Rendered](https://github.com/redwoodjs/redwood/blob/ed0eb079ff9f7a67ae7f2ff49d4aef0649a1510e/docs/localPostgresSetup.md))

