### PR TITLE
Audit CLI commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "pascalcase": "^1.0.0",
     "pluralize": "^8.0.0",
     "prettier": "^2.0.2",
+    "terminal-link": "^2.1.1",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -4,6 +4,7 @@ import path from 'path'
 import execa from 'execa'
 import Listr from 'listr'
 import VerboseRenderer from 'listr-verbose-renderer'
+import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
@@ -12,30 +13,52 @@ import { handler as generatePrismaClient } from 'src/commands/dbCommands/generat
 const apiExists = fs.existsSync(getPaths().api.src)
 const webExists = fs.existsSync(getPaths().web.src)
 
-const optionDefault = (webExists, apiExists) => {
+const optionDefault = (apiExists, webExists) => {
   let options = []
-  if (webExists) options.push('web')
   if (apiExists) options.push('api')
+  if (webExists) options.push('web')
   return options
 }
 
-export const command = 'build [app..]'
-export const desc = 'Build for production.'
-export const builder = {
-  app: {
-    choices: ['api', 'web'],
-    default: optionDefault(webExists, apiExists),
-  },
-  verbose: { type: 'boolean', default: false, alias: ['v'] },
-  stats: { type: 'boolean', default: false },
+export const command = 'build [side..]'
+export const description = 'Build for production'
+
+export const builder = (yargs) => {
+  yargs
+    .positional('side', {
+      choices: ['api', 'web'],
+      default: optionDefault(apiExists, webExists),
+      description: 'Which side(s) to build',
+      type: 'array',
+    })
+    .option('stats', {
+      default: false,
+      description: `Use ${terminalLink(
+        'Webpack Bundle Analyzer',
+        'https://github.com/webpack-contrib/webpack-bundle-analyzer'
+      )}`,
+      type: 'boolean',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: false,
+      description: 'Print more',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#build'
+      )}`
+    )
 }
 
 export const handler = async ({
-  app = ['api', 'web'],
+  side = ['api', 'web'],
   verbose = false,
   stats = false,
 }) => {
-  if (app.includes('api')) {
+  if (side.includes('api')) {
     try {
       await generatePrismaClient({ verbose, force: true })
     } catch (e) {
@@ -44,7 +67,7 @@ export const handler = async ({
     }
   }
 
-  const execCommandsForApps = {
+  const execCommandsForSides = {
     api: {
       // must use path.join() here, and for 'web' below, to support Windows
       cwd: path.join(getPaths().base, 'api'),
@@ -59,17 +82,17 @@ export const handler = async ({
   }
 
   if (stats) {
-    app = ['web']
+    side = ['web']
     console.log(
       ' ⏩ Skipping `api` build because stats only works for Webpack at the moment.'
     )
   }
 
   const tasks = new Listr(
-    app.map((appName) => {
-      const { cwd, cmd } = execCommandsForApps[appName]
+    side.map((sideName) => {
+      const { cwd, cmd } = execCommandsForSides[sideName]
       return {
-        title: `Building "${appName}"${(stats && ' for stats') || ''}...`,
+        title: `Building "${sideName}"${(stats && ' for stats') || ''}...`,
         task: () => {
           return execa(cmd, undefined, {
             stdio: verbose ? 'inherit' : 'pipe',

--- a/packages/cli/src/commands/db.js
+++ b/packages/cli/src/commands/db.js
@@ -1,6 +1,15 @@
 export const command = 'db <command>'
 export const aliases = ['database']
-export const desc = 'Database tools.'
+export const description = 'Database tools'
+import terminalLink from 'terminal-link'
 
 export const builder = (yargs) =>
-  yargs.commandDir('./dbCommands').demandCommand()
+  yargs
+    .commandDir('./dbCommands')
+    .demandCommand()
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#db'
+      )}`
+    )

--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -26,10 +26,10 @@ describe('db commands', () => {
   })
 
   it('some commands have a verbose flag', () => {
-    expect(up.builder.verbose).toBeDefined()
-    expect(down.builder.verbose).toBeDefined()
-    expect(generate.builder.verbose).toBeDefined()
-    expect(introspect.builder.verbose).toBeDefined()
+    expect(up.builder.toString()).toMatch('verbose')
+    expect(down.builder.toString()).toMatch('verbose')
+    expect(generate.builder.toString()).toMatch('verbose')
+    expect(introspect.builder.toString()).toMatch('verbose')
   })
 
   it('runs the command as expected', async () => {

--- a/packages/cli/src/commands/dbCommands/down.js
+++ b/packages/cli/src/commands/dbCommands/down.js
@@ -1,17 +1,40 @@
+import terminalLink from 'terminal-link'
+
 import { runCommandTask } from 'src/lib'
 
-export const command = 'down'
-export const desc = 'Migrate your database down.'
-export const builder = {
-  verbose: { type: 'boolean', default: true, alias: ['v'] },
+export const command = 'down [decrement]'
+export const description = 'Migrate your database down'
+export const builder = (yargs) => {
+  yargs
+    .positional('decrement', {
+      default: 1,
+      description: 'Number of backwards migrations to apply',
+      type: 'number',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: true,
+      description: 'Print more',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#db-down'
+      )}`
+    )
 }
-export const handler = async ({ verbose = true }) => {
+export const handler = async ({ decrement, verbose = true }) => {
   await runCommandTask(
     [
       {
         title: 'Migrate database down...',
         cmd: 'yarn prisma',
-        args: ['migrate down', '--experimental'],
+        args: [
+          'migrate down',
+          decrement && `${decrement}`,
+          '--experimental',
+        ].filter(Boolean),
       },
     ],
     {

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -1,13 +1,32 @@
 import fs from 'fs'
 import path from 'path'
 
+import terminalLink from 'terminal-link'
+
 import { runCommandTask, getPaths } from 'src/lib'
 
 export const command = 'generate'
-export const desc = 'Generate the Prisma client.'
-export const builder = {
-  verbose: { type: 'boolean', default: true, alias: ['v'] },
-  force: { type: 'boolean', default: true, alias: ['f'] },
+export const description = 'Generate the Prisma client'
+export const builder = (yargs) => {
+  yargs
+    .option('force', {
+      alias: 'f',
+      default: true,
+      description: 'Overwrite existing Client',
+      type: 'boolean',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: true,
+      description: 'Print more',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#db-generate'
+      )}`
+    )
 }
 export const handler = async ({ verbose = true, force = false }) => {
   const schemaExists = fs.existsSync(getPaths().api.dbSchema)

--- a/packages/cli/src/commands/dbCommands/introspect.js
+++ b/packages/cli/src/commands/dbCommands/introspect.js
@@ -1,10 +1,24 @@
+import terminalLink from 'terminal-link'
+
 import { getPaths, runCommandTask } from 'src/lib'
 
 export const command = 'introspect'
-export const desc =
-  'Introspect your database and generate the models in api/prisma/schema.prisma (overwrites existing models).'
-export const builder = {
-  verbose: { type: 'boolean', default: true, alias: ['v'] },
+export const description =
+  'Introspect your database and generate models in ./api/prisma/schema.prisma, overwriting existing models'
+export const builder = (yargs) => {
+  yargs
+    .option('verbose', {
+      alias: 'v',
+      default: true,
+      description: 'Print more',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#db-introspect'
+      )}`
+    )
 }
 
 export const handler = async ({ verbose = true }) => {

--- a/packages/cli/src/commands/dbCommands/save.js
+++ b/packages/cli/src/commands/dbCommands/save.js
@@ -1,10 +1,29 @@
+import terminalLink from 'terminal-link'
+
 import { runCommandTask } from 'src/lib'
 
 export const command = 'save [name..]'
-export const desc = 'Create a new migration.'
-export const builder = {
-  verbose: { type: 'boolean', default: true, alias: ['v'] },
+export const description = 'Create a new migration'
+export const builder = (yargs) => {
+  yargs
+    .positional('name', {
+      description: 'Name of the migration',
+      type: 'array',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: true,
+      description: 'Print more',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#db-save'
+      )}`
+    )
 }
+
 export const handler = async ({ name, verbose = true }) => {
   await runCommandTask(
     [
@@ -13,7 +32,7 @@ export const handler = async ({ name, verbose = true }) => {
         cmd: 'yarn prisma',
         args: [
           'migrate save',
-          name && `--name ${name}`,
+          name.length && `--name ${name}`,
           '--experimental',
         ].filter(Boolean),
       },

--- a/packages/cli/src/commands/dbCommands/seed.js
+++ b/packages/cli/src/commands/dbCommands/seed.js
@@ -1,7 +1,17 @@
+import terminalLink from 'terminal-link'
+
 import { getPaths, runCommandTask } from 'src/lib'
 
 export const command = 'seed'
-export const desc = 'Seed your database with test data.'
+export const description = 'Seed your database with test data'
+export const builder = (yargs) => {
+  yargs.epilogue(
+    `Also see the ${terminalLink(
+      'Redwood CLI Reference',
+      'https://redwoodjs.com/reference/command-line-interface#db-seed'
+    )}`
+  )
+}
 export const handler = () => {
   runCommandTask(
     [

--- a/packages/cli/src/commands/dbCommands/up.js
+++ b/packages/cli/src/commands/dbCommands/up.js
@@ -1,20 +1,52 @@
+import terminalLink from 'terminal-link'
+
 import { runCommandTask } from 'src/lib'
 import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
-export const command = 'up'
-export const desc = 'Generate the Prisma client and apply migrations.'
-export const builder = {
-  verbose: { type: 'boolean', default: true, alias: ['v'] },
-  dbClient: { type: 'boolean', default: true },
+export const command = 'up [increment]'
+export const description = 'Generate the Prisma client and apply migrations'
+export const builder = (yargs) => {
+  yargs
+    .positional('increment', {
+      description:
+        'Number of forward migrations to apply. Defaults to the latest',
+      type: 'number',
+    })
+    .option('dbClient', {
+      default: true,
+      description: 'Generate the Prisma client',
+      type: 'boolean',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: true,
+      description: 'Print more',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#db-up'
+      )}`
+    )
 }
 
-export const handler = async ({ verbose = true, dbClient = true }) => {
+export const handler = async ({
+  increment,
+  verbose = true,
+  dbClient = true,
+}) => {
   const success = await runCommandTask(
     [
       {
         title: 'Migrate database up...',
         cmd: 'yarn prisma',
-        args: ['migrate up', '--experimental', '--create-db'],
+        args: [
+          'migrate up',
+          increment && `${increment}`,
+          '--experimental',
+          '--create-db',
+        ].filter(Boolean),
       },
     ],
     { verbose }

--- a/packages/cli/src/commands/destroy.js
+++ b/packages/cli/src/commands/destroy.js
@@ -1,6 +1,6 @@
 export const command = 'destroy <type>'
 export const aliases = ['d']
-export const desc = 'Rollback changes made by the generate command.'
+export const description = 'Rollback changes made by the generate command'
 
 export const builder = (yargs) =>
   yargs.commandDir('./destroy', { recurse: true }).demandCommand()

--- a/packages/cli/src/commands/destroy/cell/cell.js
+++ b/packages/cli/src/commands/destroy/cell/cell.js
@@ -3,7 +3,7 @@ import { createYargsForComponentDestroy } from '../helpers'
 
 export const {
   command,
-  desc,
+  description,
   builder,
   handler,
   tasks,

--- a/packages/cli/src/commands/destroy/component/component.js
+++ b/packages/cli/src/commands/destroy/component/component.js
@@ -1,7 +1,7 @@
 import { files as componentFiles } from '../../generate/component/component'
 import { createYargsForComponentDestroy } from '../helpers'
 
-export const desc = 'Destroy a component.'
+export const description = 'Destroy a component'
 
 export const {
   command,

--- a/packages/cli/src/commands/destroy/function/function.js
+++ b/packages/cli/src/commands/destroy/function/function.js
@@ -1,14 +1,16 @@
 import { files as functionFiles } from '../../generate/function/function'
 import { createYargsForComponentDestroy } from '../helpers'
 
-export const desc = 'Destroy a function'
+export const description = 'Destroy a Function'
 
-export const {
-  builder,
-  command,
-  handler,
-  tasks,
-} = createYargsForComponentDestroy({
+export const builder = (yargs) => {
+  yargs.positional('name', {
+    description: 'Name of the Function',
+    type: 'string',
+  })
+}
+
+export const { command, handler, tasks } = createYargsForComponentDestroy({
   componentName: 'function',
   filesFn: functionFiles,
 })

--- a/packages/cli/src/commands/destroy/helpers.js
+++ b/packages/cli/src/commands/destroy/helpers.js
@@ -20,7 +20,13 @@ const tasks = ({ componentName, filesFn, name }) =>
 export const createYargsForComponentDestroy = ({ componentName, filesFn }) => {
   return {
     command: `${componentName} <name>`,
-    desc: `Destroy a ${componentName} component.`,
+    description: `Destroy a ${componentName} component`,
+    builder: (yargs) => {
+      yargs.positional('name', {
+        description: `Name of the ${componentName}`,
+        type: 'string',
+      })
+    },
     handler: async ({ name }) => {
       const t = tasks({ componentName, filesFn, name })
 

--- a/packages/cli/src/commands/destroy/layout/layout.js
+++ b/packages/cli/src/commands/destroy/layout/layout.js
@@ -3,7 +3,7 @@ import { createYargsForComponentDestroy } from '../helpers'
 
 export const {
   command,
-  desc,
+  description,
   builder,
   handler,
   tasks,

--- a/packages/cli/src/commands/destroy/page/page.js
+++ b/packages/cli/src/commands/destroy/page/page.js
@@ -8,7 +8,17 @@ import { pathName } from '../../generate/helpers'
 import { files as pageFiles } from '../../generate/page/page'
 
 export const command = 'page <name> [path]'
-export const desc = 'Destroy a page component.'
+export const description = 'Destroy a page and route component'
+export const builder = (yargs) => {
+  yargs.positional('name', {
+    description: 'Name of the page',
+    type: 'string',
+  })
+  yargs.positional('path', {
+    description: 'URL path to the page. Defaults to name',
+    type: 'string',
+  })
+}
 
 export const tasks = ({ name, path }) =>
   new Listr(

--- a/packages/cli/src/commands/destroy/scaffold/scaffold.js
+++ b/packages/cli/src/commands/destroy/scaffold/scaffold.js
@@ -10,7 +10,15 @@ import {
 } from '../../generate/scaffold/scaffold'
 
 export const command = 'scaffold <model>'
-export const desc = 'Destroy pages, SDL, and a services object.'
+export const description =
+  'Destroy pages, SDL, and Services files based on a given DB schema Model'
+
+export const builder = (yargs) => {
+  yargs.positional('model', {
+    description: 'Model to destroy the scaffold of',
+    type: 'string',
+  })
+}
 
 export const tasks = ({ model, path }) =>
   new Listr(

--- a/packages/cli/src/commands/destroy/sdl/sdl.js
+++ b/packages/cli/src/commands/destroy/sdl/sdl.js
@@ -6,13 +6,21 @@ import c from 'src/lib/colors'
 import { files } from '../../generate/sdl/sdl'
 
 export const command = 'sdl <model>'
-export const desc = 'Destroy a GraphQL schema and service object.'
+export const description =
+  'Destroy a GraphQL schema and service component based on a given DB schema Model'
+
+export const builder = (yargs) => {
+  yargs.positional('model', {
+    description: 'Model to destroy the sdl of',
+    type: 'string',
+  })
+}
 
 export const tasks = ({ model }) =>
   new Listr(
     [
       {
-        title: 'Destroying GraphQL schema and service object files...',
+        title: 'Destroying GraphQL schema and service component files...',
         task: async () => {
           const f = await files({ name: model })
           return deleteFilesTask(f)

--- a/packages/cli/src/commands/destroy/service/service.js
+++ b/packages/cli/src/commands/destroy/service/service.js
@@ -15,9 +15,12 @@ export const filesWithTemplateVars = (templateVars) => {
   return (args) => files({ ...args, ...templateVars })
 }
 
-export const { command, desc, handler, tasks } = createYargsForComponentDestroy(
-  {
-    componentName: 'service',
-    filesFn: filesWithTemplateVars(getDefaultArgs(builder)),
-  }
-)
+export const {
+  command,
+  description,
+  handler,
+  tasks,
+} = createYargsForComponentDestroy({
+  componentName: 'service',
+  filesFn: filesWithTemplateVars(getDefaultArgs(builder)),
+})

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -2,17 +2,30 @@ import fs from 'fs'
 import path from 'path'
 
 import concurrently from 'concurrently'
+import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
-export const command = 'dev [app..]'
-export const desc = 'Run development servers for db, api, and web.'
-export const builder = {
-  app: { choices: ['db', 'api', 'web'], default: ['db', 'api', 'web'] },
+export const command = 'dev [side..]'
+export const description = 'Start development servers for api, db, and web'
+export const builder = (yargs) => {
+  yargs
+    .positional('side', {
+      choices: ['api', 'db', 'web'],
+      default: ['api', 'db', 'web'],
+      description: 'Which dev server(s) to start',
+      type: 'array',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#dev'
+      )}`
+    )
 }
 
-export const handler = async ({ app = ['db', 'api', 'web'] }) => {
+export const handler = async ({ side = ['api', 'db', 'web'] }) => {
   // We use BASE_DIR when we need to effectively set the working dir
   const BASE_DIR = getPaths().base
   // For validation, e.g. dirExists?, we use these
@@ -50,7 +63,7 @@ export const handler = async ({ app = ['db', 'api', 'web'] }) => {
 
   concurrently(
     Object.keys(jobs)
-      .map((n) => app.includes(n) && jobs[n])
+      .map((n) => side.includes(n) && jobs[n])
       .filter((job) => job && job.runWhen()),
     {
       restartTries: 3,

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -1,6 +1,15 @@
 export const command = 'generate <type>'
 export const aliases = ['g']
-export const desc = 'Save time by generating boilerplate code.'
+export const description = 'Save time by generating boilerplate code'
+import terminalLink from 'terminal-link'
 
 export const builder = (yargs) =>
-  yargs.commandDir('./generate', { recurse: true }).demandCommand()
+  yargs
+    .commandDir('./generate', { recurse: true })
+    .demandCommand()
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-alias-g'
+      )}`
+    )

--- a/packages/cli/src/commands/generate/auth/auth.js
+++ b/packages/cli/src/commands/generate/auth/auth.js
@@ -3,6 +3,7 @@ import path from 'path'
 
 import execa from 'execa'
 import Listr from 'listr'
+import terminalLink from 'terminal-link'
 
 import { getPaths, writeFilesTask } from 'src/lib'
 import c from 'src/lib/colors'
@@ -109,9 +110,26 @@ export const graphFunctionDoesExist = () => {
 }
 
 export const command = 'auth <provider>'
-export const desc = 'Generates auth configuration.'
-export const builder = {
-  force: { type: 'boolean', default: false },
+export const description = 'Generate an auth configuration'
+export const builder = (yargs) => {
+  yargs
+    .positional('provider', {
+      choices: ['netlify', 'auth0', 'magic-link'],
+      description: 'Auth provider to configure',
+      type: 'string',
+    })
+    .option('force', {
+      alias: 'f',
+      default: false,
+      description: 'Overwrite existing configuration',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-auth'
+      )}`
+    )
 }
 
 export const handler = async ({ provider, force }) => {

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -38,7 +38,7 @@ export const files = ({ name }) => {
 
 export const {
   command,
-  desc,
+  description,
   builder,
   handler,
 } = createYargsForComponentGeneration({

--- a/packages/cli/src/commands/generate/component/component.js
+++ b/packages/cli/src/commands/generate/component/component.js
@@ -41,7 +41,7 @@ export const files = ({ name, typescript, javascript }) => {
   }, {})
 }
 
-export const desc = 'Generate a component.'
+export const description = 'Generate a component'
 
 export const { command, builder, handler } = createYargsForComponentGeneration({
   componentName: 'component',

--- a/packages/cli/src/commands/generate/function/function.js
+++ b/packages/cli/src/commands/generate/function/function.js
@@ -1,6 +1,7 @@
 import path from 'path'
 
 import camelcase from 'camelcase'
+import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
 
@@ -24,10 +25,26 @@ export const files = async ({ name, ...rest }) => {
   return { [file[0]]: file[1] }
 }
 
-export const desc = 'Generate a function'
+export const description = 'Generate a Function'
 
-export const builder = {
-  force: { type: 'boolean', default: false },
+export const builder = (yargs) => {
+  yargs
+    .positional('name', {
+      description: 'Name of the Function',
+      type: 'string',
+    })
+    .option('force', {
+      alias: 'f',
+      default: false,
+      description: 'Overwrite existing files',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-function'
+      )}`
+    )
 }
 
 export const { command, handler } = createYargsForComponentGeneration({

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -5,6 +5,7 @@ import pluralize from 'pluralize'
 import Listr from 'listr'
 import pascalcase from 'pascalcase'
 import { paramCase } from 'param-case'
+import terminalLink from 'terminal-link'
 
 import { generateTemplate, getPaths, writeFilesTask } from 'src/lib'
 import c from 'src/lib/colors'
@@ -62,26 +63,46 @@ export const pathName = (path, name) => {
 export const createYargsForComponentGeneration = ({
   componentName,
   filesFn,
-  builder = {
-    force: { type: 'boolean', default: false },
-    typescript: {
-      type: 'boolean',
+  builderObj = {
+    force: {
+      alias: 'f',
       default: false,
-      describe: 'Generate TypeScript files',
-      alias: 'ts',
+      description: 'Overwrite existing files',
+      type: 'boolean',
     },
     javascript: {
-      type: 'boolean',
-      default: true,
-      describe: 'Generate JavaScript files',
       alias: 'js',
+      default: true,
+      description: 'Generate JavaScript files',
+      type: 'boolean',
+    },
+    typescript: {
+      alias: 'ts',
+      default: false,
+      description: 'Generate TypeScript files',
+      type: 'boolean',
     },
   },
 }) => {
   return {
     command: `${componentName} <name>`,
-    desc: `Generate a ${componentName} component.`,
-    builder,
+    description: `Generate a ${componentName} component`,
+    builder: (yargs) => {
+      yargs
+        .positional('name', {
+          description: `Name of the ${componentName}`,
+          type: 'string',
+        })
+        .epilogue(
+          `Also see the ${terminalLink(
+            'Redwood CLI Reference',
+            `https://redwoodjs.com/reference/command-line-interface#generate-${componentName}`
+          )}`
+        )
+      Object.entries(builderObj).forEach(([option, config]) => {
+        yargs.option(option, config)
+      })
+    },
     handler: async (options) => {
       const tasks = new Listr(
         [

--- a/packages/cli/src/commands/generate/layout/layout.js
+++ b/packages/cli/src/commands/generate/layout/layout.js
@@ -38,7 +38,7 @@ export const files = ({ name }) => {
 
 export const {
   command,
-  desc,
+  description,
   builder,
   handler,
 } = createYargsForComponentGeneration({

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -1,6 +1,7 @@
 import Listr from 'listr'
 import camelcase from 'camelcase'
 import pascalcase from 'pascalcase'
+import terminalLink from 'terminal-link'
 
 import { writeFilesTask, addRoutesToRouterTask } from 'src/lib'
 import c from 'src/lib/colors'
@@ -51,8 +52,30 @@ export const routes = ({ name, path }) => {
 }
 
 export const command = 'page <name> [path]'
-export const desc = 'Generate a page component.'
-export const builder = { force: { type: 'boolean', default: false } }
+export const description = 'Generate a page and route component'
+export const builder = (yargs) => {
+  yargs
+    .positional('name', {
+      description: 'Name of the page',
+      type: 'string',
+    })
+    .positional('path', {
+      description: 'URL path to the page. Defaults to name',
+      type: 'string',
+    })
+    .option('force', {
+      alias: 'f',
+      default: false,
+      description: 'Overwrite existing files',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-page'
+      )}`
+    )
+}
 
 export const handler = async ({ name, path, force }) => {
   const tasks = new Listr(

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -7,6 +7,7 @@ import pascalcase from 'pascalcase'
 import pluralize from 'pluralize'
 import { paramCase } from 'param-case'
 import humanize from 'humanize-string'
+import terminalLink from 'terminal-link'
 
 import {
   generateTemplate,
@@ -333,28 +334,39 @@ const addScaffoldImport = () => {
 
 export const defaults = {
   force: {
+    alias: 'f',
     default: false,
+    description: 'Overwrite existing files',
+    type: 'boolean',
+  },
+  javascript: {
+    alias: 'js',
+    default: true,
+    description: 'Generate JavaScript files',
     type: 'boolean',
   },
   typescript: {
-    type: 'boolean',
+    alias: 'ts',
     default: false,
-    desc: 'Generate TypeScript files',
-  },
-  javascript: {
+    description: 'Generate TypeScript files',
     type: 'boolean',
-    default: true,
-    desc: 'Generate JavaScript files',
   },
 }
 export const command = 'scaffold <model>'
-export const desc =
-  'Generate Pages, SDL, and Services files based on a given DB schema Model. Also accepts <path/model>.'
+export const description =
+  'Generate Pages, SDL, and Services files based on a given DB schema Model. Also accepts <path/model>'
 export const builder = (yargs) => {
-  yargs.positional('model', {
-    description:
-      "Model to scaffold. You can also use <path/model> to nest files by type at the given path directory (or directories). For example, 'rw g scaffold admin/post'.",
-  })
+  yargs
+    .positional('model', {
+      description:
+        "Model to scaffold. You can also use <path/model> to nest files by type at the given path directory (or directories). For example, 'rw g scaffold admin/post'",
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-scaffold'
+      )}`
+    )
   Object.entries(defaults).forEach(([option, config]) => {
     yargs.option(option, config)
   })

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.js
@@ -100,7 +100,7 @@ const itCreatesASDLFileWithEnumDefinitions = (baseArgs = {}) => {
 }
 
 describe('in javascript mode', () => {
-  const baseArgs = getDefaultArgs(sdl.builder)
+  const baseArgs = getDefaultArgs(sdl.defaults)
 
   itReturnsExactlyThreeFiles(baseArgs)
   itCreatesAService(baseArgs)
@@ -112,7 +112,7 @@ describe('in javascript mode', () => {
 })
 
 describe('in typescript mode', () => {
-  const baseArgs = { ...getDefaultArgs(sdl.builder), typescript: true }
+  const baseArgs = { ...getDefaultArgs(sdl.defaults), typescript: true }
 
   itReturnsExactlyThreeFiles(baseArgs)
   itCreatesAService(baseArgs)

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -4,6 +4,7 @@ import Listr from 'listr'
 import camelcase from 'camelcase'
 import pascalcase from 'pascalcase'
 import pluralize from 'pluralize'
+import terminalLink from 'terminal-link'
 
 import {
   generateTemplate,
@@ -145,14 +146,50 @@ export const files = async ({ name, crud, typescript, javascript }) => {
   }
 }
 
+export const defaults = {
+  crud: {
+    default: false,
+    description: 'Also generate mutations',
+    type: 'boolean',
+  },
+  force: {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing files',
+    type: 'boolean',
+  },
+  javascript: {
+    alias: 'js',
+    default: true,
+    description: 'Generate JavaScript files',
+    type: 'boolean',
+  },
+  typescript: {
+    alias: 'ts',
+    default: false,
+    description: 'Generate TypeScript files',
+    type: 'boolean',
+  },
+}
+
 export const command = 'sdl <model>'
-export const desc = 'Generate a GraphQL schema and service object.'
-export const builder = {
-  services: { type: 'boolean', default: true },
-  crud: { type: 'boolean', default: false },
-  force: { type: 'boolean', default: false },
-  javascript: { type: 'boolean', default: true },
-  typescript: { type: 'boolean', default: false },
+export const description =
+  'Generate a GraphQL schema and service component based on a given DB schema Model'
+export const builder = (yargs) => {
+  yargs
+    .positional('model', {
+      description: 'Model to generate the sdl for',
+      type: 'string',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-sdl'
+      )}`
+    )
+  Object.entries(defaults).forEach(([option, config]) => {
+    yargs.option(option, config)
+  })
 }
 // TODO: Add --dry-run command
 export const handler = async ({

--- a/packages/cli/src/commands/generate/service/__tests__/service.test.js
+++ b/packages/cli/src/commands/generate/service/__tests__/service.test.js
@@ -196,7 +196,7 @@ const itCreatesASingleWordServiceFileWithMultipleRelations = (baseArgs) => {
 }
 
 describe('in javascript mode', () => {
-  const baseArgs = getDefaultArgs(service.builder)
+  const baseArgs = getDefaultArgs(service.defaults)
 
   itReturnsExactly2Files(baseArgs)
   itCreatesASingleWordServiceFile(baseArgs)
@@ -213,7 +213,7 @@ describe('in javascript mode', () => {
 })
 
 describe('in typescript mode', () => {
-  const baseArgs = { ...getDefaultArgs(service.builder), typescript: true }
+  const baseArgs = { ...getDefaultArgs(service.defaults), typescript: true }
 
   itReturnsExactly2Files(baseArgs)
   itCreatesASingleWordServiceFile(baseArgs)

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -1,5 +1,6 @@
 import camelcase from 'camelcase'
 import pluralize from 'pluralize'
+import terminalLink from 'terminal-link'
 
 import { transformTSToJS } from '../../../lib'
 import {
@@ -53,23 +54,54 @@ export const files = async ({
   }, {})
 }
 
-export const builder = {
-  crud: { type: 'boolean', default: false, desc: 'Create CRUD functions' },
-  force: { type: 'boolean', default: false },
-  typescript: {
-    type: 'boolean',
+export const defaults = {
+  crud: {
     default: false,
-    desc: 'Generate TypeScript files',
+    description: 'Create CRUD functions',
+    type: 'boolean',
+  },
+  force: {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing files',
+    type: 'boolean',
   },
   javascript: {
-    type: 'boolean',
+    alias: 'js',
     default: true,
-    desc: 'Generate JavaScript files',
+    description: 'Generate JavaScript files',
+    type: 'boolean',
+  },
+  typescript: {
+    alias: 'ts',
+    default: false,
+    description: 'Generate TypeScript files',
+    type: 'boolean',
   },
 }
 
-export const { command, desc, handler } = createYargsForComponentGeneration({
+export const builder = (yargs) => {
+  yargs
+    .positional('name', {
+      description: 'Name of the service',
+      type: 'string',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#generate-service'
+      )}`
+    )
+  Object.entries(defaults).forEach(([option, config]) => {
+    yargs.option(option, config)
+  })
+}
+
+export const {
+  command,
+  description,
+  handler,
+} = createYargsForComponentGeneration({
   componentName: 'service',
   filesFn: files,
-  builder,
 })

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -1,9 +1,18 @@
 // inspired by gatsby/packages/gatsby-cli/src/create-cli.js and
 // and gridsome/packages/cli/lib/commands/info.js
 import envinfo from 'envinfo'
+import terminalLink from 'terminal-link'
 
 export const command = 'info'
-export const desc = 'Prints your system environment information'
+export const description = 'Print your system environment information'
+export const builder = (yargs) => {
+  yargs.epilogue(
+    `Also see the ${terminalLink(
+      'Redwood CLI Reference',
+      'https://redwoodjs.com/reference/command-line-interface#info'
+    )}`
+  )
+}
 export const handler = async () => {
   try {
     const output = await envinfo.run({

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -1,11 +1,23 @@
 import execa from 'execa'
+import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
 
 export const command = 'lint'
-export const desc = 'Lint your files.'
-export const builder = {
-  fix: { type: 'boolean', default: false },
+export const description = 'Lint your files'
+export const builder = (yargs) => {
+  yargs
+    .option('fix', {
+      default: false,
+      description: 'Try to fix errors',
+      type: 'boolean',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#lint'
+      )}`
+    )
 }
 
 export const handler = ({ fix }) => {

--- a/packages/cli/src/commands/open.js
+++ b/packages/cli/src/commands/open.js
@@ -1,8 +1,17 @@
 import execa from 'execa'
 import { getConfig } from '@redwoodjs/internal'
+import terminalLink from 'terminal-link'
 
 export const command = 'open'
-export const desc = 'Open your project in your browser.'
+export const description = 'Open your project in your browser'
+export const builder = (yargs) => {
+  yargs.epilogue(
+    `Also see the ${terminalLink(
+      'Redwood CLI Reference',
+      'https://redwoodjs.com/reference/command-line-interface#open'
+    )}`
+  )
+}
 export const handler = () => {
   execa(`open http://localhost:${getConfig().web.port}`, { shell: true })
 }

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -1,17 +1,30 @@
 import execa from 'execa'
 import Listr from 'listr'
 import VerboseRenderer from 'listr-verbose-renderer'
+import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
-export const command = 'test [app..]'
-export const desc = 'Run Jest tests for api and web.'
-export const builder = {
-  app: { choices: ['api', 'web'], default: ['api', 'web'] },
+export const command = 'test [side..]'
+export const description = 'Run Jest tests for api and web'
+export const builder = (yargs) => {
+  yargs
+    .positional('side', {
+      choices: ['api', 'web'],
+      default: ['api', 'web'],
+      description: 'Which side(s) to test',
+      type: 'array',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#test'
+      )}`
+    )
 }
 
-export const handler = async ({ app }) => {
+export const handler = async ({ side }) => {
   const { base: BASE_DIR } = getPaths()
   const execCommands = {
     api: {
@@ -33,10 +46,10 @@ export const handler = async ({ app }) => {
   }
 
   const tasks = new Listr(
-    app.map((appName) => {
-      const { cmd, args, cwd } = execCommands[appName]
+    side.map((sideName) => {
+      const { cmd, args, cwd } = execCommands[sideName]
       return {
-        title: `Running '${appName}' jest tests`,
+        title: `Running '${sideName}' jest tests`,
         task: () => {
           return execa(cmd, args, {
             stdio: 'inherit',

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -1,25 +1,40 @@
 import execa from 'execa'
 import Listr from 'listr'
+import terminalLink from 'terminal-link'
 
 import c from 'src/lib/colors'
 
 export const command = 'upgrade'
-export const desc = 'Upgrade all @redwoodjs packages via interactive CLI'
+export const description = 'Upgrade all @redwoodjs packages via interactive CLI'
 
 export const builder = (yargs) => {
   yargs
     .option('dry-run', {
       alias: 'd',
-      type: 'boolean',
       description: 'Check for outdated packages without upgrading',
+      type: 'boolean',
     })
     .option('tag', {
       alias: 't',
       choices: ['canary', 'rc'],
       description:
-        'WARNING: Unstable releases. Force upgrades packages to most recent version for the given --tag.',
+        'WARNING: Unstable releases! Force upgrades packages to the most recent version for the given --tag',
+      type: 'string',
     })
-    .strict()
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#upgrade'
+      )}`
+    )
+    // Just to make an empty line
+    .epilogue('')
+    .epilogue(
+      `We are < v1.0.0, so breaking changes occur frequently. For more information on the current release, see the ${terminalLink(
+        'release page',
+        'https://github.com/redwoodjs/redwood/releases'
+      )}`
+    )
 }
 
 const rwPackages =


### PR DESCRIPTION
This is a follow-up on #322: after making the CLI Reference, I audited the repo for consistency. I made some general changes and some specific ones. Based on what we do here I'll open a PR for the CLI Reference. 

**Positionals:** I added positionals (explained in this blog post http://yargs.js.org/2017/10/20/yargs-10.html) across the board. This means that the exported `builder` const is now usually a function instead of an object.

Many of the previous positional arguments were listed in help as options instead of arguments; take `build` as example:

<details><summary>Before:</summary>

```diff
rw build [app..]

Build for production.

Options:
  --help         Show help                                             [boolean]
  --version      Show version number                                   [boolean]
- --app                         [choices: "api", "web"] [default: ["api","web"]]
  --verbose, -v                                       [boolean] [default: false]
  --stats                                             [boolean] [default: false]
Done in 0.90s.
```
</details>

<details><summary>After:</summary>

```diff
rw build [app..]

Build for production

+Positionals:
+  app  Which side(s) to build
+                        [array] [choices: "api", "web"] [default: ["web","api"]]

Options:
  --help         Show help                                             [boolean]
  --version      Show version number                                   [boolean]
  --stats        Use Webpack Bundle Analyzer          [boolean] [default: false]
  --verbose, -v  Print more information while building[boolean] [default: false]

Also see the Redwood CLI Reference
Done in 1.08s.
```
</details>


**[app..] -> [side..]:** I've changed the argument from `[app..]`  to `[side..]` in `build`, `dev`, and `test` because I thought that was the more correct term. Thoughts?

**desc, describe, description:** Which one should we use? I've seen both `desc` and `description`. Should we stick to `desc`?

**Punctuating desc/describe/description?** (_Possibly trivial point no. 1_): Should we end `desc` with periods or not? Again I've seen both.

**Linking to the CLI Reference:** Yargs has an `.epilogue` method that adds a string to the end of the help message. I've been using this to link to the reference:

![link](https://user-images.githubusercontent.com/32992335/82742587-12974900-9d15-11ea-9048-19733c172a77.gif)

I added [terminal-link](https://github.com/sindresorhus/terminal-link) to do this.

**Order of props in yargs.positional/option:** (_Possibly trivial point no. 2_) The order of props in the `builder` const always seems to be slightly different. Should we keep it alphabetical? Doesn't matter?

```
yargs.positional('side', {
  choices: ['api', 'web'],
  default: ['api', 'web'],
  desc: 'Which side(s) to build',
  type: 'array'
}
```

**generate**

The positional arg's currently `<type>`. For db, another entry-point command, it's `<command>`.
Type makes sense, but it'd be nice if the help said said Types instead of Commands:

```
rw generate <type>

Save time by generating boilerplate code

Commands:
  rw g auth <provider>     Generates auth configuration.
  rw g cell <name>         Generate a cell component
  rw g component <name>    Generate a component component
  rw g function <name>     Generate a Function
  rw g layout <name>       Generate a layout component
  rw g page <name> [path]  Generates a page component
  rw g scaffold <model>    Generate Pages, SDL, and Services files based on a
                           given DB schema Model. Also accepts <path/model>
  rw g sdl <model>         Generate a GraphQL schema and service object.
  rw g service <name>      Generate a service component

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]

Also see the Redwood CLI Reference
Done in 0.97s.
```

I need to double check some things so I'll list this as a draft for now, but let me know what you think about the above.