### PR TITLE
change rwdev to redwood-tools, aliased rwt

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,6 @@
     "rw": "./dist/index.js",
     "redwood-tools": "./dist/redwood-tools.js",
     "rwt": "./dist/redwood-tools.js"
-
   },
   "files": [
     "dist"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,9 @@
   "bin": {
     "redwood": "./dist/index.js",
     "rw": "./dist/index.js",
-    "rwdev": "./dist/rwdev.js"
+    "redwood-tools": "./dist/redwood-tools.js",
+    "rwt": "./dist/redwood-tools.js"
+
   },
   "files": [
     "dist"

--- a/packages/cli/src/redwood-tools.js
+++ b/packages/cli/src/redwood-tools.js
@@ -11,7 +11,8 @@ import _ from 'lodash'
 const RW_BINS = {
   redwood: 'cli/dist/index.js',
   rw: 'cli/dist/index.js',
-  rwdev: 'cli/dist/rwdev.js',
+  'redwood-tools': 'cli/dist/redwood-tools.js',
+  rwt: 'cli/dist/redwood-tools.js',
   'dev-server': 'dev-server/dist/main.js',
 }
 
@@ -142,4 +143,5 @@ yargs
       fixProjectBinaries(getPaths().base)
     }
   )
-  .demandCommand().argv
+  .demandCommand()
+  .strict().argv


### PR DESCRIPTION
@peterp I think I'm getting the hang of this workflow! Thanks again for putting in the time.

- switched command $0 from 'rwdev' to 'redwood-tools', aliased to 'rwt'. 
I think the main need to keep 'redwood-tools' around (if there is one), is it's more readable as a filename. I played around with --help description and couldn't find a way to have alias displayed for $0 command. So might not be needed.
- added `.strict()` to improve error catching on options

Handing over to you for any further tweaks. Go ahead and merge if it's ready.