### PR TITLE
Hot reload [Web] and [Router] during local development

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -40,7 +40,6 @@ module.exports = {
             path.resolve(__dirname, 'packages', 'web', 'src'),
           ],
         },
-        loglevel: 'info',
       },
     ],
     ['@babel/plugin-proposal-class-properties', { loose: true }],

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const TARGETS_NODE = '12.13.0'
 const TARGETS_BROWSERS = 'defaults'
 // Warning! Recommended to specify used minor core-js version, like corejs: '3.6',
@@ -9,6 +11,7 @@ const CORE_JS_VERSION = '3.6'
 // We use the recommended babel configuration for monorepos, which is a base directory
 // `babel.config.js` file, but then use a per-project `.babelrc.js` file.
 // Learn more: https://babeljs.io/docs/en/config-files#monorepos
+
 module.exports = {
   presets: [
     [
@@ -31,8 +34,13 @@ module.exports = {
       'babel-plugin-module-resolver',
       {
         alias: {
-          src: './src',
+          src: [
+            './src',
+            path.resolve(__dirname, 'packages', 'router', 'src'),
+            path.resolve(__dirname, 'packages', 'web', 'src'),
+          ],
         },
+        loglevel: 'info',
       },
     ],
     ['@babel/plugin-proposal-class-properties', { loose: true }],

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,7 @@ const CORE_JS_VERSION = '3.6'
 // `babel.config.js` file, but then use a per-project `.babelrc.js` file.
 // Learn more: https://babeljs.io/docs/en/config-files#monorepos
 
-module.exports = {
+module.exports = (api) => ({
   presets: [
     [
       '@babel/preset-env',
@@ -34,11 +34,14 @@ module.exports = {
       'babel-plugin-module-resolver',
       {
         alias: {
-          src: [
-            './src',
-            path.resolve(__dirname, 'packages', 'router', 'src'),
-            path.resolve(__dirname, 'packages', 'web', 'src'),
-          ],
+          // For some reason jest doesn not like multiple targets for an alias
+          src: api.env('test')
+            ? './src'
+            : [
+                './src',
+                path.resolve(__dirname, 'packages', 'router', 'src'),
+                path.resolve(__dirname, 'packages', 'web', 'src'),
+              ],
         },
       },
     ],
@@ -97,4 +100,4 @@ module.exports = {
     process.env.NODE_ENV === 'production'
       ? [/\.test\.(js|ts)/, '**/__tests__', '**/__mocks__']
       : [],
-}
+})

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -135,7 +135,22 @@ module.exports = (webpackEnv) => {
             },
             {
               test: /\.(js|jsx|ts|tsx)$/,
-              exclude: /(node_modules)/,
+              include: /redwood\/.*/,
+              exclude: /node_modules/,
+              resolve: {
+                mainFields: ['module', 'main', 'browser'],
+              },
+              use: {
+                loader: 'babel-loader',
+                options: {
+                  root: path.resolve(__dirname, '..', '..', '..'),
+                  cacheDirectory: true,
+                },
+              },
+            },
+            {
+              test: /\.(js|jsx|ts|tsx)$/,
+              exclude: /node_modules/,
               use: {
                 loader: 'babel-loader',
                 options: {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -2,9 +2,11 @@
   "name": "@redwoodjs/router",
   "version": "0.6.0",
   "files": [
+    "src",
     "dist"
   ],
   "main": "dist/index.js",
+  "module": "src/index.js",
   "license": "MIT",
   "dependencies": {
     "core-js": "3.6.4"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,9 +2,11 @@
   "name": "@redwoodjs/web",
   "version": "0.6.0",
   "files": [
+    "src",
     "dist"
   ],
   "main": "dist/index.js",
+  "module": "src/index.js",
   "license": "MIT",
   "dependencies": {
     "@apollo/react-components": "^3.1.3",


### PR DESCRIPTION
After a painful day learning about ins and outs of Babel I ended up with this.

In short what I did:
- `yarn link` on `cli`, `core`, `web` and `router`.
- Expose uncompiled `es6` code through `module` field in `package.json` of `router` and `web`.
- Tell webpack to pick up the `module` version (if exists) of any Redwood packages. If doesn't exist, take `main`.
- Because the `src` alias exists in your local project already as well, Babel can't resolve that one. Luckily you can specify multiple module locations for `alias` nowadays, so we tell Babel if it's not available locally it could also be in a Redwood package.

Using this you can hot-reload `router` and `web` just by yarn linking them!

Pitfall: It won't work if there's something in a `dist` in one of the modules. When dealing with a `node_module`, the order of `mainFields` matters and Webpack correctly takes the `module` version. When following the symlink to the actual location (default in Webpack) it seems to ignore the specified `mainFields`. 

**Things I think but I'm not sure of**
Without symlinks the whole `/redwood\/.*/` regex is skipped, because it doesn't match. To be sure we could specify exact paths.

**Note**: I don't think this is finished as is. I'm not sure how hacky or how good of a practice this is, but I think it's.... ok? I thought it could be good to open a PR so people can view the code, comment on it and perhaps have better ideas!