### PR TITLE
Remove code comment in localPostgresSetup.md

### DIFF
--- a/docs/localPostgresSetup.md
+++ b/docs/localPostgresSetup.md
@@ -34,7 +34,6 @@ following example uses `redwoodblog_dev` for the database. It also has `postgres
 superuser for ease of use.
 
 ```env
-# .env
 DATABASE_URL="postgresql://postgres@localhost/redwoodblog_dev?connection_limit=1"
 ```
 


### PR DESCRIPTION
This was tripping up the HTML parser and causing it to add `.env` to the TOC.

![image](https://user-images.githubusercontent.com/14339/79154554-bf3ced00-7d9d-11ea-80e0-86f0127c8b31.png)