### PR TITLE
Improve building api by first checking if `api/prisma/` exists

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 
 import execa from 'execa'
 import Listr from 'listr'
@@ -45,11 +46,12 @@ export const handler = async ({
 
   const execCommandsForApps = {
     api: {
-      cwd: getPaths().api.base,
+      // must use path.join() here, and for 'web' below, to support Windows
+      cwd: path.join(getPaths().base, 'api'),
       cmd: 'yarn cross-env NODE_ENV=production babel src --out-dir dist',
     },
     web: {
-      cwd: getPaths().web.base,
+      cwd: path.join(getPaths().base, 'web'),
       cmd: `yarn webpack --config ../node_modules/@redwoodjs/core/config/webpack.${
         stats ? 'stats' : 'production'
       }.js`,

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import path from 'path'
 
 import execa from 'execa'
 import Listr from 'listr'
@@ -9,11 +8,8 @@ import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
-// For Windows: Replaces ` ` with `\ ` to sanitize paths
-const BASE_DIR = getPaths().base.replace(' ', '\\ ')
-const apiExists = fs.existsSync(path.join(BASE_DIR, 'api'))
-const webExists = fs.existsSync(path.join(BASE_DIR, 'web'))
-const prismaExists = fs.existsSync(path.join(BASE_DIR, 'api/prisma'))
+const apiExists = fs.existsSync(getPaths().api.src)
+const webExists = fs.existsSync(getPaths().web.src)
 
 const optionDefault = (webExists, apiExists) => {
   let options = []
@@ -38,9 +34,7 @@ export const handler = async ({
   verbose = false,
   stats = false,
 }) => {
-  const { base: BASE_DIR } = getPaths()
-
-  if (app.includes('api') && prismaExists) {
+  if (app.includes('api')) {
     try {
       await generatePrismaClient({ verbose, force: true })
     } catch (e) {
@@ -51,11 +45,11 @@ export const handler = async ({
 
   const execCommandsForApps = {
     api: {
-      cwd: `${BASE_DIR}/api`,
+      cwd: getPaths().api.base,
       cmd: 'yarn cross-env NODE_ENV=production babel src --out-dir dist',
     },
     web: {
-      cwd: `${BASE_DIR}/web`,
+      cwd: getPaths().web.base,
       cmd: `yarn webpack --config ../node_modules/@redwoodjs/core/config/webpack.${
         stats ? 'stats' : 'production'
       }.js`,

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -13,6 +13,7 @@ import { handler as generatePrismaClient } from 'src/commands/dbCommands/generat
 const BASE_DIR = getPaths().base.replace(' ', '\\ ')
 const apiExists = fs.existsSync(path.join(BASE_DIR, 'api'))
 const webExists = fs.existsSync(path.join(BASE_DIR, 'web'))
+const prismaExists = fs.existsSync(path.join(BASE_DIR, 'api/prisma'))
 
 const optionDefault = (webExists, apiExists) => {
   let options = []
@@ -39,7 +40,7 @@ export const handler = async ({
 }) => {
   const { base: BASE_DIR } = getPaths()
 
-  if (app.includes('api')) {
+  if (app.includes('api') && prismaExists) {
     try {
       await generatePrismaClient({ verbose, force: true })
     } catch (e) {

--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -11,7 +11,7 @@ jest.mock('src/lib', () => {
   return {
     ...require.requireActual('src/lib'),
     runCommandTask: jest.fn((commands) => {
-      return commands.map(({ cmd, args }) => `${cmd} ${args.join(' ')}`)
+      return commands.map(({ cmd, args }) => `${cmd} ${args?.join(' ')}`)
     }),
     getPaths: () => ({
       api: {},
@@ -38,7 +38,8 @@ describe('db commands', () => {
       'yarn prisma migrate up --experimental --create-db',
     ])
     expect(runCommandTask.mock.results[1].value).toEqual([
-      'yarn prisma generate',
+      //TODO: use mock fs for getPaths().api.dbSchema
+      'echo "no schema.prisma file found" undefined',
     ])
 
     await down.handler({})
@@ -53,7 +54,8 @@ describe('db commands', () => {
 
     await generate.handler({})
     expect(runCommandTask.mock.results[4].value).toEqual([
-      'yarn prisma generate',
+      //TODO: use mock fs for getPaths().api.dbSchema
+      'echo "no schema.prisma file found" undefined',
     ])
 
     await introspect.handler({})

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 
 import { runCommandTask, getPaths } from 'src/lib'
@@ -8,7 +9,9 @@ export const builder = {
   verbose: { type: 'boolean', default: true, alias: ['v'] },
   force: { type: 'boolean', default: true, alias: ['f'] },
 }
-export const handler = async ({ verbose = true, force = true }) => {
+export const handler = async ({ verbose = true, force = false }) => {
+  const schemaExists = fs.existsSync(getPaths().api.dbSchema)
+
   // Do not generate the Prisma client if it exists.
   if (!force) {
     // The Prisma client throws if it is not generated.
@@ -16,10 +19,13 @@ export const handler = async ({ verbose = true, force = true }) => {
       // Import the client from the redwood apps node_modules path.
       const { PrismaClient } = require(path.join(
         getPaths().base,
-        'node_modules/@prisma/client'
+        'node_modules/.prisma/client'
       ))
-      // eslint-disable-next-line
-      new PrismaClient()
+      if (schemaExists) {
+        // eslint-disable-next-line
+        new PrismaClient()
+      }
+      console.log('schema path: ', getPaths().api.dbSchema)
       return undefined
     } catch (e) {
       // Swallow your pain.
@@ -29,9 +35,13 @@ export const handler = async ({ verbose = true, force = true }) => {
   return await runCommandTask(
     [
       {
-        title: 'Generating the Prisma client...',
-        cmd: 'yarn prisma',
-        args: ['generate'],
+        title: schemaExists
+          ? 'Generating the Prisma client...'
+          : 'Skipping Prisma Client: no schema.prisma found',
+        cmd: schemaExists
+          ? 'yarn prisma'
+          : 'echo "no schema.prisma file found"',
+        args: schemaExists ? ['generate'] : [],
       },
     ],
     {

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -25,7 +25,6 @@ export const handler = async ({ verbose = true, force = false }) => {
         // eslint-disable-next-line
         new PrismaClient()
       }
-      console.log('schema path: ', getPaths().api.dbSchema)
       return undefined
     } catch (e) {
       // Swallow your pain.
@@ -39,9 +38,8 @@ export const handler = async ({ verbose = true, force = false }) => {
           ? 'Generating the Prisma client...'
           : 'Skipping Prisma Client: no schema.prisma found',
         cmd: schemaExists
-          ? 'yarn prisma'
+          ? 'yarn prisma generate'
           : 'echo "no schema.prisma file found"',
-        args: schemaExists ? ['generate'] : [],
       },
     ],
     {


### PR DESCRIPTION
If an App does not include `api/prisma/`, then `yarn rw build` throws an error.

This adds a simple check to determine whether to generate the Prisma Client based on whether `prisma/` exists.