### PR TITLE
Add README stubs to packages lacking one

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,27 @@
+# API
+
+<!-- toc -->
+- [Purpose/aspirational vision](#Purpose/aspirational-vision)
+- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
+- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
+- [Overview](#Overview)
+- [Contributing](#Contributing)
+- [FAQ](#FAQ)
+
+## Purpose/aspirational vision
+TODO
+
+## Package Lead (i.e. the decision maker or go-to for questions)
+TODO
+
+## Roadmap and/or near-term priorities
+TODO
+
+## Overview
+TODO
+
+## Contributing
+TODO
+
+## FAQ
+TODO

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,27 +1,28 @@
 # API
 
 <!-- toc -->
-- [Purpose/aspirational vision](#Purpose/aspirational-vision)
-- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
-- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
-- [Overview](#Overview)
+- [Purpose and Vision](#Purpose-and-Vision)
+- [Package Lead](#Package-Lead)
+- [Roadmap](#Roadmap)
 - [Contributing](#Contributing)
 - [FAQ](#FAQ)
 
-## Purpose/aspirational vision
-TODO
+## Purpose and Vision
+Summarise the project's values, purpose, and aspirational vision.
 
-## Package Lead (i.e. the decision maker or go-to for questions)
-TODO
+## Package Lead
+Identify the decision maker and/or go-to for questions.
 
-## Roadmap and/or near-term priorities
-TODO
-
-## Overview
-TODO
+## Roadmap
+Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
-TODO
+Explains how to contribute by addressing the following three points:
+
+1) Core technologies a contributor should be a familiar with.
+2) How this package fits into the Redwood Framework, if it depends on other Redwood packages, etc.
+3) The structure of the package and/or an explanation of its contents.
 
 ## FAQ
-TODO
+
+Answers to frequently asked questions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,27 +1,28 @@
 # Core
 
 <!-- toc -->
-- [Purpose/aspirational vision](#Purpose/aspirational-vision)
-- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
-- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
-- [Overview](#Overview)
+- [Purpose and Vision](#Purpose-and-Vision)
+- [Package Lead](#Package-Lead)
+- [Roadmap](#Roadmap)
 - [Contributing](#Contributing)
 - [FAQ](#FAQ)
 
-## Purpose/aspirational vision
-TODO
+## Purpose and Vision
+Summarise the project's values, purpose, and aspirational vision.
 
-## Package Lead (i.e. the decision maker or go-to for questions)
-TODO
+## Package Lead
+Identify the decision maker and/or go-to for questions.
 
-## Roadmap and/or near-term priorities
-TODO
-
-## Overview
-TODO
+## Roadmap
+Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
-TODO
+Explains how to contribute by addressing the following three points:
+
+1) Core technologies a contributor should be a familiar with.
+2) How this package fits into the Redwood Framework, if it depends on other Redwood packages, etc.
+3) The structure of the package and/or an explanation of its contents.
 
 ## FAQ
-TODO
+
+Answers to frequently asked questions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,27 @@
+# Core
+
+<!-- toc -->
+- [Purpose/aspirational vision](#Purpose/aspirational-vision)
+- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
+- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
+- [Overview](#Overview)
+- [Contributing](#Contributing)
+- [FAQ](#FAQ)
+
+## Purpose/aspirational vision
+TODO
+
+## Package Lead (i.e. the decision maker or go-to for questions)
+TODO
+
+## Roadmap and/or near-term priorities
+TODO
+
+## Overview
+TODO
+
+## Contributing
+TODO
+
+## FAQ
+TODO

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -1,0 +1,27 @@
+# create-redwood-app
+
+<!-- toc -->
+- [Purpose/aspirational vision](#Purpose/aspirational-vision)
+- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
+- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
+- [Overview](#Overview)
+- [Contributing](#Contributing)
+- [FAQ](#FAQ)
+
+## Purpose/aspirational vision
+TODO
+
+## Package Lead (i.e. the decision maker or go-to for questions)
+TODO
+
+## Roadmap and/or near-term priorities
+TODO
+
+## Overview
+TODO
+
+## Contributing
+TODO
+
+## FAQ
+TODO

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -1,27 +1,28 @@
 # create-redwood-app
 
 <!-- toc -->
-- [Purpose/aspirational vision](#Purpose/aspirational-vision)
-- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
-- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
-- [Overview](#Overview)
+- [Purpose and Vision](#Purpose-and-Vision)
+- [Package Lead](#Package-Lead)
+- [Roadmap](#Roadmap)
 - [Contributing](#Contributing)
 - [FAQ](#FAQ)
 
-## Purpose/aspirational vision
-TODO
+## Purpose and Vision
+Summarise the project's values, purpose, and aspirational vision.
 
-## Package Lead (i.e. the decision maker or go-to for questions)
-TODO
+## Package Lead
+Identify the decision maker and/or go-to for questions.
 
-## Roadmap and/or near-term priorities
-TODO
-
-## Overview
-TODO
+## Roadmap
+Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
-TODO
+Explains how to contribute by addressing the following three points:
+
+1) Core technologies a contributor should be a familiar with.
+2) How this package fits into the Redwood Framework, if it depends on other Redwood packages, etc.
+3) The structure of the package and/or an explanation of its contents.
 
 ## FAQ
-TODO
+
+Answers to frequently asked questions.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,0 +1,27 @@
+# ESLint Config
+
+<!-- toc -->
+- [Purpose/aspirational vision](#Purpose/aspirational-vision)
+- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
+- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
+- [Overview](#Overview)
+- [Contributing](#Contributing)
+- [FAQ](#FAQ)
+
+## Purpose/aspirational vision
+TODO
+
+## Package Lead (i.e. the decision maker or go-to for questions)
+TODO
+
+## Roadmap and/or near-term priorities
+TODO
+
+## Overview
+TODO
+
+## Contributing
+TODO
+
+## FAQ
+TODO

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,27 +1,28 @@
 # ESLint Config
 
 <!-- toc -->
-- [Purpose/aspirational vision](#Purpose/aspirational-vision)
-- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
-- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
-- [Overview](#Overview)
+- [Purpose and Vision](#Purpose-and-Vision)
+- [Package Lead](#Package-Lead)
+- [Roadmap](#Roadmap)
 - [Contributing](#Contributing)
 - [FAQ](#FAQ)
 
-## Purpose/aspirational vision
-TODO
+## Purpose and Vision
+Summarise the project's values, purpose, and aspirational vision.
 
-## Package Lead (i.e. the decision maker or go-to for questions)
-TODO
+## Package Lead
+Identify the decision maker and/or go-to for questions.
 
-## Roadmap and/or near-term priorities
-TODO
-
-## Overview
-TODO
+## Roadmap
+Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
-TODO
+Explains how to contribute by addressing the following three points:
+
+1) Core technologies a contributor should be a familiar with.
+2) How this package fits into the Redwood Framework, if it depends on other Redwood packages, etc.
+3) The structure of the package and/or an explanation of its contents.
 
 ## FAQ
-TODO
+
+Answers to frequently asked questions.

--- a/packages/eslint-plugin-redwood/README.md
+++ b/packages/eslint-plugin-redwood/README.md
@@ -1,27 +1,28 @@
 # ESLint Plugin
 
 <!-- toc -->
-- [Purpose/aspirational vision](#Purpose/aspirational-vision)
-- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
-- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
-- [Overview](#Overview)
+- [Purpose and Vision](#Purpose-and-Vision)
+- [Package Lead](#Package-Lead)
+- [Roadmap](#Roadmap)
 - [Contributing](#Contributing)
 - [FAQ](#FAQ)
 
-## Purpose/aspirational vision
-TODO
+## Purpose and Vision
+Summarise the project's values, purpose, and aspirational vision.
 
-## Package Lead (i.e. the decision maker or go-to for questions)
-TODO
+## Package Lead
+Identify the decision maker and/or go-to for questions.
 
-## Roadmap and/or near-term priorities
-TODO
-
-## Overview
-TODO
+## Roadmap
+Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
-TODO
+Explains how to contribute by addressing the following three points:
+
+1) Core technologies a contributor should be a familiar with.
+2) How this package fits into the Redwood Framework, if it depends on other Redwood packages, etc.
+3) The structure of the package and/or an explanation of its contents.
 
 ## FAQ
-TODO
+
+Answers to frequently asked questions.

--- a/packages/eslint-plugin-redwood/README.md
+++ b/packages/eslint-plugin-redwood/README.md
@@ -1,0 +1,27 @@
+# ESLint Plugin
+
+<!-- toc -->
+- [Purpose/aspirational vision](#Purpose/aspirational-vision)
+- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
+- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
+- [Overview](#Overview)
+- [Contributing](#Contributing)
+- [FAQ](#FAQ)
+
+## Purpose/aspirational vision
+TODO
+
+## Package Lead (i.e. the decision maker or go-to for questions)
+TODO
+
+## Roadmap and/or near-term priorities
+TODO
+
+## Overview
+TODO
+
+## Contributing
+TODO
+
+## FAQ
+TODO

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,27 +1,28 @@
 # Web
 
 <!-- toc -->
-- [Purpose/aspirational vision](#Purpose/aspirational-vision)
-- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
-- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
-- [Overview](#Overview)
+- [Purpose and Vision](#Purpose-and-Vision)
+- [Package Lead](#Package-Lead)
+- [Roadmap](#Roadmap)
 - [Contributing](#Contributing)
 - [FAQ](#FAQ)
 
-## Purpose/aspirational vision
-TODO
+## Purpose and Vision
+Summarise the project's values, purpose, and aspirational vision.
 
-## Package Lead (i.e. the decision maker or go-to for questions)
-TODO
+## Package Lead
+Identify the decision maker and/or go-to for questions.
 
-## Roadmap and/or near-term priorities
-TODO
-
-## Overview
-TODO
+## Roadmap
+Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
-TODO
+Explains how to contribute by addressing the following three points:
+
+1) Core technologies a contributor should be a familiar with.
+2) How this package fits into the Redwood Framework, if it depends on other Redwood packages, etc.
+3) The structure of the package and/or an explanation of its contents.
 
 ## FAQ
-TODO
+
+Answers to frequently asked questions.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,27 @@
+# Web
+
+<!-- toc -->
+- [Purpose/aspirational vision](#Purpose/aspirational-vision)
+- [Package Lead (i.e. the decision maker or go-to for questions)](#Package-Lead-(i.e.-the-decision-maker-or-go-to-for-questions))
+- [Roadmap and/or near-term priorities](#Roadmap-and/or-near-term-priorities)
+- [Overview](#Overview)
+- [Contributing](#Contributing)
+- [FAQ](#FAQ)
+
+## Purpose/aspirational vision
+TODO
+
+## Package Lead (i.e. the decision maker or go-to for questions)
+TODO
+
+## Roadmap and/or near-term priorities
+TODO
+
+## Overview
+TODO
+
+## Contributing
+TODO
+
+## FAQ
+TODO


### PR DESCRIPTION
Some of the Redwood packages lack a README. This PR adds stubs that serve as 1) placeholders and 2) outlines of what's to come. The stubs comprise the following table of contents:

* Purpose
* Package lead
* Roadmap
* Overview
* Contributing
* FAQ
  
I got the list from @thedavidprice and added a few (Overview, FAQ) myself. This early on, FAQ might be unnecessary (if not impossible).

Not all the sections have to be a section ("Package lead" could be a sentence), but all of them should probably be addressed. Definitely note that this structure is extremely general and will/probably should change between packages.

Definitely welcome feedback on this structure. And answers! (Who is the package lead?)