### PR TITLE
Upgrade to Prisma-2.0.0-beta.4

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/main.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.0.0-beta.3",
+    "@prisma/client": "2.0.0-beta.4",
     "@redwoodjs/internal": "^0.6.0",
     "apollo-server-lambda": "2.11.0",
     "babel-plugin-macros": "^2.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "^2.0.0-beta.3",
+    "@prisma/sdk": "^2.0.0-beta.4",
     "@redwoodjs/internal": "^0.6.0",
     "camelcase": "^5.3.1",
     "chalk": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime-corejs3": "^7.9.2",
-    "@prisma/cli": "2.0.0-beta.3",
+    "@prisma/cli": "2.0.0-beta.4",
     "@redwoodjs/cli": "^0.6.0",
     "@redwoodjs/dev-server": "^0.6.0",
     "@redwoodjs/eslint-config": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,15 +2154,15 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@prisma/cli@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.3.tgz#54ac441bd538aade10acb07912b6751698c766df"
-  integrity sha512-VZxeTLLMenhkAyaY4tvTqChcW6QtUkiVvZj7N6A2vi6HsM1Tnf0fIZsiH1h3e/LEnaaDGIUC8F4Gkh2SeyeyCg==
+"@prisma/cli@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.4.tgz#4989dab626ba5de0591af1a14f423db4838a5e8c"
+  integrity sha512-z9si4cmn/dN7bxVx3hbdDFL6fQuosTzj45EhVrCYt6VCWcJ5jYn0Fzamr+npZvbR/Gl6eLhexXP1sa7iGe8gjA==
 
-"@prisma/client@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.3.tgz#a1b2cce4744973481d2891fcb919ab099f118952"
-  integrity sha512-itwRDl9PS8pD9InbHFeh1m3kyMibpZbkMHx9/Q7lNVaxvBJeJjNlVFmclL9AIFMDAUhD+KtspqkBwUHKgJpd7g==
+"@prisma/client@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.4.tgz#fd94c3780108d9886c31526e85eba42369050f0c"
+  integrity sha512-LEtHIQVJrM7Y8H0G288sKxvsFv1od7tG8SiaWQvzv51AZo7IsK+n+wJ8A1/tJ6eL/7UQWHZQjZN7JLgpxetFvw==
 
 "@prisma/engine-core@2.0.0-beta.4":
   version "2.0.0-beta.4"
@@ -2218,7 +2218,7 @@
   dependencies:
     debug "^4.1.1"
 
-"@prisma/sdk@^2.0.0-beta.3":
+"@prisma/sdk@^2.0.0-beta.4":
   version "2.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.4.tgz#41414edaa8f04bf18122063b93377838553354f8"
   integrity sha512-zE1Rkjm923NopMFcWVuxCYRU8B7UUepIluD5oKc5626WxUeidFmvxnsp5YUSnqikivpu1hd22tM/jGKqOSO//A==


### PR DESCRIPTION
Prisma release notes: https://github.com/prisma/prisma/releases/tag/2.0.0-beta.4
- **Support for JSON types** unknown if JSON will work with RW, but experiment in progress here https://community.redwoodjs.com/t/jsonb-support-from-prisma-2-0-0-beta4/508/5
- **Support for Yarn workspaces** I'm not sure this applies to RW's setup. In any event, a simple test running `yarn prisma generate` from root failed. This likely has more to do with installation than CLI.
- **Prisma Studio** tests running `yarn prisma studio --experimental` failed. It does not seem studio supports the use of `env(...)` in the schema. Nor supports workspaces (running from api/ couldn't find client in root 'node_modules/.prisma/'

Passing manual tests locally:

 - [x] yarn rw db save
 - [x] yarn rw db up
 - [x] yarn rw dev
 - [x] DB migration file compatibility from beta.3 to beta.4
 - [x] CRUD query/mutations for tutorial blog posts
⚠️ I have not yet tested deploy. To do before a new release.