### PR TITLE
Switch out "Hammer" data source

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/schema.prisma
@@ -1,4 +1,4 @@
-datasource hammerDatasource {
+datasource DS {
   provider = "sqlite"
   url = env("DB_HOST")
 }

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
@@ -1,4 +1,4 @@
-datasource hammerDatasource {
+datasource DS {
   provider = "mysql"
   url = env("DB_HOST")
 }

--- a/packages/cli/src/lib/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/lib/__tests__/fixtures/schema.prisma
@@ -1,4 +1,4 @@
-datasource hammerDatasource {
+datasource DS {
   provider = "sqlite"
   url = env("DB_HOST")
 }


### PR DESCRIPTION
Just noticed these were still in some of the fixture schemas.