### PR TITLE
Upgrade to Prisma-2.0.0-beta.8

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/main.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.0.0-beta.7",
+    "@prisma/client": "2.0.0-beta.8",
     "@redwoodjs/internal": "^0.8.2",
     "apollo-server-lambda": "2.11.0",
     "babel-plugin-macros": "^2.8.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "^2.0.0-beta.7",
+    "@prisma/sdk": "^2.0.0-beta.8",
     "@redwoodjs/internal": "^0.8.2",
     "camelcase": "^5.3.1",
     "chalk": "^3.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime-corejs3": "^7.9.2",
-    "@prisma/cli": "2.0.0-beta.7",
+    "@prisma/cli": "2.0.0-beta.8",
     "@redwoodjs/cli": "^0.8.2",
     "@redwoodjs/dev-server": "^0.8.2",
     "@redwoodjs/eslint-config": "^0.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,31 +2428,33 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@prisma/cli@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.7.tgz#3184dd350b24d5eeee86a20408d366e5ce564d5a"
-  integrity sha512-Cjz7h3lfG3mFb9KMSEISe1/lgtvsMgq4EViqBJuysTj6BTDNbVMx+rSQTOdY9+8xJFGUkWszE+aAyHRFEcKgAA==
+"@prisma/cli@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0-beta.8.tgz#18356d5464040339c9c01cdf9a4241c1bccc5dea"
+  integrity sha512-l1bHUmPzjdOF87MzIkcE55AkGLDKV2apmS2D9ZuYM+7hWWMk7lcJjjquDr9RAtSDMN8nuvYQcXnFFg7JP4DUxw==
 
-"@prisma/client@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.7.tgz#0546b0ef8cdd8489bb648f22b554414085852726"
-  integrity sha512-sJg5fK8tgf9GsQ/doWqMyhwvq34eWCvyDnsO9CtgK8m7qSvBgHKA/ivfrkDKQWPpuzhm1kJlzs9wctqEadE6Yw==
+"@prisma/client@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.0.0-beta.8.tgz#1f2effb3b377fab4453fef894a04cc16bf46ef8f"
+  integrity sha512-MOUYJ5IRsmufhEoBs+sBNlmkxkUcsE0ONY/RcvQ+F1svU8iKeGi7UNFUxKwzYCe15mmAfvhh/ZaJ34/tUkpBeQ==
+  dependencies:
+    pkg-up "^3.1.0"
 
-"@prisma/debug@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.0.0-beta.7.tgz#1c946cac5f8eed6953b93f842c0a3cd8a5dfed33"
-  integrity sha512-7EP0DGZDQesZx4IK1OLg5vkCI2DuqMc3AZ9jmGPDgdvgHIVi0oJj+eXoHUl13VLNonx/ZexSrVLkODoR5qY7nw==
+"@prisma/debug@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.0.0-beta.8.tgz#35a91c076c420dc95d9376b4e313d1aa0cc3a634"
+  integrity sha512-IISanL4LaC+WCdxvTKa08K0Ud6HveXBMy/GKXduWCQ3E8IKr3423RqDYS0C8ZaK3z9OZkFuzpcN+RTe4oruspA==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.0.0-beta.7.tgz#5ae1c8cf103c430bd47d0c531828bcafa157928c"
-  integrity sha512-EFmInft82li4hW39ie5LaBa1aGJFpZdZ+NO5+8wrQT4a8w7rzqUvCqzFX/hYAHQI4KPVhOVOEdZZk4IM86o/Ow==
+"@prisma/engine-core@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.0.0-beta.8.tgz#ce27c6d3c025820667431e322442a6c86418ecd5"
+  integrity sha512-EbW8ajW9Q1z5r3n3qq3jN7WgTtr1QBhF0ZDZWVeTiXWaER7hcO+9E5wpCsX6FxgOadxeJ2yy6bePoLZFPosr7g==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.7"
-    "@prisma/generator-helper" "2.0.0-beta.7"
-    "@prisma/get-platform" "2.0.0-beta.7"
+    "@prisma/debug" "2.0.0-beta.8"
+    "@prisma/generator-helper" "2.0.0-beta.8"
+    "@prisma/get-platform" "2.0.0-beta.8"
     bent "^7.1.2"
     chalk "^3.0.0"
     cross-fetch "^3.0.4"
@@ -2464,13 +2466,13 @@
     terminal-link "^2.1.1"
     undici mcollina/undici
 
-"@prisma/fetch-engine@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.0.0-beta.7.tgz#b1c55e61d98b100dbfb158ec753fb7b25efa6285"
-  integrity sha512-RuIozR2AoJHp7x0fAkKJ4D8WFWMpBKOC+8lEzlYevTdG3W7NTrtowAU2vHEg8lkD6gHcpP6f8R1FFlEHlmy/kA==
+"@prisma/fetch-engine@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.0.0-beta.8.tgz#e2e70358fbe371f458c97527811f90cac758ee76"
+  integrity sha512-OZyE/o1AVeEinnnKo/9IuG3eG3yuBYyDpoJHGiBOQ4qRoXU/c5l0HEKOSMTrSm7PX/m3bJyiw6LffNKoknpWnA==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.7"
-    "@prisma/get-platform" "2.0.0-beta.7"
+    "@prisma/debug" "2.0.0-beta.8"
+    "@prisma/get-platform" "2.0.0-beta.8"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -2487,41 +2489,41 @@
     rimraf "^3.0.2"
     tempy "^0.5.0"
 
-"@prisma/generator-helper@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.0.0-beta.7.tgz#10ec6607f9cfca7c99a8d2892a3d73584749bdda"
-  integrity sha512-6KgM70FBqLf7v/z0H81qsMy7fJOAyHox89tRpy77fEWi2bcf1vMfwku5p5OdMqWzb2LR3krx4L5572EITDF+Ag==
+"@prisma/generator-helper@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.0.0-beta.8.tgz#c7b72f50fcc35d7f9d76e85ffbcc0160274446cd"
+  integrity sha512-wvzuh8J7hqVuHAWz8H68zOiOVHJAoJWGUKnpei8k6f8ryUZsO4BDKz4Z5JHVtqka0GM2CMyyguTUd78BgKu12g==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.7"
+    "@prisma/debug" "2.0.0-beta.8"
     "@types/cross-spawn" "^6.0.1"
     chalk "^3.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.0.0-beta.7.tgz#b307a69141ed845bd17fbc1b746456e6f338cc8b"
-  integrity sha512-c9IR/wEY/jsLm6+dHbd4xl/sr1TBuWEkuzOGe1hSiMq79tq5WVmH2WrD0DfZw+aypKkxrQiKA9zCKM5Z5bhfeQ==
+"@prisma/get-platform@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.0.0-beta.8.tgz#3d86fa27c4052c54ae6521d793c050de28f48f62"
+  integrity sha512-gptrd0jCf3iCkyvNIMT1KdugdFF+dB/0lUL0I4utwdoWBoNq4l1ToyUgewYqhewnhpcd1orbxz6JKxLtHM+axw==
   dependencies:
-    "@prisma/debug" "2.0.0-beta.7"
+    "@prisma/debug" "2.0.0-beta.8"
 
-"@prisma/sdk@^2.0.0-beta.7":
-  version "2.0.0-beta.7"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.7.tgz#e2422fbddad719d5a7f56f58b93c02963db2ec92"
-  integrity sha512-0LVQMPkGU0PBRKIx/v16npkKNG71yOnD5K4tn97v/Gv4AkhJ/JCaqYkL+WMxY+XTtmkEI32e8fjGkfOYNEug0g==
+"@prisma/sdk@^2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.0.0-beta.8.tgz#44fef14dd940676732cf6ab380567301c388522e"
+  integrity sha512-XMMq/vmaFx4heFDaLMe4UCGDwpalm+kxdoVZRev5JEYsKVrV3UMpdhE+ZJvIJG6e932Is9qWZy1toModd0ObqA==
   dependencies:
     "@apexearth/copy" "^1.4.5"
-    "@prisma/debug" "2.0.0-beta.7"
-    "@prisma/engine-core" "2.0.0-beta.7"
-    "@prisma/fetch-engine" "2.0.0-beta.7"
-    "@prisma/generator-helper" "2.0.0-beta.7"
-    "@prisma/get-platform" "2.0.0-beta.7"
-    archiver "^3.1.1"
+    "@prisma/debug" "2.0.0-beta.8"
+    "@prisma/engine-core" "2.0.0-beta.8"
+    "@prisma/fetch-engine" "2.0.0-beta.8"
+    "@prisma/generator-helper" "2.0.0-beta.8"
+    "@prisma/get-platform" "2.0.0-beta.8"
+    archiver "^4.0.0"
     arg "^4.1.3"
     chalk "3.0.0"
     checkpoint-client "^1.0.7"
     cli-truncate "^2.1.0"
     execa "^4.0.0"
-    globby "^9.2.0"
+    globby "^11.0.0"
     has-yarn "^2.1.0"
     make-dir "^3.0.2"
     node-fetch "2.6.0"
@@ -2537,7 +2539,7 @@
     temp-write "^4.0.0"
     tempy "^0.5.0"
     terminal-link "^2.1.1"
-    tmp "0.1.0"
+    tmp "0.2.1"
     url-parse "^1.4.7"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
@@ -4213,18 +4215,18 @@ archiver-utils@^2.1.0:
     normalize-path "^3.0.0"
     readable-stream "^2.0.0"
 
-archiver@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/archiver/-/archiver-3.1.1.tgz#9db7819d4daf60aec10fe86b16cb9258ced66ea0"
-  integrity sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==
+archiver@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-4.0.1.tgz#3f722b121777e361ca9fad374ecda38e77e63c7f"
+  integrity sha512-/YV1pU4Nhpf/rJArM23W6GTUjT0l++VbjykrCRua1TSXrn+yM8Qs7XvtwSiRse0iCe49EPNf7ktXnPsWuSb91Q==
   dependencies:
     archiver-utils "^2.1.0"
     async "^2.6.3"
     buffer-crc32 "^0.2.1"
-    glob "^7.1.4"
-    readable-stream "^3.4.0"
-    tar-stream "^2.1.0"
-    zip-stream "^2.1.2"
+    glob "^7.1.6"
+    readable-stream "^3.6.0"
+    tar-stream "^2.1.2"
+    zip-stream "^3.0.1"
 
 archy@^1.0.0:
   version "1.0.0"
@@ -5629,15 +5631,15 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-compress-commons@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-2.1.1.tgz#9410d9a534cf8435e3fbbb7c6ce48de2dc2f0610"
-  integrity sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==
+compress-commons@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-3.0.0.tgz#833944d84596e537224dd91cf92f5246823d4f1d"
+  integrity sha512-FyDqr8TKX5/X0qo+aVfaZ+PVmNJHJeckFBlq8jZGSJOgnynhfifoyl24qaqdUdDIBe0EVTHByN6NAkqYvE/2Xg==
   dependencies:
     buffer-crc32 "^0.2.13"
     crc32-stream "^3.0.1"
     normalize-path "^3.0.0"
-    readable-stream "^2.3.6"
+    readable-stream "^2.3.7"
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -8374,6 +8376,18 @@ globby@^10.0.1:
     glob "^7.1.3"
     ignore "^5.1.1"
     merge2 "^1.2.3"
+    slash "^3.0.0"
+
+globby@^11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
+  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
     slash "^3.0.0"
 
 globby@^6.1.0:
@@ -13196,7 +13210,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@^2.3.7, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -14954,7 +14968,7 @@ tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar-stream@^2.1.0:
+tar-stream@^2.1.0, tar-stream@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
   integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
@@ -15476,9 +15490,9 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-undici@mcollina/undici:
-  version "0.5.0"
-  resolved "https://codeload.github.com/mcollina/undici/tar.gz/ed672a39ee63f4c5fa13d0c826a0d47edf77e9fa"
+"undici@github:mcollina/undici":
+  version "1.0.0"
+  resolved "https://codeload.github.com/mcollina/undici/tar.gz/359dea825c73cf21d6ae16bb2075842b9f48bcd3"
   dependencies:
     http-parser-js "^0.5.2"
 
@@ -16493,11 +16507,11 @@ zen-observable@^0.8.0:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zip-stream@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-2.1.3.tgz#26cc4bdb93641a8590dd07112e1f77af1758865b"
-  integrity sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==
+zip-stream@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-3.0.1.tgz#cb8db9d324a76c09f9b76b31a12a48638b0b9708"
+  integrity sha512-r+JdDipt93ttDjsOVPU5zaq5bAyY+3H19bDrThkvuVxC0xMQzU1PJcS6D+KrP3u96gH9XLomcHPb+2skoDjulQ==
   dependencies:
     archiver-utils "^2.1.0"
-    compress-commons "^2.1.1"
-    readable-stream "^3.4.0"
+    compress-commons "^3.0.0"
+    readable-stream "^3.6.0"


### PR DESCRIPTION
Prisma release notes: https://github.com/prisma/prisma/releases/tag/2.0.0-beta.8

Passing manual tests locally:
- [x] yarn rw db save
- [x] yarn rw db up
- [x] yarn rw dev (both Tutorial cold start and existing App)
- [x] DB migration file compatibility from beta.7 to beta.8
- [x] CRUD query/mutations for tutorial blog posts

⚠️ I have not yet tested deploy. To do before a new release.