### PR TITLE
Fix dev server run error when path contains spaces

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -24,25 +24,25 @@ export const handler = async ({ app = ['db', 'api', 'web'] }) => {
   const jobs = {
     api: {
       name: 'api',
-      command: `cd ${path.join(BASE_DIR, 'api')} && yarn dev-server`,
+      command: `cd "${path.join(BASE_DIR, 'api')}" && yarn dev-server`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(API_DIR_SRC),
     },
     db: {
       name: ' db', // prefixed with ` ` to match output indentation.
-      command: `cd ${path.join(
+      command: `cd "${path.join(
         BASE_DIR,
         'api'
-      )} && yarn prisma generate --watch`,
+      )}" && yarn prisma generate --watch`,
       prefixColor: 'magenta',
       runWhen: () => fs.existsSync(PRISMA_SCHEMA),
     },
     web: {
       name: 'web',
-      command: `cd ${path.join(
+      command: `cd "${path.join(
         BASE_DIR,
         'web'
-      )} && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js`,
+      )}" && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js`,
       prefixColor: 'blue',
       runWhen: () => fs.existsSync(WEB_DIR_SRC),
     },

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -13,13 +13,12 @@ export const builder = {
 }
 
 export const handler = async ({ app = ['db', 'api', 'web'] }) => {
-  // For Windows: Replaces ` ` with `\ `. Damn, there has got to be a better
-  // way to sanitize paths?!
   // We use BASE_DIR when we need to effectively set the working dir
-  const BASE_DIR = getPaths().base.replace(' ', '\\ ')
+  const BASE_DIR = getPaths().base
   // For validation, e.g. dirExists?, we use these
-  const API_DIR = getPaths().api.base
-  const WEB_DIR = getPaths().web.base
+  // note: getPaths().web|api.base returns undefined on Windows
+  const API_DIR_SRC = getPaths().api.src
+  const WEB_DIR_SRC = getPaths().web.src
   const PRISMA_SCHEMA = getPaths().api.dbSchema
 
   const jobs = {
@@ -27,7 +26,7 @@ export const handler = async ({ app = ['db', 'api', 'web'] }) => {
       name: 'api',
       command: `cd ${path.join(BASE_DIR, 'api')} && yarn dev-server`,
       prefixColor: 'cyan',
-      runWhen: () => fs.existsSync(API_DIR),
+      runWhen: () => fs.existsSync(API_DIR_SRC),
     },
     db: {
       name: ' db', // prefixed with ` ` to match output indentation.
@@ -45,7 +44,7 @@ export const handler = async ({ app = ['db', 'api', 'web'] }) => {
         'web'
       )} && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js`,
       prefixColor: 'blue',
-      runWhen: () => fs.existsSync(WEB_DIR),
+      runWhen: () => fs.existsSync(WEB_DIR_SRC),
     },
   }
 

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -15,14 +15,17 @@ export const builder = {
 export const handler = async ({ app = ['db', 'api', 'web'] }) => {
   // For Windows: Replaces ` ` with `\ `. Damn, there has got to be a better
   // way to sanitize paths?!
+  // We use BASE_DIR when we need to effectively set the working dir
   const BASE_DIR = getPaths().base.replace(' ', '\\ ')
-  const API_DIR = path.join(BASE_DIR, 'api')
-  const WEB_DIR = path.join(BASE_DIR, 'web')
+  // For validation, e.g. dirExists?, we use these
+  const API_DIR = getPaths().api.base
+  const WEB_DIR = getPaths().web.base
+  const PRISMA_SCHEMA = getPaths().api.dbSchema
 
   const jobs = {
     api: {
       name: 'api',
-      command: `cd ${API_DIR} && yarn dev-server`,
+      command: `cd ${path.join(BASE_DIR, 'api')} && yarn dev-server`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(API_DIR),
     },
@@ -33,7 +36,7 @@ export const handler = async ({ app = ['db', 'api', 'web'] }) => {
         'api'
       )} && yarn prisma generate --watch`,
       prefixColor: 'magenta',
-      runWhen: () => fs.existsSync(API_DIR),
+      runWhen: () => fs.existsSync(PRISMA_SCHEMA),
     },
     web: {
       name: 'web',


### PR DESCRIPTION
Related #596

**This addresses two separate problems when paths contain spaces:**
1. errors when checking if dir or file exists: the previous implementation gave a false-negative if the path contained a space
2. running the commands with `concurrently`: running commands will fail if the path spaces are not sanitized
 
**Solutions:**
- for dir and file validation checks, uses `getPaths()`
- in case of DB, now checks if `schema.prisma` exists
- in case of effectively setting the working directory for `concurrently` (e.g. `cd api/`), we still need to use the "sanitize-path" method  `replace(' ', '\\ ')`, otherwise spaces still cause the run(s) to fail