### PR TITLE
Adds --canary option to CLI upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -14,22 +14,45 @@ export const builder = (yargs) => {
       default: false,
       description: 'Check for outdated packages without upgrading',
     })
+    .option('canary', {
+      type: 'boolean',
+      default: false,
+      description:
+        'WARNING: Force upgrades packages to most recent, unstable release from master branch',
+    })
     .strict()
 }
 
 const rwPackages =
   '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router'
 
+// yarn upgrade-interactive does not allow tags, so we resort to this mess
+const installCanaryCommand =
+  'yarn workspace api upgrade @redwoodjs/api@canary' +
+  '&& yarn workspace web upgrade @redwoodjs/web@canary @redwoodjs/router@canary' +
+  '&& yarn upgrade @redwoodjs/core@canary'
+
 // yargs allows passing the 'dry-run' alias 'd' here,
 // which we need to use because babel fails on 'dry-run'
-export const handler = async ({ d }) => {
+export const handler = async ({ d, canary }) => {
   const tasks = new Listr([
     {
       title: "Running 'redwood upgrade'",
       task: (_ctx, task) => {
         if (d) {
-          task.title = 'Checking available upgrades for @redwoodjs packages'
-          execa.command(`yarn outdated ${rwPackages}`, {
+          task.title = canary
+            ? 'The --dry-run option is not supported for --canary'
+            : 'Checking available upgrades for @redwoodjs packages'
+          if (!canary) {
+            execa.command(`yarn outdated ${rwPackages}`, {
+              stdio: 'inherit',
+              shell: true,
+            })
+          }
+        } else if (canary) {
+          task.title =
+            'Force upgrading @redwoodjs packages to latest canary release'
+          execa.command(installCanaryCommand, {
             stdio: 'inherit',
             shell: true,
           })


### PR DESCRIPTION
Adds `--canary` option to `yarn rw upgrade`. 

Yarn itself offers poor support targeting any tag besides 'latest' for our use case of workspaces and `yarn upgrade-interactive`. As a result, we are limited to using `yarn upgrade [package@canary]`, which will effectively force upgrade to the most recent 'canary' release. Unfortunately, `yarn outdated`, which checks to see if more recent release is available, is not supported for tags -- this means the `--dry-run` option does not work here either.

Given all this, I'm approaching this as a "Warning, please understand what you are doing before you hit enter" use-case.
- added WARNING in the option description with appropriate language about unstable versions
- did not provide an alias, thus require full use of `--canary`