### PR TITLE
Update scaffold css to use semantic classes

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/assets/scaffold.css
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/assets/scaffold.css
@@ -4,10 +4,10 @@
 
 .rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{box-sizing:inherit;border-width:0;border-style:solid;border-color:#e2e8f0}
 .rw-scaffold main{display:block}
-.rw-scaffold h1,.rw-scaffold h2{margin:0;}
-.rw-scaffold a{background-color:transparent;}
-.rw-scaffold ul{list-style:none;margin:0;padding:0}
-.rw-scaffold input{font-family:inherit;font-size:100%;line-height:1.15;overflow:visible}
+.rw-scaffold h1,.rw-scaffold h2{margin:0}
+.rw-scaffold a{background-color:transparent}
+.rw-scaffold ul{margin:0;padding:0}
+.rw-scaffold input{font-family:inherit;font-size:100%;overflow:visible}
 .rw-scaffold input:-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::placeholder{color:#a0aec0}
@@ -30,25 +30,26 @@
 .rw-heading.rw-heading-secondary{font-size:.875rem}
 .rw-heading .rw-link{color:#4a5568;text-decoration: none}
 .rw-heading .rw-link:hover{color:#1a202c;text-decoration:underline}
-.rw-form-wrapper{box-sizing:border-box;font-size:.875rem;margin-top:-1rem;}
+.rw-form-wrapper{box-sizing:border-box;font-size:.875rem;margin-top:-1rem}
 .rw-form-error-wrapper{padding:1rem;background-color:#fff5f5;color:#c53030;border-width:1px;border-color:#feb2b2;border-radius:.25rem;margin:1rem 0}
 .rw-form-error-title{margin-top:0;font-weight:600}
 .rw-form-error-list{margin-top:.5rem;list-style-type:disc;list-style-position:inside}
-.rw-button{color:#718096;display:flex;font-size:.75rem;font-weight:600;padding:.25rem 1rem;text-transform:uppercase;text-decoration: none;letter-spacing:.025em;border-radius:.25rem;line-height: 2}
+.rw-button{color:#718096;cursor:pointer;display:flex;justify-content:center;font-size:.75rem;font-weight:600;padding:.25rem 1rem;text-transform:uppercase;text-decoration: none;letter-spacing:.025em;border-radius:.25rem;line-height: 2}
 .rw-button:hover{background-color:#718096;color:#fff}
-.rw-button.rw-button-small{font-size:.75rem;border-radius:.125rem;padding:.25rem .5rem;line-height:inherit;}
-.rw-button.rw-button-green{background-color:#48bb78;color:#fff;}
+.rw-button.rw-button-small{font-size:.75rem;border-radius:.125rem;padding:.25rem .5rem;line-height:inherit}
+.rw-button.rw-button-green{background-color:#48bb78;color:#fff}
 .rw-button.rw-button-green:hover{background-color:#38a169;color:#fff}
 .rw-button.rw-button-blue{background-color:#3182ce;color:#fff}
-.rw-button.rw-button-blue:hover{background-color:#2b6cb0;}
+.rw-button.rw-button-blue:hover{background-color:#2b6cb0}
 .rw-button.rw-button-red{background-color:#e53e3e;color:#fff}
-.rw-button.rw-button-red:hover{background-color:#c53030;}
+.rw-button.rw-button-red:hover{background-color:#c53030}
 .rw-button-icon{font-size:1.25rem;line-height:1;margin-right:.25rem}
-.rw-button-group {padding: 1rem .5rem; text-align:center; }
-.rw-button-group .rw-button { display: inline-block; margin: 0 .25rem}
+.rw-button-group {display:flex;justify-content:center;margin:.75rem .5rem}
+.rw-button-group .rw-button { margin: 0 .25rem}
+.rw-form-wrapper .rw-button-group{margin-top:2rem;margin-bottom:0}
 .rw-label{display:block;margin-top:1.5rem;color:#4a5568;font-weight:600}
 .rw-label.rw-label-error{color:#c53030}
-.rw-input{display:block;margin-top:.5rem;width:100%;padding:.5rem;border-width:1px;border-color:#e2e8f0;color:#4a5568;border-radius:.25rem;outline:none;}
+.rw-input{display:block;margin-top:.5rem;width:100%;padding:.5rem;border-width:1px;border-color:#e2e8f0;color:#4a5568;border-radius:.25rem;outline:none}
 .rw-input:focus{border-color:#a0aec0}
 .rw-input-error{border-color:#c53030;color:#c53030}
 .rw-field-error{display:block;margin-top:.25rem;font-weight:600;text-transform:uppercase;font-size:.75rem;color:#c53030}
@@ -58,17 +59,16 @@
 .rw-table th,
 .rw-table td{padding:.75rem}
 .rw-table thead tr{background-color:#e2e8f0;color:#4a5568}
-.rw-table th {font-weight:600; text-align:left;}
-.rw-table thead th {text-align:left;}
-.rw-table tbody th {text-align:right;}
+.rw-table th {font-weight:600;text-align:left}
+.rw-table thead th {text-align:left}
+.rw-table tbody th {text-align:right}
 @media (min-width:768px) {
   .rw-table tbody th {width:20%}
 }
 .rw-table tbody tr{background-color:#f7fafc;border-top-width:1px}
 .rw-table tbody tr:nth-child(even){background-color:#fff}
-.rw-table .rw-table-actions {padding-right:1rem;text-align:right;white-space:nowrap}
-.rw-table .rw-table-actions li {display:inline-block}
-.rw-table-actions .rw-button{background-color:#f7fafc;}
+.rw-table-actions {display:flex;justify-content:flex-end;align-items: center;height:17px;padding-right:.25rem}
+.rw-table-actions .rw-button{background-color:transparent}
 .rw-table-actions .rw-button:hover{background-color:#718096;color:#fff}
 .rw-table-actions .rw-button-blue{color:#3182ce}
 .rw-table-actions .rw-button-blue:hover{background-color:#3182ce;color:#fff}

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/assets/scaffold.css
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/assets/scaffold.css
@@ -1,167 +1,77 @@
 /*
-  This file was created automatically as the result of the scaffold generator.
-  If you decide to use TailwindCSS in your project then you can safely delete
-  this file, but first remove the <div className="rw-scaffold"> from the Layout
-  that your scaffold is wrapped in. Check the comment blocks below for a
-  couple of config options you'll need to add to Tailwind to preserve the
-  scaffold appearance.
-
-  If you don't use Tailwind then you should keep it here until you have
-  completely converted your scaffolded pages or removed them, or if you don't
-  mind your scaffolded pages being monumentally ugly.
-*/
-
-/*
   normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css
 */
 
+.rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{box-sizing:inherit;border-width:0;border-style:solid;border-color:#e2e8f0}
 .rw-scaffold main{display:block}
-.rw-scaffold h1{font-size:2em;margin:.67em 0}
-.rw-scaffold a{background-color:transparent}
-.rw-scaffold input{font-family:inherit;font-size:100%;line-height:1.15;margin:0}
-.rw-scaffold input{overflow:visible}
-.rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{box-sizing:inherit}
-.rw-scaffold h1,.rw-scaffold h2{margin:0}
+.rw-scaffold h1,.rw-scaffold h2{margin:0;}
+.rw-scaffold a{background-color:transparent;}
 .rw-scaffold ul{list-style:none;margin:0;padding:0}
-.rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{border-width:0;border-style:solid;border-color:#e2e8f0}
+.rw-scaffold input{font-family:inherit;font-size:100%;line-height:1.15;overflow:visible}
 .rw-scaffold input:-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::placeholder{color:#a0aec0}
 .rw-scaffold table{border-collapse:collapse}
-.rw-scaffold h1,.rw-scaffold .rw-scaffold h2{font-size:inherit;font-weight:inherit}
-.rw-scaffold a{color:inherit;text-decoration:inherit}
-.rw-scaffold input{padding:0;line-height:inherit;color:inherit}
 
 /*
-  Classes we use in scaffolds from TailwindCSS v1.1.4
+  Style
 */
 
-.rw-scaffold .bg-white{background-color:#fff}
-.rw-scaffold .bg-gray-100{background-color:#f7fafc}
-.rw-scaffold .bg-gray-300{background-color:#e2e8f0}
-.rw-scaffold .bg-red-100{background-color:#fff5f5}
-.rw-scaffold .bg-red-600{background-color:#e53e3e}
-.rw-scaffold .bg-green-500{background-color:#48bb78}
-.rw-scaffold .bg-blue-600{background-color:#3182ce}
-.rw-scaffold .hover\:bg-gray-600:hover{background-color:#718096}
-.rw-scaffold .hover\:bg-red-600:hover{background-color:#e53e3e}
-.rw-scaffold .hover\:bg-red-700:hover{background-color:#c53030}
-.rw-scaffold .hover\:bg-green-600:hover{background-color:#38a169}
-.rw-scaffold .hover\:bg-blue-600:hover{background-color:#3182ce}
-.rw-scaffold .hover\:bg-blue-700:hover{background-color:#2b6cb0}
-.rw-scaffold .border-gray-300{border-color:#e2e8f0}
-.rw-scaffold .border-red-300{border-color:#feb2b2}
-.rw-scaffold .border-red-700{border-color:#c53030}
-.rw-scaffold .focus\:border-gray-500:focus{border-color:#a0aec0}
-.rw-scaffold .rounded-sm{border-radius:.125rem}
-.rw-scaffold .rounded{border-radius:.25rem}
-.rw-scaffold .rounded-lg{border-radius:.5rem}
-.rw-scaffold .border{border-width:1px}
-.rw-scaffold .border-t{border-top-width:1px}
-.rw-scaffold .block{display:block}
-.rw-scaffold .inline-block{display:inline-block}
-.rw-scaffold .flex{display:flex}
-.rw-scaffold .table{display:table}
-.rw-scaffold .justify-between{justify-content:space-between}
-.rw-scaffold .font-sans{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"}
-.rw-scaffold .font-semibold{font-weight:600}
-.rw-scaffold .leading-none{line-height:1}
-.rw-scaffold .leading-loose{line-height:2}
-.rw-scaffold .list-inside{list-style-position:inside}
-.rw-scaffold .list-disc{list-style-type:disc}
-.rw-scaffold .mx-2{margin-left:.5rem;margin-right:.5rem}
-.rw-scaffold .my-4{margin-top:1rem;margin-bottom:1rem}
-.rw-scaffold .mx-4{margin-left:1rem;margin-right:1rem}
-.rw-scaffold .mt-0{margin-top:0}
-.rw-scaffold .mt-1{margin-top:.25rem}
-.rw-scaffold .ml-1{margin-left:.25rem}
-.rw-scaffold .mt-2{margin-top:.5rem}
-.rw-scaffold .ml-2{margin-left:.5rem}
-.rw-scaffold .mt-4{margin-top:1rem}
-.rw-scaffold .mb-4{margin-bottom:1rem}
-.rw-scaffold .mt-6{margin-top:1.5rem}
-.rw-scaffold .mt-8{margin-top:2rem}
-.rw-scaffold .-mt-4{margin-top:-1rem}
-.rw-scaffold .focus\:outline-none:focus{outline:0}
-.rw-scaffold .overflow-hidden{overflow:hidden}
-.rw-scaffold .overflow-x-scroll{overflow-x:scroll}
-.rw-scaffold .p-2{padding:.5rem}
-.rw-scaffold .p-3{padding:.75rem}
-.rw-scaffold .p-4{padding:1rem}
-.rw-scaffold .py-1{padding-top:.25rem;padding-bottom:.25rem}
-.rw-scaffold .py-2{padding-top:.5rem;padding-bottom:.5rem}
-.rw-scaffold .px-2{padding-left:.5rem;padding-right:.5rem}
-.rw-scaffold .py-3{padding-top:.75rem;padding-bottom:.75rem}
-.rw-scaffold .px-3{padding-left:.75rem;padding-right:.75rem}
-.rw-scaffold .py-4{padding-top:1rem;padding-bottom:1rem}
-.rw-scaffold .px-4{padding-left:1rem;padding-right:1rem}
-.rw-scaffold .px-8{padding-left:2rem;padding-right:2rem}
-.rw-scaffold .pr-4{padding-right:1rem}
-.rw-scaffold .pb-4{padding-bottom:1rem}
-.rw-scaffold .table-auto{table-layout:auto}
-.rw-scaffold .text-left{text-align:left}
-.rw-scaffold .text-center{text-align:center}
-.rw-scaffold .text-right{text-align:right}
-.rw-scaffold .text-white{color:#fff}
-.rw-scaffold .text-gray-600{color:#718096}
-.rw-scaffold .text-gray-700{color:#4a5568}
-.rw-scaffold .text-gray-900{color:#1a202c}
-.rw-scaffold .text-red-600{color:#e53e3e}
-.rw-scaffold .text-red-700{color:#c53030}
-.rw-scaffold .text-red-900{color:#742a2a}
-.rw-scaffold .text-blue-500{color:#4299e1}
-.rw-scaffold .text-blue-600{color:#3182ce}
-.rw-scaffold .hover\:text-white:hover{color:#fff}
-.rw-scaffold .hover\:text-gray-900:hover{color:#1a202c}
-.rw-scaffold .hover\:text-blue-700:hover{color:#2b6cb0}
-.rw-scaffold .text-xs{font-size:.75rem}
-.rw-scaffold .text-sm{font-size:.875rem}
-.rw-scaffold .text-xl{font-size:1.25rem}
-.rw-scaffold .uppercase{text-transform:uppercase}
-.rw-scaffold .underline{text-decoration:underline}
-.rw-scaffold .hover\:underline:hover{text-decoration:underline}
-.rw-scaffold .tracking-wide{letter-spacing:.025em}
-.rw-scaffold .whitespace-no-wrap{white-space:nowrap}
-.rw-scaffold .truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.rw-scaffold .w-full{width:100%}
-.rw-scaffold .box-border{box-sizing:border-box}
+.rw-scaffold{background-color:#fff;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"}
+.rw-header{display:flex;justify-content:space-between;padding: 1rem 2rem 1rem 2rem}
+.rw-main{margin-left:1rem;margin-right:1rem;padding-bottom:1rem}
+.rw-segment{ background-color:#fff;border-width:1px;border-radius:.5rem;overflow:hidden}
+.rw-segment-header{background-color:#e2e8f0;color:#4a5568;padding:.75rem 1rem}
+.rw-segment-main{background-color:#f7fafc;padding: 1rem}
+.rw-link {color:#4299e1;text-decoration:underline}
+.rw-link:hover {color:#2b6cb0}
+.rw-heading {font-weight:600}
+.rw-heading.rw-heading-primary{font-size:1.25rem}
+.rw-heading.rw-heading-secondary{font-size:.875rem}
+.rw-heading .rw-link{color:#4a5568;text-decoration: none}
+.rw-heading .rw-link:hover{color:#1a202c;text-decoration:underline}
+.rw-form-wrapper{box-sizing:border-box;font-size:.875rem;margin-top:-1rem;}
+.rw-form-error-wrapper{padding:1rem;background-color:#fff5f5;color:#c53030;border-width:1px;border-color:#feb2b2;border-radius:.25rem;margin:1rem 0}
+.rw-form-error-title{margin-top:0;font-weight:600}
+.rw-form-error-list{margin-top:.5rem;list-style-type:disc;list-style-position:inside}
+.rw-button{color:#718096;display:flex;font-size:.75rem;font-weight:600;padding:.25rem 1rem;text-transform:uppercase;text-decoration: none;letter-spacing:.025em;border-radius:.25rem;line-height: 2}
+.rw-button:hover{background-color:#718096;color:#fff}
+.rw-button.rw-button-small{font-size:.75rem;border-radius:.125rem;padding:.25rem .5rem;line-height:inherit;}
+.rw-button.rw-button-green{background-color:#48bb78;color:#fff;}
+.rw-button.rw-button-green:hover{background-color:#38a169;color:#fff}
+.rw-button.rw-button-blue{background-color:#3182ce;color:#fff}
+.rw-button.rw-button-blue:hover{background-color:#2b6cb0;}
+.rw-button.rw-button-red{background-color:#e53e3e;color:#fff}
+.rw-button.rw-button-red:hover{background-color:#c53030;}
+.rw-button-icon{font-size:1.25rem;line-height:1;margin-right:.25rem}
+.rw-button-group {padding: 1rem .5rem; text-align:center; }
+.rw-button-group .rw-button { display: inline-block; margin: 0 .25rem}
+.rw-label{display:block;margin-top:1.5rem;color:#4a5568;font-weight:600}
+.rw-label.rw-label-error{color:#c53030}
+.rw-input{display:block;margin-top:.5rem;width:100%;padding:.5rem;border-width:1px;border-color:#e2e8f0;color:#4a5568;border-radius:.25rem;outline:none;}
+.rw-input:focus{border-color:#a0aec0}
+.rw-input-error{border-color:#c53030;color:#c53030}
+.rw-field-error{display:block;margin-top:.25rem;font-weight:600;text-transform:uppercase;font-size:.75rem;color:#c53030}
+.rw-table-wrapper-responsive{overflow-x: scroll}
+.rw-table-wrapper-responsive .rw-table{min-width:48rem}
+.rw-table{table-layout:auto;width:100%;font-size:.875rem}
+.rw-table th,
+.rw-table td{padding:.75rem}
+.rw-table thead tr{background-color:#e2e8f0;color:#4a5568}
+.rw-table th {font-weight:600; text-align:left;}
+.rw-table thead th {text-align:left;}
+.rw-table tbody th {text-align:right;}
 @media (min-width:768px) {
-  .rw-scaffold .md\:w-1\/5{width:20%}
+  .rw-table tbody th {width:20%}
 }
-
-/*
-  Here are variants (:odd, :even) that aren't enabled in Tailwind by default.
-  If you decide to include Tailwind yourself and still want scaffolds to look
-  the same then you can tell it to build these variants by adding the following
-  to tailwind.config.js:
-
-    module.exports = {
-      variants: {
-        backgroundColor: ['hover', 'focus', 'odd', 'even']
-      }
-    }
-
-  Tailwind variant customization docs: https://tailwindcss.com/docs/configuring-variants
-*/
-
-.rw-scaffold .odd\:bg-gray-100:nth-child(odd) {background-color: #f7fafc}
-.rw-scaffold .even\:bg-white:nth-child(even) {background-color: #ffffff;}
-
-/*
-  Any custom styles that Tailwind doesn't provide. You can add these to your
-  own install of Tailwind by adding the following to tailwind.config.js:
-
-    module.exports = {
-      theme: {
-        extend: {
-          minWidth: {
-            '3xl': '48rem'
-          }
-        }
-      }
-    }
-
-  Tailwind theme extension docs: https://tailwindcss.com/docs/theme#extending-the-default-theme
-*/
-
-.rw-scaffold .min-w-3xl {min-width: 48rem}
+.rw-table tbody tr{background-color:#f7fafc;border-top-width:1px}
+.rw-table tbody tr:nth-child(even){background-color:#fff}
+.rw-table .rw-table-actions {padding-right:1rem;text-align:right;white-space:nowrap}
+.rw-table .rw-table-actions li {display:inline-block}
+.rw-table-actions .rw-button{background-color:#f7fafc;}
+.rw-table-actions .rw-button:hover{background-color:#718096;color:#fff}
+.rw-table-actions .rw-button-blue{color:#3182ce}
+.rw-table-actions .rw-button-blue:hover{background-color:#3182ce;color:#fff}
+.rw-table-actions .rw-button-red{color:#e53e3e}
+.rw-table-actions .rw-button-red:hover{background-color:#e53e3e;color:#fff}
+.rw-text-center{text-align:center}

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/editCell.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/editCell.js
@@ -37,11 +37,11 @@ export const Success = ({ post }) => {
   }
 
   return (
-    <div className="bg-white border rounded-lg overflow-hidden">
-      <header className="bg-gray-300 text-gray-700 py-3 px-4">
-        <h2 className="text-sm font-semibold">Edit Post {post.id}</h2>
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">Edit Post {post.id}</h2>
       </header>
-      <div className="bg-gray-100 p-4">
+      <div className="rw-segment-main">
         <PostForm post={post} onSave={onSave} error={error} loading={loading} />
       </div>
     </div>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/edit.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/edit.js
@@ -34,11 +34,11 @@ export const Success = ({ userProfile }) => {
   }
 
   return (
-    <div className="bg-white border rounded-lg overflow-hidden">
-      <header className="bg-gray-300 text-gray-700 py-3 px-4">
-        <h2 className="text-sm font-semibold">Edit UserProfile {userProfile.id}</h2>
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">Edit UserProfile {userProfile.id}</h2>
       </header>
-      <div className="bg-gray-100 p-4">
+      <div className="rw-segment-main">
         <UserProfileForm userProfile={userProfile} onSave={onSave} error={error} loading={loading} />
       </div>
     </div>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
@@ -23,11 +23,11 @@ const NewUserProfile = () => {
   }
 
   return (
-    <div className="bg-white border rounded-lg overflow-hidden">
-      <header className="bg-gray-300 text-gray-700 py-3 px-4">
-        <h2 className="text-sm font-semibold">New UserProfile</h2>
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">New UserProfile</h2>
       </header>
-      <div className="bg-gray-100 p-4">
+      <div className="rw-segment-main">
         <UserProfileForm onSave={onSave} loading={loading} error={error} />
       </div>
     </div>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
@@ -7,14 +7,6 @@ import {
   Submit,
 } from '@redwoodjs/web'
 
-const CSS = {
-  label: 'rw-label',
-  labelError: 'rw-label rw-label-error',
-  input: 'rw-input',
-  inputError: 'rw-input rw-input-error',
-  errorMessage: 'rw-field-error',
-}
-
 const PostForm = (props) => {
   const onSubmit = (data) => {
     props.onSave(data, props?.post?.id)
@@ -32,99 +24,99 @@ const PostForm = (props) => {
 
         <Label
           name="title"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           Title
         </Label>
         <TextField
           name="title"
           defaultValue={props.post?.title}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="title" className={CSS.errorMessage} />
+        <FieldError name="title" className="rw-field-error" />
 
         <Label
           name="slug"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           Slug
         </Label>
         <TextField
           name="slug"
           defaultValue={props.post?.slug}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="slug" className={CSS.errorMessage} />
+        <FieldError name="slug" className="rw-field-error" />
 
         <Label
           name="author"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           Author
         </Label>
         <TextField
           name="author"
           defaultValue={props.post?.author}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="author" className={CSS.errorMessage} />
+        <FieldError name="author" className="rw-field-error" />
 
         <Label
           name="body"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           Body
         </Label>
         <TextField
           name="body"
           defaultValue={props.post?.body}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="body" className={CSS.errorMessage} />
+        <FieldError name="body" className="rw-field-error" />
 
         <Label
           name="image"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           Image
         </Label>
         <TextField
           name="image"
           defaultValue={props.post?.image}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="image" className={CSS.errorMessage} />
+        <FieldError name="image" className="rw-field-error" />
 
         <Label
           name="postedAt"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           Posted at
         </Label>
         <TextField
           name="postedAt"
           defaultValue={props.post?.postedAt}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="postedAt" className={CSS.errorMessage} />
+        <FieldError name="postedAt" className="rw-field-error" />
 
         <div className="rw-button-group">
           <Submit

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
@@ -8,13 +8,11 @@ import {
 } from '@redwoodjs/web'
 
 const CSS = {
-  label: 'block mt-6 text-gray-700 font-semibold',
-  labelError: 'block mt-6 font-semibold text-red-700',
-  input:
-    'block mt-2 w-full p-2 border border-gray-300 text-gray-700 rounded focus:outline-none focus:border-gray-500',
-  inputError:
-    'block mt-2 w-full p-2 border border-red-700 text-red-900 rounded focus:outline-none',
-  errorMessage: 'block mt-1 font-semibold uppercase text-xs text-red-700',
+  label: 'rw-label',
+  labelError: 'rw-label rw-label-error',
+  input: 'rw-input',
+  inputError: 'rw-input rw-input-error',
+  errorMessage: 'rw-field-error',
 }
 
 const PostForm = (props) => {
@@ -23,13 +21,13 @@ const PostForm = (props) => {
   }
 
   return (
-    <div className="box-border text-sm -mt-4">
+    <div className="rw-form-wrapper">
       <Form onSubmit={onSubmit} error={props.error}>
         <FormError
           error={props.error}
-          wrapperClassName="p-4 bg-red-100 text-red-700 border border-red-300 rounded mt-4 mb-4"
-          titleClassName="mt-0 font-semibold"
-          listClassName="mt-2 list-disc list-inside"
+          wrapperClassName="rw-form-error-wrapper"
+          titleClassName="rw-form-error-title"
+          listClassName="rw-form-error-list"
         />
 
         <Label
@@ -128,10 +126,10 @@ const PostForm = (props) => {
         />
         <FieldError name="postedAt" className={CSS.errorMessage} />
 
-        <div className="mt-8 text-center">
+        <div className="rw-button-group">
           <Submit
             disabled={props.loading}
-            className="bg-blue-600 text-white hover:bg-blue-700 text-xs rounded px-4 py-2 uppercase font-semibold tracking-wide"
+            className="rw-button rw-button-blue"
           >
             Save
           </Submit>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
@@ -61,38 +61,30 @@ const PostsList = ({ posts }) => {
               <td>{truncate(post.body)}</td>
               <td>{truncate(post.image)}</td>
               <td>{timeTag(post.postedAt)}</td>
-              <td className="rw-table-actions">
-                <nav>
-                  <ul>
-                    <li>
-                      <Link
-                        to={routes.post({ id: post.id })}
-                        title={'Show post ' + post.id + ' detail'}
-                        className="rw-button rw-button-small"
-                      >
-                        Show
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        to={routes.editPost({ id: post.id })}
-                        title={'Edit post ' + post.id}
-                        className="rw-button rw-button-small rw-button-blue"
-                      >
-                        Edit
-                      </Link>
-                    </li>
-                    <li>
-                      <a
-                        href="#"
-                        title={'Delete post ' + post.id}
-                        className="rw-button rw-button-small rw-button-red"
-                        onClick={() => onDeleteClick(post.id)}
-                      >
-                        Delete
-                      </a>
-                    </li>
-                  </ul>
+              <td>
+                <nav className="rw-table-actions">
+                  <Link
+                    to={routes.post({ id: post.id })}
+                    title={'Show post ' + post.id + ' detail'}
+                    className="rw-button rw-button-small"
+                  >
+                    Show
+                  </Link>
+                  <Link
+                    to={routes.editPost({ id: post.id })}
+                    title={'Edit post ' + post.id}
+                    className="rw-button rw-button-small rw-button-blue"
+                  >
+                    Edit
+                  </Link>
+                  <a
+                    href="#"
+                    title={'Delete post ' + post.id}
+                    className="rw-button rw-button-small rw-button-red"
+                    onClick={() => onDeleteClick(post.id)}
+                  >
+                    Delete
+                  </a>
                 </nav>
               </td>
             </tr>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
@@ -37,59 +37,56 @@ const PostsList = ({ posts }) => {
   }
 
   return (
-    <div className="bg-white text-gray-900 border rounded-lg overflow-x-scroll">
-      <table className="table-auto w-full min-w-3xl text-sm">
+    <div className="rw-segment rw-table-wrapper-responsive">
+      <table className="rw-table">
         <thead>
-          <tr className="bg-gray-300 text-gray-700">
-            <th className="font-semibold text-left p-3">id</th>
-            <th className="font-semibold text-left p-3">title</th>
-            <th className="font-semibold text-left p-3">slug</th>
-            <th className="font-semibold text-left p-3">author</th>
-            <th className="font-semibold text-left p-3">body</th>
-            <th className="font-semibold text-left p-3">image</th>
-            <th className="font-semibold text-left p-3">postedAt</th>
-            <th className="font-semibold text-left p-3">&nbsp;</th>
+          <tr>
+            <th>id</th>
+            <th>title</th>
+            <th>slug</th>
+            <th>author</th>
+            <th>body</th>
+            <th>image</th>
+            <th>postedAt</th>
+            <th>&nbsp;</th>
           </tr>
         </thead>
         <tbody>
           {posts.map((post) => (
-            <tr
-              key={post.id}
-              className="odd:bg-gray-100 even:bg-white border-t"
-            >
-              <td className="p-3">{truncate(post.id)}</td>
-              <td className="p-3">{truncate(post.title)}</td>
-              <td className="p-3">{truncate(post.slug)}</td>
-              <td className="p-3">{truncate(post.author)}</td>
-              <td className="p-3">{truncate(post.body)}</td>
-              <td className="p-3">{truncate(post.image)}</td>
-              <td className="p-3">{timeTag(post.postedAt)}</td>
-              <td className="p-3 pr-4 text-right whitespace-no-wrap">
+            <tr key={post.id}>
+              <td>{truncate(post.id)}</td>
+              <td>{truncate(post.title)}</td>
+              <td>{truncate(post.slug)}</td>
+              <td>{truncate(post.author)}</td>
+              <td>{truncate(post.body)}</td>
+              <td>{truncate(post.image)}</td>
+              <td>{timeTag(post.postedAt)}</td>
+              <td className="rw-table-actions">
                 <nav>
                   <ul>
-                    <li className="inline-block">
+                    <li>
                       <Link
                         to={routes.post({ id: post.id })}
                         title={'Show post ' + post.id + ' detail'}
-                        className="text-xs bg-gray-100 text-gray-600 hover:bg-gray-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
+                        className="rw-button rw-button-small"
                       >
                         Show
                       </Link>
                     </li>
-                    <li className="inline-block">
+                    <li>
                       <Link
                         to={routes.editPost({ id: post.id })}
                         title={'Edit post ' + post.id}
-                        className="text-xs bg-gray-100 text-blue-600 hover:bg-blue-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
+                        className="rw-button rw-button-small rw-button-blue"
                       >
                         Edit
                       </Link>
                     </li>
-                    <li className="inline-block">
+                    <li>
                       <a
                         href="#"
                         title={'Delete post ' + post.id}
-                        className="text-xs bg-gray-100 text-red-600 hover:bg-red-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
+                        className="rw-button rw-button-small rw-button-red"
                         onClick={() => onDeleteClick(post.id)}
                       >
                         Delete

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/indexCell.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/indexCell.js
@@ -24,11 +24,11 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => {
   return (
-    <div className="text-center">
+    <div className="rw-text-center">
       {'No posts yet. '}
       <Link
         to={routes.newPost()}
-        className="text-blue-500 underline hover:text-blue-700"
+        className="rw-link"
       >
         {'Create one?'}
       </Link>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
@@ -22,11 +22,11 @@ const NewPost = () => {
   }
 
   return (
-    <div className="bg-white border rounded-lg overflow-hidden">
-      <header className="bg-gray-300 text-gray-700 py-3 px-4">
-        <h2 className="text-sm font-semibold">New Post</h2>
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">New Post</h2>
       </header>
-      <div className="bg-gray-100 p-4">
+      <div className="rw-segment-main">
         <PostForm onSave={onSave} loading={loading} error={error} />
       </div>
     </div>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
@@ -32,25 +32,25 @@ const Post = ({ post }) => {
         <table className="rw-table">
           <tbody>
             <tr>
-              <td>id</td>
+              <th>id</th>
               <td>{post.id}</td>
             </tr><tr>
-              <td>title</td>
+              <th>title</th>
               <td>{post.title}</td>
             </tr><tr>
-              <td>slug</td>
+              <th>slug</th>
               <td>{post.slug}</td>
             </tr><tr>
-              <td>author</td>
+              <th>author</th>
               <td>{post.author}</td>
             </tr><tr>
-              <td>body</td>
+              <th>body</th>
               <td>{post.body}</td>
             </tr><tr>
-              <td>image</td>
+              <th>image</th>
               <td>{post.image}</td>
             </tr><tr>
-              <td>postedAt</td>
+              <th>postedAt</th>
               <td>{post.postedAt}</td>
             </tr>
           </tbody>

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
@@ -25,57 +25,51 @@ const Post = ({ post }) => {
 
   return (
     <>
-      <div className="bg-white border rounded-lg overflow-hidden">
-        <header className="bg-gray-300 text-gray-700 py-3 px-4">
-          <h2 className="text-sm font-semibold">Post {post.id} Detail</h2>
+      <div className="rw-segment">
+        <header className="rw-segment-header">
+          <h2 className="rw-heading rw-heading-secondary">Post {post.id} Detail</h2>
         </header>
-        <table className="w-full text-sm">
+        <table className="rw-table">
           <tbody>
-            <tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">id</td>
-              <td className="p-3">{post.id}</td>
-            </tr><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">title</td>
-              <td className="p-3">{post.title}</td>
-            </tr><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">slug</td>
-              <td className="p-3">{post.slug}</td>
-            </tr><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">author</td>
-              <td className="p-3">{post.author}</td>
-            </tr><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">body</td>
-              <td className="p-3">{post.body}</td>
-            </tr><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">image</td>
-              <td className="p-3">{post.image}</td>
-            </tr><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5">postedAt</td>
-              <td className="p-3">{post.postedAt}</td>
+            <tr>
+              <td>id</td>
+              <td>{post.id}</td>
+            </tr><tr>
+              <td>title</td>
+              <td>{post.title}</td>
+            </tr><tr>
+              <td>slug</td>
+              <td>{post.slug}</td>
+            </tr><tr>
+              <td>author</td>
+              <td>{post.author}</td>
+            </tr><tr>
+              <td>body</td>
+              <td>{post.body}</td>
+            </tr><tr>
+              <td>image</td>
+              <td>{post.image}</td>
+            </tr><tr>
+              <td>postedAt</td>
+              <td>{post.postedAt}</td>
             </tr>
           </tbody>
         </table>
       </div>
-      <nav className="my-4 mx-2 text-center">
-        <ul>
-          <li className="inline-block ml-2">
-            <Link
-              to={routes.editPost({ id: post.id })}
-              className="text-xs bg-blue-600 text-white hover:bg-blue-700 rounded px-4 py-2 uppercase font-semibold tracking-wide"
-            >
-              Edit
-            </Link>
-          </li>
-          <li className="inline-block ml-2">
-            <a
-              href="#"
-              className="text-xs bg-red-600 text-white hover:bg-red-700 rounded px-4 py-2 uppercase font-semibold tracking-wide"
-              onClick={() => onDeleteClick(post.id)}
-            >
-              Delete
-            </a>
-          </li>
-        </ul>
+      <nav className="rw-button-group">
+        <Link
+          to={routes.editPost({ id: post.id })}
+          className="rw-button rw-button-blue"
+        >
+          Edit
+        </Link>
+        <a
+          href="#"
+          className="rw-button rw-button-red"
+          onClick={() => onDeleteClick(post.id)}
+        >
+          Delete
+        </a>
       </nav>
     </>
   )

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/layouts/layout.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/layouts/layout.js
@@ -3,26 +3,23 @@ import { Link, routes } from '@redwoodjs/router'
 const PostsLayout = (props) => {
   return (
     <div className="rw-scaffold">
-      <div className="bg-white font-sans">
-        <header className="flex justify-between py-4 px-8">
-          <h1 className="text-xl font-semibold">
-            <Link
-              to={routes.posts()}
-              className="text-gray-700 hover:text-gray-900 hover:underline"
-            >
-              Posts
-            </Link>
-          </h1>
+      <header className="rw-header">
+        <h1 className="rw-heading rw-heading-primary">
           <Link
-            to={routes.newPost()}
-            className="flex bg-green-500 hover:bg-green-600 text-white text-xs font-semibold px-3 py-1 uppercase tracking-wide rounded"
+            to={routes.posts()}
+            className="rw-link"
           >
-            <div className="text-xl leading-none">+</div>
-            <div className="ml-1 leading-loose">New Post</div>
+            Posts
           </Link>
-        </header>
-        <main className="mx-4 pb-4">{props.children}</main>
-      </div>
+        </h1>
+        <Link
+          to={routes.newPost()}
+          className="rw-button rw-button-green"
+        >
+          <div className="rw-button-icon">+</div> New Post
+        </Link>
+      </header>
+      <main className="rw-main">{props.children}</main>
     </div>
   )
 }

--- a/packages/cli/src/commands/generate/scaffold/templates/assets/scaffold.css.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/assets/scaffold.css.template
@@ -4,10 +4,10 @@
 
 .rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{box-sizing:inherit;border-width:0;border-style:solid;border-color:#e2e8f0}
 .rw-scaffold main{display:block}
-.rw-scaffold h1,.rw-scaffold h2{margin:0;}
-.rw-scaffold a{background-color:transparent;}
-.rw-scaffold ul{list-style:none;margin:0;padding:0}
-.rw-scaffold input{font-family:inherit;font-size:100%;line-height:1.15;overflow:visible}
+.rw-scaffold h1,.rw-scaffold h2{margin:0}
+.rw-scaffold a{background-color:transparent}
+.rw-scaffold ul{margin:0;padding:0}
+.rw-scaffold input{font-family:inherit;font-size:100%;overflow:visible}
 .rw-scaffold input:-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::placeholder{color:#a0aec0}
@@ -30,25 +30,26 @@
 .rw-heading.rw-heading-secondary{font-size:.875rem}
 .rw-heading .rw-link{color:#4a5568;text-decoration: none}
 .rw-heading .rw-link:hover{color:#1a202c;text-decoration:underline}
-.rw-form-wrapper{box-sizing:border-box;font-size:.875rem;margin-top:-1rem;}
+.rw-form-wrapper{box-sizing:border-box;font-size:.875rem;margin-top:-1rem}
 .rw-form-error-wrapper{padding:1rem;background-color:#fff5f5;color:#c53030;border-width:1px;border-color:#feb2b2;border-radius:.25rem;margin:1rem 0}
 .rw-form-error-title{margin-top:0;font-weight:600}
 .rw-form-error-list{margin-top:.5rem;list-style-type:disc;list-style-position:inside}
-.rw-button{color:#718096;display:flex;font-size:.75rem;font-weight:600;padding:.25rem 1rem;text-transform:uppercase;text-decoration: none;letter-spacing:.025em;border-radius:.25rem;line-height: 2}
+.rw-button{color:#718096;cursor:pointer;display:flex;justify-content:center;font-size:.75rem;font-weight:600;padding:.25rem 1rem;text-transform:uppercase;text-decoration: none;letter-spacing:.025em;border-radius:.25rem;line-height: 2}
 .rw-button:hover{background-color:#718096;color:#fff}
-.rw-button.rw-button-small{font-size:.75rem;border-radius:.125rem;padding:.25rem .5rem;line-height:inherit;}
-.rw-button.rw-button-green{background-color:#48bb78;color:#fff;}
+.rw-button.rw-button-small{font-size:.75rem;border-radius:.125rem;padding:.25rem .5rem;line-height:inherit}
+.rw-button.rw-button-green{background-color:#48bb78;color:#fff}
 .rw-button.rw-button-green:hover{background-color:#38a169;color:#fff}
 .rw-button.rw-button-blue{background-color:#3182ce;color:#fff}
-.rw-button.rw-button-blue:hover{background-color:#2b6cb0;}
+.rw-button.rw-button-blue:hover{background-color:#2b6cb0}
 .rw-button.rw-button-red{background-color:#e53e3e;color:#fff}
-.rw-button.rw-button-red:hover{background-color:#c53030;}
+.rw-button.rw-button-red:hover{background-color:#c53030}
 .rw-button-icon{font-size:1.25rem;line-height:1;margin-right:.25rem}
-.rw-button-group {padding: 1rem .5rem; text-align:center; }
-.rw-button-group .rw-button { display: inline-block; margin: 0 .25rem}
+.rw-button-group {display:flex;justify-content:center;margin:.75rem .5rem}
+.rw-button-group .rw-button { margin: 0 .25rem}
+.rw-form-wrapper .rw-button-group{margin-top:2rem;margin-bottom:0}
 .rw-label{display:block;margin-top:1.5rem;color:#4a5568;font-weight:600}
 .rw-label.rw-label-error{color:#c53030}
-.rw-input{display:block;margin-top:.5rem;width:100%;padding:.5rem;border-width:1px;border-color:#e2e8f0;color:#4a5568;border-radius:.25rem;outline:none;}
+.rw-input{display:block;margin-top:.5rem;width:100%;padding:.5rem;border-width:1px;border-color:#e2e8f0;color:#4a5568;border-radius:.25rem;outline:none}
 .rw-input:focus{border-color:#a0aec0}
 .rw-input-error{border-color:#c53030;color:#c53030}
 .rw-field-error{display:block;margin-top:.25rem;font-weight:600;text-transform:uppercase;font-size:.75rem;color:#c53030}
@@ -58,17 +59,16 @@
 .rw-table th,
 .rw-table td{padding:.75rem}
 .rw-table thead tr{background-color:#e2e8f0;color:#4a5568}
-.rw-table th {font-weight:600; text-align:left;}
-.rw-table thead th {text-align:left;}
-.rw-table tbody th {text-align:right;}
+.rw-table th {font-weight:600;text-align:left}
+.rw-table thead th {text-align:left}
+.rw-table tbody th {text-align:right}
 @media (min-width:768px) {
   .rw-table tbody th {width:20%}
 }
 .rw-table tbody tr{background-color:#f7fafc;border-top-width:1px}
 .rw-table tbody tr:nth-child(even){background-color:#fff}
-.rw-table .rw-table-actions {padding-right:1rem;text-align:right;white-space:nowrap}
-.rw-table .rw-table-actions li {display:inline-block}
-.rw-table-actions .rw-button{background-color:#f7fafc;}
+.rw-table-actions {display:flex;justify-content:flex-end;align-items: center;height:17px;padding-right:.25rem}
+.rw-table-actions .rw-button{background-color:transparent}
 .rw-table-actions .rw-button:hover{background-color:#718096;color:#fff}
 .rw-table-actions .rw-button-blue{color:#3182ce}
 .rw-table-actions .rw-button-blue:hover{background-color:#3182ce;color:#fff}

--- a/packages/cli/src/commands/generate/scaffold/templates/assets/scaffold.css.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/assets/scaffold.css.template
@@ -1,167 +1,77 @@
 /*
-  This file was created automatically as the result of the scaffold generator.
-  If you decide to use TailwindCSS in your project then you can safely delete
-  this file, but first remove the <div className="rw-scaffold"> from the Layout
-  that your scaffold is wrapped in. Check the comment blocks below for a
-  couple of config options you'll need to add to Tailwind to preserve the
-  scaffold appearance.
-
-  If you don't use Tailwind then you should keep it here until you have
-  completely converted your scaffolded pages or removed them, or if you don't
-  mind your scaffolded pages being monumentally ugly.
-*/
-
-/*
   normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css
 */
 
+.rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{box-sizing:inherit;border-width:0;border-style:solid;border-color:#e2e8f0}
 .rw-scaffold main{display:block}
-.rw-scaffold h1{font-size:2em;margin:.67em 0}
-.rw-scaffold a{background-color:transparent}
-.rw-scaffold input{font-family:inherit;font-size:100%;line-height:1.15;margin:0}
-.rw-scaffold input{overflow:visible}
-.rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{box-sizing:inherit}
-.rw-scaffold h1,.rw-scaffold h2{margin:0}
+.rw-scaffold h1,.rw-scaffold h2{margin:0;}
+.rw-scaffold a{background-color:transparent;}
 .rw-scaffold ul{list-style:none;margin:0;padding:0}
-.rw-scaffold *,.rw-scaffold ::after,.rw-scaffold ::before{border-width:0;border-style:solid;border-color:#e2e8f0}
+.rw-scaffold input{font-family:inherit;font-size:100%;line-height:1.15;overflow:visible}
 .rw-scaffold input:-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::-ms-input-placeholder{color:#a0aec0}
 .rw-scaffold input::placeholder{color:#a0aec0}
 .rw-scaffold table{border-collapse:collapse}
-.rw-scaffold h1,.rw-scaffold .rw-scaffold h2{font-size:inherit;font-weight:inherit}
-.rw-scaffold a{color:inherit;text-decoration:inherit}
-.rw-scaffold input{padding:0;line-height:inherit;color:inherit}
 
 /*
-  Classes we use in scaffolds from TailwindCSS v1.1.4
+  Style
 */
 
-.rw-scaffold .bg-white{background-color:#fff}
-.rw-scaffold .bg-gray-100{background-color:#f7fafc}
-.rw-scaffold .bg-gray-300{background-color:#e2e8f0}
-.rw-scaffold .bg-red-100{background-color:#fff5f5}
-.rw-scaffold .bg-red-600{background-color:#e53e3e}
-.rw-scaffold .bg-green-500{background-color:#48bb78}
-.rw-scaffold .bg-blue-600{background-color:#3182ce}
-.rw-scaffold .hover\:bg-gray-600:hover{background-color:#718096}
-.rw-scaffold .hover\:bg-red-600:hover{background-color:#e53e3e}
-.rw-scaffold .hover\:bg-red-700:hover{background-color:#c53030}
-.rw-scaffold .hover\:bg-green-600:hover{background-color:#38a169}
-.rw-scaffold .hover\:bg-blue-600:hover{background-color:#3182ce}
-.rw-scaffold .hover\:bg-blue-700:hover{background-color:#2b6cb0}
-.rw-scaffold .border-gray-300{border-color:#e2e8f0}
-.rw-scaffold .border-red-300{border-color:#feb2b2}
-.rw-scaffold .border-red-700{border-color:#c53030}
-.rw-scaffold .focus\:border-gray-500:focus{border-color:#a0aec0}
-.rw-scaffold .rounded-sm{border-radius:.125rem}
-.rw-scaffold .rounded{border-radius:.25rem}
-.rw-scaffold .rounded-lg{border-radius:.5rem}
-.rw-scaffold .border{border-width:1px}
-.rw-scaffold .border-t{border-top-width:1px}
-.rw-scaffold .block{display:block}
-.rw-scaffold .inline-block{display:inline-block}
-.rw-scaffold .flex{display:flex}
-.rw-scaffold .table{display:table}
-.rw-scaffold .justify-between{justify-content:space-between}
-.rw-scaffold .font-sans{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"}
-.rw-scaffold .font-semibold{font-weight:600}
-.rw-scaffold .leading-none{line-height:1}
-.rw-scaffold .leading-loose{line-height:2}
-.rw-scaffold .list-inside{list-style-position:inside}
-.rw-scaffold .list-disc{list-style-type:disc}
-.rw-scaffold .mx-2{margin-left:.5rem;margin-right:.5rem}
-.rw-scaffold .my-4{margin-top:1rem;margin-bottom:1rem}
-.rw-scaffold .mx-4{margin-left:1rem;margin-right:1rem}
-.rw-scaffold .mt-0{margin-top:0}
-.rw-scaffold .mt-1{margin-top:.25rem}
-.rw-scaffold .ml-1{margin-left:.25rem}
-.rw-scaffold .mt-2{margin-top:.5rem}
-.rw-scaffold .ml-2{margin-left:.5rem}
-.rw-scaffold .mt-4{margin-top:1rem}
-.rw-scaffold .mb-4{margin-bottom:1rem}
-.rw-scaffold .mt-6{margin-top:1.5rem}
-.rw-scaffold .mt-8{margin-top:2rem}
-.rw-scaffold .-mt-4{margin-top:-1rem}
-.rw-scaffold .focus\:outline-none:focus{outline:0}
-.rw-scaffold .overflow-hidden{overflow:hidden}
-.rw-scaffold .overflow-x-scroll{overflow-x:scroll}
-.rw-scaffold .p-2{padding:.5rem}
-.rw-scaffold .p-3{padding:.75rem}
-.rw-scaffold .p-4{padding:1rem}
-.rw-scaffold .py-1{padding-top:.25rem;padding-bottom:.25rem}
-.rw-scaffold .py-2{padding-top:.5rem;padding-bottom:.5rem}
-.rw-scaffold .px-2{padding-left:.5rem;padding-right:.5rem}
-.rw-scaffold .py-3{padding-top:.75rem;padding-bottom:.75rem}
-.rw-scaffold .px-3{padding-left:.75rem;padding-right:.75rem}
-.rw-scaffold .py-4{padding-top:1rem;padding-bottom:1rem}
-.rw-scaffold .px-4{padding-left:1rem;padding-right:1rem}
-.rw-scaffold .px-8{padding-left:2rem;padding-right:2rem}
-.rw-scaffold .pr-4{padding-right:1rem}
-.rw-scaffold .pb-4{padding-bottom:1rem}
-.rw-scaffold .table-auto{table-layout:auto}
-.rw-scaffold .text-left{text-align:left}
-.rw-scaffold .text-center{text-align:center}
-.rw-scaffold .text-right{text-align:right}
-.rw-scaffold .text-white{color:#fff}
-.rw-scaffold .text-gray-600{color:#718096}
-.rw-scaffold .text-gray-700{color:#4a5568}
-.rw-scaffold .text-gray-900{color:#1a202c}
-.rw-scaffold .text-red-600{color:#e53e3e}
-.rw-scaffold .text-red-700{color:#c53030}
-.rw-scaffold .text-red-900{color:#742a2a}
-.rw-scaffold .text-blue-500{color:#4299e1}
-.rw-scaffold .text-blue-600{color:#3182ce}
-.rw-scaffold .hover\:text-white:hover{color:#fff}
-.rw-scaffold .hover\:text-gray-900:hover{color:#1a202c}
-.rw-scaffold .hover\:text-blue-700:hover{color:#2b6cb0}
-.rw-scaffold .text-xs{font-size:.75rem}
-.rw-scaffold .text-sm{font-size:.875rem}
-.rw-scaffold .text-xl{font-size:1.25rem}
-.rw-scaffold .uppercase{text-transform:uppercase}
-.rw-scaffold .underline{text-decoration:underline}
-.rw-scaffold .hover\:underline:hover{text-decoration:underline}
-.rw-scaffold .tracking-wide{letter-spacing:.025em}
-.rw-scaffold .whitespace-no-wrap{white-space:nowrap}
-.rw-scaffold .truncate{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.rw-scaffold .w-full{width:100%}
-.rw-scaffold .box-border{box-sizing:border-box}
+.rw-scaffold{background-color:#fff;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"}
+.rw-header{display:flex;justify-content:space-between;padding: 1rem 2rem 1rem 2rem}
+.rw-main{margin-left:1rem;margin-right:1rem;padding-bottom:1rem}
+.rw-segment{ background-color:#fff;border-width:1px;border-radius:.5rem;overflow:hidden}
+.rw-segment-header{background-color:#e2e8f0;color:#4a5568;padding:.75rem 1rem}
+.rw-segment-main{background-color:#f7fafc;padding: 1rem}
+.rw-link {color:#4299e1;text-decoration:underline}
+.rw-link:hover {color:#2b6cb0}
+.rw-heading {font-weight:600}
+.rw-heading.rw-heading-primary{font-size:1.25rem}
+.rw-heading.rw-heading-secondary{font-size:.875rem}
+.rw-heading .rw-link{color:#4a5568;text-decoration: none}
+.rw-heading .rw-link:hover{color:#1a202c;text-decoration:underline}
+.rw-form-wrapper{box-sizing:border-box;font-size:.875rem;margin-top:-1rem;}
+.rw-form-error-wrapper{padding:1rem;background-color:#fff5f5;color:#c53030;border-width:1px;border-color:#feb2b2;border-radius:.25rem;margin:1rem 0}
+.rw-form-error-title{margin-top:0;font-weight:600}
+.rw-form-error-list{margin-top:.5rem;list-style-type:disc;list-style-position:inside}
+.rw-button{color:#718096;display:flex;font-size:.75rem;font-weight:600;padding:.25rem 1rem;text-transform:uppercase;text-decoration: none;letter-spacing:.025em;border-radius:.25rem;line-height: 2}
+.rw-button:hover{background-color:#718096;color:#fff}
+.rw-button.rw-button-small{font-size:.75rem;border-radius:.125rem;padding:.25rem .5rem;line-height:inherit;}
+.rw-button.rw-button-green{background-color:#48bb78;color:#fff;}
+.rw-button.rw-button-green:hover{background-color:#38a169;color:#fff}
+.rw-button.rw-button-blue{background-color:#3182ce;color:#fff}
+.rw-button.rw-button-blue:hover{background-color:#2b6cb0;}
+.rw-button.rw-button-red{background-color:#e53e3e;color:#fff}
+.rw-button.rw-button-red:hover{background-color:#c53030;}
+.rw-button-icon{font-size:1.25rem;line-height:1;margin-right:.25rem}
+.rw-button-group {padding: 1rem .5rem; text-align:center; }
+.rw-button-group .rw-button { display: inline-block; margin: 0 .25rem}
+.rw-label{display:block;margin-top:1.5rem;color:#4a5568;font-weight:600}
+.rw-label.rw-label-error{color:#c53030}
+.rw-input{display:block;margin-top:.5rem;width:100%;padding:.5rem;border-width:1px;border-color:#e2e8f0;color:#4a5568;border-radius:.25rem;outline:none;}
+.rw-input:focus{border-color:#a0aec0}
+.rw-input-error{border-color:#c53030;color:#c53030}
+.rw-field-error{display:block;margin-top:.25rem;font-weight:600;text-transform:uppercase;font-size:.75rem;color:#c53030}
+.rw-table-wrapper-responsive{overflow-x: scroll}
+.rw-table-wrapper-responsive .rw-table{min-width:48rem}
+.rw-table{table-layout:auto;width:100%;font-size:.875rem}
+.rw-table th,
+.rw-table td{padding:.75rem}
+.rw-table thead tr{background-color:#e2e8f0;color:#4a5568}
+.rw-table th {font-weight:600; text-align:left;}
+.rw-table thead th {text-align:left;}
+.rw-table tbody th {text-align:right;}
 @media (min-width:768px) {
-  .rw-scaffold .md\:w-1\/5{width:20%}
+  .rw-table tbody th {width:20%}
 }
-
-/*
-  Here are variants (:odd, :even) that aren't enabled in Tailwind by default.
-  If you decide to include Tailwind yourself and still want scaffolds to look
-  the same then you can tell it to build these variants by adding the following
-  to tailwind.config.js:
-
-    module.exports = {
-      variants: {
-        backgroundColor: ['hover', 'focus', 'odd', 'even']
-      }
-    }
-
-  Tailwind variant customization docs: https://tailwindcss.com/docs/configuring-variants
-*/
-
-.rw-scaffold .odd\:bg-gray-100:nth-child(odd) {background-color: #f7fafc}
-.rw-scaffold .even\:bg-white:nth-child(even) {background-color: #ffffff;}
-
-/*
-  Any custom styles that Tailwind doesn't provide. You can add these to your
-  own install of Tailwind by adding the following to tailwind.config.js:
-
-    module.exports = {
-      theme: {
-        extend: {
-          minWidth: {
-            '3xl': '48rem'
-          }
-        }
-      }
-    }
-
-  Tailwind theme extension docs: https://tailwindcss.com/docs/theme#extending-the-default-theme
-*/
-
-.rw-scaffold .min-w-3xl {min-width: 48rem}
+.rw-table tbody tr{background-color:#f7fafc;border-top-width:1px}
+.rw-table tbody tr:nth-child(even){background-color:#fff}
+.rw-table .rw-table-actions {padding-right:1rem;text-align:right;white-space:nowrap}
+.rw-table .rw-table-actions li {display:inline-block}
+.rw-table-actions .rw-button{background-color:#f7fafc;}
+.rw-table-actions .rw-button:hover{background-color:#718096;color:#fff}
+.rw-table-actions .rw-button-blue{color:#3182ce}
+.rw-table-actions .rw-button-blue:hover{background-color:#3182ce;color:#fff}
+.rw-table-actions .rw-button-red{color:#e53e3e}
+.rw-table-actions .rw-button-red:hover{background-color:#e53e3e;color:#fff}
+.rw-text-center{text-align:center}

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
@@ -32,11 +32,11 @@ export const Success = ({ ${singularCamelName} }) => {
   }
 
   return (
-    <div className="bg-white border rounded-lg overflow-hidden">
-      <header className="bg-gray-300 text-gray-700 py-3 px-4">
-        <h2 className="text-sm font-semibold">Edit ${singularPascalName} {${singularCamelName}.id}</h2>
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">Edit ${singularPascalName} {${singularCamelName}.id}</h2>
       </header>
-      <div className="bg-gray-100 p-4">
+      <div className="rw-segment-main">
         <${singularPascalName}Form ${singularCamelName}={${singularCamelName}} onSave={onSave} error={error} loading={loading} />
       </div>
     </div>

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
@@ -32,7 +32,7 @@ const ${singularPascalName} = ({ ${singularCamelName} }) => {
         <table className="rw-table">
           <tbody>
             <% columns.forEach(column => { %><tr>
-              <td><%= column.name %></td>
+              <th><%= column.name %></th>
               <td>{${singularCamelName}.<%= column.name %>}</td>
             </tr><% }) %>
           </tbody>

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
@@ -25,39 +25,33 @@ const ${singularPascalName} = ({ ${singularCamelName} }) => {
 
   return (
     <>
-      <div className="bg-white border rounded-lg overflow-hidden">
-        <header className="bg-gray-300 text-gray-700 py-3 px-4">
-          <h2 className="text-sm font-semibold">${singularPascalName} {${singularCamelName}.id} Detail</h2>
+      <div className="rw-segment">
+        <header className="rw-segment-header">
+          <h2 className="rw-heading rw-heading-secondary">${singularPascalName} {${singularCamelName}.id} Detail</h2>
         </header>
-        <table className="w-full text-sm">
+        <table className="rw-table">
           <tbody>
-            <% columns.forEach(column => { %><tr className="odd:bg-gray-100 even:bg-white border-t">
-              <td className="font-semibold p-3 text-right md:w-1/5"><%= column.name %></td>
-              <td className="p-3">{${singularCamelName}.<%= column.name %>}</td>
+            <% columns.forEach(column => { %><tr>
+              <td><%= column.name %></td>
+              <td>{${singularCamelName}.<%= column.name %>}</td>
             </tr><% }) %>
           </tbody>
         </table>
       </div>
-      <nav className="my-4 mx-2 text-center">
-        <ul>
-          <li className="inline-block ml-2">
-            <Link
-              to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
-              className="text-xs bg-blue-600 text-white hover:bg-blue-700 rounded px-4 py-2 uppercase font-semibold tracking-wide"
-            >
-              Edit
-            </Link>
-          </li>
-          <li className="inline-block ml-2">
-            <a
-              href="#"
-              className="text-xs bg-red-600 text-white hover:bg-red-700 rounded px-4 py-2 uppercase font-semibold tracking-wide"
-              onClick={() => onDeleteClick(${singularCamelName}.id)}
-            >
-              Delete
-            </a>
-          </li>
-        </ul>
+      <nav className="rw-button-group">
+        <Link
+          to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
+          className="rw-button rw-button-blue"
+        >
+          Edit
+        </Link>
+        <a
+          href="#"
+          className="rw-button rw-button-red"
+          onClick={() => onDeleteClick(${singularCamelName}.id)}
+        >
+          Delete
+        </a>
       </nav>
     </>
   )

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -7,14 +7,6 @@ import {
   Submit,
 } from '@redwoodjs/web'
 
-const CSS = {
-  label: 'rw-label',
-  labelError: 'rw-label rw-label-error',
-  input: 'rw-input',
-  inputError: 'rw-input rw-input-error',
-  errorMessage: 'rw-field-error',
-}
-
 const ${singularPascalName}Form = (props) => {
   const onSubmit = (data) => {
     props.onSave(data, props?.${singularCamelName}?.id)
@@ -32,19 +24,19 @@ const ${singularPascalName}Form = (props) => {
 <% editableColumns.forEach(column => { %>
         <Label
           name="<%= column.name %>"
-          className={CSS.label}
-          errorClassName={CSS.labelError}
+          className="rw-label"
+          errorClassName="rw-label rw-label-error"
         >
           <%= column.label %>
         </Label>
         <TextField
           name="<%= column.name %>"
           defaultValue={props.${singularCamelName}?.<%= column.name %>}
-          className={CSS.input}
-          errorClassName={CSS.inputError}
+          className="rw-input"
+          errorClassName="rw-input rw-input-error"
           validation={{ required: true }}
         />
-        <FieldError name="<%= column.name %>" className={CSS.errorMessage} />
+        <FieldError name="<%= column.name %>" className="rw-field-error" />
 <% }) %>
         <div className="rw-button-group">
           <Submit

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -8,13 +8,11 @@ import {
 } from '@redwoodjs/web'
 
 const CSS = {
-  label: 'block mt-6 text-gray-700 font-semibold',
-  labelError: 'block mt-6 font-semibold text-red-700',
-  input:
-    'block mt-2 w-full p-2 border border-gray-300 text-gray-700 rounded focus:outline-none focus:border-gray-500',
-  inputError:
-    'block mt-2 w-full p-2 border border-red-700 text-red-900 rounded focus:outline-none',
-  errorMessage: 'block mt-1 font-semibold uppercase text-xs text-red-700',
+  label: 'rw-label',
+  labelError: 'rw-label rw-label-error',
+  input: 'rw-input',
+  inputError: 'rw-input rw-input-error',
+  errorMessage: 'rw-field-error',
 }
 
 const ${singularPascalName}Form = (props) => {
@@ -23,13 +21,13 @@ const ${singularPascalName}Form = (props) => {
   }
 
   return (
-    <div className="box-border text-sm -mt-4">
+    <div className="rw-form-wrapper">
       <Form onSubmit={onSubmit} error={props.error}>
         <FormError
           error={props.error}
-          wrapperClassName="p-4 bg-red-100 text-red-700 border border-red-300 rounded mt-4 mb-4"
-          titleClassName="mt-0 font-semibold"
-          listClassName="mt-2 list-disc list-inside"
+          wrapperClassName="rw-form-error-wrapper"
+          titleClassName="rw-form-error-title"
+          listClassName="rw-form-error-list"
         />
 <% editableColumns.forEach(column => { %>
         <Label
@@ -48,10 +46,10 @@ const ${singularPascalName}Form = (props) => {
         />
         <FieldError name="<%= column.name %>" className={CSS.errorMessage} />
 <% }) %>
-        <div className="mt-8 text-center">
+        <div className="rw-button-group">
           <Submit
             disabled={props.loading}
-            className="bg-blue-600 text-white hover:bg-blue-700 text-xs rounded px-4 py-2 uppercase font-semibold tracking-wide"
+            className="rw-button rw-button-blue"
           >
             Save
           </Submit>

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
@@ -37,47 +37,44 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
   }
 
   return (
-    <div className="bg-white text-gray-900 border rounded-lg overflow-x-scroll">
-      <table className="table-auto w-full min-w-3xl text-sm">
+    <div className="rw-segment rw-table-wrapper-responsive">
+      <table className="rw-table">
         <thead>
-          <tr className="bg-gray-300 text-gray-700"><% columns.forEach(column => { %>
-            <th className="font-semibold text-left p-3"><%= column.name %></th><% }) %>
-            <th className="font-semibold text-left p-3">&nbsp;</th>
+          <tr><% columns.forEach(column => { %>
+            <th><%= column.name %></th><% }) %>
+            <th>&nbsp;</th>
           </tr>
         </thead>
         <tbody>
           {${pluralCamelName}.map((${singularCamelName}) => (
-            <tr
-              key={${singularCamelName}.id}
-              className="odd:bg-gray-100 even:bg-white border-t"
-            ><% columns.forEach(column => { %>
-              <td className="p-3">{<% if (column.type === 'DateTime') { %>timeTag<% } else { %>truncate<% } %>(${singularCamelName}.<%= column.name %>)}</td><% }) %>
-              <td className="p-3 pr-4 text-right whitespace-no-wrap">
+            <tr key={${singularCamelName}.id}><% columns.forEach(column => { %>
+              <td>{<% if (column.type === 'DateTime') { %>timeTag<% } else { %>truncate<% } %>(${singularCamelName}.<%= column.name %>)}</td><% }) %>
+              <td className="rw-table-actions">
                 <nav>
                   <ul>
-                    <li className="inline-block">
+                    <li>
                       <Link
                         to={routes.${singularRouteName}({ id: ${singularCamelName}.id })}
                         title={'Show ${singularCamelName} ' + ${singularCamelName}.id + ' detail'}
-                        className="text-xs bg-gray-100 text-gray-600 hover:bg-gray-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
+                        className="rw-button rw-button-small"
                       >
                         Show
                       </Link>
                     </li>
-                    <li className="inline-block">
+                    <li>
                       <Link
                         to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
                         title={'Edit ${singularCamelName} ' + ${singularCamelName}.id}
-                        className="text-xs bg-gray-100 text-blue-600 hover:bg-blue-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
+                        className="rw-button rw-button-small rw-button-blue"
                       >
                         Edit
                       </Link>
                     </li>
-                    <li className="inline-block">
+                    <li>
                       <a
                         href="#"
                         title={'Delete ${singularCamelName} ' + ${singularCamelName}.id}
-                        className="text-xs bg-gray-100 text-red-600 hover:bg-red-600 hover:text-white rounded-sm px-2 py-1 uppercase font-semibold tracking-wide"
+                        className="rw-button rw-button-small rw-button-red"
                         onClick={() => onDeleteClick(${singularCamelName}.id)}
                       >
                         Delete

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
@@ -49,38 +49,30 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
           {${pluralCamelName}.map((${singularCamelName}) => (
             <tr key={${singularCamelName}.id}><% columns.forEach(column => { %>
               <td>{<% if (column.type === 'DateTime') { %>timeTag<% } else { %>truncate<% } %>(${singularCamelName}.<%= column.name %>)}</td><% }) %>
-              <td className="rw-table-actions">
-                <nav>
-                  <ul>
-                    <li>
-                      <Link
-                        to={routes.${singularRouteName}({ id: ${singularCamelName}.id })}
-                        title={'Show ${singularCamelName} ' + ${singularCamelName}.id + ' detail'}
-                        className="rw-button rw-button-small"
-                      >
-                        Show
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
-                        title={'Edit ${singularCamelName} ' + ${singularCamelName}.id}
-                        className="rw-button rw-button-small rw-button-blue"
-                      >
-                        Edit
-                      </Link>
-                    </li>
-                    <li>
-                      <a
-                        href="#"
-                        title={'Delete ${singularCamelName} ' + ${singularCamelName}.id}
-                        className="rw-button rw-button-small rw-button-red"
-                        onClick={() => onDeleteClick(${singularCamelName}.id)}
-                      >
-                        Delete
-                      </a>
-                    </li>
-                  </ul>
+              <td>
+                <nav className="rw-table-actions">
+                  <Link
+                    to={routes.${singularRouteName}({ id: ${singularCamelName}.id })}
+                    title={'Show ${singularCamelName} ' + ${singularCamelName}.id + ' detail'}
+                    className="rw-button rw-button-small"
+                  >
+                    Show
+                  </Link>
+                  <Link
+                    to={routes.${editRouteName}({ id: ${singularCamelName}.id })}
+                    title={'Edit ${singularCamelName} ' + ${singularCamelName}.id}
+                    className="rw-button rw-button-small rw-button-blue"
+                  >
+                    Edit
+                  </Link>
+                  <a
+                    href="#"
+                    title={'Delete ${singularCamelName} ' + ${singularCamelName}.id}
+                    className="rw-button rw-button-small rw-button-red"
+                    onClick={() => onDeleteClick(${singularCamelName}.id)}
+                  >
+                    Delete
+                  </a>
                 </nav>
               </td>
             </tr>

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.js.template
@@ -18,11 +18,11 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => {
   return (
-    <div className="text-center">
+    <div className="rw-text-center">
       {'No ${pluralCamelName} yet. '}
       <Link
         to={routes.${newRouteName}()}
-        className="text-blue-500 underline hover:text-blue-700"
+        className="rw-link"
       >
         {'Create one?'}
       </Link>

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
@@ -23,11 +23,11 @@ const New${singularPascalName} = () => {
   }
 
   return (
-    <div className="bg-white border rounded-lg overflow-hidden">
-      <header className="bg-gray-300 text-gray-700 py-3 px-4">
-        <h2 className="text-sm font-semibold">New ${singularPascalName}</h2>
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">New ${singularPascalName}</h2>
       </header>
-      <div className="bg-gray-100 p-4">
+      <div className="rw-segment-main">
         <${singularPascalName}Form onSave={onSave} loading={loading} error={error} />
       </div>
     </div>

--- a/packages/cli/src/commands/generate/scaffold/templates/layouts/NamesLayout.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/layouts/NamesLayout.js.template
@@ -3,26 +3,23 @@ import { Link, routes } from '@redwoodjs/router'
 const ${pluralPascalName}Layout = (props) => {
   return (
     <div className="rw-scaffold">
-      <div className="bg-white font-sans">
-        <header className="flex justify-between py-4 px-8">
-          <h1 className="text-xl font-semibold">
-            <Link
-              to={routes.${pluralRouteName}()}
-              className="text-gray-700 hover:text-gray-900 hover:underline"
-            >
-              ${pluralPascalName}
-            </Link>
-          </h1>
+      <header className="rw-header">
+        <h1 className="rw-heading rw-heading-primary">
           <Link
-            to={routes.${newRouteName}()}
-            className="flex bg-green-500 hover:bg-green-600 text-white text-xs font-semibold px-3 py-1 uppercase tracking-wide rounded"
+            to={routes.${pluralRouteName}()}
+            className="rw-link"
           >
-            <div className="text-xl leading-none">+</div>
-            <div className="ml-1 leading-loose">New ${singularPascalName}</div>
+            ${pluralPascalName}
           </Link>
-        </header>
-        <main className="mx-4 pb-4">{props.children}</main>
-      </div>
+        </h1>
+        <Link
+          to={routes.${newRouteName}()}
+          className="rw-button rw-button-green"
+        >
+          <div className="rw-button-icon">+</div> New ${singularPascalName}
+        </Link>
+      </header>
+      <main className="rw-main">{props.children}</main>
     </div>
   )
 }


### PR DESCRIPTION
Update scaffold css to use semantic classes - WIP!!
- replaces utility classes with semantic classes in all scaffold generator templates
- reduces classes used in components and migrates style declarations to scaffold.css template
- these changes have no effect on the visual design of generated pages or components

Closes #610 