### PR TITLE
add process.exit(1) to ensure App build fails on error

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -25,7 +25,7 @@ export const handler = async ({
     try {
       await generatePrismaClient({ verbose, force: true })
     } catch (e) {
-      console.log(e)
+      console.log(c.error(e.message))
       process.exit(1)
     }
   }

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -22,7 +22,12 @@ export const handler = async ({
   const { base: BASE_DIR } = getPaths()
 
   if (app.includes('api')) {
-    await generatePrismaClient({ verbose, force: true })
+    try {
+      await generatePrismaClient({ verbose, force: true })
+    } catch (e) {
+      console.log(e)
+      process.exit(1)
+    }
   }
 
   const execCommandsForApps = {
@@ -68,5 +73,6 @@ export const handler = async ({
     await tasks.run()
   } catch (e) {
     console.log(c.error(e.message))
+    process.exit(1)
   }
 }


### PR DESCRIPTION
Closes #437 

During an App build process, Prisma errors that may occur do _not_ result in the build itself to fail. This is problematic during deploy: for example, a Netlify deploy may run 'successfully' when in fact the Prisma Client failed to generate or the DB migration failed, etc.

@peterp adding this to tasks.run() seemed obvious. Additionally, I added to `generatePrismaClient()` -- any reactions to this part being overly aggressive? It's hard to test actual failures locally. But the two example cases so far (my own and Chris' in #437) seem to be different sources, e.g. Chris' was Prisma Client and mine was DB migration.

When we are ready to move forward, I will publish a release-candidate for both Chris and me to test against our deployment examples.
