### PR TITLE
Upgrade to Prisma-2.0.0-beta.7

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/main.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.0.0-beta.6",
+    "@prisma/client": "2.0.0-beta.7",
     "@redwoodjs/internal": "^0.8.2",
     "apollo-server-lambda": "2.11.0",
     "babel-plugin-macros": "^2.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "^2.0.0-beta.6",
+    "@prisma/sdk": "^2.0.0-beta.7",
     "@redwoodjs/internal": "^0.8.2",
     "camelcase": "^5.3.1",
     "chalk": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime-corejs3": "^7.9.2",
-    "@prisma/cli": "2.0.0-beta.6",
+    "@prisma/cli": "2.0.0-beta.7",
     "@redwoodjs/cli": "^0.8.2",
     "@redwoodjs/dev-server": "^0.8.2",
     "@redwoodjs/eslint-config": "^0.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,31 +2400,31 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@prisma/cli@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.6.tgz#fec992901c20b0b421b5de9ba02f27ec216209c5"
-  integrity sha512-qawcjLN5c26T+IVZij5WjQocfsV6b1BtJIL3CqMQfMkDCNGo/zXsu+NB+uyZ+QRqctEuJQ36lemnY44+k6L8XA==
+"@prisma/cli@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.7.tgz#3184dd350b24d5eeee86a20408d366e5ce564d5a"
+  integrity sha512-Cjz7h3lfG3mFb9KMSEISe1/lgtvsMgq4EViqBJuysTj6BTDNbVMx+rSQTOdY9+8xJFGUkWszE+aAyHRFEcKgAA==
 
-"@prisma/client@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.6.tgz#781eb8900ed265c6d7d35f1b5dd9b19f91440b40"
-  integrity sha512-08AokCpMzL6SdxQVfShD7937t+sHntr6FJBpVKq5E/UFPVh0B2lUwU9YrA/MIAdRpGMg1wA+rdwRivtFIs5Law==
+"@prisma/client@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.7.tgz#0546b0ef8cdd8489bb648f22b554414085852726"
+  integrity sha512-sJg5fK8tgf9GsQ/doWqMyhwvq34eWCvyDnsO9CtgK8m7qSvBgHKA/ivfrkDKQWPpuzhm1kJlzs9wctqEadE6Yw==
 
-"@prisma/debug@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.0.0-beta.6.tgz#20836cb26fb907116f156587425fa941d1fa7e74"
-  integrity sha512-5JyrrnvQkjCg550w9Iey3zIuCKcVqors1EDxGS6rOGo0CiOps5PbF5KdfJvyuCp72JHzof0fdUn+hzqN9D79Pg==
+"@prisma/debug@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.0.0-beta.7.tgz#1c946cac5f8eed6953b93f842c0a3cd8a5dfed33"
+  integrity sha512-7EP0DGZDQesZx4IK1OLg5vkCI2DuqMc3AZ9jmGPDgdvgHIVi0oJj+eXoHUl13VLNonx/ZexSrVLkODoR5qY7nw==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.0.0-beta.6.tgz#e93b1c09dce22189a0db5141f1bfc4061a3c13f8"
-  integrity sha512-PXmNf0Xd1T3khEmkxPxRrxZ7+7c+meHIIMJnU0Oq2GnoOkv+ery9lTTcwGF8/RcVtorH7drJ2Og9Viq2qUGEUg==
+"@prisma/engine-core@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.0.0-beta.7.tgz#5ae1c8cf103c430bd47d0c531828bcafa157928c"
+  integrity sha512-EFmInft82li4hW39ie5LaBa1aGJFpZdZ+NO5+8wrQT4a8w7rzqUvCqzFX/hYAHQI4KPVhOVOEdZZk4IM86o/Ow==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.6"
-    "@prisma/generator-helper" "2.0.0-beta.6"
-    "@prisma/get-platform" "2.0.0-beta.6"
+    "@prisma/debug" "2.0.0-beta.7"
+    "@prisma/generator-helper" "2.0.0-beta.7"
+    "@prisma/get-platform" "2.0.0-beta.7"
     bent "^7.1.2"
     chalk "^3.0.0"
     cross-fetch "^3.0.4"
@@ -2432,16 +2432,17 @@
     get-stream "^5.1.0"
     indent-string "^4.0.0"
     new-github-issue-url "^0.2.1"
+    p-retry "^4.2.0"
     terminal-link "^2.1.1"
     undici mcollina/undici
 
-"@prisma/fetch-engine@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.0.0-beta.6.tgz#d92523eb020c8f231d289e3d968261dea47e26b9"
-  integrity sha512-YYtfahPHM5PzOchcb2ukFT1TvRf2n/Dp+XcyWK9+yCHYdRr93qCzpyfm+/NtLaEdNFVQGRI6HFSPQ/4dGjo+NA==
+"@prisma/fetch-engine@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.0.0-beta.7.tgz#b1c55e61d98b100dbfb158ec753fb7b25efa6285"
+  integrity sha512-RuIozR2AoJHp7x0fAkKJ4D8WFWMpBKOC+8lEzlYevTdG3W7NTrtowAU2vHEg8lkD6gHcpP6f8R1FFlEHlmy/kA==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.6"
-    "@prisma/get-platform" "2.0.0-beta.6"
+    "@prisma/debug" "2.0.0-beta.7"
+    "@prisma/get-platform" "2.0.0-beta.7"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -2458,35 +2459,34 @@
     rimraf "^3.0.2"
     tempy "^0.5.0"
 
-"@prisma/generator-helper@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.0.0-beta.6.tgz#daec76333406dcae0b6e69f3a7eb7ae48f002906"
-  integrity sha512-i6fkmyKD3VSnAOD6a7Py1ANrBpg1TvLKu4xw9smONi+JnNUxXGFM89/hl/SaNx4YOqh4K8EQOVQYISFO+yqAew==
+"@prisma/generator-helper@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.0.0-beta.7.tgz#10ec6607f9cfca7c99a8d2892a3d73584749bdda"
+  integrity sha512-6KgM70FBqLf7v/z0H81qsMy7fJOAyHox89tRpy77fEWi2bcf1vMfwku5p5OdMqWzb2LR3krx4L5572EITDF+Ag==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.6"
+    "@prisma/debug" "2.0.0-beta.7"
     "@types/cross-spawn" "^6.0.1"
     chalk "^3.0.0"
     cross-spawn "^7.0.2"
-    isbinaryfile "^4.0.6"
 
-"@prisma/get-platform@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.0.0-beta.6.tgz#7a3be5601bc69060416f6a623640e6fcbdf2d68b"
-  integrity sha512-EohZpMtpIykc2S91EDfIYv+AiJ4Gifus1AMpfu6BSvV3EgVONJE9NcIFwjkHn24eLCYT742O1YgCe/W2ei+SIw==
+"@prisma/get-platform@2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.0.0-beta.7.tgz#b307a69141ed845bd17fbc1b746456e6f338cc8b"
+  integrity sha512-c9IR/wEY/jsLm6+dHbd4xl/sr1TBuWEkuzOGe1hSiMq79tq5WVmH2WrD0DfZw+aypKkxrQiKA9zCKM5Z5bhfeQ==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.6"
+    "@prisma/debug" "2.0.0-beta.7"
 
-"@prisma/sdk@^2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.6.tgz#965f637365467447583220c228ec8c92a8f2598a"
-  integrity sha512-S/OXS34feAbBUH4lejjL73GP/m21VvMNzOoj6ZysdJYY9coBSHZFEO97KXCbOiWlZRZrqCJgICr/SZ0j9MVRxg==
+"@prisma/sdk@^2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.7.tgz#e2422fbddad719d5a7f56f58b93c02963db2ec92"
+  integrity sha512-0LVQMPkGU0PBRKIx/v16npkKNG71yOnD5K4tn97v/Gv4AkhJ/JCaqYkL+WMxY+XTtmkEI32e8fjGkfOYNEug0g==
   dependencies:
     "@apexearth/copy" "^1.4.5"
-    "@prisma/debug" "2.0.0-beta.6"
-    "@prisma/engine-core" "2.0.0-beta.6"
-    "@prisma/fetch-engine" "2.0.0-beta.6"
-    "@prisma/generator-helper" "2.0.0-beta.6"
-    "@prisma/get-platform" "2.0.0-beta.6"
+    "@prisma/debug" "2.0.0-beta.7"
+    "@prisma/engine-core" "2.0.0-beta.7"
+    "@prisma/fetch-engine" "2.0.0-beta.7"
+    "@prisma/generator-helper" "2.0.0-beta.7"
+    "@prisma/get-platform" "2.0.0-beta.7"
     archiver "^3.1.1"
     arg "^4.1.3"
     chalk "3.0.0"
@@ -3297,7 +3297,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.24.tgz#c57511e3a19c4b5e9692bb2995c40a3a52167944"
   integrity sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==
 
-"@types/node@^13.9.5":
+"@types/node@^13.7.0", "@types/node@^13.9.5":
   version "13.13.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.9.tgz#79df4ae965fb76d31943b54a6419599307a21394"
   integrity sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==
@@ -3306,11 +3306,6 @@
   version "6.14.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.14.10.tgz#d9ce598127eb0cc02821476862d11389cb01f6a4"
   integrity sha512-pF4HjZGSog75kGq7B1InK/wt/N08BuPATo+7HRfv7gZUzccebwv/fmWVGs/j6LvSiLWpCuGGhql51M/wcQsNzA==
-
-"@types/node@^13.7.0":
-  version "13.13.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.9.tgz#79df4ae965fb76d31943b54a6419599307a21394"
-  integrity sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -5959,7 +5954,7 @@ core-js@3.6.4:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
   integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
 
-core-js@^3.0.1, core-js@^3.2.0, core-js@^3.2.1, core-js@^3.6.4:
+core-js@3.6.5, core-js@^3.0.1, core-js@^3.2.0, core-js@^3.2.1, core-js@^3.6.4:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
@@ -9634,7 +9629,7 @@ is-ssh@^1.3.0:
   dependencies:
     protocols "^1.1.0"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -9704,11 +9699,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
-
-isbinaryfile@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.6.tgz#edcb62b224e2b4710830b67498c8e4e5a4d2610b"
-  integrity sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -10697,11 +10687,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
@@ -10711,6 +10696,11 @@ lodash.assignin@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
   integrity sha1-uo31+4QesKPoBEIysOJjqNxqKKI=
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.clone@^4.5.0:
   version "4.5.0"
@@ -15589,9 +15579,9 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-undici@mcollina/undici:
+"undici@github:mcollina/undici":
   version "0.5.0"
-  resolved "https://codeload.github.com/mcollina/undici/tar.gz/6c3d7eed592cab9c4b63d56164ecd3cc9358945a"
+  resolved "https://codeload.github.com/mcollina/undici/tar.gz/ed672a39ee63f4c5fa13d0c826a0d47edf77e9fa"
   dependencies:
     http-parser-js "^0.5.2"
 


### PR DESCRIPTION
Prisma release notes: https://github.com/prisma/prisma/releases/tag/2.0.0-beta.7

Passing manual tests locally:
- [x] yarn rw db save
- [x] yarn rw db up
- [x] yarn rw dev (both Tutorial cold start and existing App)
- [x] DB migration file compatibility from beta.6 to beta.7
- [x] CRUD query/mutations for tutorial blog posts

⚠️ I have not yet tested deploy. To do before a new release.