### PR TITLE
Fix typo in internal README

### DIFF
--- a/packages/internal/README.md
+++ b/packages/internal/README.md
@@ -1,7 +1,6 @@
 # Our Internals
 
-This package is not intended to be used directly by user's of Redwood.
+This package is not intended to be used directly by users of [Redwood](https://redwoodjs.com).
 
 This package searches for and parses the `redwood.toml` configuration
-file. The `redwood.toml` file is used to designate the base
-directory of a Redwood app.
+file, which is used to designate the base directory of a Redwood app.


### PR DESCRIPTION
Fixing an apostrophe mostly, but also added a link to Redwood & simplified the wording of the last sentence. Not super attached to these other changes, mostly wanted to fix the typo.