### PR TITLE
[WIP] Add RouteAnnouncer for accessibility

### DIFF
--- a/packages/router/src/page-loader.js
+++ b/packages/router/src/page-loader.js
@@ -1,4 +1,4 @@
-import { useContext, createRef } from 'react'
+import { useContext } from 'react'
 
 import { createNamedContext, LocationContext } from './internal'
 
@@ -32,7 +32,9 @@ const RouteAnnouncer = () => {
       role="alert"
       aria-live="assertive"
       aria-atomic="true"
-    >{announcement}</div>
+    >
+      {announcement}
+    </div>
   )
 }
 

--- a/packages/router/src/page-loader.js
+++ b/packages/router/src/page-loader.js
@@ -1,10 +1,40 @@
-import { useContext } from 'react'
+import { useContext, createRef } from 'react'
 
-import { createNamedContext } from './internal'
+import { createNamedContext, LocationContext } from './internal'
 
 export const PageLoadingContext = createNamedContext('PageLoading')
 
 export const usePageLoadingContext = () => useContext(PageLoadingContext)
+
+/**
+ * This is a WIP; the location of this component will most likely change
+ * (we'll probably move it up the tree).
+ * The majority of this code was copied from
+ * https://github.com/gatsbyjs/gatsby/blob/5b15471e793aa16d8e63ad920d0f8c4c4f46052f/packages/gatsby/cache-dir/navigation.js#L161-L208
+ * Blog post explaining this code here:
+ * https://www.gatsbyjs.org/blog/2020-02-10-accessible-client-side-routing-improvements/ */
+const RouteAnnouncer = () => {
+  const location = useContext(LocationContext)
+  const announcement = `New page at ${location.pathname}`
+
+  return (
+    <div
+      style={{
+        position: `absolute`,
+        width: 1,
+        height: 1,
+        padding: 0,
+        overflow: `hidden`,
+        clip: `rect(0, 0, 0, 0)`,
+        whiteSpace: `nowrap`,
+        border: 0,
+      }}
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+    >{announcement}</div>
+  )
+}
 
 export class PageLoader extends React.PureComponent {
   state = {
@@ -63,6 +93,7 @@ export class PageLoader extends React.PureComponent {
           value={{ loading: this.state.slowModuleImport }}
         >
           <Page {...this.state.params} />
+          <RouteAnnouncer />
         </PageLoadingContext.Provider>
       )
     } else {


### PR DESCRIPTION
> ⚠️ WIP ⚠️

This PR addresses #540 by starting to bake accessibility into Redwood via `@redwoodjs/router`. Right now, our implementation and approach are inspired by gatsby, wholesale. Relevant links:
- [Accessibility Improvements to Client Side Routing in Gatsby - Available in 2.19.8](https://www.gatsbyjs.org/blog/2020-02-10-accessible-client-side-routing-improvements/)
- [RouteAnnouncer](https://github.com/gatsbyjs/gatsby/blob/5b15471e793aa16d8e63ad920d0f8c4c4f46052f/packages/gatsby/cache-dir/navigation.js#L161-L208)

Right now this PR just adds a `RouteAnnouncer` component to `PageLoader` that announces that the page has loaded (by saying "New page" + `location.pathname`, which is obviously less than ideal, but just getting started), which was one of the two issues mentioned in #540.

### Outstanding
- [ ] the location of this component will probably change. it should probably be moved up the tree, maybe even wrapping the Router
- [ ] focus management; Marcy's research suggests a skip link should take focus. we need to both make 1) making skip links possible, part of the framework (whether that means exporting a component or...) and 2) focus them on navigation
- [ ] add a `RouteAnnoucement` component. companion to the RouteAnnouncer (here)&mdash;letting users decide what to announce
- [ ] we've got to be wary of prerender, react helmet (this is related to that https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/route-announcer-props.js)
