### PR TITLE
Add workflows for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 packages/api/importAll.macro.js
 lerna-debug.log
 yarn-error.log
+tasks/.verdaccio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,86 +3,94 @@
 Before interacting with the Redwood community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/master/CODE_OF_CONDUCT.md).
 
 **Table of Contents**
-- [Local Package Development](#Local-Package-Development-Setup)
+
+- [Local development](#Local-development)
+- [Running the Local Server(s)](#Running-the-Local-Server(s))
 - [CLI Package Development](#CLI-Package-Development)
 
 <!-- toc -->
 
-## Local Package Development Setup
+## Local development
 
-You'll want to run a local redwood app sandbox using your local @redwoodjs packages instead of the current releases from the package registry. To do this we use [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link/).
+When contributing to Redwood you'll often want to add, fix, or change something in the Redwood Framework's monorepo, and see the implementation "running "live" in your own side project or one of our example apps.
 
-### Example Setup: Package `@redwoodjs/cli` Local Dev
+We offer two workflows for making that possible: "watch and copy" with some restrictions, and "emulate npm" without restrictions. The consideration for using the "emulate npm" workflow is if you've installed or upgraded a dependency, otherwise the "watch and copy" workflow should be fine.
 
-Assuming you've already cloned `redwoodjs/redwood` locally and run `yarn install` and `yarn build`, navigate to the `packages/cli` directory and run the following command:
+### Watch and copy
 
-```
-yarn link
-```
+The first step is to watch files for changes and build those changes in the Redwood framework:
 
-You should see a message `success Registered "@redwoodjs/cli"`.
-
-If you haven't created a local redwood app for testing, first run `yarn create redwood-app [app-name]` and then run `yarn` from the app's root directory. Still in the root directory of the app, run the following:
-
-```
-yarn link @redwoodjs/cli
-```
-
-> You can link as many packages as needed at a time. Note: although some packages include others, e.g. /scripts uses /cli as a dependency, you'll still need to link packages individually.
-
-You should see a success message and can confirm the symlink was created by viewing the `/node_modules/@redwoodjs` directory from your editor or via command line `$ ls -l node_modules/@redwoodjs`
-
-> HEADS UP: it's easy to forget you're using linked local packages in your sandbox app instead of those published to the package registry. You'll need to manually `git pull` upstream changes to packages.
-
-### `Yarn Build:Watch`
-
-As you make changes to a package (in this example `packages/cli`), you'll need to publish locally so the updates are included in your sandbox app. You can manually publish using `yarn build`. But it's more convenient to have the package re-publish each time you make a change. Run the following from the root of the package you're developing, `packages/cli` in this example:
-
-```
+```terminal
+cd redwood
 yarn build:watch
+
+@redwoodjs/api: $ nodemon --watch src -e ts,js --ignore dist --exec 'yarn build'
+@redwoodjs/core: $ nodemon --ignore dist --exec 'yarn build'
+create-redwood-app: $ nodemon --ignore dist --exec 'yarn build'
+@redwoodjs/eslint-plugin-redwood: $ nodemon --ignore dist --exec 'yarn build'
 ```
 
-You'd think you could just go over to your sandbox app and run your `cli` command, like:
+The second step is to watch and copy those changes into your Redwood project:
 
-```
-yarn redwood generate scaffold MyModel
-```
+```terminal
+cd example-invoice
+yarn rwdev watch ../path/to/redwood
 
-Unfortunately thanks to a long-standing [issue](https://github.com/yarnpkg/yarn/issues/3587) in Yarn, the bin files that are generated are not executable. You can fix that before running your command like so:
-
-```
-chmod +x node_modules/.bin/redwood && yarn redwood generate scaffold MyModel
-```
-
-### Unlinking Packages
-
-Lastly, to reverse the process and remove the links, work backwords using `yarn unlink`. Starting first from the local redwood sandbox app root
-
-```
-yarn unlink @redwoodjs/cli
-yarn install --force
+Redwood Framework Path:  /Users/peterp/Personal/redwoodjs/redwood
+Trigger event:  add
+building file list ... done
 ```
 
-_The latter command reinstalls the current published package._
+You can also create a `RW_PATH` env var and then you don't have to specify the path in the watch command.
 
-Then from the package directory `/redwoodjs/redwood/packages/cli` of your local clone, run:
+Now any changes that are made in the framework are copied into your project.
 
+### Emulating package publishing
+
+Sometimes you'll want to test the full development flow from building and publishing our packages, to installing them in your project. We facilitate this using a local NPM registry called [Verdaccio](https://github.com/verdaccio/verdaccio).
+
+#### Setting up and running a local NPM registry
+
+```terminal
+yarn add global verdaccio
+./tasks/run-local-npm
 ```
-yarn unlink
-yarn install --force
+
+This starts Verdaccio (http://localhost:4873) with our configuration file.
+
+#### Publishing a package
+
+`./tasks/publish-local` will build, unpublish, and publish all the Redwood packages to your local NPM registry with a "dev" tag, for the curious it is the equivalent of running:
+
+```terminal
+npm unpublish --tag dev --registry http://localhost:4873/ --force
+npm publish --tag dev --registry http://localhost:4873/ --force
 ```
 
-### Running the Local Server(s)
+You can build a particular package by specifying the path to the package: `./tasks/publish-local ./packages/api`.
+
+#### Installing published packages
+
+Redwood installs `rwdev` a companion CLI development tool that makes installing local npm packages easy: `yarn rwdev install @redwoodjs/dev-server`.
+
+This is equivilant to running:
+
+```terminal
+rm -rf <PROJECT_PATH>/node_modules/@redwoodjs/dev-server
+yarn upgrade @redwoodjs/dev-server@dev --no-lockfile --registry http://localhost:4873/
+```
+
+## Running the Local Server(s)
 
 You can run both the API and Web servers with a single command:
 
-```
+```terminal
 yarn rw dev
 ```
 
 However, for local package development, you'll need to manually stop/start the respective server to include changes. In this case you can run the servers for each of the yarn workspaces independently:
 
-```
+```terminal
 yarn rw dev api
 yarn rw dev web
 ```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production lerna run build",
+    "build:watch": "lerna run build:watch --parallel",
     "test": "lerna run test --stream -- --colors",
     "lint": "yarn eslint packages",
     "lint:fix": "yarn eslint --fix packages"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,6 +40,7 @@
     "build": "yarn build:js && yarn build:types && yarn move-cli dist/importAll.macro.js ./importAll.macro.js",
     "build:js": "yarn del-cli importAll.macro.js && yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start --extensions \".js,.ts\" --source-maps inline",
     "build:types": "tsc --declaration --emitDeclarationOnly",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --watch src -e ts,js --ignore dist --exec 'yarn build'",
     "test": "yarn jest",
     "test:watch": "yarn test --watch"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "bin": {
     "redwood": "./dist/index.js",
-    "rw": "./dist/index.js"
+    "rw": "./dist/index.js",
+    "rwdev": "./dist/rwdev.js"
   },
   "files": [
     "dist"
@@ -27,11 +28,11 @@
     "pascalcase": "^1.0.0",
     "pluralize": "^8.0.0",
     "prettier": "^2.0.2",
-    "rimraf": "^3.0.2",
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@types/node-fetch": "^2.5.5"
+    "@types/node-fetch": "^2.5.5",
+    "rimraf": "^3.0.2"
   },
   "scripts": {
     "build": "yarn build:js && yarn build:clean-dist",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
     "build": "yarn build:js && yarn build:clean-dist",
     "build:js": "yarn cross-env NODE_ENV=production yarn babel src -d dist --delete-dir-on-start --copy-files --no-copy-ignored",
     "build:clean-dist": "yarn rimraf 'dist/**/__tests__'",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",
     "test": "jest",
     "test:watch": "yarn test --watch"

--- a/packages/cli/src/rwdev.js
+++ b/packages/cli/src/rwdev.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import path from 'path'
+import fs from 'fs'
+
+import yargs from 'yargs'
+import { getPaths } from '@redwoodjs/internal'
+import execa from 'execa'
+import chokidar from 'chokidar'
+import _ from 'lodash'
+
+const RW_BINS = {
+  redwood: 'cli/dist/index.js',
+  rw: 'cli/dist/index.js',
+  rwdev: 'cli/dist/rwdev.js',
+  'dev-server': 'dev-server/dist/main.js',
+}
+
+export const resolveFrameworkPath = (RW_PATH) => {
+  if (!fs.existsSync(RW_PATH)) {
+    console.error(`Error: '${RW_PATH}' does not exist`)
+    process.exit(1)
+  }
+  return path.resolve(process.cwd(), RW_PATH)
+}
+
+export const fixProjectBinaries = (PROJECT_PATH) => {
+  Object.keys(RW_BINS)
+    .map((name) => {
+      const from = path.join(PROJECT_PATH, 'node_modules/.bin/', name)
+      const to = path.join(
+        PROJECT_PATH,
+        'node_modules/@redwoodjs',
+        RW_BINS[name]
+      )
+      console.log(`symlink '${from}' -> '${to}'`)
+      return [from, to]
+    })
+    .forEach(([from, to]) => {
+      try {
+        fs.unlinkSync(from)
+      } catch (e) {
+        console.warn(`Warning: Could not unlink ${from}`)
+      }
+      try {
+        fs.symlinkSync(to, from)
+      } catch (e) {
+        console.warn(`Warning: Could not symlink ${from} -> ${to}`)
+        console.log(e)
+      }
+      try {
+        fs.chmodSync(from, '755')
+      } catch (e) {
+        console.warn(`Warning: Could not chmod ${from}`)
+        console.log(e)
+      }
+
+      try {
+        fs.chmodSync(from, '755')
+      } catch (e) {
+        console.error(`Warning: Could not chmod ${from}`)
+        console.error(e)
+      }
+    })
+}
+
+// eslint-disable-next-line no-unused-expressions
+yargs
+  .command(
+    ['watch [RW_PATH]', 'w'],
+    'Watch the Redwood Framework path for changes and copy them over to this project',
+    {},
+    ({ RW_PATH = process.env.RW_PATH }) => {
+      RW_PATH = resolveFrameworkPath(RW_PATH)
+
+      console.log('Redwood Framework Path: ', RW_PATH)
+
+      const src = `${RW_PATH}/packages/`
+      const dest = `${getPaths().base}/node_modules/@redwoodjs/`
+
+      chokidar
+        .watch(src, {
+          persistent: true,
+          recursive: true,
+        })
+        .on(
+          'all',
+          _.debounce(async (event) => {
+            // TODO: Figure out if we need to only run based on certain events.
+            console.log('Trigger event: ', event)
+            await execa('rsync', ['-rtvu --delete', `'${src}'`, `'${dest}'`], {
+              shell: true,
+              stdio: 'inherit',
+              cleanup: true,
+            })
+            // when rsync is run modify the permission to make binaries executable.
+            fixProjectBinaries(getPaths().base)
+          }, 500)
+        )
+    }
+  )
+  .command(
+    ['install [packageName]', 'i'],
+    'Install a package from your local NPM registry',
+    () => {},
+    ({ packageName }) => {
+      // This command upgrades a Redwood package from the local NPM registry. You
+      // run the local registry from `./tasks/run-local-npm`.
+      // See `CONTRIBUTING.md` for more information.
+      const pkgPath = path.join(getPaths().base, 'node_modules', packageName)
+      console.log(`Deleting ${pkgPath}`)
+      try {
+        fs.rmdirSync(pkgPath, { recursive: true })
+      } catch (e) {
+        console.error(`Error: Could not delete ${pkgPath}`)
+        process.exit(1)
+      }
+
+      execa(
+        'yarn',
+        [
+          'upgrade',
+          `${packageName}@dev`,
+          '--no-lockfile',
+          '--registry http://localhost:4873/',
+          '--check-files',
+        ],
+        {
+          shell: true,
+          cwd: getPaths().base,
+          stdio: 'inherit',
+          extendEnv: true,
+          cleanup: true,
+        }
+      )
+    }
+  )
+  .command(
+    ['fix-bins', 'fix'],
+    'Fix Redwood symlinks and permissions',
+    {},
+    () => {
+      fixProjectBinaries(getPaths().base)
+    }
+  )
+  .demandCommand().argv

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,6 +59,7 @@
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649",
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'"
   }
 }

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'"
   },
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649"

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -28,7 +28,8 @@
     "@types/require-dir": "^1.0.0"
   },
   "scripts": {
-    "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start --extensions \".ts\" --source-maps inline"
+    "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start --extensions \".ts\" --source-maps inline",
+    "prepublishOnly": "yarn build"
   },
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649"
 }

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -29,7 +29,8 @@
   },
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start --extensions \".ts\" --source-maps inline",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "build:watch": "nodemon --ignore dist --exec 'yarn build'"
   },
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649"
 }

--- a/packages/eslint-plugin-redwood/package.json
+++ b/packages/eslint-plugin-redwood/package.json
@@ -12,6 +12,7 @@
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649",
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'"
   }
 }

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -23,6 +23,7 @@
     "build": "yarn build:js && yarn build:types",
     "build:js": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start --extensions \".js,.ts\" --source-maps inline",
     "build:types": "tsc --declaration --emitDeclarationOnly",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",
     "test": "jest",
     "test:watch": "yarn test --watch"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'",
     "test": "yarn jest src",
     "test:watch": "yarn test --watch"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start",
+    "prepublishOnly": "yarn build",
     "build:watch": "nodemon --ignore dist --exec 'yarn build'"
   },
   "gitHead": "2801c132f40263f9fcfbdac8b1750d2e423eb649"

--- a/tasks/publish-local
+++ b/tasks/publish-local
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# This script republishes our packages to your local npm
+# registry (http://localhost:4873).
+#
+# Usage:
+# Publish a single package: ./tasks/local-publish ./packages/dev-server
+# Publish all the packages: ./tasks/local-publish
+
+if ! lsof -Pi :4873 -sTCP:LISTEN -t >/dev/null; then
+  echo "Error: Verdaccio is not listening on port 4873, start it with './tasks/run-verdaccio'"
+  exit 1
+fi
+
+
+if [ -z "$1" ]
+  then
+  # Publish all the packages
+  for d in packages/*/ ; do
+    ( cd "$d" && npm unpublish --tag dev --registry http://localhost:4873/ --force && npm publish --tag dev --registry http://localhost:4873/ --force )
+  done
+else
+  # Publish a single package
+  ( cd "$1" && npm unpublish  --tag dev --registry http://localhost:4873/ --force && npm publish --tag dev --registry http://localhost:4873/ --force )
+fi

--- a/tasks/run-local-npm
+++ b/tasks/run-local-npm
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+verdaccio --config tasks/verdaccio.yml

--- a/tasks/verdaccio.yml
+++ b/tasks/verdaccio.yml
@@ -1,0 +1,37 @@
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+storage: .verdaccio
+web:
+  title: Verdaccio
+auth:
+  htpasswd:
+    file: ./htpasswd
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@redwoodjs/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+  'create-redwood-app':
+    access: $all
+    publish: $all
+    unpublish: $all
+  '@*/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $all
+    unpublish: $all
+    proxy: npmjs
+server:
+  keepAliveTimeout: 60
+middlewares:
+  audit:
+    enabled: true
+logs:
+  - { type: stdout, format: pretty, level: http }


### PR DESCRIPTION
## Local development

When contributing to Redwood you'll often want to add, fix, or change something in the Redwood Framework's monorepo, and see the implementation "running "live" in your own side project or one of our example apps.

We offer two workflows for making that possible: "watch and copy" with some restrictions, and "emulate npm" without restrictions. The consideration for using the "emulate npm" workflow is if you've installed or upgraded a dependency, otherwise the "watch and copy" workflow should be fine.

### Watch and copy

The first step is to watch files for changes and build those changes in the Redwood framework:

```terminal
cd redwood
yarn build:watch

@redwoodjs/api: $ nodemon --watch src -e ts,js --ignore dist --exec 'yarn build'
@redwoodjs/core: $ nodemon --ignore dist --exec 'yarn build'
create-redwood-app: $ nodemon --ignore dist --exec 'yarn build'
@redwoodjs/eslint-plugin-redwood: $ nodemon --ignore dist --exec 'yarn build'
```

The second step is to watch and copy those changes into your Redwood project:

```terminal
cd example-invoice
yarn rwdev watch ../path/to/redwood

Redwood Framework Path:  /Users/peterp/Personal/redwoodjs/redwood
Trigger event:  add
building file list ... done
```

You can also create a `RW_PATH` env var and then you don't have to specify the path in the watch command.

Now any changes that are made in the framework are copied into your project.

### Emulating package publishing

Sometimes you'll want to test the full development flow from building and publishing our packages, to installing them in your project. We facilitate this using a local NPM registry called [Verdaccio](https://github.com/verdaccio/verdaccio).

#### Setting up and running a local NPM registry

```terminal
yarn add global verdaccio
./tasks/run-local-npm
```

This starts Verdaccio (http://localhost:4873) with our configuration file.

#### Publishing a package

`./tasks/publish-local` will build, unpublish, and publish all the Redwood packages to your local NPM registry with a "dev" tag, for the curious it is the equivalent of running:

```terminal
npm unpublish --tag dev --registry http://localhost:4873/ --force
npm publish --tag dev --registry http://localhost:4873/ --force
```

You can build a particular package by specifying the path to the package: `./tasks/publish-local ./packages/api`.

#### Installing published packages

Redwood installs `rwdev` a companion CLI development tool that makes installing local npm packages easy: `yarn rwdev install @redwoodjs/dev-server`.

This is equivilant to running:

```terminal
rm -rf <PROJECT_PATH>/node_modules/@redwoodjs/dev-server
yarn upgrade @redwoodjs/dev-server@dev --no-lockfile --registry http://localhost:4873/
```
