### PR TITLE
Added Github Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Use this template to report a bug.
+title: "[DESCRIPTIVE BUG NAME]"
+labels: Bug Report, Needs Triage
+---
+
+### Prerequisites
+
+- [ ] Did you perform a cursory search of open issues? Is this bug already reported elsewhere?
+- [ ] Are you running the latest Redwood version?
+
+### Description
+
+[Description of the bug.]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+### Expected behavior
+
+[What you expected to happen?]
+
+### Actual behavior
+
+[What actually happened? Please include any error stack traces you encounter.]
+
+### Code Sample
+
+[If possible, please provide a code repository, gist, code snippet or sample files to reproduce the issue.]
+
+### Environment
+
+| Software          | Version(s) |
+| ----------------- | ---------- |
+| `redwood`         |
+| `node`            |
+| `yarn`            |
+| `Browser`         |
+| `Operating System`|

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Use this template to report a bug.
 title: "[DESCRIPTIVE BUG NAME]"
-labels: Bug Report, Needs Triage
+labels: Bug Report
 ---
 
 ### Prerequisites

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,11 +20,11 @@ labels: Bug Report, Needs Triage
 2. [Second Step]
 3. [and so on...]
 
-### Expected behavior
+### Expected outcome
 
 [What you expected to happen?]
 
-### Actual behavior
+### Actual outcome
 
 [What actually happened? Please include any error stack traces you encounter.]
 
@@ -33,6 +33,16 @@ labels: Bug Report, Needs Triage
 [If possible, please provide a code repository, gist, code snippet or sample files to reproduce the issue.]
 
 ### Environment
+
+<!--
+Run the following commands in your project directory
+
+- for redwood `yarn redwood --version`
+- for yarn `yarn --version`
+- node `node --version`
+- yarn `yarn --version`
+-->
+
 
 | Software          | Version(s) |
 | ----------------- | ---------- |

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Use this template to request a new feature.
+title: "[DESCRIPTIVE FEATURE NAME]"
+labels: Feature Request
+---
+
+### Prerequisites
+
+- [ ] Did you perform a cursory search of open issues? Is this feature already requested elsewhere?
+
+### Feature Request
+
+Description of Feature Request
+
+## Context
+
+[Explain any additional context or rationale for this feature. What are you trying to accomplish?]
+
+## Examples
+
+[Do you have any example(s) for the requested feature? If so, describe/demonstrate your example(s) here.]

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -18,8 +18,8 @@ labels: Question
 
 | Software          | Version(s) |
 | ----------------- | ---------- |
-| `redwood`         |            |
-| `node`            |            |
-| `yarn`            |            |
-| `Browser`         |            |
-| `Operating System`|            |
+| `redwood`         |
+| `node`            |
+| `yarn`            |
+| `Browser`         |
+| `Operating System`|

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -16,6 +16,16 @@ labels: Question
 
 ### Environment
 
+<!--
+Run the following commands in your project directory
+
+- for redwood `yarn redwood --version`
+- for yarn `yarn --version`
+- node `node --version`
+- yarn `yarn --version`
+-->
+
+
 | Software          | Version(s) |
 | ----------------- | ---------- |
 | `redwood`         |

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,25 @@
+---
+name: Question
+about: Use this template to request help or ask a question.
+title: "[WHAT'S YOUR QUESTION?]"
+labels: Question
+---
+
+### Prerequisites
+
+- [ ] Did you perform a cursory search of open issues? Is this question already asked elsewhere?
+
+
+### Question
+
+[Ask your question here, please be as detailed as possible!]
+
+### Environment
+
+| Software          | Version(s) |
+| ----------------- | ---------- |
+| `redwood`         |            |
+| `node`            |            |
+| `yarn`            |            |
+| `Browser`         |            |
+| `Operating System`|            |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+### Pull Request
+
+[Please provide a general summary of the pull request]
+
+### Package Modified
+- [ ] api
+- [ ] auth
+- [ ] cli
+- [ ] core
+- [ ] create-redwood-app
+- [ ] dev-server
+- [ ] eslint-config
+- [ ] eslint-plugin-redwood
+- [ ] internal
+- [ ] router
+- [ ] testing
+- [ ] web
+
+### Versioning
+- [ ] Patch: Bug Fix?
+- [ ] Minor: New Feature?
+- [ ] Major: Breaking Change?
+
+### Fixed Issues
+
+- [List any fixed issues here like: completed xxx]
+
+### Test instructions
+
+[Explain any additional context needed to test the PR/feature/bug fix.]
+
+###  Update `CHANGELOG.md`
+
+- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,11 +15,12 @@
 - [ ] router
 - [ ] testing
 - [ ] web
+- [ ] other
 
 ### Versioning
-- [ ] Patch: Bug Fix?
-- [ ] Minor: New Feature?
-- [ ] Major: Breaking Change?
+- [ ] Patch: Bug Fix
+- [ ] Minor: New Feature
+- [ ] Major: Breaking Change
 
 ### Fixed Issues
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,3 @@
 ### Test instructions
 
 [Explain any additional context needed to test the PR/feature/bug fix.]
-
-###  Update `CHANGELOG.md`
-
-- [ ] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.


### PR DESCRIPTION
### Pull Request

I have created the GitHub templates for;
- pull request
- bug report
- feature request
- question 

I want these to help organize the conversations that are happening on the redwood. Also, it makes it easier to find what people need. Potentially also will help with automatic tagging based upon the template selected. 

### Package Modified
- [ ] api
- [ ] auth
- [ ] cli
- [ ] core
- [ ] create-redwood-app
- [ ] dev-server
- [ ] eslint-config
- [ ] eslint-plugin-redwood
- [ ] internal
- [ ] router
- [ ] testing
- [ ] web
- [x] other

### Versioning
- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change

### Fixed Issues
N/A

### Test instructions
N/A