### PR TITLE
Fix windows matching paths in babel.

### DIFF
--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -137,7 +137,7 @@ module.exports = () => ({
     // Automatically import files in `./web/src/pages/*` in to
     // the `./web/src/Routes.[ts|jsx]` file.
     {
-      test: /\/web\/src\/Routes.(js|tsx)$/,
+      test: ['./web/src/Routes.js', './web/src/Routes.tsx'],
       plugins: [require('../dist/babel-plugin-redwood-routes-auto-loader')],
     },
   ],


### PR DESCRIPTION
It looks like regex matching doesn't normalize path slashes like strings do in babel's "test" fields.

I'll add tests for these scenarios.

Closes #657 