### PR TITLE
Remove cleanup from some generator test templates

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/multiWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/multiWordCell.test.js
@@ -1,12 +1,8 @@
-import { render, cleanup, screen } from '@redwoodjs/testing'
+import { render, screen } from '@redwoodjs/testing'
 
 import { Loading, Empty, Failure, Success } from './UserProfileCell'
 
 describe('UserProfileCell', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('Loading renders successfully', () => {
     render(<Loading />)
     // Use screen.debug() to see output.

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/singleWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/singleWordCell.test.js
@@ -1,12 +1,8 @@
-import { render, cleanup, screen } from '@redwoodjs/testing'
+import { render, screen } from '@redwoodjs/testing'
 
 import { Loading, Empty, Failure, Success } from './UserCell'
 
 describe('UserCell', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('Loading renders successfully', () => {
     render(<Loading />)
     // Use screen.debug() to see output.

--- a/packages/cli/src/commands/generate/cell/templates/test.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/test.js.template
@@ -1,12 +1,8 @@
-import { render, cleanup, screen } from '@redwoodjs/testing'
+import { render, screen } from '@redwoodjs/testing'
 
 import { Loading, Empty, Failure, Success } from './${pascalName}Cell'
 
 describe('${pascalName}Cell', () => {
-  afterEach(() => {
-    cleanup()
-  })
-
   it('Loading renders successfully', () => {
     render(<Loading />)
     // Use screen.debug() to see output.

--- a/packages/cli/src/commands/generate/component/__tests__/fixtures/multiWordComponent.test.tsx
+++ b/packages/cli/src/commands/generate/component/__tests__/fixtures/multiWordComponent.test.tsx
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import UserProfile from './UserProfile'
 
 describe('UserProfile', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<UserProfile />)

--- a/packages/cli/src/commands/generate/component/__tests__/fixtures/singleWordComponent.test.tsx
+++ b/packages/cli/src/commands/generate/component/__tests__/fixtures/singleWordComponent.test.tsx
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import User from './User'
 
 describe('User', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<User />)

--- a/packages/cli/src/commands/generate/component/templates/test.tsx.template
+++ b/packages/cli/src/commands/generate/component/templates/test.tsx.template
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import ${pascalName} from './${pascalName}'
 
 describe('${pascalName}', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<${pascalName} />)

--- a/packages/cli/src/commands/generate/layout/__tests__/fixtures/multiWordLayout.test.js
+++ b/packages/cli/src/commands/generate/layout/__tests__/fixtures/multiWordLayout.test.js
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import SinglePageLayout from './SinglePageLayout'
 
 describe('SinglePageLayout', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<SinglePageLayout />)

--- a/packages/cli/src/commands/generate/layout/__tests__/fixtures/singleWordLayout.test.js
+++ b/packages/cli/src/commands/generate/layout/__tests__/fixtures/singleWordLayout.test.js
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import AppLayout from './AppLayout'
 
 describe('AppLayout', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<AppLayout />)

--- a/packages/cli/src/commands/generate/layout/templates/test.js.template
+++ b/packages/cli/src/commands/generate/layout/templates/test.js.template
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import ${pascalName}Layout from './${pascalName}Layout'
 
 describe('${pascalName}Layout', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<${pascalName}Layout />)

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.test.js
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import ContactUsPage from './ContactUsPage'
 
 describe('ContactUsPage', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<ContactUsPage />)

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.test.js
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import HomePage from './HomePage'
 
 describe('HomePage', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<HomePage />)

--- a/packages/cli/src/commands/generate/page/templates/test.js.template
+++ b/packages/cli/src/commands/generate/page/templates/test.js.template
@@ -1,11 +1,8 @@
-import { render, cleanup } from '@redwoodjs/testing'
+import { render } from '@redwoodjs/testing'
 
 import ${pascalName}Page from './${pascalName}Page'
 
 describe('${pascalName}Page', () => {
-  afterEach(() => {
-    cleanup()
-  })
   it('renders successfully', () => {
     expect(() => {
       render(<${pascalName}Page />)


### PR DESCRIPTION
Removes cleanup from cell, component, layout, and page because it already runs automatically: https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup.