### PR TITLE
CLI upgrade command: add option --tag with choices 'canary' or 'rc'

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -11,14 +11,13 @@ export const builder = (yargs) => {
     .option('dry-run', {
       alias: 'd',
       type: 'boolean',
-      default: false,
       description: 'Check for outdated packages without upgrading',
     })
-    .option('canary', {
-      type: 'boolean',
-      default: false,
+    .option('tag', {
+      alias: 't',
+      choices: ['canary', 'rc'],
       description:
-        'WARNING: Force upgrades packages to most recent, unstable release from master branch',
+        'WARNING: Unstable releases. Force upgrades packages to most recent version for the given --tag.',
     })
     .strict()
 }
@@ -27,11 +26,20 @@ const rwPackages =
   '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router @redwoodjs/auth'
 
 // yarn upgrade-interactive does not allow --tags, so we resort to this mess
-// @redwoodjs/auth may not be installed so we don't include here
-let installCanaryCommand =
-  'yarn upgrade @redwoodjs/core@canary' +
-  ' && yarn workspace api upgrade @redwoodjs/api@canary' +
-  ' && yarn workspace web upgrade @redwoodjs/web@canary @redwoodjs/router@canary'
+// @redwoodjs/auth may not be installed so we add check
+const installTags = (tag, isAuth) => {
+  const mainString = `yarn upgrade @redwoodjs/core@${tag} \
+  && yarn workspace api upgrade @redwoodjs/api@${tag} \
+  && yarn workspace web upgrade @redwoodjs/web@${tag} @redwoodjs/router@${tag}`
+
+  const authString = ` @redwoodjs/auth@${tag}`
+
+  if (isAuth) {
+    return mainString + authString
+  } else {
+    return mainString
+  }
+}
 
 const checkInstalled = () => {
   return [
@@ -41,13 +49,13 @@ const checkInstalled = () => {
       // TODO: this will not support cases where api/ or web/ do not exist;
       // need to build a list of installed and use reference object to map commands
       title: '...',
-      task: async (_ctx, task) => {
+      task: async (ctx, task) => {
         try {
           const { stdout } = await execa.command(
             'yarn list --depth 0 --pattern @redwoodjs/auth'
           )
           if (stdout.includes('redwoodjs/auth')) {
-            installCanaryCommand += ' @redwoodjs/auth@canary'
+            ctx.auth = true
             task.title = 'Found @redwoodjs/auth'
           } else {
             task.title = 'Done'
@@ -63,31 +71,29 @@ const checkInstalled = () => {
 
 // yargs allows passing the 'dry-run' alias 'd' here,
 // which we need to use because babel fails on 'dry-run'
-const runUpgrade = ({ d, canary }) => {
+const runUpgrade = ({ d, tag }) => {
   return [
     {
       title: '...',
-      task: (_ctx, task) => {
+      task: (ctx, task) => {
         if (d) {
-          task.title = canary
-            ? 'The --dry-run option is not supported for --canary'
+          task.title = tag
+            ? 'The --dry-run option is not supported for --tags'
             : 'Checking available upgrades for @redwoodjs packages'
           // 'yarn outdated --scope @redwoodjs' will include netlify plugin
           // so we have to use hardcoded list,
           // which will NOT display info for uninstalled packages
-          if (!canary) {
+          if (!tag) {
             execa.command(`yarn outdated ${rwPackages}`, {
               stdio: 'inherit',
-              shell: true,
             })
           } else {
             throw new Error()
           }
           // using @tag with workspaces limits us to use 'upgrade' with full list
-        } else if (canary) {
-          task.title =
-            'Force upgrading @redwoodjs packages to latest canary release'
-          execa.command(installCanaryCommand, {
+        } else if (tag) {
+          task.title = `Force upgrading @redwoodjs packages to latest ${tag} release`
+          execa.command(installTags(tag, ctx.auth), {
             stdio: 'inherit',
             shell: true,
           })
@@ -107,7 +113,7 @@ const runUpgrade = ({ d, canary }) => {
   ]
 }
 
-export const handler = async ({ d, canary }) => {
+export const handler = async ({ d, tag }) => {
   // structuring as nested tasks to avoid bug with task.title causing duplicates
   const tasks = new Listr(
     [
@@ -117,7 +123,7 @@ export const handler = async ({ d, canary }) => {
       },
       {
         title: 'Running upgrade command',
-        task: () => new Listr(runUpgrade({ d, canary })),
+        task: () => new Listr(runUpgrade({ d, tag })),
       },
     ],
     { collapse: false }


### PR DESCRIPTION
This replaces --canary (boolean) with --tag (choices: canary, rc).

