### PR TITLE
Upgrade to Prisma-2.0.0-beta.6

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/main.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.0.0-beta.5",
+    "@prisma/client": "2.0.0-beta.6",
     "@redwoodjs/internal": "^0.7.1-canary.8",
     "apollo-server-lambda": "2.11.0",
     "babel-plugin-macros": "^2.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "^2.0.0-beta.5",
+    "@prisma/sdk": "^2.0.0-beta.6",
     "@redwoodjs/internal": "^0.7.1-canary.8",
     "camelcase": "^5.3.1",
     "chalk": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime-corejs3": "^7.9.2",
-    "@prisma/cli": "2.0.0-beta.5",
+    "@prisma/cli": "2.0.0-beta.6",
     "@redwoodjs/testing": "0.7.0",
     "@redwoodjs/cli": "^0.7.1-canary.8",
     "@redwoodjs/dev-server": "^0.7.1-canary.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2162,37 +2162,49 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@prisma/cli@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.5.tgz#9116e9ba08131fce47bb96d9bc19e8a443a2b893"
-  integrity sha512-Kl3IqOq6sYdajnLA034SLJxFCB0IxXcrSLYR8W9XTOyt3RRP/TCUPp5yBVfO9B21Kwe9YrFujTbSD2qQaDg1QA==
+"@prisma/cli@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.6.tgz#fec992901c20b0b421b5de9ba02f27ec216209c5"
+  integrity sha512-qawcjLN5c26T+IVZij5WjQocfsV6b1BtJIL3CqMQfMkDCNGo/zXsu+NB+uyZ+QRqctEuJQ36lemnY44+k6L8XA==
 
-"@prisma/client@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.5.tgz#e2192831e868c4c65257b7dd2c679234f1fcdf4a"
-  integrity sha512-Ov7rOV5h+nu+zSFG61OvOTsDjQX+QSa8AI0sYbNSsfL9MvEMtb7mMCiGsQRdHGvxbqErFuqlN83+eUCR/umb1Q==
+"@prisma/client@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.6.tgz#781eb8900ed265c6d7d35f1b5dd9b19f91440b40"
+  integrity sha512-08AokCpMzL6SdxQVfShD7937t+sHntr6FJBpVKq5E/UFPVh0B2lUwU9YrA/MIAdRpGMg1wA+rdwRivtFIs5Law==
 
-"@prisma/engine-core@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.0.0-beta.5.tgz#f997e0fbe89e4d7f3ccdece7a49cd83b0b499b15"
-  integrity sha512-d876+85Mev1LKqFRcDXOpimJJVzOISxG+g5cZhitAtCu5c+gOQExA3u9r7+zxZVWRDcsfKLSClwmfTeTUeyOQA==
+"@prisma/debug@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.0.0-beta.6.tgz#20836cb26fb907116f156587425fa941d1fa7e74"
+  integrity sha512-5JyrrnvQkjCg550w9Iey3zIuCKcVqors1EDxGS6rOGo0CiOps5PbF5KdfJvyuCp72JHzof0fdUn+hzqN9D79Pg==
   dependencies:
-    "@prisma/generator-helper" "2.0.0-beta.5"
-    "@prisma/get-platform" "2.0.0-beta.5"
+    debug "^4.1.1"
+
+"@prisma/engine-core@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.0.0-beta.6.tgz#e93b1c09dce22189a0db5141f1bfc4061a3c13f8"
+  integrity sha512-PXmNf0Xd1T3khEmkxPxRrxZ7+7c+meHIIMJnU0Oq2GnoOkv+ery9lTTcwGF8/RcVtorH7drJ2Og9Viq2qUGEUg==
+  dependencies:
+    "@prisma/debug" "2.0.0-beta.6"
+    "@prisma/generator-helper" "2.0.0-beta.6"
+    "@prisma/get-platform" "2.0.0-beta.6"
     bent "^7.1.2"
     chalk "^3.0.0"
     cross-fetch "^3.0.4"
-    debug "^4.1.1"
+    fast-json-stringify "^2.0.0"
+    get-stream "^5.1.0"
     indent-string "^4.0.0"
+    new-github-issue-url "^0.2.1"
+    terminal-link "^2.1.1"
+    undici mcollina/undici
 
-"@prisma/fetch-engine@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.0.0-beta.5.tgz#633c2bd54da6d617d23029823c7520d3928c9aec"
-  integrity sha512-h+4TqVhfVmRJg18wE3mv7V34A3IOWzCrOieFi5hqBgFREvuvWbSsfPWp61gsOZQy8x/mRft3iTpu9qRM5m+lPw==
+"@prisma/fetch-engine@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.0.0-beta.6.tgz#d92523eb020c8f231d289e3d968261dea47e26b9"
+  integrity sha512-YYtfahPHM5PzOchcb2ukFT1TvRf2n/Dp+XcyWK9+yCHYdRr93qCzpyfm+/NtLaEdNFVQGRI6HFSPQ/4dGjo+NA==
   dependencies:
-    "@prisma/get-platform" "2.0.0-beta.5"
+    "@prisma/debug" "2.0.0-beta.6"
+    "@prisma/get-platform" "2.0.0-beta.6"
     chalk "^4.0.0"
-    debug "^4.1.1"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
     hasha "^5.2.0"
@@ -2208,34 +2220,35 @@
     rimraf "^3.0.2"
     tempy "^0.5.0"
 
-"@prisma/generator-helper@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.0.0-beta.5.tgz#d1103eb4e07072ab4d843319249938b9968d211d"
-  integrity sha512-pL25Wn7ybVrw74PI/smiNkKFhE/mVvHZsGCVq9sQxEJMV5KkCnb6DmWdE5EWsO5oiZpF74vgoV4XEZY9DGSscw==
+"@prisma/generator-helper@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.0.0-beta.6.tgz#daec76333406dcae0b6e69f3a7eb7ae48f002906"
+  integrity sha512-i6fkmyKD3VSnAOD6a7Py1ANrBpg1TvLKu4xw9smONi+JnNUxXGFM89/hl/SaNx4YOqh4K8EQOVQYISFO+yqAew==
   dependencies:
+    "@prisma/debug" "2.0.0-beta.6"
     "@types/cross-spawn" "^6.0.1"
     chalk "^3.0.0"
     cross-spawn "^7.0.2"
-    debug "4.1.1"
     isbinaryfile "^4.0.6"
 
-"@prisma/get-platform@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.0.0-beta.5.tgz#8798ad177684255326d3630348ea237664508224"
-  integrity sha512-/NgR0cMJeFz2IzLz2gNGBMfeOK4CjRtsJWTkcpVruqMX366sUDf/JV/SlfrkzRWHedbxRvp2X7DIDW4QHsUPyQ==
+"@prisma/get-platform@2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.0.0-beta.6.tgz#7a3be5601bc69060416f6a623640e6fcbdf2d68b"
+  integrity sha512-EohZpMtpIykc2S91EDfIYv+AiJ4Gifus1AMpfu6BSvV3EgVONJE9NcIFwjkHn24eLCYT742O1YgCe/W2ei+SIw==
   dependencies:
-    debug "^4.1.1"
+    "@prisma/debug" "2.0.0-beta.6"
 
-"@prisma/sdk@^2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.5.tgz#1cfaf692b8b19c8cc0d2170c59ae049ad17cf93f"
-  integrity sha512-OLaoHWhI5/Lx9DOMRVEQ4VsAJeVn3ZyILc7aVWhyP7VN+6blbOMJKqQlcelecoEBMELY58IrM9r35+u6I5p2Sg==
+"@prisma/sdk@^2.0.0-beta.6":
+  version "2.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.6.tgz#965f637365467447583220c228ec8c92a8f2598a"
+  integrity sha512-S/OXS34feAbBUH4lejjL73GP/m21VvMNzOoj6ZysdJYY9coBSHZFEO97KXCbOiWlZRZrqCJgICr/SZ0j9MVRxg==
   dependencies:
     "@apexearth/copy" "^1.4.5"
-    "@prisma/engine-core" "2.0.0-beta.5"
-    "@prisma/fetch-engine" "2.0.0-beta.5"
-    "@prisma/generator-helper" "2.0.0-beta.5"
-    "@prisma/get-platform" "2.0.0-beta.5"
+    "@prisma/debug" "2.0.0-beta.6"
+    "@prisma/engine-core" "2.0.0-beta.6"
+    "@prisma/fetch-engine" "2.0.0-beta.6"
+    "@prisma/generator-helper" "2.0.0-beta.6"
+    "@prisma/get-platform" "2.0.0-beta.6"
     archiver "^3.1.1"
     arg "^4.1.3"
     chalk "3.0.0"
@@ -3564,7 +3577,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.0, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -6016,7 +6029,7 @@ debug@3.1.0, debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -7406,6 +7419,15 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-json-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.0.0.tgz#37d3809000cdc05d4aa0fd2831847039c0d1940e"
+  integrity sha512-q3b2sMbYySzXdQSX4F9ILle3oJzpV1/7p5wPfpDL3mH2euzdL7qiEeg9B4lS/lGTjYBriAplSnpoqYLTy/p8Ew==
+  dependencies:
+    ajv "^6.11.0"
+    deepmerge "^4.2.2"
+    string-similarity "^4.0.1"
+
 fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -8619,7 +8641,7 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
-http-parser-js@>=0.5.1:
+http-parser-js@>=0.5.1, http-parser-js@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.2.tgz#da2e31d237b393aae72ace43882dd7e270a8ff77"
   integrity sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==
@@ -11286,6 +11308,11 @@ netmask@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
   integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
+
+new-github-issue-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/new-github-issue-url/-/new-github-issue-url-0.2.1.tgz#e17be1f665a92de465926603e44b9f8685630c1d"
+  integrity sha512-md4cGoxuT4T4d/HDOXbrUHkTKrp/vp+m3aOA7XXVYwNsUNMK49g3SQicTSeV5GIz/5QVGAeYRAOlyp9OvlgsYA==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -14396,6 +14423,11 @@ string-length@^3.1.0:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
 
+string-similarity@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.1.tgz#ea7c11f0093cb3088cdcc5eb16cfd90cb54962f7"
+  integrity sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -15232,6 +15264,12 @@ undefsafe@^2.0.2:
   integrity sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==
   dependencies:
     debug "^2.2.0"
+
+"undici@github:mcollina/undici":
+  version "0.5.0"
+  resolved "https://codeload.github.com/mcollina/undici/tar.gz/6c3d7eed592cab9c4b63d56164ecd3cc9358945a"
+  dependencies:
+    http-parser-js "^0.5.2"
 
 unfetch@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Prisma release notes: https://github.com/prisma/prisma/releases/tag/2.0.0-beta.6

Passing manual tests locally:
- [x] yarn rw db save
- [x] yarn rw db up
- [x] yarn rw dev (both Tutorial cold start and existing App)
- [x] DB migration file compatibility from beta.3 to beta.4
- [x] CRUD query/mutations for tutorial blog posts
⚠️ I have not yet tested deploy. To do before a new release.