### PR TITLE
Use input type="email" on email fields in scaffolded forms

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -38,7 +38,8 @@ const ${singularPascalName}Form = (props) => {
           errorClassName={CSS.labelError}
         />
         <TextField
-          name="<%= column.name %>"
+          name="<%= column.name %>"${column.name === 'email' && `
+          type="email"`}
           defaultValue={props.${singularCamelName}?.<%= column.name %>}
           className={CSS.input}
           errorClassName={CSS.inputError}

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -38,8 +38,8 @@ const ${singularPascalName}Form = (props) => {
           errorClassName={CSS.labelError}
         />
         <TextField
-          name="<%= column.name %>"${column.name === 'email' && `
-          type="email"`}
+          name="<%= column.name %>"${column.name === 'email' ? `
+          type="email"` : ''}
           defaultValue={props.${singularCamelName}?.<%= column.name %>}
           className={CSS.input}
           errorClassName={CSS.inputError}


### PR DESCRIPTION
<img width="496" alt="Screen Shot 2020-05-02 at 5 45 26 PM" src="https://user-images.githubusercontent.com/5074763/80893029-cbc9ac80-8c9c-11ea-8419-f21b415e9a5f.png">

In an effort to improve the default scaffolded forms, especially for mobile users, when a field is called `email`, this PR automatically sets the input `type` to `email` as well.