### PR TITLE
SCSS/CSS Module support

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -45,6 +45,7 @@ module.exports = (webpackEnv) => {
             loader: 'css-loader',
             options: {
               modules: true,
+              sourceMap: !isEnvProduction,
             },
           },
           'sass-loader',
@@ -58,6 +59,7 @@ module.exports = (webpackEnv) => {
             loader: 'css-loader',
             options: {
               modules: true,
+              sourceMap: !isEnvProduction,
             },
           },
         ],

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -37,7 +37,9 @@ module.exports = (webpackEnv) => {
 
   const getStyleLoaders = () => {
     // Obscured classnames in production, more expressive classnames in development.
-    const localIdentName = isEnvProduction ? '[hash:base64]' : '[path][name]__[local]--[hash:base64:5]'
+    const localIdentName = isEnvProduction
+      ? '[hash:base64]'
+      : '[path][name]__[local]--[hash:base64:5]'
     return [
       {
         test: /\.module\.scss$/,

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -66,17 +66,27 @@ module.exports = (webpackEnv) => {
       },
       {
         test: /\.scss$/,
-        use: [
+        loader: [
           isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader',
-          'css-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: !isEnvProduction,
+            },
+          },
           'sass-loader',
         ],
       },
       {
         test: /\.css$/,
-        use: [
+        loader: [
           isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader',
-          'css-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: !isEnvProduction,
+            },
+          },
         ],
       },
     ]

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -38,6 +38,31 @@ module.exports = (webpackEnv) => {
   const getStyleLoaders = () => {
     return [
       {
+        test: /\.module\.scss$/,
+        loader: [
+          isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+            },
+          },
+          'sass-loader',
+        ],
+      },
+      {
+        test: /\.module\.css$/,
+        loader: [
+          isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+            },
+          },
+        ],
+      },
+      {
         test: /\.scss$/,
         use: [
           isEnvProduction ? MiniCssExtractPlugin.loader : 'style-loader',

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -36,6 +36,8 @@ module.exports = (webpackEnv) => {
   const isEnvProduction = webpackEnv === 'production'
 
   const getStyleLoaders = () => {
+    // Obscured classnames in production, more expressive classnames in development.
+    const localIdentName = isEnvProduction ? '[hash:base64]' : '[path][name]__[local]--[hash:base64:5]'
     return [
       {
         test: /\.module\.scss$/,
@@ -44,7 +46,9 @@ module.exports = (webpackEnv) => {
           {
             loader: 'css-loader',
             options: {
-              modules: true,
+              modules: {
+                localIdentName,
+              },
               sourceMap: !isEnvProduction,
             },
           },
@@ -58,7 +62,9 @@ module.exports = (webpackEnv) => {
           {
             loader: 'css-loader',
             options: {
-              modules: true,
+              modules: {
+                localIdentName,
+              },
               sourceMap: !isEnvProduction,
             },
           },


### PR DESCRIPTION
This PR adds SCSS/CSS module support. Usage is as follows:

```scss
// Filename: HomePage.module.scss
.hero {
  color: red;
}
```

```jsx
// Filename: HomePage.js
import styles from './HomePage.module.scss'

const HomePage = () => (
  <div className={styles.hero}>Hello</div>
)

export default HomePage
```
The div that contains hello will have the `hero` class applied to it.


This also adds sourcemap support for SCSS/CSS with or without modules. So in your web inspector, you can view the source for the styles, instead of it saying `<style>` for the source.
![image](https://user-images.githubusercontent.com/47246/83958791-89ffc900-a83b-11ea-9b00-1ffb4bdbf201.png)


Classnames are generated with hashes in production builds, like in the image above. In dev, the names are more descriptive like: `.src-pages-HomePage-HomePage-module__heroName--rNGDY`. This is based on the [recommendations](https://github.com/webpack-contrib/css-loader#localidentname) in css-loader's documentation.
