### PR TITLE
Add link to includeEnvironmentVariables in config.ts

### DIFF
--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -39,6 +39,7 @@ export interface Config {
   }
 }
 
+// Note that web's includeEnvironmentVariables is handled in https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/core/config/webpack.common.js#L19
 const DEFAULT_CONFIG: Config = {
   web: {
     host: 'localhost',

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -39,7 +39,8 @@ export interface Config {
   }
 }
 
-// Note that web's includeEnvironmentVariables is handled in https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/core/config/webpack.common.js#L19
+// Note that web's includeEnvironmentVariables is handled in `webpack.common.js`
+// https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/core/config/webpack.common.js#L19
 const DEFAULT_CONFIG: Config = {
   web: {
     host: 'localhost',


### PR DESCRIPTION
This PR adds a comment that points people to webpack.common.js for web's includeEnvironmentVariables. Via https://github.com/redwoodjs/redwoodjs.com/pull/173#issuecomment-644537696