### PR TITLE
Auth0Client needs to be destructured from @auth0/auth0-spa-js

### DIFF
--- a/packages/cli/src/commands/generate/auth/providers/auth0.js
+++ b/packages/cli/src/commands/generate/auth/providers/auth0.js
@@ -1,6 +1,6 @@
 // the lines that need to be added to index.js
 export const config = {
-  imports: [{ import: 'Auth0Client', from: '@auth0/auth0-spa-js' }],
+  imports: [{ import: '{ Auth0Client }', from: '@auth0/auth0-spa-js' }],
   init: `const auth0 = new Auth0Client({
     domain: process.env.AUTH0_DOMAIN,
     client_id: process.env.AUTH0_CLIENT_ID,


### PR DESCRIPTION
@peterp Not sure how I missed this but the auth0 generator wouldn't have been importing correctly according to your docs (meaning your docs were correct but the generator didn't create the right import). How's it look now?