### PR TITLE
Add path specification to scaffolds

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPath.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPath.test.js
@@ -1,0 +1,515 @@
+global.__dirname = __dirname
+import path from 'path'
+
+import { loadGeneratorFixture } from 'src/lib/test' // eslint-disable-line
+
+import * as scaffold from '../scaffold'
+
+let filesLower, filesUpper
+
+beforeAll(async () => {
+  filesLower = await scaffold.files({ model: 'post', path: 'admin' })
+  filesUpper = await scaffold.files({ model: 'Post', path: 'Admin' })
+})
+
+describe('admin/post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesLower).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/Admin/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/pages/Admin/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(`import EditPostCell from 'src/components/Admin/EditPostCell'`)
+    })
+
+    test('creates a index page', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/pages/Admin/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/Admin/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/pages/Admin/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/Admin/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesLower['/path/to/project/web/src/pages/Admin/PostPage/PostPage.js']
+      ).toMatch(`import PostCell from 'src/components/Admin/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/components/Admin/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/components/Admin/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/Admin/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/components/Admin/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/Admin/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesLower[
+          '/path/to/project/web/src/components/Admin/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesLower).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/Admin/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(await scaffold.routes({ model: 'post', path: 'admin' })).toEqual([
+        '<Route path="/admin/posts/new" page={AdminNewPostPage} name="adminNewPost" />',
+        '<Route path="/admin/posts/{id:Int}/edit" page={AdminEditPostPage} name="adminEditPost" />',
+        '<Route path="/admin/posts/{id:Int}" page={AdminPostPage} name="adminPost" />',
+        '<Route path="/admin/posts" page={AdminPostsPage} name="adminPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'userProfile', path: 'admin' })
+      ).toEqual([
+        '<Route path="/admin/user-profiles/new" page={AdminNewUserProfilePage} name="adminNewUserProfile" />',
+        '<Route path="/admin/user-profiles/{id:Int}/edit" page={AdminEditUserProfilePage} name="adminEditUserProfile" />',
+        '<Route path="/admin/user-profiles/{id:Int}" page={AdminUserProfilePage} name="adminUserProfile" />',
+        '<Route path="/admin/user-profiles" page={AdminUserProfilesPage} name="adminUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/Admin/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})
+
+describe('Admin/Post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesUpper).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/layouts/Admin/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/pages/Admin/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(`import EditPostCell from 'src/components/Admin/EditPostCell'`)
+    })
+
+    test('creates a index page', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/pages/Admin/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/Admin/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/pages/Admin/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/Admin/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesUpper['/path/to/project/web/src/pages/Admin/PostPage/PostPage.js']
+      ).toMatch(`import PostCell from 'src/components/Admin/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/components/Admin/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/components/Admin/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/Admin/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/components/Admin/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/Admin/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesUpper[
+          '/path/to/project/web/src/components/Admin/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesUpper).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/Admin/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(await scaffold.routes({ model: 'Post', path: 'Admin' })).toEqual([
+        '<Route path="/admin/posts/new" page={AdminNewPostPage} name="adminNewPost" />',
+        '<Route path="/admin/posts/{id:Int}/edit" page={AdminEditPostPage} name="adminEditPost" />',
+        '<Route path="/admin/posts/{id:Int}" page={AdminPostPage} name="adminPost" />',
+        '<Route path="/admin/posts" page={AdminPostsPage} name="adminPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'UserProfile', path: 'Admin' })
+      ).toEqual([
+        '<Route path="/admin/user-profiles/new" page={AdminNewUserProfilePage} name="adminNewUserProfile" />',
+        '<Route path="/admin/user-profiles/{id:Int}/edit" page={AdminEditUserProfilePage} name="adminEditUserProfile" />',
+        '<Route path="/admin/user-profiles/{id:Int}" page={AdminUserProfilePage} name="adminUserProfile" />',
+        '<Route path="/admin/user-profiles" page={AdminUserProfilesPage} name="adminUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/UserProfilesCell/UserProfilesCell.js'
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiword.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiword.test.js
@@ -1,0 +1,1062 @@
+global.__dirname = __dirname
+import path from 'path'
+
+import { loadGeneratorFixture } from 'src/lib/test' // eslint-disable-line
+
+import * as scaffold from '../scaffold'
+
+let filesMultiwordLower,
+  filesMultiwordUpper,
+  filesMultiwordDash,
+  filesMultiwordUnderscore
+
+beforeAll(async () => {
+  filesMultiwordLower = await scaffold.files({
+    model: 'post',
+    path: 'adminPages',
+  })
+  filesMultiwordUpper = await scaffold.files({
+    model: 'Post',
+    path: 'AdminPages',
+  })
+  filesMultiwordDash = await scaffold.files({
+    model: 'post',
+    path: 'admin-pages',
+  })
+  filesMultiwordUnderscore = await scaffold.files({
+    model: 'post',
+    path: 'admin_pages',
+  })
+})
+
+describe('adminPages/post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesMultiwordLower).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/AdminPages/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(
+        `import EditPostCell from 'src/components/AdminPages/EditPostCell'`
+      )
+    })
+
+    test('creates a index page', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/AdminPages/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/AdminPages/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js'
+        ]
+      ).toMatch(`import PostCell from 'src/components/AdminPages/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/AdminPages/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/AdminPages/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesMultiwordLower[
+          '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/AdminPages/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'post', path: 'adminPages' })
+      ).toEqual([
+        '<Route path="/admin-pages/posts/new" page={AdminPagesNewPostPage} name="adminPagesNewPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}/edit" page={AdminPagesEditPostPage} name="adminPagesEditPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}" page={AdminPagesPostPage} name="adminPagesPost" />',
+        '<Route path="/admin-pages/posts" page={AdminPagesPostsPage} name="adminPagesPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'userProfile', path: 'adminPages' })
+      ).toEqual([
+        '<Route path="/admin-pages/user-profiles/new" page={AdminPagesNewUserProfilePage} name="adminPagesNewUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}/edit" page={AdminPagesEditUserProfilePage} name="adminPagesEditUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}" page={AdminPagesUserProfilePage} name="adminPagesUserProfile" />',
+        '<Route path="/admin-pages/user-profiles" page={AdminPagesUserProfilesPage} name="adminPagesUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'adminPages',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/AdminPages/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'adminPages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'adminPages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'adminPages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'adminPages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})
+
+describe('AdminPages/Post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesMultiwordUpper).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/AdminPages/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(
+        `import EditPostCell from 'src/components/AdminPages/EditPostCell'`
+      )
+    })
+
+    test('creates a index page', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/AdminPages/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/AdminPages/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js'
+        ]
+      ).toMatch(`import PostCell from 'src/components/AdminPages/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/AdminPages/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/AdminPages/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesMultiwordUpper[
+          '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesMultiwordUpper).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/AdminPages/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'Post', path: 'AdminPages' })
+      ).toEqual([
+        '<Route path="/admin-pages/posts/new" page={AdminPagesNewPostPage} name="adminPagesNewPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}/edit" page={AdminPagesEditPostPage} name="adminPagesEditPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}" page={AdminPagesPostPage} name="adminPagesPost" />',
+        '<Route path="/admin-pages/posts" page={AdminPagesPostsPage} name="adminPagesPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'UserProfile', path: 'AdminPages' })
+      ).toEqual([
+        '<Route path="/admin-pages/user-profiles/new" page={AdminPagesNewUserProfilePage} name="adminPagesNewUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}/edit" page={AdminPagesEditUserProfilePage} name="adminPagesEditUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}" page={AdminPagesUserProfilePage} name="adminPagesUserProfile" />',
+        '<Route path="/admin-pages/user-profiles" page={AdminPagesUserProfilesPage} name="adminPagesUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'AdminPages',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/AdminPages/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'AdminPages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'AdminPages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'AdminPages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'AdminPages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})
+
+describe('admin-pages/post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesMultiwordDash).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/AdminPages/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(
+        `import EditPostCell from 'src/components/AdminPages/EditPostCell'`
+      )
+    })
+
+    test('creates a index page', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/AdminPages/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/AdminPages/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js'
+        ]
+      ).toMatch(`import PostCell from 'src/components/AdminPages/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/AdminPages/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/AdminPages/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesMultiwordDash[
+          '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesMultiwordDash).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/AdminPages/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'post', path: 'admin-pages' })
+      ).toEqual([
+        '<Route path="/admin-pages/posts/new" page={AdminPagesNewPostPage} name="adminPagesNewPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}/edit" page={AdminPagesEditPostPage} name="adminPagesEditPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}" page={AdminPagesPostPage} name="adminPagesPost" />',
+        '<Route path="/admin-pages/posts" page={AdminPagesPostsPage} name="adminPagesPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'userProfile', path: 'admin-pages' })
+      ).toEqual([
+        '<Route path="/admin-pages/user-profiles/new" page={AdminPagesNewUserProfilePage} name="adminPagesNewUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}/edit" page={AdminPagesEditUserProfilePage} name="adminPagesEditUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}" page={AdminPagesUserProfilePage} name="adminPagesUserProfile" />',
+        '<Route path="/admin-pages/user-profiles" page={AdminPagesUserProfilesPage} name="adminPagesUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin-pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/AdminPages/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin-pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin-pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin-pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin-pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})
+
+describe('admin_pages/post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesMultiwordUnderscore).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesMultiwordLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/AdminPages/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/pages/AdminPages/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(
+        `import EditPostCell from 'src/components/AdminPages/EditPostCell'`
+      )
+    })
+
+    test('creates a index page', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/pages/AdminPages/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/AdminPages/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/pages/AdminPages/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/AdminPages/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/pages/AdminPages/PostPage/PostPage.js'
+        ]
+      ).toMatch(`import PostCell from 'src/components/AdminPages/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/components/AdminPages/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/components/AdminPages/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/AdminPages/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/components/AdminPages/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/AdminPages/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesMultiwordUnderscore[
+          '/path/to/project/web/src/components/AdminPages/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/AdminPages/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesMultiwordUnderscore).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/AdminPages/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'post', path: 'admin_pages' })
+      ).toEqual([
+        '<Route path="/admin-pages/posts/new" page={AdminPagesNewPostPage} name="adminPagesNewPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}/edit" page={AdminPagesEditPostPage} name="adminPagesEditPost" />',
+        '<Route path="/admin-pages/posts/{id:Int}" page={AdminPagesPostPage} name="adminPagesPost" />',
+        '<Route path="/admin-pages/posts" page={AdminPagesPostsPage} name="adminPagesPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'userProfile', path: 'admin_pages' })
+      ).toEqual([
+        '<Route path="/admin-pages/user-profiles/new" page={AdminPagesNewUserProfilePage} name="adminPagesNewUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}/edit" page={AdminPagesEditUserProfilePage} name="adminPagesEditUserProfile" />',
+        '<Route path="/admin-pages/user-profiles/{id:Int}" page={AdminPagesUserProfilePage} name="adminPagesUserProfile" />',
+        '<Route path="/admin-pages/user-profiles" page={AdminPagesUserProfilesPage} name="adminPagesUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin-pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/AdminPages/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin_pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin_pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin_pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin_pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/AdminPages/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathNested.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathNested.test.js
@@ -1,0 +1,535 @@
+global.__dirname = __dirname
+import path from 'path'
+
+import { loadGeneratorFixture } from 'src/lib/test' // eslint-disable-line
+
+import * as scaffold from '../scaffold'
+
+let filesNestedLower, filesNestedUpper
+
+beforeAll(async () => {
+  filesNestedLower = await scaffold.files({
+    model: 'post',
+    path: 'admin/pages',
+  })
+  filesNestedUpper = await scaffold.files({
+    model: 'Post',
+    path: 'Admin/Pages',
+  })
+})
+
+describe('admin/pages/post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesNestedLower).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/Admin/Pages/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/pages/Admin/Pages/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(
+        `import EditPostCell from 'src/components/Admin/Pages/EditPostCell'`
+      )
+    })
+
+    test('creates a index page', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/pages/Admin/Pages/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/Admin/Pages/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/pages/Admin/Pages/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/Admin/Pages/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/pages/Admin/Pages/PostPage/PostPage.js'
+        ]
+      ).toMatch(`import PostCell from 'src/components/Admin/Pages/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/components/Admin/Pages/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/Pages/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/components/Admin/Pages/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/Admin/Pages/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/components/Admin/Pages/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/Admin/Pages/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesNestedLower[
+          '/path/to/project/web/src/components/Admin/Pages/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/Pages/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/Admin/Pages/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'post', path: 'admin/pages' })
+      ).toEqual([
+        '<Route path="/admin/pages/posts/new" page={AdminPagesNewPostPage} name="adminPagesNewPost" />',
+        '<Route path="/admin/pages/posts/{id:Int}/edit" page={AdminPagesEditPostPage} name="adminPagesEditPost" />',
+        '<Route path="/admin/pages/posts/{id:Int}" page={AdminPagesPostPage} name="adminPagesPost" />',
+        '<Route path="/admin/pages/posts" page={AdminPagesPostsPage} name="adminPagesPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'userProfile', path: 'admin/pages' })
+      ).toEqual([
+        '<Route path="/admin/pages/user-profiles/new" page={AdminPagesNewUserProfilePage} name="adminPagesNewUserProfile" />',
+        '<Route path="/admin/pages/user-profiles/{id:Int}/edit" page={AdminPagesEditUserProfilePage} name="adminPagesEditUserProfile" />',
+        '<Route path="/admin/pages/user-profiles/{id:Int}" page={AdminPagesUserProfilePage} name="adminPagesUserProfile" />',
+        '<Route path="/admin/pages/user-profiles" page={AdminPagesUserProfilesPage} name="adminPagesUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin/pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/Admin/Pages/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin/pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/Pages/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin/pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/Pages/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin/pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'userProfile',
+        path: 'admin/pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})
+
+describe('Admin/Pages/Post', () => {
+  describe('creates the correct files with the correct imports', () => {
+    test('returns exactly 16 files', () => {
+      expect(Object.keys(filesNestedUpper).length).toEqual(16)
+    })
+
+    // Layout
+
+    test('creates a layout', async () => {
+      expect(filesNestedLower).toHaveProperty([
+        '/path/to/project/web/src/layouts/Admin/Pages/PostsLayout/PostsLayout.js',
+      ])
+    })
+
+    // Pages
+
+    test('creates a edit page', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/EditPostPage/EditPostPage.js',
+      ])
+    })
+
+    test('the edit page correctly imports the edit cell', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/pages/Admin/Pages/EditPostPage/EditPostPage.js'
+        ]
+      ).toMatch(
+        `import EditPostCell from 'src/components/Admin/Pages/EditPostCell'`
+      )
+    })
+
+    test('creates a index page', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/PostsPage/PostsPage.js',
+      ])
+    })
+
+    test('the index page correctly imports the index cell', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/pages/Admin/Pages/PostsPage/PostsPage.js'
+        ]
+      ).toMatch(`import PostsCell from 'src/components/Admin/Pages/PostsCell'`)
+    })
+
+    test('creates a new page', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/NewPostPage/NewPostPage.js',
+      ])
+    })
+
+    test('the new page correctly imports the new component', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/pages/Admin/Pages/NewPostPage/NewPostPage.js'
+        ]
+      ).toMatch(`import NewPost from 'src/components/Admin/Pages/NewPost'`)
+    })
+
+    test('creates a show page', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/pages/Admin/Pages/PostPage/PostPage.js',
+      ])
+    })
+
+    test('the show page correctly imports the show cell', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/pages/Admin/Pages/PostPage/PostPage.js'
+        ]
+      ).toMatch(`import PostCell from 'src/components/Admin/Pages/PostCell'`)
+    })
+
+    // Cells
+
+    test('creates an edit cell', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/EditPostCell/EditPostCell.js',
+      ])
+    })
+
+    test('the edit cell correctly imports the form', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/components/Admin/Pages/EditPostCell/EditPostCell.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/Pages/PostForm'`)
+    })
+
+    test('creates an index cell', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/PostsCell/PostsCell.js',
+      ])
+    })
+
+    test('the index cell correctly imports the index component', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/components/Admin/Pages/PostsCell/PostsCell.js'
+        ]
+      ).toMatch(`import Posts from 'src/components/Admin/Pages/Posts'`)
+    })
+
+    test('creates a show cell', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/PostCell/PostCell.js',
+      ])
+    })
+
+    test('the show cell correctly imports the show component', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/components/Admin/Pages/PostCell/PostCell.js'
+        ]
+      ).toMatch(`import Post from 'src/components/Admin/Pages/Post'`)
+    })
+
+    // Components
+
+    test('creates a form component', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/PostForm/PostForm.js',
+      ])
+    })
+
+    test('creates an index component', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/Posts/Posts.js',
+      ])
+    })
+
+    test('creates a new component', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/NewPost/NewPost.js',
+      ])
+    })
+
+    test('the new component correctly imports the form', async () => {
+      expect(
+        filesNestedUpper[
+          '/path/to/project/web/src/components/Admin/Pages/NewPost/NewPost.js'
+        ]
+      ).toMatch(`import PostForm from 'src/components/Admin/Pages/PostForm'`)
+    })
+
+    test('creates a show component', async () => {
+      expect(filesNestedUpper).toHaveProperty([
+        path.normalize(
+          '/path/to/project/web/src/components/Admin/Pages/Post/Post.js'
+        ),
+      ])
+    })
+  })
+
+  describe('creates the correct routes', () => {
+    // Routes
+
+    test('creates a single-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'Post', path: 'Admin/Pages' })
+      ).toEqual([
+        '<Route path="/admin/pages/posts/new" page={AdminPagesNewPostPage} name="adminPagesNewPost" />',
+        '<Route path="/admin/pages/posts/{id:Int}/edit" page={AdminPagesEditPostPage} name="adminPagesEditPost" />',
+        '<Route path="/admin/pages/posts/{id:Int}" page={AdminPagesPostPage} name="adminPagesPost" />',
+        '<Route path="/admin/pages/posts" page={AdminPagesPostsPage} name="adminPagesPosts" />',
+      ])
+    })
+
+    test('creates a multi-word name routes', async () => {
+      expect(
+        await scaffold.routes({ model: 'UserProfile', path: 'Admin/Pages' })
+      ).toEqual([
+        '<Route path="/admin/pages/user-profiles/new" page={AdminPagesNewUserProfilePage} name="adminPagesNewUserProfile" />',
+        '<Route path="/admin/pages/user-profiles/{id:Int}/edit" page={AdminPagesEditUserProfilePage} name="adminPagesEditUserProfile" />',
+        '<Route path="/admin/pages/user-profiles/{id:Int}" page={AdminPagesUserProfilePage} name="adminPagesUserProfile" />',
+        '<Route path="/admin/pages/user-profiles" page={AdminPagesUserProfilesPage} name="adminPagesUserProfiles" />',
+      ])
+    })
+  })
+
+  describe('GraphQL queries', () => {
+    test('the GraphQL in the index query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin/Pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          path.normalize(
+            '/path/to/project/web/src/components/Admin/Pages/UserProfilesCell/UserProfilesCell.js'
+          )
+        ]
+
+      const query = cell.match(/(userProfiles.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the show query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin/Pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/Pages/UserProfileCell/UserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+
+    test('the GraphQL in the edit query does not contain object types', async () => {
+      const userProfileFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin/Pages',
+      })
+
+      const cell =
+        userProfileFiles[
+          '/path/to/project/web/src/components/Admin/Pages/EditUserProfileCell/EditUserProfileCell.js'
+        ]
+
+      const query = cell.match(/(userProfile.*?\})/s)[1]
+
+      expect(query).not.toMatch(/^\s+user$/m)
+    })
+  })
+
+  describe('Foreign key casting', () => {
+    test('creates a new component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin/Pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/NewUserProfile/NewUserProfile.js',
+      ])
+    })
+
+    test('creates an edit component with int foreign keys converted in onSave', async () => {
+      const foreignKeyFiles = await scaffold.files({
+        model: 'UserProfile',
+        path: 'Admin/Pages',
+      })
+
+      expect(foreignKeyFiles).toHaveProperty([
+        '/path/to/project/web/src/components/Admin/Pages/EditUserProfileCell/EditUserProfileCell.js',
+      ])
+    })
+  })
+})

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -46,7 +46,7 @@ const getIdType = (model) => {
   return model.fields.find((field) => field.isId)?.type
 }
 
-export const files = async ({ model: name }) => {
+export const files = async ({ model: name, path: scaffoldPath = '' }) => {
   const model = await getSchema(pascalcase(pluralize.singular(name)))
 
   return {
@@ -57,9 +57,9 @@ export const files = async ({ model: name }) => {
       relations: relationsForModel(model),
     })),
     ...assetFiles(name),
-    ...layoutFiles(name),
-    ...pageFiles(name),
-    ...(await componentFiles(name)),
+    ...layoutFiles(name, scaffoldPath),
+    ...pageFiles(name, scaffoldPath),
+    ...(await componentFiles(name, scaffoldPath)),
   }
 }
 
@@ -88,10 +88,26 @@ const assetFiles = (name) => {
   return fileList
 }
 
-const layoutFiles = (name) => {
+const layoutFiles = (name, scaffoldPath = '') => {
   const pluralName = pascalcase(pluralize(name))
   const singularName = pascalcase(pluralize.singular(name))
   let fileList = {}
+
+  const pascalScaffoldPath =
+    scaffoldPath === ''
+      ? scaffoldPath
+      : scaffoldPath.split('/').map(pascalcase).join('/') + '/'
+
+  const pluralCamelName = camelcase(pluralName)
+  const camelScaffoldPath = camelcase(pascalcase(scaffoldPath))
+
+  const pluralRouteName =
+    scaffoldPath === '' ? pluralCamelName : `${camelScaffoldPath}${pluralName}`
+
+  const newRouteName =
+    scaffoldPath === ''
+      ? `new${singularName}`
+      : `${camelScaffoldPath}New${singularName}`
 
   LAYOUTS.forEach((layout) => {
     const outputLayoutName = layout
@@ -100,6 +116,7 @@ const layoutFiles = (name) => {
       .replace(/\.template/, '')
     const outputPath = path.join(
       getPaths().web.layouts,
+      pascalScaffoldPath,
       outputLayoutName.replace(/\.js/, ''),
       outputLayoutName
     )
@@ -107,6 +124,9 @@ const layoutFiles = (name) => {
       path.join('scaffold', 'templates', 'layouts', layout),
       {
         name,
+        pascalScaffoldPath,
+        pluralRouteName,
+        newRouteName,
       }
     )
     fileList[outputPath] = template
@@ -115,10 +135,15 @@ const layoutFiles = (name) => {
   return fileList
 }
 
-const pageFiles = (name) => {
+const pageFiles = (name, scaffoldPath = '') => {
   const pluralName = pascalcase(pluralize(name))
   const singularName = pascalcase(pluralize.singular(name))
   let fileList = {}
+
+  const pascalScaffoldPath =
+    scaffoldPath === ''
+      ? scaffoldPath
+      : scaffoldPath.split('/').map(pascalcase).join('/') + '/'
 
   PAGES.forEach((page) => {
     const outputPageName = page
@@ -127,6 +152,7 @@ const pageFiles = (name) => {
       .replace(/\.template/, '')
     const outputPath = path.join(
       getPaths().web.pages,
+      pascalScaffoldPath,
       outputPageName.replace(/\.js/, ''),
       outputPageName
     )
@@ -134,6 +160,7 @@ const pageFiles = (name) => {
       path.join('scaffold', 'templates', 'pages', page),
       {
         name,
+        pascalScaffoldPath,
       }
     )
     fileList[outputPath] = template
@@ -142,7 +169,7 @@ const pageFiles = (name) => {
   return fileList
 }
 
-const componentFiles = async (name) => {
+const componentFiles = async (name, scaffoldPath = '') => {
   const pluralName = pascalcase(pluralize(name))
   const singularName = pascalcase(pluralize.singular(name))
   const model = await getSchema(singularName)
@@ -159,6 +186,32 @@ const componentFiles = async (name) => {
       label: humanize(column.name),
     }))
 
+  const pascalScaffoldPath =
+    scaffoldPath === ''
+      ? scaffoldPath
+      : scaffoldPath.split('/').map(pascalcase).join('/') + '/'
+
+  const pluralCamelName = camelcase(pluralName)
+  const camelScaffoldPath = camelcase(pascalcase(scaffoldPath))
+
+  const pluralRouteName =
+    scaffoldPath === '' ? pluralCamelName : `${camelScaffoldPath}${pluralName}`
+
+  const editRouteName =
+    scaffoldPath === ''
+      ? `edit${singularName}`
+      : `${camelScaffoldPath}Edit${singularName}`
+
+  const singularRouteName =
+    scaffoldPath === ''
+      ? camelcase(singularName)
+      : `${camelScaffoldPath}${singularName}`
+
+  const newRouteName =
+    scaffoldPath === ''
+      ? `new${singularName}`
+      : `${camelScaffoldPath}New${singularName}`
+
   await asyncForEach(COMPONENTS, (component) => {
     const outputComponentName = component
       .replace(/Names/, pluralName)
@@ -166,6 +219,7 @@ const componentFiles = async (name) => {
       .replace(/\.template/, '')
     const outputPath = path.join(
       getPaths().web.components,
+      pascalScaffoldPath,
       outputComponentName.replace(/\.js/, ''),
       outputComponentName
     )
@@ -178,6 +232,11 @@ const componentFiles = async (name) => {
         editableColumns,
         idType,
         intForeignKeys,
+        pascalScaffoldPath,
+        pluralRouteName,
+        editRouteName,
+        singularRouteName,
+        newRouteName,
       }
     )
     fileList[outputPath] = template
@@ -187,7 +246,7 @@ const componentFiles = async (name) => {
 }
 
 // add routes for all pages
-export const routes = async ({ model: name }) => {
+export const routes = async ({ model: name, path: scaffoldPath = '' }) => {
   const singularPascalName = pascalcase(pluralize.singular(name))
   const pluralPascalName = pascalcase(pluralize(name))
   const singularCamelName = camelcase(singularPascalName)
@@ -196,11 +255,44 @@ export const routes = async ({ model: name }) => {
   const model = await getSchema(singularPascalName)
   const idRouteParam = getIdType(model) === 'Int' ? ':Int' : ''
 
+  const paramScaffoldPath =
+    scaffoldPath === ''
+      ? scaffoldPath
+      : scaffoldPath.split('/').map(paramCase).join('/') + '/'
+  const pascalScaffoldPath = pascalcase(scaffoldPath)
+  const camelScaffoldPath = camelcase(pascalScaffoldPath)
+
+  const newRouteName =
+    scaffoldPath === ''
+      ? `new${singularPascalName}`
+      : `${camelScaffoldPath}New${singularPascalName}`
+
+  const editRouteName =
+    scaffoldPath === ''
+      ? `edit${singularPascalName}`
+      : `${camelScaffoldPath}Edit${singularPascalName}`
+
+  const singularRouteName =
+    scaffoldPath === ''
+      ? singularCamelName
+      : `${camelScaffoldPath}${singularPascalName}`
+
+  const pluralRouteName =
+    scaffoldPath === ''
+      ? pluralCamelName
+      : `${camelScaffoldPath}${pluralPascalName}`
+
+  // TODO: These names look like they need changing
+
   return [
-    `<Route path="/${pluralParamName}/new" page={New${singularPascalName}Page} name="new${singularPascalName}" />`,
-    `<Route path="/${pluralParamName}/{id${idRouteParam}}/edit" page={Edit${singularPascalName}Page} name="edit${singularPascalName}" />`,
-    `<Route path="/${pluralParamName}/{id${idRouteParam}}" page={${singularPascalName}Page} name="${singularCamelName}" />`,
-    `<Route path="/${pluralParamName}" page={${pluralPascalName}Page} name="${pluralCamelName}" />`,
+    // new
+    `<Route path="/${paramScaffoldPath}${pluralParamName}/new" page={${pascalScaffoldPath}New${singularPascalName}Page} name="${newRouteName}" />`,
+    // edit
+    `<Route path="/${paramScaffoldPath}${pluralParamName}/{id${idRouteParam}}/edit" page={${pascalScaffoldPath}Edit${singularPascalName}Page} name="${editRouteName}" />`,
+    // singular
+    `<Route path="/${paramScaffoldPath}${pluralParamName}/{id${idRouteParam}}" page={${pascalScaffoldPath}${singularPascalName}Page} name="${singularRouteName}" />`,
+    // plural
+    `<Route path="/${paramScaffoldPath}${pluralParamName}" page={${pascalScaffoldPath}${pluralPascalName}Page} name="${pluralRouteName}" />`,
   ]
 }
 
@@ -221,25 +313,42 @@ const addScaffoldImport = () => {
   return 'Added scaffold import to index.js'
 }
 
-export const command = 'scaffold <model>'
+export const command = 'scaffold <pathSlashModel>'
 export const desc = 'Generate pages, SDL, and a services object.'
 export const builder = {
   force: { type: 'boolean', default: false },
+  // So the user can specify a path to nest the generated files under.
+  // E.g. yarn rw g scaffold post --path=admin
+  path: { type: 'string', default: false },
 }
-export const handler = async ({ model, force }) => {
+// The user can also specify a path in the argument.
+// E.g. yarn rw g scaffold admin/post
+export const handler = async ({ pathSlashModel, force, path: pathFlag }) => {
+  let path
+  // If path is specified by both pathSlashModel and pathFlag,
+  // we give pathFlag precedence.
+  pathFlag
+    ? (path = pathFlag)
+    : (path = pathSlashModel.split('/').slice(0, -1).join('/'))
+
+  // This code will work whether or not there's a path in pathSlashModel
+  // E.g. if pathSlashModel is just 'post',
+  // path.split('/') will return ['post'].
+  const model = pathSlashModel.split('/').pop()
+
   const tasks = new Listr(
     [
       {
         title: 'Generating scaffold files...',
         task: async () => {
-          const f = await files({ model })
+          const f = await files({ model, path })
           return writeFilesTask(f, { overwriteExisting: force })
         },
       },
       {
         title: 'Adding scaffold routes...',
         task: async () => {
-          return addRoutesToRouterTask(await routes({ model }))
+          return addRoutesToRouterTask(await routes({ model, path }))
         },
       },
       {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
@@ -1,6 +1,6 @@
 import { useMutation } from '@redwoodjs/web'
 import { navigate, routes } from '@redwoodjs/router'
-import ${singularPascalName}Form from 'src/components/${singularPascalName}Form'
+import ${singularPascalName}Form from 'src/components/${pascalScaffoldPath}${singularPascalName}Form'
 
 export const QUERY = gql`
   query FIND_${singularConstantName}_BY_ID($id: ${idType}!) {
@@ -22,7 +22,7 @@ export const Loading = () => <div>Loading...</div>
 export const Success = ({ ${singularCamelName} }) => {
   const [update${singularPascalName}, { loading, error }] = useMutation(UPDATE_${singularConstantName}_MUTATION, {
     onCompleted: () => {
-      navigate(routes.${pluralCamelName}())
+      navigate(routes.${pluralRouteName}())
     },
   })
 

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
@@ -12,7 +12,7 @@ const DELETE_${singularConstantName}_MUTATION = gql`
 const ${singularPascalName} = ({ ${singularCamelName} }) => {
   const [delete${singularPascalName}] = useMutation(DELETE_${singularConstantName}_MUTATION, {
     onCompleted: () => {
-      navigate(routes.${pluralCamelName}())
+      navigate(routes.${pluralRouteName}())
       location.reload()
     },
   })
@@ -42,7 +42,7 @@ const ${singularPascalName} = ({ ${singularCamelName} }) => {
         <ul>
           <li className="inline-block ml-2">
             <Link
-              to={routes.edit${singularPascalName}({ id: ${singularCamelName}.id })}
+              to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
               className="text-xs bg-blue-600 text-white hover:bg-blue-700 rounded px-4 py-2 uppercase font-semibold tracking-wide"
             >
               Edit

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameCell.js.template
@@ -1,4 +1,4 @@
-import ${singularPascalName} from 'src/components/${singularPascalName}'
+import ${singularPascalName} from 'src/components/${pascalScaffoldPath}${singularPascalName}'
 
 export const QUERY = gql`
   query FIND_${singularConstantName}_BY_ID($id: ${idType}!) {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
@@ -57,7 +57,7 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
                   <ul>
                     <li className="inline-block">
                       <Link
-                        to={routes.${singularCamelName}({ id: ${singularCamelName}.id })}
+                        to={routes.${singularRouteName}({ id: ${singularCamelName}.id })}
                         title={'Show ${singularCamelName} ' + ${singularCamelName}.id + ' detail'}
                         className="text-xs bg-gray-100 text-gray-600 hover:bg-gray-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
                       >
@@ -66,7 +66,7 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
                     </li>
                     <li className="inline-block">
                       <Link
-                        to={routes.edit${singularPascalName}({ id: ${singularCamelName}.id })}
+                        to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
                         title={'Edit ${singularCamelName} ' + ${singularCamelName}.id}
                         className="text-xs bg-gray-100 text-blue-600 hover:bg-blue-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
                       >

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.js.template
@@ -1,6 +1,6 @@
 import { Link, routes } from '@redwoodjs/router'
 
-import ${pluralPascalName} from 'src/components/${pluralPascalName}'
+import ${pluralPascalName} from 'src/components/${pascalScaffoldPath}${pluralPascalName}'
 
 export const QUERY = gql`
   query ${pluralConstantName} {
@@ -21,7 +21,7 @@ export const Empty = () => {
     <div className="text-center">
       {'No ${pluralCamelName} yet. '}
       <Link
-        to={routes.new${singularPascalName}()}
+        to={routes.${newRouteName}()}
         className="text-blue-500 underline hover:text-blue-700"
       >
         {'Create one?'}

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
@@ -1,6 +1,6 @@
 import { useMutation } from '@redwoodjs/web'
 import { navigate, routes } from '@redwoodjs/router'
-import ${singularPascalName}Form from 'src/components/${singularPascalName}Form'
+import ${singularPascalName}Form from 'src/components/${pascalScaffoldPath}${singularPascalName}Form'
 
 const CREATE_${singularConstantName}_MUTATION = gql`
   mutation Create${singularPascalName}Mutation($input: Create${singularPascalName}Input!) {
@@ -13,7 +13,7 @@ const CREATE_${singularConstantName}_MUTATION = gql`
 const New${singularPascalName} = () => {
   const [create${singularPascalName}, { loading, error }] = useMutation(CREATE_${singularConstantName}_MUTATION, {
     onCompleted: () => {
-      navigate(routes.${pluralCamelName}())
+      navigate(routes.${pluralRouteName}())
     },
   })
 

--- a/packages/cli/src/commands/generate/scaffold/templates/layouts/NamesLayout.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/layouts/NamesLayout.js.template
@@ -7,14 +7,14 @@ const ${pluralPascalName}Layout = (props) => {
         <header className="flex justify-between py-4 px-8">
           <h1 className="text-xl font-semibold">
             <Link
-              to={routes.${pluralCamelName}()}
+              to={routes.${pluralRouteName}()}
               className="text-gray-700 hover:text-gray-900 hover:underline"
             >
               ${pluralPascalName}
             </Link>
           </h1>
           <Link
-            to={routes.new${singularPascalName}()}
+            to={routes.${newRouteName}()}
             className="flex bg-green-500 hover:bg-green-600 text-white text-xs font-semibold px-3 py-1 uppercase tracking-wide rounded"
           >
             <div className="text-xl leading-none">+</div>

--- a/packages/cli/src/commands/generate/scaffold/templates/pages/EditNamePage.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/pages/EditNamePage.js.template
@@ -1,5 +1,5 @@
-import ${pluralPascalName}Layout from 'src/layouts/${pluralPascalName}Layout'
-import Edit${singularPascalName}Cell from 'src/components/Edit${singularPascalName}Cell'
+import ${pluralPascalName}Layout from 'src/layouts/${pascalScaffoldPath}${pluralPascalName}Layout'
+import Edit${singularPascalName}Cell from 'src/components/${pascalScaffoldPath}Edit${singularPascalName}Cell'
 
 const Edit${singularPascalName}Page = ({ id }) => {
   return (

--- a/packages/cli/src/commands/generate/scaffold/templates/pages/NamePage.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/pages/NamePage.js.template
@@ -1,5 +1,5 @@
-import ${pluralPascalName}Layout from 'src/layouts/${pluralPascalName}Layout'
-import ${singularPascalName}Cell from 'src/components/${singularPascalName}Cell'
+import ${pluralPascalName}Layout from 'src/layouts/${pascalScaffoldPath}${pluralPascalName}Layout'
+import ${singularPascalName}Cell from 'src/components/${pascalScaffoldPath}${singularPascalName}Cell'
 
 const ${singularPascalName}Page = ({ id }) => {
   return (

--- a/packages/cli/src/commands/generate/scaffold/templates/pages/NamesPage.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/pages/NamesPage.js.template
@@ -1,5 +1,5 @@
-import ${pluralPascalName}Layout from 'src/layouts/${pluralPascalName}Layout'
-import ${pluralPascalName}Cell from 'src/components/${pluralPascalName}Cell'
+import ${pluralPascalName}Layout from 'src/layouts/${pascalScaffoldPath}${pluralPascalName}Layout'
+import ${pluralPascalName}Cell from 'src/components/${pascalScaffoldPath}${pluralPascalName}Cell'
 
 const ${pluralPascalName}Page = () => {
   return (

--- a/packages/cli/src/commands/generate/scaffold/templates/pages/NewNamePage.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/pages/NewNamePage.js.template
@@ -1,5 +1,5 @@
-import ${pluralPascalName}Layout from 'src/layouts/${pluralPascalName}Layout'
-import New${singularPascalName} from 'src/components/New${singularPascalName}'
+import ${pluralPascalName}Layout from 'src/layouts/${pascalScaffoldPath}${pluralPascalName}Layout'
+import New${singularPascalName} from 'src/components/${pascalScaffoldPath}New${singularPascalName}'
 
 const New${singularPascalName}Page = () => {
   return (

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -117,7 +117,7 @@ export const processPagesDir = (
         deps.push({
           const: importName,
           path: path.join(webPagesDir, entry.name),
-          importStatement: `const ${importName} = { name: '${importName}', loader: () => import('${importFile}') }`,
+          importStatement: `const ${importName.split(',').join('')} = { name: '${importName.split(',').join('')}', loader: () => import('${importFile}') }`,
         })
       } catch (e) {
         // If the Page doesn't exist then we are in a directory of Page


### PR DESCRIPTION
This PR proposes the following change to the `g scaffold` command:

```
yarn rw g scaffold <path/model>
```

E.g. given the model user, running `yarn rw g scaffold admin/user` will output:

```
yarn run v1.22.4
$ /home/dominic/projects/redwood/redwood-test/node_modules/.bin/rw g scaffold admin/users
  ✔ Generating scaffold files...
    ✔ Writing `./api/src/graphql/users.sdl.js`...
    ✔ Writing `./api/src/services/users/users.test.js`...
    ✔ Writing `./api/src/services/users/users.js`...
    ✔ Writing `./web/src/scaffold.css`...
    ✔ Writing `./web/src/layouts/UsersLayout/UsersLayout.js`...
    ✔ Writing `./web/src/pages/Admin/EditUserPage/EditUserPage.js`...
    ✔ Writing `./web/src/pages/Admin/UserPage/UserPage.js`...
    ✔ Writing `./web/src/pages/Admin/UsersPage/UsersPage.js`...
    ✔ Writing `./web/src/pages/Admin/NewUserPage/NewUserPage.js`...
    ✔ Writing `./web/src/components/Admin/EditUserCell/EditUserCell.js`...
    ✔ Writing `./web/src/components/Admin/User/User.js`...
    ✔ Writing `./web/src/components/Admin/UserCell/UserCell.js`...
    ✔ Writing `./web/src/components/Admin/UserForm/UserForm.js`...
    ✔ Writing `./web/src/components/Admin/Users/Users.js`...
    ✔ Writing `./web/src/components/Admin/UsersCell/UsersCell.js`...
    ✔ Writing `./web/src/components/Admin/NewUser/NewUser.js`...
  ✔ Adding scaffold routes...
  ✔ Adding scaffold asset imports...
Done in 1.07s.
```

## Motivation

Scaffolds are amazing and could be a bit more amazing. The knock against scaffolds this PR addresses is their tendency to pollute the namespace.

The specific problem I had was suddenly having to contrive names for my app's real components and pages. I.e. I had a model called `notes`, and scaffolding this out gave me a CRUD, but key names were taken: `Note` and `Notes` as components, `NotePage` and `NotesPages` as a pages, etc. I wanted to keep the scaffold as a CRUD while fleshing things out, but having to manually change everything seemed like a lot of work that I thought redwood should've made trivial from the get-go. Specifying a path can make the kind of admin organization seen in [example-blog](https://github.com/redwoodjs/example-blog) possible right away. 

There's an understandably tight link between a model's name and the scaffold generated. But this coupling must be loosened a bit. Specifying a path is one way of doing this. Another that's been thrown around involves a `--prefix` flag to literally add a prefix to component and page names. 

> This PR stems from discussions on discourse: see [How to Think About Scaffolds](https://community.redwoodjs.com/t/how-to-think-about-scaffolds/254) and [The scaffolding command makes it hard to delete files and folders later](https://community.redwoodjs.com/t/the-scaffolding-command-makes-it-hard-to-delete-files-and-folders-later/320).

I'll continue to scheme/push changes, but wanted to get this out to start a discussion/get help before moving too far in any one direction. Thanks/please help @cannikin @thedavidprice @olance.

Questions
* The way I finagled yargs command seems very suspect?
* Maybe I should just make another Listr task to move it all after it's been generated? Right now I'm making changes to the first task (`Generating scaffold files...`).
* Should the generated layout be in a nested dir too? Can it even be?