### PR TITLE
CLI: Centralize yargs defaults

### DIFF
--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
@@ -5,7 +5,8 @@ import fs from 'fs'
 import 'src/lib/test'
 import { getPaths, getDefaultArgs } from 'src/lib'
 
-import { defaults, files } from '../../../generate/scaffold/scaffold'
+import { yargsDefaults as defaults } from '../../../generate'
+import { files } from '../../../generate/scaffold/scaffold'
 import { tasks } from '../scaffold'
 
 jest.mock('fs')

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -13,3 +13,24 @@ export const builder = (yargs) =>
         'https://redwoodjs.com/reference/command-line-interface#generate-alias-g'
       )}`
     )
+
+export const yargsDefaults = {
+  force: {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing files',
+    type: 'boolean',
+  },
+  javascript: {
+    alias: 'js',
+    default: true,
+    description: 'Generate JavaScript files',
+    type: 'boolean',
+  },
+  typescript: {
+    alias: 'ts',
+    default: false,
+    description: 'Generate TypeScript files',
+    type: 'boolean',
+  },
+}

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -10,6 +10,8 @@ import terminalLink from 'terminal-link'
 import { generateTemplate, getPaths, writeFilesTask } from 'src/lib'
 import c from 'src/lib/colors'
 
+import { yargsDefaults } from '../generate'
+
 /**
  * Reduces boilerplate for generating an output path and content to write to disk
  * for a component.
@@ -67,26 +69,7 @@ export const pathName = (path, name) => {
 export const createYargsForComponentGeneration = ({
   componentName,
   filesFn,
-  builderObj = {
-    force: {
-      alias: 'f',
-      default: false,
-      description: 'Overwrite existing files',
-      type: 'boolean',
-    },
-    javascript: {
-      alias: 'js',
-      default: true,
-      description: 'Generate JavaScript files',
-      type: 'boolean',
-    },
-    typescript: {
-      alias: 'ts',
-      default: false,
-      description: 'Generate TypeScript files',
-      type: 'boolean',
-    },
-  },
+  builderObj = yargsDefaults,
 }) => {
   return {
     command: `${componentName} <name>`,

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { loadGeneratorFixture } from 'src/lib/test'
 import { getDefaultArgs } from 'src/lib'
 
+import { yargsDefaults as defaults } from '../../../generate'
 import * as scaffold from '../scaffold'
 
 describe('in javascript (defualt) mode', () => {
@@ -11,7 +12,7 @@ describe('in javascript (defualt) mode', () => {
 
   beforeAll(async () => {
     files = await scaffold.files({
-      ...getDefaultArgs(scaffold.defaults),
+      ...getDefaultArgs(defaults),
       model: 'Post',
     })
   })
@@ -295,7 +296,7 @@ describe('in typescript mode', () => {
 
   beforeAll(async () => {
     files = await scaffold.files({
-      ...getDefaultArgs(scaffold.defaults),
+      ...getDefaultArgs(defaults),
       model: 'Post',
       typescript: true,
     })

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -23,6 +23,7 @@ import {
 } from 'src/lib'
 import c from 'src/lib/colors'
 
+import { yargsDefaults } from '../../generate'
 import { relationsForModel, intForeignKeysForModel } from '../helpers'
 import { files as sdlFiles, builder as sdlBuilder } from '../sdl/sdl'
 import {
@@ -332,26 +333,6 @@ const addScaffoldImport = () => {
   return 'Added scaffold import to index.js'
 }
 
-export const defaults = {
-  force: {
-    alias: 'f',
-    default: false,
-    description: 'Overwrite existing files',
-    type: 'boolean',
-  },
-  javascript: {
-    alias: 'js',
-    default: true,
-    description: 'Generate JavaScript files',
-    type: 'boolean',
-  },
-  typescript: {
-    alias: 'ts',
-    default: false,
-    description: 'Generate TypeScript files',
-    type: 'boolean',
-  },
-}
 export const command = 'scaffold <model>'
 export const description =
   'Generate Pages, SDL, and Services files based on a given DB schema Model. Also accepts <path/model>'
@@ -367,7 +348,7 @@ export const builder = (yargs) => {
         'https://redwoodjs.com/reference/command-line-interface#generate-scaffold'
       )}`
     )
-  Object.entries(defaults).forEach(([option, config]) => {
+  Object.entries(yargsDefaults).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -16,6 +16,7 @@ import {
 } from 'src/lib'
 import c from 'src/lib/colors'
 
+import { yargsDefaults } from '../../generate'
 import { files as serviceFiles } from '../service/service'
 import { relationsForModel } from '../helpers'
 
@@ -147,27 +148,10 @@ export const files = async ({ name, crud, typescript, javascript }) => {
 }
 
 export const defaults = {
+  ...yargsDefaults,
   crud: {
     default: false,
     description: 'Also generate mutations',
-    type: 'boolean',
-  },
-  force: {
-    alias: 'f',
-    default: false,
-    description: 'Overwrite existing files',
-    type: 'boolean',
-  },
-  javascript: {
-    alias: 'js',
-    default: true,
-    description: 'Generate JavaScript files',
-    type: 'boolean',
-  },
-  typescript: {
-    alias: 'ts',
-    default: false,
-    description: 'Generate TypeScript files',
     type: 'boolean',
   },
 }

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -3,6 +3,7 @@ import pluralize from 'pluralize'
 import terminalLink from 'terminal-link'
 
 import { transformTSToJS } from '../../../lib'
+import { yargsDefaults } from '../../generate'
 import {
   templateForComponentFile,
   createYargsForComponentGeneration,
@@ -55,27 +56,10 @@ export const files = async ({
 }
 
 export const defaults = {
+  ...yargsDefaults,
   crud: {
     default: false,
     description: 'Create CRUD functions',
-    type: 'boolean',
-  },
-  force: {
-    alias: 'f',
-    default: false,
-    description: 'Overwrite existing files',
-    type: 'boolean',
-  },
-  javascript: {
-    alias: 'js',
-    default: true,
-    description: 'Generate JavaScript files',
-    type: 'boolean',
-  },
-  typescript: {
-    alias: 'ts',
-    default: false,
-    description: 'Generate TypeScript files',
     type: 'boolean',
   },
 }

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -153,12 +153,14 @@ export const prettify = (templateFilename, renderedTemplate) => {
 
 export const readFile = (target) => fs.readFileSync(target)
 
+const SUPPORTED_EXTENSIONS = ['.js', '.ts', '.tsx']
+
 export const deleteFile = (file) => {
   const extension = path.extname(file)
-  if (['.js', '.ts'].includes(extension)) {
+  if (SUPPORTED_EXTENSIONS.includes(extension)) {
     const baseFile = getBaseFile(file)
-    const files = [baseFile + '.js', baseFile + '.ts']
-    files.forEach((f) => {
+    SUPPORTED_EXTENSIONS.forEach((ext) => {
+      const f = baseFile + ext
       if (fs.existsSync(f)) {
         fs.unlinkSync(f)
       }
@@ -172,9 +174,9 @@ const getBaseFile = (file) => file.replace(/\.\w*$/, '')
 
 const existsAnyExtensionSync = (file) => {
   const extension = path.extname(file)
-  if (['.js', '.ts'].includes(extension)) {
+  if (SUPPORTED_EXTENSIONS.includes(extension)) {
     const baseFile = getBaseFile(file)
-    return fs.existsSync(`${baseFile}.js`) || fs.existsSync(`${baseFile}.ts`)
+    return SUPPORTED_EXTENSIONS.some((ext) => fs.existsSync(baseFile + ext))
   }
 
   return fs.existsSync(file)


### PR DESCRIPTION
As a follow-up to https://github.com/redwoodjs/redwood/pull/594 (which is itself a follow-up on #322 :^)) and @peterp's suggestion on https://github.com/kimadeline/redwood/pull/1#discussion_r434722128 I did a bit of cleanup:

🧹 Moved the defaults for the javascript, typescript and force args to `src/commands/generate.js`;
🧹 There are 2 methods in `src/lib/index.js` that were both iterating on `[ '.js', '.ts']`, so I merged both arrays together and added `.tsx` to it.


✨ I did this cleanup as part of a PR to convert the Layout generator to TS, but since I was cramming too many changes in one PR I figured I'd split them, stay tuned for a Layout generator PR ✌️ 