### PR TITLE
[Core] Convert custom webpack cell-loader into Babel Plugin

### DIFF
--- a/packages/core/config/__tests__/__fixtures__/commented/code.js
+++ b/packages/core/config/__tests__/__fixtures__/commented/code.js
@@ -1,0 +1,28 @@
+export const QUERY = gql`
+  query {
+    posts {
+      id
+      title
+      body
+    }
+  }
+`
+
+// export const beforeQuery = () => ({})
+export const afterQuery = () => ({})
+
+export function Loading() {
+  return 'Loading'
+}
+
+// export function Empty() {
+//   return 'Empty'
+// }
+
+export function Failure({ error }) {
+  return error.message
+}
+
+export const Success = ({ posts }) => {
+  return JSON.stringify(posts, null, 2)
+}

--- a/packages/core/config/__tests__/__fixtures__/commented/output.js
+++ b/packages/core/config/__tests__/__fixtures__/commented/output.js
@@ -1,0 +1,31 @@
+import { withCell } from '@redwoodjs/web'
+export const QUERY = gql`
+  query {
+    posts {
+      id
+      title
+      body
+    }
+  }
+` // export const beforeQuery = () => ({})
+
+export const afterQuery = () => ({})
+export function Loading() {
+  return 'Loading'
+} // export function Empty() {
+//   return 'Empty'
+// }
+
+export function Failure({ error }) {
+  return error.message
+}
+export const Success = ({ posts }) => {
+  return JSON.stringify(posts, null, 2)
+}
+export default withCell({
+  QUERY,
+  afterQuery,
+  Loading,
+  Failure,
+  Success,
+})

--- a/packages/core/config/__tests__/__fixtures__/complete-cell/code.js
+++ b/packages/core/config/__tests__/__fixtures__/complete-cell/code.js
@@ -1,0 +1,28 @@
+export const QUERY = gql`
+  query {
+    posts {
+      id
+      title
+      body
+    }
+  }
+`
+
+export const beforeQuery = () => ({})
+export const afterQuery = () => ({})
+
+export function Loading() {
+  return 'Loading'
+}
+
+export function Empty() {
+  return 'Empty'
+}
+
+export function Failure({ error }) {
+  return error.message
+}
+
+export const Success = ({ posts }) => {
+  return JSON.stringify(posts, null, 2)
+}

--- a/packages/core/config/__tests__/__fixtures__/complete-cell/output.js
+++ b/packages/core/config/__tests__/__fixtures__/complete-cell/output.js
@@ -1,0 +1,33 @@
+import { withCell } from '@redwoodjs/web'
+export const QUERY = gql`
+  query {
+    posts {
+      id
+      title
+      body
+    }
+  }
+`
+export const beforeQuery = () => ({})
+export const afterQuery = () => ({})
+export function Loading() {
+  return 'Loading'
+}
+export function Empty() {
+  return 'Empty'
+}
+export function Failure({ error }) {
+  return error.message
+}
+export const Success = ({ posts }) => {
+  return JSON.stringify(posts, null, 2)
+}
+export default withCell({
+  QUERY,
+  beforeQuery,
+  afterQuery,
+  Loading,
+  Empty,
+  Failure,
+  Success,
+})

--- a/packages/core/config/__tests__/babel-plugin-redwood-cell.test.js
+++ b/packages/core/config/__tests__/babel-plugin-redwood-cell.test.js
@@ -1,0 +1,11 @@
+import path from 'path'
+
+import pluginTester from 'babel-plugin-tester'
+
+import redwoodCellPlugin from '../babel-plugin-redwood-cell'
+
+pluginTester({
+  plugin: redwoodCellPlugin,
+  pluginName: 'Redwood Cell',
+  fixtures: path.join(__dirname, '__fixtures__'),
+})

--- a/packages/core/config/babel-plugin-redwood-cell.js
+++ b/packages/core/config/babel-plugin-redwood-cell.js
@@ -1,0 +1,70 @@
+module.exports = function ({ types: t }) {
+  const names = [
+    'QUERY',
+    'Loading',
+    'Success',
+    'Failure',
+    'Empty',
+    'beforeQuery',
+    'afterQuery',
+  ]
+
+  let exportNames = []
+
+  return {
+    visitor: {
+      Program: {
+        exit(path) {
+          // import { withCell } from '@redwoodjs/web'
+          path.node.body.unshift(
+            t.importDeclaration(
+              [
+                t.importSpecifier(
+                  t.identifier('withCell'),
+                  t.identifier('withCell')
+                ),
+              ],
+              t.stringLiteral('@redwoodjs/web')
+            )
+          )
+
+          // export default withCell({ QUERY?, Loading?, Succes?, Failure?, Empty?, beforeQuery?, afterQuery? })
+          path.node.body.push(
+            t.exportDefaultDeclaration(
+              t.callExpression(t.identifier('withCell'), [
+                t.objectExpression(
+                  exportNames.map((name) =>
+                    t.objectProperty(
+                      t.identifier(name),
+                      t.identifier(name),
+                      false,
+                      true
+                    )
+                  )
+                ),
+              ])
+            )
+          )
+
+          exportNames = []
+        },
+      },
+      ExportNamedDeclaration(path) {
+        const { declaration } = path.node
+
+        let name
+        if (declaration.type === 'VariableDeclaration') {
+          name = declaration.declarations[0].id.name
+        }
+
+        if (declaration.type === 'FunctionDeclaration') {
+          name = declaration.id.name
+        }
+
+        if (names.includes(name)) {
+          exportNames.push(name)
+        }
+      },
+    },
+  }
+}

--- a/packages/core/config/babel-plugin-redwood-cell.js
+++ b/packages/core/config/babel-plugin-redwood-cell.js
@@ -1,5 +1,13 @@
+// This is supposed to wrap a file that's has a suffix of `Cell` in Redwood's `withCell` higher order component.
+// The HOC is responsible for the lifecycle methods during a graphQL query.
+// The end result of this plugin is something like:
+// ```js
+// import { withCell } from '@redwoodjs/web'
+// export default withCell({ QUERY, Loading, Succes, Failure, Empty, beforeQuery, afterQuery })
+// ```
 module.exports = function ({ types: t }) {
-  const names = [
+  // These are the expected named exports from a Cell file.
+  const EXPORTS_FROM_CELL = [
     'QUERY',
     'Loading',
     'Success',
@@ -61,7 +69,7 @@ module.exports = function ({ types: t }) {
           name = declaration.id.name
         }
 
-        if (names.includes(name)) {
+        if (EXPORTS_FROM_CELL.includes(name)) {
           exportNames.push(name)
         }
       },

--- a/packages/core/config/babel-plugin-redwood-cell.js
+++ b/packages/core/config/babel-plugin-redwood-cell.js
@@ -3,11 +3,12 @@
 // The end result of this plugin is something like:
 // ```js
 // import { withCell } from '@redwoodjs/web'
+// 
 // export default withCell({ QUERY, Loading, Succes, Failure, Empty, beforeQuery, afterQuery })
 // ```
 module.exports = function ({ types: t }) {
   // These are the expected named exports from a Cell file.
-  const EXPORTS_FROM_CELL = [
+  const EXPECTED_EXPORTS_FROM_CELL = [
     'QUERY',
     'Loading',
     'Success',
@@ -17,10 +18,30 @@ module.exports = function ({ types: t }) {
     'afterQuery',
   ]
 
+  // This array will
+  // - collect exports from the Cell file during ExportNamedDeclaration
+  // - collected exports will then be passed to `withCell`
+  // - be cleared after Program exit to prepare for the next file
   let exportNames = []
 
   return {
     visitor: {
+      ExportNamedDeclaration(path) {
+        const { declaration } = path.node
+
+        let name
+        if (declaration.type === 'VariableDeclaration') {
+          name = declaration.declarations[0].id.name
+        }
+
+        if (declaration.type === 'FunctionDeclaration') {
+          name = declaration.id.name
+        }
+
+        if (EXPECTED_EXPORTS_FROM_CELL.includes(name)) {
+          exportNames.push(name)
+        }
+      },
       Program: {
         exit(path) {
           // import { withCell } from '@redwoodjs/web'
@@ -56,22 +77,6 @@ module.exports = function ({ types: t }) {
 
           exportNames = []
         },
-      },
-      ExportNamedDeclaration(path) {
-        const { declaration } = path.node
-
-        let name
-        if (declaration.type === 'VariableDeclaration') {
-          name = declaration.declarations[0].id.name
-        }
-
-        if (declaration.type === 'FunctionDeclaration') {
-          name = declaration.id.name
-        }
-
-        if (EXPORTS_FROM_CELL.includes(name)) {
-          exportNames.push(name)
-        }
       },
     },
   }

--- a/packages/core/config/babel-plugin-redwood-cell.js
+++ b/packages/core/config/babel-plugin-redwood-cell.js
@@ -3,7 +3,6 @@
 // The end result of this plugin is something like:
 // ```js
 // import { withCell } from '@redwoodjs/web'
-// 
 // export default withCell({ QUERY, Loading, Succes, Failure, Empty, beforeQuery, afterQuery })
 // ```
 module.exports = function ({ types: t }) {

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -128,5 +128,9 @@ module.exports = () => ({
         ],
       ],
     },
+    {
+      test: /.+Cell.(js|tsx)$/,
+      plugins: [require('./babel-plugin-redwood-cell')],
+    },
   ],
 })

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -168,15 +168,6 @@ module.exports = (webpackEnv) => {
             ),
           },
         },
-        {
-          // "Create" an `index.js` file adjacent to a user's Cell.js|tsx file
-          // so that the Cell exports are run through the `withCell` HOC
-          test: /.+Cell.(js|tsx)$/,
-          include: path.join(redwoodPaths.base, 'web/src/components'),
-          use: {
-            loader: path.resolve(__dirname, '../dist/loaders/cell-loader.js'),
-          },
-        },
       ],
     },
     optimization: {

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/*.test.[jt]s?(x)'],
+  testPathIgnorePatterns: ['fixtures', '__fixtures__'],
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,6 @@
     "babel-plugin-auto-import": "^1.0.5",
     "babel-plugin-graphql-tag": "^2.5.0",
     "babel-plugin-module-resolver": "^4.0.0",
-    "babel-plugin-tester": "^9.0.1",
     "copy-webpack-plugin": "^5.1.1",
     "core-js": "3.6.4",
     "css-loader": "^3.4.2",
@@ -65,5 +64,8 @@
     "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'",
     "test": "jest",
     "test:watch": "yarn test --watch"
+  },
+  "devDependencies": {
+    "babel-plugin-tester": "^9.0.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-auto-import": "^1.0.5",
     "babel-plugin-graphql-tag": "^2.5.0",
     "babel-plugin-module-resolver": "^4.0.0",
+    "babel-plugin-tester": "^9.0.1",
     "copy-webpack-plugin": "^5.1.1",
     "core-js": "3.6.4",
     "css-loader": "^3.4.2",
@@ -61,6 +62,8 @@
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src --out-dir dist  --extensions \".ts\" --delete-dir-on-start",
     "prepublishOnly": "yarn build",
-    "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'"
+    "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'",
+    "test": "jest",
+    "test:watch": "yarn test --watch"
   }
 }


### PR DESCRIPTION
This implements #503 and opens up the possibility for using Cells in Jest!

I've never written a Babel Plugin or done anything with AST's before, so I just wanted to get this out here to gather some feedback before looking into writing tests for it, and also to discuss on where to locate the plugin file!

This also fixes some issues with Cells where they break if you comment out some const exports and supports using function declarations instead of variable function declarations!

