### PR TITLE
Add IP address to the Lambda event's requestContext in dev server

### DIFF
--- a/packages/dev-server/src/main.ts
+++ b/packages/dev-server/src/main.ts
@@ -100,6 +100,11 @@ const lambdaEventForExpressRequest = (
     headers: request.headers,
     path: request.path,
     queryStringParameters: qs.parse(request.url.split(/\?(.+)/)[1]),
+    requestContext: {
+      identity: {
+        sourceIp: request.ip,
+      },
+    },
     ...parseBody(request.body), // adds `body` and `isBase64Encoded`
   } as APIGatewayProxyEvent
 }


### PR DESCRIPTION
This allows accessing the IP address of the client when using the dev-server.