### PR TITLE
Generate Prisma client if it doesn't exist

### DIFF
--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -37,38 +37,28 @@ describe('db commands', () => {
     expect(runCommandTask.mock.results[0].value).toEqual([
       'yarn prisma migrate up --experimental --create-db',
     ])
-    expect(runCommandTask.mock.results[1].value).toEqual([
-      //TODO: use mock fs for getPaths().api.dbSchema
-      'echo "no schema.prisma file found" undefined',
-    ])
 
     await up.handler({ dbClient: true, autoApprove: true })
-    expect(runCommandTask.mock.results[2].value).toEqual([
+    expect(runCommandTask.mock.results[1].value).toEqual([
       'yarn prisma migrate up --experimental --create-db --auto-approve',
     ])
 
     await down.handler({})
-    expect(runCommandTask.mock.results[4].value).toEqual([
+    expect(runCommandTask.mock.results[2].value).toEqual([
       'yarn prisma migrate down --experimental',
     ])
 
     await save.handler({ name: 'my-migration' })
-    expect(runCommandTask.mock.results[5].value).toEqual([
+    expect(runCommandTask.mock.results[3].value).toEqual([
       'yarn prisma migrate save --name my-migration --create-db --experimental',
     ])
 
-    await generate.handler({})
-    expect(runCommandTask.mock.results[6].value).toEqual([
-      //TODO: use mock fs for getPaths().api.dbSchema
-      'echo "no schema.prisma file found" undefined',
-    ])
-
     await introspect.handler({})
-    expect(runCommandTask.mock.results[7].value).toEqual([
+    expect(runCommandTask.mock.results[4].value).toEqual([
       'yarn prisma introspect',
     ])
 
     await seed.handler({})
-    expect(runCommandTask.mock.results[8].value).toEqual(['node seeds.js'])
+    expect(runCommandTask.mock.results[5].value).toEqual(['node seeds.js'])
   })
 })

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -49,8 +49,9 @@ export const handler = async ({ verbose = true, force = true }) => {
       ))
       // eslint-disable-next-line
       new PrismaClient()
+      return // Client exists, so abort.
     } catch (e) {
-      // Swallow your pain.
+      // Swallow your pain, and generate.
     }
   }
 

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -28,8 +28,15 @@ export const builder = (yargs) => {
       )}`
     )
 }
-export const handler = async ({ verbose = true, force = false }) => {
-  const schemaExists = fs.existsSync(getPaths().api.dbSchema)
+export const handler = async ({ verbose = true, force = true }) => {
+  if (!fs.existsSync(getPaths().api.dbSchema)) {
+    console.log(
+      `Skipping database and Prisma client generation, no \`schema.prisma\` file found: \`${
+        getPaths().api.dbSchema
+      }\``
+    )
+    return
+  }
 
   // Do not generate the Prisma client if it exists.
   if (!force) {
@@ -40,11 +47,8 @@ export const handler = async ({ verbose = true, force = false }) => {
         getPaths().base,
         'node_modules/.prisma/client'
       ))
-      if (schemaExists) {
-        // eslint-disable-next-line
-        new PrismaClient()
-      }
-      return undefined
+      // eslint-disable-next-line
+      new PrismaClient()
     } catch (e) {
       // Swallow your pain.
     }
@@ -53,12 +57,8 @@ export const handler = async ({ verbose = true, force = false }) => {
   return await runCommandTask(
     [
       {
-        title: schemaExists
-          ? 'Generating the Prisma client...'
-          : 'Skipping Prisma Client: no schema.prisma found',
-        cmd: schemaExists
-          ? 'yarn prisma generate'
-          : 'echo "no schema.prisma file found"',
+        title: 'Generating the Prisma client...',
+        cmd: 'yarn prisma generate',
       },
     ],
     {

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -6,6 +6,7 @@ import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
+import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
 export const command = 'dev [side..]'
 export const description = 'Start development servers for api, db, and web'
@@ -32,6 +33,14 @@ export const handler = async ({ side = ['api', 'web'] }) => {
   // note: getPaths().web|api.base returns undefined on Windows
   const API_DIR_SRC = getPaths().api.src
   const WEB_DIR_SRC = getPaths().web.src
+
+  if (side.includes('api')) {
+    try {
+      await generatePrismaClient({ verbose: false, force: false })
+    } catch (e) {
+      console.log(c.error(e.message))
+    }
+  }
 
   const jobs = {
     api: {


### PR DESCRIPTION
Since we moved the Prisma generate --watch command we now need to generate the client before we start the dev server.