### PR TITLE
Split rwdev watch into copy and copy:watch

### DIFF
--- a/packages/cli/src/rwdev.js
+++ b/packages/cli/src/rwdev.js
@@ -63,10 +63,36 @@ export const fixProjectBinaries = (PROJECT_PATH) => {
     })
 }
 
+export const copyFiles = async (src, dest) => {
+  // TODO: Figure out if we need to only run based on certain events.
+  await execa('rsync', ['-rtvu --delete', `'${src}'`, `'${dest}'`], {
+    shell: true,
+    stdio: 'inherit',
+    cleanup: true,
+  })
+  // when rsync is run modify the permission to make binaries executable.
+  fixProjectBinaries(getPaths().base)
+}
+
 // eslint-disable-next-line no-unused-expressions
 yargs
   .command(
-    ['watch [RW_PATH]', 'w'],
+    ['copy [RW_PATH]', 'cp'],
+    'Copy the Redwood Framework path to this project',
+    {},
+    ({ RW_PATH = process.env.RW_PATH }) => {
+      RW_PATH = resolveFrameworkPath(RW_PATH)
+
+      console.log('Redwood Framework Path: ', RW_PATH)
+
+      const src = `${RW_PATH}/packages/`
+      const dest = `${getPaths().base}/node_modules/@redwoodjs/` // eslint-disable-line
+
+      copyFiles(src, dest)
+    }
+  )
+  .command(
+    ['copy:watch [RW_PATH]', 'cpw'],
     'Watch the Redwood Framework path for changes and copy them over to this project',
     {},
     ({ RW_PATH = process.env.RW_PATH }) => {
@@ -84,16 +110,10 @@ yargs
         })
         .on(
           'all',
-          _.debounce(async (event) => {
+          _.debounce((event) => {
             // TODO: Figure out if we need to only run based on certain events.
             console.log('Trigger event: ', event)
-            await execa('rsync', ['-rtvu --delete', `'${src}'`, `'${dest}'`], {
-              shell: true,
-              stdio: 'inherit',
-              cleanup: true,
-            })
-            // when rsync is run modify the permission to make binaries executable.
-            fixProjectBinaries(getPaths().base)
+            copyFiles(src, dest)
           }, 500)
         )
     }


### PR DESCRIPTION
The CLI for local development, `rwdev` (soon to be renamed!) has a `watch` command, the structure of which seems like it could benefit by being more analogous to `yarn build` and `yarn build:watch`. So it's been reworked to be that way. Now you can run the following commands (complete with aliases).

To copy just once, similar to `yarn build`:

```
yarn rwdev copy RW_PATH
yarn rwdev cp RW_PATH
```

To copy and watch for changes, similar to `yarn build:watch`:

```
yarn rwdev copy:watch RW_PATH
yarn rwdev cpw RW_PATH
```

@peterp I tried to be DRY and factored out a function I called `copyFiles`. Lemme know what you think of this way of doing it.