### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,7 +5,8 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "semver:patch"
+    # Uncomment when confident that patch PRs for dev-dependencies are reasonable
+    # automerged_updates:
+    #   - match:
+    #       dependency_type: "development"
+    #       update_type: "semver:patch"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "development"
+          update_type: "semver:patch"


### PR DESCRIPTION
I've commented out `automerged_updates` part for now. Once it is uncommented it will automatically merge PRs for patch updates to dev-devs if tests pass. 

In the pilot phase we might encounter packages that update too frequently. I suggest we disable Dependabot for those package. 