### PR TITLE
Add MSW to testing package

### DIFF
--- a/packages/core/config/jest.setup.web.js
+++ b/packages/core/config/jest.setup.web.js
@@ -1,1 +1,12 @@
 require('@testing-library/jest-dom')
+require('whatwg-fetch')
+
+const { server } = require('@redwoodjs/testing')
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterAll(() => {
+  server.close()
+})

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,8 @@
   "devDependencies": {
     "@types/babel-core": "^6.25.6",
     "@types/babel-plugin-tester": "^9.0.0",
-    "babel-plugin-tester": "^9.0.1"
+    "babel-plugin-tester": "^9.0.1",
+    "whatwg-fetch": "^3.0.0"
   },
   "resolutions": {
     "@types/react": "16.9.35"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@redwoodjs/internal": "^0.10.0",
     "@redwoodjs/web": "^0.10.0",
-    "@testing-library/react": "^10.0.4"
+    "@testing-library/react": "^10.0.4",
+    "msw": "^0.19.0"
   },
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start --extensions \".js,.ts\" --source-maps inline",

--- a/packages/testing/src/index.js
+++ b/packages/testing/src/index.js
@@ -3,3 +3,6 @@ export { MockRouter } from './MockRouter'
 // https://testing-library.com/docs/react-testing-library/setup#custom-render
 export * from '@testing-library/react'
 export { customRender as render } from './render'
+
+export * from 'msw'
+export { default as server } from './mockServer'

--- a/packages/testing/src/mockServer.ts
+++ b/packages/testing/src/mockServer.ts
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node'
+
+const server = setupServer()
+
+export default server

--- a/packages/testing/src/render.js
+++ b/packages/testing/src/render.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { getPaths } from '@redwoodjs/internal'
 import { render } from '@testing-library/react'
+import { RedwoodProvider } from '@redwoodjs/web'
 
 // Import the user's Router from `./web/src/Router.js`.
 // We use the `children` from this Router that are rendered via
@@ -9,10 +10,10 @@ const { default: UserRouterWithRoutes } = require(getPaths().web.routes)
 
 const AllTheProviders = ({ children }) => {
   return (
-    <>
+    <RedwoodProvider>
       <UserRouterWithRoutes />
       {children}
-    </>
+    </RedwoodProvider>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,7 +2428,12 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@prisma/cli@2.0.0":
+"@open-draft/until@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
+
+"@prisma/cli@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.0.0.tgz#d5638c627e98faaa93230359185072a19e17a020"
   integrity sha512-RID4fOX6Y+2uHrBiFsoVt+F9oa7Z7IaO+AbwA+uepyYcjWjIhvl1cgml2mStGLyig8uuYmTOJGmh8XDkOyo10g==
@@ -3009,6 +3014,11 @@
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.3.tgz#0aa116701955c2faa0717fc69cd1596095e49d96"
   integrity sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==
+
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
 "@types/cookies@*":
   version "0.7.4"
@@ -5847,6 +5857,11 @@ cookie@^0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -8506,6 +8521,11 @@ graphql@^14.5.3, graphql@^14.6.0:
   dependencies:
     iterall "^1.2.2"
 
+graphql@^15.0.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.1.0.tgz#b93e28de805294ec08e1630d901db550cb8960a1"
+  integrity sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -8665,6 +8685,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+headers-utils@^1.1.3, headers-utils@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.2.0.tgz#5e10d1bc9d2bccf789547afca5b991a3167241e8"
+  integrity sha512-4/BMXcWrJErw7JpM87gF8MNEXcIMLzepYZjNRv/P9ctgupl2Ywa3u1PgHtNhSRq84bHH9Ndlkdy7bSi+bZ9I9A==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -9593,7 +9618,7 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
-isomorphic-fetch@2.2.1:
+isomorphic-fetch@2.2.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
@@ -11344,6 +11369,22 @@ ms@2.1.2, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+msw@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.19.0.tgz#fd37015787d40db82d243a2853be66c466675e72"
+  integrity sha512-1TpmJzJ+afBWTRNJYoeW8KwLQbCVlvvhw2u/eRuIYfel+bPqcut5NaSgo+Bi4C0Q/7M5wza00w1GEuOXQu6FCA==
+  dependencies:
+    "@open-draft/until" "^1.0.0"
+    "@types/cookie" "^0.3.3"
+    chalk "^4.0.0"
+    cookie "^0.4.1"
+    graphql "^15.0.0"
+    headers-utils "^1.1.9"
+    node-match-path "^0.4.2"
+    node-request-interceptor "^0.2.4"
+    statuses "^2.0.0"
+    yargs "^15.3.1"
+
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -11575,6 +11616,11 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
+node-match-path@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.4.2.tgz#30cc39510fa493bff03c3d0d2fff711c868ec457"
+  integrity sha512-wfde4FOC5A8RTSUVZ7pTpBV+dJsr2vVxT6374VrNam6wnnhx6EvwAwL/E/r3AW/YU6XkeZggF5xfBlu4a/ULBg==
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -11595,6 +11641,14 @@ node-releases@^1.1.29, node-releases@^1.1.53:
   version "1.1.57"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.57.tgz#f6754ce225fad0611e61228df3e09232e017ea19"
   integrity sha512-ZQmnWS7adi61A9JsllJ2gdj2PauElcjnOwTp2O011iGzoakTxUsDGSe+6vD7wXbKdqhSFymC0OSx35aAMhrSdw==
+
+node-request-interceptor@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.2.4.tgz#f03a1b874823d0bea311a14280227707be946298"
+  integrity sha512-/htjDLmygBczT5qYPaSxfAEtMkc0LGuH6jqAP1o+TKfQh6yQfFyTtac25cpY8+pb4EawHljCLUN7dCeed9SdPA==
+  dependencies:
+    debug "^4.1.1"
+    headers-utils "^1.1.3"
 
 nodemon@^2.0.2:
   version "2.0.4"
@@ -14581,6 +14635,11 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+statuses@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.0.tgz#aa7b107e018eb33e08e8aee2e7337e762dda1028"
+  integrity sha512-w9jNUUQdpuVoYqXxnyOakhckBbOxRaoYqJscyIBYCS5ixyCnO7nQn7zBZvP9zf5QOPZcz2DLUpE3KsNPbJBOFA==
+
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -15478,9 +15537,9 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-"undici@github:mcollina/undici":
+undici@mcollina/undici:
   version "1.0.1"
-  resolved "https://codeload.github.com/mcollina/undici/tar.gz/4a54988c5451db8506fd2f954da2bc70d9b799ad"
+  resolved "https://codeload.github.com/mcollina/undici/tar.gz/26d01d9f79564a7119e49d776262e7a73bd211ca"
   dependencies:
     http-parser-js "^0.5.2"
 
@@ -16040,7 +16099,7 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
@peterp I just started playing around with and this tools is totally awesome!

There's probably a lot more magic we can do for users, like providing a default file where users can define default mocks, but I think this is something we can figure out while we implement config extension and that kind of business.

Check this example for how to use: https://github.com/RobertBroersma/redwood-testing/blob/master/web/src/pages/BlogPostPage/BlogPostPage.test.js

It's good that this decouples us from Apollo.

It does add some tiny constraints, like you can't test anonymous GraphQL queries (or at least _I didn't manage to) but I think that could even be a positive as it enforces the better practice of naming your queries.

This should also Just Work™ with mutations but I haven't tested that yet. I got too excited and instantly opened this PR.