### PR TITLE
Support ENV vars in webpack projects

### DIFF
--- a/docs/redwood.toml.md
+++ b/docs/redwood.toml.md
@@ -18,6 +18,10 @@ The port number (integer) to listen to for the web side.
 
 TODO
 
+### includeEnvironmentVariables
+
+The set of environment variable keys (list of strings) to include for the web side, in addition to any that are prefixed with `REDWOOD_ENV_`.
+
 ## [api]
 
 This table contains the configuration for api side.

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -39,6 +39,14 @@ module.exports = (webpackEnv) => {
     ]
   }
 
+  const redwoodEnvPrefix = 'REDWOOD_ENV_'
+  const redwoodEnvKeys = Object.keys(process.env).reduce((prev, next) => {
+    if (next.startsWith(redwoodEnvPrefix)) {
+      prev[`process.env.${next}`] = JSON.stringify(process.env[next])
+    }
+    return prev
+  }, {})
+
   return {
     mode: isEnvProduction ? 'production' : 'development',
     devtool: isEnvProduction ? 'source-map' : 'cheap-module-source-map',
@@ -92,6 +100,7 @@ module.exports = (webpackEnv) => {
           // absolute path of imported file
           return JSON.stringify(runtimeValue.module.resource)
         }),
+        ...redwoodEnvKeys,
       }),
       new Dotenv({
         path: path.resolve(redwoodPaths.base, '.env'),

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -40,8 +40,12 @@ module.exports = (webpackEnv) => {
   }
 
   const redwoodEnvPrefix = 'REDWOOD_ENV_'
+  const includeEnvKeys = redwoodConfig.web.includeEnvironmentVariables
   const redwoodEnvKeys = Object.keys(process.env).reduce((prev, next) => {
-    if (next.startsWith(redwoodEnvPrefix)) {
+    if (
+      next.startsWith(redwoodEnvPrefix) ||
+      (includeEnvKeys && includeEnvKeys.includes(next))
+    ) {
       prev[`process.env.${next}`] = JSON.stringify(process.env[next])
     }
     return prev


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/427

This PR updates `core/config/webpack.common.js` to include `process.env.*` variables, via `webpack.DefinePlugin`, in 2 cases:
 - Prefixed with `REDWOOD_ENV_`
 - Matching the set defined in `redwoodConfig.web.includeEnvironmentVariables` via `redwood.toml`

@peterp 