### PR TITLE
Add @redwoodjs/auth package to CLI upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -29,10 +29,9 @@ const rwPackages =
 // yarn upgrade-interactive does not allow --tags, so we resort to this mess
 // @redwoodjs/auth may not be installed so we don't include here
 let installCanaryCommand =
-  // 'yarn upgrade @redwoodjs/core@canary' +
-  // ' && yarn workspace api upgrade @redwoodjs/api@canary' +
-  // ' && yarn workspace web upgrade @redwoodjs/web@canary @redwoodjs/router@canary'
-  'yarn workspace web upgrade @redwoodjs/web@canary'
+  'yarn upgrade @redwoodjs/core@canary' +
+  ' && yarn workspace api upgrade @redwoodjs/api@canary' +
+  ' && yarn workspace web upgrade @redwoodjs/web@canary @redwoodjs/router@canary'
 
 // yargs allows passing the 'dry-run' alias 'd' here,
 // which we need to use because babel fails on 'dry-run'
@@ -40,14 +39,13 @@ export const handler = async ({ d, canary }) => {
   const tasks = new Listr([
     {
       // yarn upgrade will install listed packages even if not already installed
-      // this is a hack to check for install and then add to options if true
+      // this is a hack to check for Auth install and then add to options if true
       title: 'Checking installed packages...',
       task: async (_ctx, task) => {
         try {
           const { stdout } = await execa.command(
             'yarn list --depth 0 --pattern @redwoodjs/auth'
           )
-          console.log('===this is stdout===\n', stdout)
           if (stdout.includes('redwoodjs/auth')) {
             installCanaryCommand += ' @redwoodjs/auth@canary'
             task.title = 'Checking installed packages... found @redwoodjs/auth'
@@ -67,7 +65,7 @@ export const handler = async ({ d, canary }) => {
           task.title = canary
             ? 'The --dry-run option is not supported for --canary'
             : 'Checking available upgrades for @redwoodjs packages'
-          // 'yarn outdated --scope @redwoodjs' will include netlify plugin ¯\_(ツ)_/¯
+          // 'yarn outdated --scope @redwoodjs' will include netlify plugin
           // so we have to use hardcoded list,
           // which will NOT display info for uninstalled packages
           if (!canary) {
@@ -76,7 +74,7 @@ export const handler = async ({ d, canary }) => {
               shell: true,
             })
           }
-          // using @tag with workspaces limits us to 'upgrade' with full list
+          // using @tag with workspaces limits us to use 'upgrade' with full list
         } else if (canary) {
           task.title =
             'Force upgrading @redwoodjs packages to latest canary release'


### PR DESCRIPTION
closes #546

@peterp Due to inconsistent ways Yarn itself handles 1) workspaces and 2) tags (e.g. @canary), this one got a bit messy. It _is_ working now:
- for each option, upgrade and @canary upgrade, it checks to see if Auth package is installed to determine if it should be included. `yarn upgrade-interactive ...` will do this by default. For `yarn upgrade ...@canary`, things were a bit messier. (Note: upgrade-interactive does not support tags)
- refuses to --dry-run with --canary options; canary effectively force updates to most recent canary, and the `yarn outdated ...` doesn’t know how to handle tags

The only annoying thing left to fixe is **Listr duplicating the titles** when I try to dynamically change them. This was working fine until I added the logic in the first step, 'Checking installed packages...'. **Any thoughts about how to make the first two duplicates correctly go away?** This used to happen on `create-redwood-app.js` and somehow you fixed it:
<img width="509" alt="Screen Shot 2020-05-17 at 10 00 49 PM" src="https://user-images.githubusercontent.com/2951/82177092-6de8b780-988d-11ea-9839-b1db407137c0.png">
