### PR TITLE
Set browser.open default to false

### DIFF
--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -28,8 +28,7 @@ const baseConfig = merge(webpackConfig('development'), {
     },
     inline: true,
     overlay: true,
-    // checks for override in redwood.toml, defaults to true
-    open: redwoodConfig.browser ? redwoodConfig.browser.open : false,
+    open: redwoodConfig.browser.open,
   },
   optimization: {
     removeAvailableModules: false,

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -16,7 +16,7 @@ describe('getConfig', () => {
           "target": "node",
         },
         "browser": Object {
-          "open": true,
+          "open": false,
         },
         "web": Object {
           "apiProxyPath": "/.netlify/functions",

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -55,7 +55,7 @@ const DEFAULT_CONFIG: Config = {
     target: TargetEnum.NODE,
   },
   browser: {
-    open: true,
+    open: false,
   },
 }
 


### PR DESCRIPTION
This PR makes it so that if `browser.open` is not in a Redwood app's redwood.toml, it'll default to `false` instead of `true`. This is the desired behavior. For background, ~~see #173~~ referenced the wrong issue, it's actually https://github.com/redwoodjs/redwoodjs.com/pull/173#issuecomment-645647833

This PR also removes an extraneous conditional in webpack.development.js.