### PR TITLE
Auth: Rename state and functions

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -92,7 +92,7 @@ ReactDOM.render(
 
 ```js
 const UserAuthTools = () => {
-  const { loading, authenticated, login, logout } = useAuth()
+  const { loading, isAuthenticated, logIn, logOut } = useAuth()
 
   if (loading) {
     // auth is rehydrating
@@ -102,15 +102,15 @@ const UserAuthTools = () => {
   return (
     <Button
       onClick={async () => {
-        if (authenticated) {
-          await logout()
+        if (isAuthenticated) {
+          await logOut()
           navigate('/')
         } else {
-          await login()
+          await logIn()
         }
       }}
     >
-      {authenticated ? 'Logout' : 'Login'}
+      {isAuthenticated ? 'Logout' : 'Login'}
     </Button>
   )
 }

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -110,7 +110,7 @@ const UserAuthTools = () => {
         }
       }}
     >
-      {isAuthenticated ? 'Logout' : 'Login'}
+      {isAuthenticated ? 'Log out' : 'Log in'}
     </Button>
   )
 }

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -11,10 +11,10 @@ import { createAuthClient } from './authClient'
 
 export interface AuthContextInterface {
   loading: boolean
-  authenticated: boolean
+  isAuthenticated: boolean
   currentUser: null | GoTrueUser | Auth0User
-  login(): Promise<void>
-  logout(): Promise<void>
+  logIn(): Promise<void>
+  logOut(): Promise<void>
   getToken(): Promise<null | string>
   client: null | SupportedAuthClients
   type: null | SupportedAuthTypes
@@ -31,7 +31,7 @@ type AuthProviderProps = {
 
 type AuthProviderState = {
   loading: boolean
-  authenticated: boolean
+  isAuthenticated: boolean
   currentUser: null | Auth0User | GoTrueUser
 }
 /**
@@ -50,7 +50,7 @@ export class AuthProvider extends React.Component<
 > {
   state: AuthProviderState = {
     loading: true,
-    authenticated: false,
+    isAuthenticated: false,
     currentUser: null,
   }
 
@@ -66,19 +66,19 @@ export class AuthProvider extends React.Component<
     const currentUser = await this.rwClient.currentUser()
     this.setState({
       currentUser,
-      authenticated: currentUser !== null,
+      isAuthenticated: currentUser !== null,
       loading: false,
     })
   }
 
-  login = async (options?) => {
+  logIn = async (options?) => {
     const currentUser = await this.rwClient.login(options)
-    this.setState({ currentUser, authenticated: currentUser !== null })
+    this.setState({ currentUser, isAuthenticated: currentUser !== null })
   }
 
-  logout = async () => {
+  logOut = async () => {
     await this.rwClient.logout()
-    this.setState({ currentUser: null, authenticated: false })
+    this.setState({ currentUser: null, isAuthenticated: false })
   }
 
   render() {
@@ -88,8 +88,8 @@ export class AuthProvider extends React.Component<
       <AuthContext.Provider
         value={{
           ...this.state,
-          login: this.login,
-          logout: this.logout,
+          logIn: this.logIn,
+          logOut: this.logOut,
           getToken: this.rwClient.getToken,
           client: client,
           type: type,

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -34,13 +34,13 @@ Private.propTypes = {
 }
 
 const PrivatePageLoader = ({ useAuth, unauthenticatedRoute, children }) => {
-  const { loading, authenticated } = useAuth()
+  const { loading, isAuthenticated } = useAuth()
 
   if (loading) {
     return null
   }
 
-  if (authenticated) {
+  if (isAuthenticated) {
     return children
   } else {
     return <Redirect to={unauthenticatedRoute()} />

--- a/packages/web/src/components/RedwoodProvider.js
+++ b/packages/web/src/components/RedwoodProvider.js
@@ -29,7 +29,6 @@ const GraphQLProviderWithAuth = ({
     return null
   }
 
-  console.log(isAuthenticated)
 
   if (!isAuthenticated) {
     return (

--- a/packages/web/src/components/RedwoodProvider.js
+++ b/packages/web/src/components/RedwoodProvider.js
@@ -1,47 +1,97 @@
 import { useState, useEffect } from 'react'
 
-import { GraphQLProvider, createGraphQLClient } from 'src/graphql'
+import { GraphQLProvider } from 'src/graphql'
 
-const useAuthStub = () => ({ loading: false, authenticated: false })
+const GraphQLProviderWithAuth = ({
+  useAuth,
+  graphQLClientConfig = { headers: {} },
+  children,
+  ...rest
+}) => {
+  const { loading, isAuthenticated, getToken, type } = useAuth()
+  const [authToken, setAuthToken] = useState()
+
+  useEffect(() => {
+    const fetchAuthToken = async () => {
+      const token = await getToken()
+      setAuthToken(token)
+    }
+
+    if (isAuthenticated) {
+      fetchAuthToken()
+    }
+  }, [isAuthenticated, getToken])
+
+  // This really sucks because rendering is completely blocked whilst we're
+  // restoring authentication. In a lot of cases that's OK since the token is stored
+  // in localstorage or a secure cookie.
+  if (loading) {
+    return null
+  }
+
+  console.log(isAuthenticated)
+
+  if (!isAuthenticated) {
+    return (
+      <GraphQLProvider config={graphQLClientConfig} {...rest}>
+        {children}
+      </GraphQLProvider>
+    )
+  }
+
+  // The user is authenticated, so we have to wait for the auth token to be retrieved
+  // before continueing.
+  if (!authToken) {
+    return null
+  }
+
+  return (
+    <GraphQLProvider
+      config={{
+        ...graphQLClientConfig,
+        headers: {
+          /** `auth-provider` is used by the API to determine how to decode the token */
+          'auth-provider': type,
+          authorization: `Bearer ${authToken}`,
+          ...graphQLClientConfig.headers,
+        },
+      }}
+    >
+      {children}
+    </GraphQLProvider>
+  )
+}
 
 /**
  * Redwood's Provider is a zeroconf way to tie together authentication and
  * GraphQL requests.
  *
- * When the `useAuth` hook from `@redwoodjs/auth` is available the authentication
- * token is automatically added to the Authorization headers of each GraphQL request.
+ * When `AuthProvider` is instantiated this component will automatically add
+ * Authorization headers to each request.
  */
 const RedwoodProvider = ({
-  useAuth = window.__REDWOOD__USE_AUTH || useAuthStub,
+  useAuth = window.__REDWOOD__USE_AUTH,
+  graphQLClientConfig,
   children,
+  ...rest
 }) => {
-  const { loading, authenticated, getToken, type } = useAuth()
-  const [authToken, setAuthToken] = useState()
-
-  useEffect(() => {
-    if (authenticated) {
-      getToken().then((token) => setAuthToken(token))
-    }
-  }, [authenticated, getToken])
-
-  // This really sucks because rendering is completely blocked whilst we're
-  // restoring authentication.
-  if (loading) {
-    return null
+  if (typeof useAuth === 'undefined') {
+    return (
+      <GraphQLProvider config={graphQLClientConfig} {...rest}>
+        {children}
+      </GraphQLProvider>
+    )
   }
-  // If we have an authToken then modify the headers of the GraphQL client.
-  // TODO: Add a way for user's to pass in custom headers to GraphQL, or just a custom client.
-  const client = authToken
-    ? createGraphQLClient({
-        headers: {
-          // Used by `api` to determine the auth type.
-          'auth-provider': type,
-          authorization: `Bearer ${authToken}`,
-        },
-      })
-    : undefined
 
-  return <GraphQLProvider client={client}>{children}</GraphQLProvider>
+  return (
+    <GraphQLProviderWithAuth
+      useAuth={useAuth}
+      config={graphQLClientConfig}
+      {...rest}
+    >
+      {children}
+    </GraphQLProviderWithAuth>
+  )
 }
 
 export default RedwoodProvider

--- a/packages/web/src/graphql/index.js
+++ b/packages/web/src/graphql/index.js
@@ -19,9 +19,8 @@ export const createGraphQLClient = (config) => {
 /**
  * A GraphQL provider that instantiates a client automatically.
  */
-export const GraphQLProvider = ({
-  client = createGraphQLClient(),
-  ...rest
-}) => {
-  return <ApolloProvider client={client} {...rest} />
+export const GraphQLProvider = ({ config, ...rest }) => {
+  console.log(config)
+
+  return <ApolloProvider client={createGraphQLClient(config)} {...rest} />
 }

--- a/packages/web/src/graphql/index.js
+++ b/packages/web/src/graphql/index.js
@@ -20,7 +20,6 @@ export const createGraphQLClient = (config) => {
  * A GraphQL provider that instantiates a client automatically.
  */
 export const GraphQLProvider = ({ config, ...rest }) => {
-  console.log(config)
 
   return <ApolloProvider client={createGraphQLClient(config)} {...rest} />
 }


### PR DESCRIPTION
- [x] Renamed: `login` -> `logIn`, `logout` -> `logOut` and `authenticated` -> `isAuthenticated`
- [x] Fixed a bug where async `getToken` wasn't taken in account.
