### PR TITLE
feature: add checkbox field

### DIFF
--- a/packages/web/src/form/README.md
+++ b/packages/web/src/form/README.md
@@ -13,6 +13,7 @@ Redwood currently provides the following form components:
 * `<TextAreaField>` is used in place of the HTML `<textarea>` tag and can accept validation options and be styled differently in the presence of an error
 * `<RadioField>` is used in place of the HTML `<input type="radio">` tag and can accept validation options.
  The default validation for `required` is `false` for this field, To make it required, please pass the prop `validation={{ required: true }}` for all the `<RadioField>`.
+*`<CheckBox>`is used in place of the HTML `<input type="checkbox">` tag. If it needs to be required to be checked before the form submission, please pass the prop `validation={{ required: true }}` in the `<CheckBox>` component.
 * `<FieldError>` will display error messages from form validation and server errors
 * `<Submit>` is used in place of `<button type="submit">` and will trigger a validation check and "submission" of the form (actually executes the function given to the `onSubmit` attribute on `<Form>`)
 

--- a/packages/web/src/form/form.js
+++ b/packages/web/src/form/form.js
@@ -226,6 +226,21 @@ const RadioField = (props) => {
   )
 }
 
+// Renders an <input type="checkbox"> field
+const CheckBox = (props) => {
+  const { register } = useFormContext()
+  const tagProps = inputTagProps(props)
+
+  return (
+    <input
+      {...tagProps}
+      type="checkbox"
+      id={props.id || props.name}
+      ref={register(props.validation || { required: false })}
+    />
+  )
+}
+
 // Renders a <select> field
 
 const SelectField = (props) => {
@@ -256,6 +271,7 @@ export {
   TextAreaField,
   TextField,
   RadioField,
+  CheckBox,
   SelectField,
   Submit,
 }


### PR DESCRIPTION
Close #463

This PR is the implementation of the `checkbox` field in the redwood framework.

The default required attribute is false for the `checkbox` field. If the user wants to have `checkbox` checked before the form submission, for that the user has to pass the prop `validation={{ required: true }}` for the particular `checkbox`.
