### PR TITLE
Add console log on rebuild complete

### DIFF
--- a/packages/dev-server/src/main.ts
+++ b/packages/dev-server/src/main.ts
@@ -185,8 +185,12 @@ app.all('/:routeName', async (req, res) => {
 
 const reloadLambdas = () => {
   console.log('Change detected, rebuilding...')
+  const start = new Date().getTime();
   purgeRequireCache()
   lambdaFunctions = requireLambdaFunctions(PATH)
+  const end = new Date().getTime();
+  const timeTakenInRebuild = end - start
+  console.log(`Done in ${timeTakenInRebuild}ms.`)
 }
 
 const startServer = () => app.listen(PORT, () => showHeader(lambdaFunctions))


### PR DESCRIPTION
while following along the redwood tutorial on youtube, I found that we are not logging something after the rebuild. I kept looking on the screen.xD. Then I just tried the request. and it worked.
A console log on rebuild complete might be helpful for people when they are looking in the terminal for the build processes.
Let me know if something is off or it needs further improvement. thanks!!

attaching screenshots for better understanding. 

**before the console log it looks like this. 
<img width="1680" alt="Screenshot 2020-05-03 at 4 29 00 PM" src="https://user-images.githubusercontent.com/50338945/80912944-4c9cad00-8d5e-11ea-8dcb-0fbb847b8e80.png">

** after putting the console log it looks like this. 
<img width="1680" alt="Screenshot 2020-05-03 at 4 39 43 PM" src="https://user-images.githubusercontent.com/50338945/80912953-60481380-8d5e-11ea-8fe5-f9d1daa39210.png">
