### PR TITLE
Remove `prisma generate --watch` task from dev command.

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -12,8 +12,8 @@ export const description = 'Start development servers for api, db, and web'
 export const builder = (yargs) => {
   yargs
     .positional('side', {
-      choices: ['api', 'db', 'web'],
-      default: ['api', 'db', 'web'],
+      choices: ['api', 'web'],
+      default: ['api', 'web'],
       description: 'Which dev server(s) to start',
       type: 'array',
     })
@@ -25,14 +25,13 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ side = ['api', 'db', 'web'] }) => {
+export const handler = async ({ side = ['api', 'web'] }) => {
   // We use BASE_DIR when we need to effectively set the working dir
   const BASE_DIR = getPaths().base
   // For validation, e.g. dirExists?, we use these
   // note: getPaths().web|api.base returns undefined on Windows
   const API_DIR_SRC = getPaths().api.src
   const WEB_DIR_SRC = getPaths().web.src
-  const PRISMA_SCHEMA = getPaths().api.dbSchema
 
   const jobs = {
     api: {
@@ -40,15 +39,6 @@ export const handler = async ({ side = ['api', 'db', 'web'] }) => {
       command: `cd "${path.join(BASE_DIR, 'api')}" && yarn dev-server`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(API_DIR_SRC),
-    },
-    db: {
-      name: ' db', // prefixed with ` ` to match output indentation.
-      command: `cd "${path.join(
-        BASE_DIR,
-        'api'
-      )}" && yarn prisma generate --watch`,
-      prefixColor: 'magenta',
-      runWhen: () => fs.existsSync(PRISMA_SCHEMA),
     },
     web: {
       name: 'web',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15640,9 +15640,9 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-"undici@github:mcollina/undici":
-  version "1.0.2"
-  resolved "https://codeload.github.com/mcollina/undici/tar.gz/259efa1dc490cff577cb3e668d02b51069b8c149"
+undici@mcollina/undici:
+  version "1.0.3"
+  resolved "https://codeload.github.com/mcollina/undici/tar.gz/df7bade8b8e06ef13936520d5126cbf93889a356"
   dependencies:
     http-parser-js "^0.5.2"
 


### PR DESCRIPTION
This command no longer makes sense since database migrations are not applied automatically. When we run `yarn rw db up` (which is required when the schema changes) the client is already generated.