### PR TITLE
Add 'yarn rw upgrade' helper to upgrade @redwoodjs packages

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -20,12 +20,14 @@ export const builder = (yargs) => {
 const rwPackages =
   '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router'
 
-export const handler = async ({ dry-run }) => {
+// yargs allows passing the 'dry-run' alias 'd' here,
+// which we need to use because babel fails on 'dry-run'
+export const handler = async ({ d }) => {
   const tasks = new Listr([
     {
       title: "Running 'redwood upgrade'",
       task: (_ctx, task) => {
-        if (dry-run) {
+        if (d) {
           task.title = 'Checking available upgrades for @redwoodjs packages'
           execa.command(`yarn outdated ${rwPackages}`, {
             stdio: 'inherit',

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -1,0 +1,34 @@
+import execa from 'execa'
+import Listr from 'listr'
+
+import c from 'src/lib/colors'
+
+export const command = 'upgrade'
+export const desc = 'Upgrade all @redwoodjs packages via interactive CLI'
+
+export const handler = async () => {
+  const execCommands = {
+    cmd:
+      'yarn upgrade-interactive @redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router',
+    args: ['--latest'],
+  }
+
+  const tasks = new Listr([
+    {
+      title: 'Running @redwoodjs Interactive Upgrade CLI',
+      task: () => {
+        const { cmd, args } = execCommands
+        execa(cmd, args, {
+          stdio: 'inherit',
+          shell: true,
+        })
+      },
+    },
+  ])
+
+  try {
+    await tasks.run()
+  } catch (e) {
+    console.log(c.error(e.message))
+  }
+}

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -6,22 +6,38 @@ import c from 'src/lib/colors'
 export const command = 'upgrade'
 export const desc = 'Upgrade all @redwoodjs packages via interactive CLI'
 
-export const handler = async () => {
-  const execCommands = {
-    cmd:
-      'yarn upgrade-interactive @redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router',
-    args: ['--latest'],
-  }
+export const builder = (yargs) => {
+  yargs
+    .option('check', {
+      alias: 'c',
+      type: 'boolean',
+      default: false,
+      description: 'Check for outdated packages without upgrading',
+    })
+    .strict()
+}
 
+const rwPackages =
+  '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router'
+
+export const handler = async ({ check }) => {
   const tasks = new Listr([
     {
-      title: 'Running @redwoodjs Interactive Upgrade CLI',
-      task: () => {
-        const { cmd, args } = execCommands
-        execa(cmd, args, {
-          stdio: 'inherit',
-          shell: true,
-        })
+      title: "Running 'redwood upgrade'",
+      task: (_ctx, task) => {
+        if (check) {
+          task.title = 'Checking available upgrades for @redwoodjs packages'
+          execa(`yarn outdated ${rwPackages}`, undefined, {
+            stdio: 'inherit',
+            shell: true,
+          })
+        } else {
+          task.title = 'Running @redwoodjs package interactive upgrade CLI'
+          execa(`yarn upgrade-interactive ${rwPackages}`, ['--latest'], {
+            stdio: 'inherit',
+            shell: true,
+          })
+        }
       },
     },
   ])

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -8,8 +8,8 @@ export const desc = 'Upgrade all @redwoodjs packages via interactive CLI'
 
 export const builder = (yargs) => {
   yargs
-    .option('check', {
-      alias: 'c',
+    .option('dry-run', {
+      alias: 'd',
       type: 'boolean',
       default: false,
       description: 'Check for outdated packages without upgrading',
@@ -20,12 +20,12 @@ export const builder = (yargs) => {
 const rwPackages =
   '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router'
 
-export const handler = async ({ check }) => {
+export const handler = async ({ dry-run }) => {
   const tasks = new Listr([
     {
       title: "Running 'redwood upgrade'",
       task: (_ctx, task) => {
-        if (check) {
+        if (dry-run) {
           task.title = 'Checking available upgrades for @redwoodjs packages'
           execa(`yarn outdated ${rwPackages}`, undefined, {
             stdio: 'inherit',


### PR DESCRIPTION
Step 1 of #271 

- `yarn rw upgrade` runs an interactive upgrade process
- `yarn rw upgrade --check` checks for outdated packages (without upgrading)

Experimented with [npm-check-updates](https://www.npmjs.com/package/npm-check-updates), [npm-check](https://www.npmjs.com/package/npm-check), and [yarn-check](https://www.npmjs.com/package/yarn-check). Ended up using yarn built-in checks and upgrade. However, [yarn doesn't play nice with its own workspaces](https://github.com/yarnpkg/yarn/issues/4442), go figure, so I was limited to use `yarn upgrade-interactive [packages] --latest`. Other commands/options would not work. 👎 

I also attempted to first build this without Listr, but Execa didn't play nice with the interactive terminal. So Listr it is (I seem to recall we've had this problem before, yes?).

Note the `.strict()` in the option -- it does pick up error in the "check" flag, which is an improvement on no error checking at all.

Tested on Windows Bash for Ubuntu and worked fine. Wasn't able to figure out how to test cli package on Powershell... ?

