### PR TITLE
Do not attempt to publish canary if not original repo

### DIFF
--- a/.github/workflows/publish-npm-canary.yaml
+++ b/.github/workflows/publish-npm-canary.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'redwoodjs/redwood'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
When I update my master branch it keeps failing the actions because it tries to publish the canary version of redwood.

With this the publish version action is only run in the main repository.