### PR TITLE
Suggestion: Change custom authHeader to return type

### DIFF
--- a/packages/api/src/auth/authHeaders.ts
+++ b/packages/api/src/auth/authHeaders.ts
@@ -70,16 +70,22 @@ export const decodeAuthToken = async ({
       decoded = await verifyAuth0Token(token)
       break
     }
-    // These tokens require a 3rd party library for decoding that we don't want to
-    // bundle with each installation. We'll cover it in the documentation.
-    case 'custom':
+
     case 'firebase':
     case 'magicLink': {
       decoded = token
       break
     }
-    default:
-      throw new Error(`Auth-Provider of type "${type}" is not supported.`)
+
+    // These tokens require a 3rd party library for decoding that we don't want to
+    // bundle with each installation. We'll cover it in the documentation.
+    default: {
+      decoded = {
+        type,
+        token,
+      }
+      break
+    }
   }
 
   if (decoded === null) {


### PR DESCRIPTION
Suggestion: Return the type of unknown token so that it can be handled in `api/src/lib/auth.js` 

**Why?**
For example, you might want to support multiple types of auth within the same redwood api. In our case we use both JWT and an opaque token

Relevant discussion: [Community discussion](https://community.redwoodjs.com/t/custom-github-jwt-auth-with-redwood-auth-advice-needed/610/11?u=danny)

---
Please note I am unable to test it with 0.11 - copy:watch isn't work for me, however I have been using patch-package in 0.10 with this code successfully