### PR TITLE
Updates GraphQL SDL Required Types logic

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/editCell.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/editCell.js
@@ -16,7 +16,7 @@ export const QUERY = gql`
   }
 `
 const UPDATE_POST_MUTATION = gql`
-  mutation UpdatePostMutation($id: Int!, $input: PostInput!) {
+  mutation UpdatePostMutation($id: Int!, $input: UpdatePostInput!) {
     updatePost(id: $id, input: $input) {
       id
     }

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/edit.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/edit.js
@@ -12,7 +12,7 @@ export const QUERY = gql`
   }
 `
 const UPDATE_POST_MUTATION = gql`
-  mutation UpdateUserProfileMutation($id: Int!, $input: UserProfileInput!) {
+  mutation UpdateUserProfileMutation($id: Int!, $input: UpdateUserProfileInput!) {
     updateUserProfile(id: $id, input: $input) {
       id
     }

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
@@ -3,7 +3,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import UserProfileForm from 'src/components/UserProfileForm'
 
 const CREATE_POST_MUTATION = gql`
-  mutation CreateUserProfileMutation($input: UserProfileInput!) {
+  mutation CreateUserProfileMutation($input: CreateUserProfileInput!) {
     createUserProfile(input: $input) {
       id
     }

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
@@ -3,7 +3,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import PostForm from 'src/components/PostForm'
 
 const CREATE_POST_MUTATION = gql`
-  mutation CreatePostMutation($input: PostInput!) {
+  mutation CreatePostMutation($input: CreatePostInput!) {
     createPost(input: $input) {
       id
     }

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
@@ -10,7 +10,7 @@ export const QUERY = gql`
   }
 `
 const UPDATE_POST_MUTATION = gql`
-  mutation Update${singularPascalName}Mutation($id: ${idType}!, $input: ${singularPascalName}Input!) {
+  mutation Update${singularPascalName}Mutation($id: ${idType}!, $input: Update${singularPascalName}Input!) {
     update${singularPascalName}(id: $id, input: $input) {
       id
     }

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
@@ -3,7 +3,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import ${singularPascalName}Form from 'src/components/${singularPascalName}Form'
 
 const CREATE_POST_MUTATION = gql`
-  mutation Create${singularPascalName}Mutation($input: ${singularPascalName}Input!) {
+  mutation Create${singularPascalName}Mutation($input: Create${singularPascalName}Input!) {
     create${singularPascalName}(input: $input) {
       id
     }

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdl.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdl.js
@@ -10,8 +10,13 @@ export const schema = gql`
     userProfiles: [UserProfile!]!
   }
 
-  input UserProfileInput {
+  input CreateUserProfileInput {
     username: String!
     userId: Int!
+  }
+
+  input UpdateUserProfileInput {
+    username: String
+    userId: Int
   }
 `

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdl.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdl.js
@@ -7,7 +7,7 @@ export const schema = gql`
   }
 
   type Query {
-    userProfiles: [UserProfile]
+    userProfiles: [UserProfile!]!
   }
 
   input UserProfileInput {

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdl.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdl.js
@@ -11,7 +11,7 @@ export const schema = gql`
   }
 
   input UserProfileInput {
-    username: String
-    userId: Int
+    username: String!
+    userId: Int!
   }
 `

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdlCrud.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdlCrud.js
@@ -12,8 +12,8 @@ export const schema = gql`
   }
 
   input UserProfileInput {
-    username: String
-    userId: Int
+    username: String!
+    userId: Int!
   }
 
   type Mutation {

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdlCrud.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdlCrud.js
@@ -11,14 +11,19 @@ export const schema = gql`
     userProfile(id: Int!): UserProfile!
   }
 
-  input UserProfileInput {
+  input CreateUserProfileInput {
     username: String!
     userId: Int!
   }
 
+  input UpdateUserProfileInput {
+    username: String
+    userId: Int
+  }
+
   type Mutation {
-    createUserProfile(input: UserProfileInput!): UserProfile
-    updateUserProfile(id: Int!, input: UserProfileInput!): UserProfile
-    deleteUserProfile(id: Int!): UserProfile
+    createUserProfile(input: CreateUserProfileInput!): UserProfile!
+    updateUserProfile(id: Int!, input: UpdateUserProfileInput!): UserProfile!
+    deleteUserProfile(id: Int!): UserProfile!
   }
 `

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdlCrud.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/multiWordSdlCrud.js
@@ -7,8 +7,8 @@ export const schema = gql`
   }
 
   type Query {
-    userProfiles: [UserProfile]
-    userProfile(id: Int!): UserProfile
+    userProfiles: [UserProfile!]!
+    userProfile(id: Int!): UserProfile!
   }
 
   input UserProfileInput {

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdl.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdl.js
@@ -13,7 +13,7 @@ export const schema = gql`
 
   input UserInput {
     name: String
-    email: String
-    isAdmin: Boolean
+    email: String!
+    isAdmin: Boolean!
   }
 `

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdl.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdl.js
@@ -11,9 +11,15 @@ export const schema = gql`
     users: [User!]!
   }
 
-  input UserInput {
+  input CreateUserInput {
     name: String
     email: String!
     isAdmin: Boolean!
+  }
+
+  input UpdateUserInput {
+    name: String
+    email: String
+    isAdmin: Boolean
   }
 `

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdl.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdl.js
@@ -8,7 +8,7 @@ export const schema = gql`
   }
 
   type Query {
-    users: [User]
+    users: [User!]!
   }
 
   input UserInput {

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdlCrud.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdlCrud.js
@@ -14,7 +14,7 @@ export const schema = gql`
     post(id: Int!): Post!
   }
 
-  input PostInput {
+  input CreatePostInput {
     title: String!
     slug: String!
     author: String!
@@ -23,9 +23,18 @@ export const schema = gql`
     postedAt: DateTime
   }
 
+  input UpdatePostInput {
+    title: String
+    slug: String
+    author: String
+    body: String
+    image: String
+    postedAt: DateTime
+  }
+
   type Mutation {
-    createPost(input: PostInput!): Post
-    updatePost(id: Int!, input: PostInput!): Post
-    deletePost(id: Int!): Post
+    createPost(input: CreatePostInput!): Post!
+    updatePost(id: Int!, input: UpdatePostInput!): Post!
+    deletePost(id: Int!): Post!
   }
 `

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdlCrud.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdlCrud.js
@@ -15,10 +15,10 @@ export const schema = gql`
   }
 
   input PostInput {
-    title: String
-    slug: String
-    author: String
-    body: String
+    title: String!
+    slug: String!
+    author: String!
+    body: String!
     image: String
     postedAt: DateTime
   }

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdlCrud.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/singleWordSdlCrud.js
@@ -10,8 +10,8 @@ export const schema = gql`
   }
 
   type Query {
-    posts: [Post]
-    post(id: Int!): Post
+    posts: [Post!]!
+    post(id: Int!): Post!
   }
 
   input PostInput {

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -35,7 +35,7 @@ const inputSDL = (model, types = {}) => {
         field.kind !== 'object'
       )
     })
-    .map((field) => modelFieldToSDL(field, false, types))
+    .map((field) => modelFieldToSDL(field, true, types))
 }
 
 const idType = (model) => {

--- a/packages/cli/src/commands/generate/sdl/templates/sdl.js.template
+++ b/packages/cli/src/commands/generate/sdl/templates/sdl.js.template
@@ -8,13 +8,17 @@ export const schema = gql`
     ${singularCamelName}(id: ${idType}!): ${singularPascalName}!<% } %>
   }
 
-  input ${singularPascalName}Input {
-    ${input}
+  input Create${singularPascalName}Input {
+    ${createInput}
+  }
+
+  input Update${singularPascalName}Input {
+    ${updateInput}
   }<% if (crud) { %>
 
   type Mutation {
-    create${singularPascalName}(input: ${singularPascalName}Input!): ${singularPascalName}
-    update${singularPascalName}(id: ${idType}!, input: ${singularPascalName}Input!): ${singularPascalName}
-    delete${singularPascalName}(id: ${idType}!): ${singularPascalName}
+    create${singularPascalName}(input: Create${singularPascalName}Input!): ${singularPascalName}!
+    update${singularPascalName}(id: ${idType}!, input: Update${singularPascalName}Input!): ${singularPascalName}!
+    delete${singularPascalName}(id: ${idType}!): ${singularPascalName}!
   }<% } %>
 `

--- a/packages/cli/src/commands/generate/sdl/templates/sdl.js.template
+++ b/packages/cli/src/commands/generate/sdl/templates/sdl.js.template
@@ -4,8 +4,8 @@ export const schema = gql`
   }
 
   type Query {
-    ${pluralCamelName}: [${singularPascalName}]<% if (crud) { %>
-    ${singularCamelName}(id: ${idType}!): ${singularPascalName}<% } %>
+    ${pluralCamelName}: [${singularPascalName}!]!<% if (crud) { %>
+    ${singularCamelName}(id: ${idType}!): ${singularPascalName}!<% } %>
   }
 
   input ${singularPascalName}Input {


### PR DESCRIPTION
Following discussions in #316 and #324 I made some updates to the SDL generators. Assuming the following `schema.prisma` definition:

```
model Post {
  id       Int      @id @default(autoincrement())
  title    String
  slug     String @unique
  author   String
  body     String
  image    String?
  postedAt DateTime?
}
```

Currently Redwood generates a CRUD SDL that looks like:

```
export const schema = gql`
  type Post {
    id: Int!
    title: String!
    slug: String!
    author: String!
    body: String!
    image: String
    postedAt: DateTime
  }

  type Query {
    posts: [Post]
    post(id: Int!): Post
  }

  input PostInput {
    title: String
    slug: String
    author: String
    body: String
    image: String
    postedAt: DateTime
  }

  type Mutation {
    createPost(input: PostInput!): Post
    updatePost(id: Int!, input: PostInput!): Post
    deletePost(id: Int!): Post
  }
`
```

Note that no input types are required in `PostInput` even though they are required in the schema. If you try to save this record, Prisma will throw up a pretty gross error that isn't immediately clear what happened. After pondering the discussion in #316 I discussed with @mojombo and we like the idea proposed by @weaversam8 in which there are two input types, one for `Create` where everything that's required in `schema.prisma` is also required in GraphQL, as well as an `Update` where no fields are required:

```
input CreatePostInput {
  title: String!
  slug: String!
  author: String!
  body: String!
  image: String
  postedAt: DateTime
}

input UpdatePostInput {
  title: String
  slug: String
  author: String
  body: String
  image: String
  postedAt: DateTime
}

type Mutation {
  createPost(input: CreatePostInput!): Post!
  updatePost(id: Int!, input: UpdatePostInput!): Post!
  deletePost(id: Int!): Post!
}
```

This is a developer experience decision. If you have a database table with 50 columns, all of which are required for a record to exist, you obviously must provide all of them to create a record. However if you only want to edit a single one, you don't want to have to also send along the 49 other required fields along with the 1 you actually need to change. If you absolutely want your GraphQL interface to provide only mutations for each individual field you are free to create 50 `Update` input types, one for each field. 

---

This PR also covers some suggestions in #324 where returns in Query types are required. 

Currently:

```
  type Query {
    posts: [Post]
    post(id: Int!): Post
  }
```

This pull request changes that to:

```
  type Query {
    posts: [Post!]!
    post(id: Int!): Post!
  }
```

So on `posts` you know you'll always get an array, and those array elements will only be of type `Post`. Likewise the `post` query will always return a `Post`.