### PR TITLE
Rename pathSlashModel to model and remove path flag

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -313,28 +313,25 @@ const addScaffoldImport = () => {
   return 'Added scaffold import to index.js'
 }
 
-export const command = 'scaffold <pathSlashModel>'
-export const desc = 'Generate pages, SDL, and a services object.'
-export const builder = {
-  force: { type: 'boolean', default: false },
-  // So the user can specify a path to nest the generated files under.
-  // E.g. yarn rw g scaffold post --path=admin
-  path: { type: 'string', default: false },
+export const command = 'scaffold <model>'
+export const desc =
+  'Generate Pages, SDL, and Services files based on a given DB schema Model. Also accepts <path/model>.'
+export const builder = (yargs) => {
+  yargs.positional('model', {
+    description:
+      "Model to scaffold. You can also use <path/model> to nest files by type at the given path directory (or directories). For example, 'rw g scaffold admin/post'.",
+  })
+  yargs.option('force', {
+    default: false,
+    type: 'boolean',
+  })
 }
-// The user can also specify a path in the argument.
-// E.g. yarn rw g scaffold admin/post
-export const handler = async ({ pathSlashModel, force, path: pathFlag }) => {
-  let path
-  // If path is specified by both pathSlashModel and pathFlag,
-  // we give pathFlag precedence.
-  pathFlag
-    ? (path = pathFlag)
-    : (path = pathSlashModel.split('/').slice(0, -1).join('/'))
-
-  // This code will work whether or not there's a path in pathSlashModel
-  // E.g. if pathSlashModel is just 'post',
+export const handler = async ({ model: modelArg, force }) => {
+  let path = modelArg.split('/').slice(0, -1).join('/')
+  // This code will work whether or not there's a path in model
+  // E.g. if model is just 'post',
   // path.split('/') will return ['post'].
-  const model = pathSlashModel.split('/').pop()
+  const model = modelArg.split('/').pop()
 
   const tasks = new Listr(
     [


### PR DESCRIPTION
This PR resolves a sub-discussion of #487, and is a continuation of #423. @thedavidprice @cannikin @antonmoiseev

The functionality introduced in #423 remains unchanged--you can still specify a path in the model, but we're no longer calling it `pathSlashModel`. Just `model` now, and the functionality will be revealed in a help message:

<details><summary>Output for <code>yarn rw g scaffold --help</code></summary>

```
~/redwood-app$ yarn rw g scaffold --help
yarn run v1.22.4
$ /redwood-app/node_modules/.bin/rw g scaffold --help
rw g scaffold <model>

Generate Pages, SDL, and Services files based on a given DB schema Model.

Positionals:
  model  Model to scaffold. Optionally may use "path/model" to nest files by
         type at the given path directory (or directories)            [required]

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --force                                             [boolean] [default: false]
```
</details>

We're also taking out the path flag here, so now there's only one way to do it. 