### PR TITLE
Fix link markup

### DIFF
--- a/docs/connectionPooling.md
+++ b/docs/connectionPooling.md
@@ -14,7 +14,7 @@ For Postgres, see [How to Manage Connection Pools](https://www.digitalocean.com/
 Connection Pooling for MySQL is not yet supported.
 
 ## AWS
-Use [Amazon RDS Proxy] https://aws.amazon.com/rds/proxy for MySQL or RDS PostgreSQL.
+Use [Amazon RDS Proxy](https://aws.amazon.com/rds/proxy) for MySQL or RDS PostgreSQL.
 
 
 ## Why Connection Pooling?

--- a/docs/connectionPooling.md
+++ b/docs/connectionPooling.md
@@ -14,7 +14,7 @@ For Postgres, see [How to Manage Connection Pools](https://www.digitalocean.com/
 Connection Pooling for MySQL is not yet supported.
 
 ## AWS
-Use [Amazon RDS Proxy](https://aws.amazon.com/rds/proxy) for MySQL or RDS PostgreSQL.
+Use [Amazon RDS Proxy](https://aws.amazon.com/rds/proxy) for MySQL or PostgreSQL.
 
 
 ## Why Connection Pooling?


### PR DESCRIPTION
It's a little weird that line says "MySQL or RDS PostgreSQL". Why is RDS included before "PostgreSQL" but not "MySQL"?

Amazon says connection pooling is supported for "Aurora MySQL, RDS MySQL, Aurora PostgreSQL, and RDS PostgreSQL"

I wonder if we should change "MySQL or RDS PostgreSQL" to just be "MySQL or PostgreSQL"