### PR TITLE
Fix NamesCell reload after deleting item

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
@@ -32,7 +32,7 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
 
   const onDeleteClick = (id) => {
     if (confirm('Are you sure you want to delete ${singularCamelName} ' + id + '?')) {
-      delete${singularPascalName}({ variables: { id }, refetchQueries: ['POSTS'] })
+      delete${singularPascalName}({ variables: { id }, refetchQueries: ['${pluralConstantName}'] })
     }
   }
 


### PR DESCRIPTION
Use pluralCamelName in place of hardcoded string when performing refetchQuery in delete handler

Fixes #518 