### PR TITLE
Humanize labels on scaffold forms

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "dotenv-defaults": "^1.1.1",
     "envinfo": "^7.5.1",
     "execa": "^4.0.0",
+    "humanize-string": "^2.1.0",
     "listr": "^0.14.3",
     "listr-verbose-renderer": "^0.6.0",
     "lodash": "^4.17.15",

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
@@ -36,7 +36,9 @@ const PostForm = (props) => {
           name="title"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          Title
+        </Label>
         <TextField
           name="title"
           defaultValue={props.post?.title}
@@ -50,7 +52,9 @@ const PostForm = (props) => {
           name="slug"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          Slug
+        </Label>
         <TextField
           name="slug"
           defaultValue={props.post?.slug}
@@ -64,7 +68,9 @@ const PostForm = (props) => {
           name="author"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          Author
+        </Label>
         <TextField
           name="author"
           defaultValue={props.post?.author}
@@ -78,7 +84,9 @@ const PostForm = (props) => {
           name="body"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          Body
+        </Label>
         <TextField
           name="body"
           defaultValue={props.post?.body}
@@ -92,7 +100,9 @@ const PostForm = (props) => {
           name="image"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          Image
+        </Label>
         <TextField
           name="image"
           defaultValue={props.post?.image}
@@ -106,7 +116,9 @@ const PostForm = (props) => {
           name="postedAt"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          Posted at
+        </Label>
         <TextField
           name="postedAt"
           defaultValue={props.post?.postedAt}

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -6,6 +6,7 @@ import camelcase from 'camelcase'
 import pascalcase from 'pascalcase'
 import pluralize from 'pluralize'
 import { paramCase } from 'param-case'
+import humanize from 'humanize-string'
 
 import {
   generateTemplate,
@@ -149,9 +150,14 @@ const componentFiles = async (name) => {
   const columns = model.fields.filter((field) => field.kind !== 'object')
   const intForeignKeys = intForeignKeysForModel(model)
   let fileList = {}
-  const editableColumns = columns.filter((column) => {
-    return NON_EDITABLE_COLUMNS.indexOf(column.name) === -1
-  })
+  const editableColumns = columns
+    .filter((column) => {
+      return NON_EDITABLE_COLUMNS.indexOf(column.name) === -1
+    })
+    .map((column) => ({
+      ...column,
+      label: humanize(column.name),
+    }))
 
   await asyncForEach(COMPONENTS, (component) => {
     const outputComponentName = component

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -36,7 +36,9 @@ const ${singularPascalName}Form = (props) => {
           name="<%= column.name %>"
           className={CSS.label}
           errorClassName={CSS.labelError}
-        />
+        >
+          <%= column.label %>
+        </Label>
         <TextField
           name="<%= column.name %>"
           defaultValue={props.${singularCamelName}?.<%= column.name %>}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5410,6 +5410,13 @@ decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decamelize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
+  integrity sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==
+  dependencies:
+    xregexp "4.0.0"
+
 decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
@@ -7723,6 +7730,13 @@ humanize-ms@^1.2.1:
   integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
   dependencies:
     ms "^2.0.0"
+
+humanize-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/humanize-string/-/humanize-string-2.1.0.tgz#a7d7062e5e514e04f072607ded0df853be8a1f2f"
+  integrity sha512-sQ+hqmxyXW8Cj7iqxcQxD7oSy3+AXnIZXdUF9lQMkzaG8dtbKAB8U7lCtViMnwQ+MpdCKsO2Kiij3G6UUXq/Xg==
+  dependencies:
+    decamelize "^2.0.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -13972,6 +13986,11 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xregexp@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
+  integrity sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
 
 xregexp@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
This is my first code contribution to Redwood, so hoping I did this right!

Right now, when you generate scaffolding, the input labels are exactly the names of the database columns. If I were making a Pitchfork clone, it might have this:
<img width="814" alt="Screen Shot 2020-05-02 at 4 28 10 PM" src="https://user-images.githubusercontent.com/5074763/80891693-aedcab80-8c93-11ea-8674-95921838d89e.png">

I really like how Rails converts those names to more readable labels. Now, using [humanize-string](https://github.com/sindresorhus/humanize-string):
<img width="787" alt="Screen Shot 2020-05-02 at 4 39 44 PM" src="https://user-images.githubusercontent.com/5074763/80891694-aedcab80-8c93-11ea-8d8b-9b973e3bb357.png">

This adds a dependency to the CLI package, but we already have a number of string-converting libraries in use for scaffolding, & it doesn't add any weight to the app dependencies or the forms themselves.