### PR TITLE
Correct lambda function dir info in dev server README

### DIFF
--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -1,9 +1,6 @@
 # Redwood's HTTP server for serverless Functions
 
-The dev server looks for "lambda functions" in the directory
-(default: `./api/src/functions`) specified by your `redwood.toml`
-configuration file.
-
+The dev server looks for "lambda functions" in `./api/src/functions`.
 Each lambda function is mapped to a URI based on their filename, as
 an example: `./api/src/functions/graphql.js` would be accessible
 at `http://localhost:8911/graphql`.


### PR DESCRIPTION
(To my knowledge) there's no configuration option in ./redwood.toml that lets you change where the dev server looks for lambda functions. So this PR removes the line saying there is one from the dev server's README.md. (Please correct me if I'm wrong and I'll update the app configuration doc too.)