### PR TITLE
add node v14 to CI matrix build

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: ['12']
+        node-version: ['12', '14']
       fail-fast: false
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
     steps:


### PR DESCRIPTION
Interested to see what this does to total CI run time.

Not necessarily convinced we need to include v14 in CI until it's under LTS (6 months away). Open to suggestions either way.