### PR TITLE
Changing from magic-link to magicLink in docs

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -14,13 +14,14 @@ Check out the [Auth Playground](https://github.com/redwoodjs/playground-auth).
 ## Installation
 
 ### CLI Auth Generator
+
 The following CLI command will install required packages and generate boilerplate code and files for Redwood Projects:
 
 ```terminal
 yarn rw g auth [provider]
 ```
-*`[provider]` values can be either "netlify", "auth0", "magic-link" or "firebase".*
 
+*`[provider]` values can be either "netlify", "auth0", "magicLink" or "firebase".*
 
 ### Manual Install
 
@@ -200,7 +201,6 @@ The following values are available from the `useAuth` hook:
 * `client`: Access the instance of the client which you passed into `AuthProvider`
 * `isAuthenticated`: used to determine if the current user has authenticated
 * `loading`: The auth state is restored asynchronously when the user visits the site for the first time, use this to determine if you have the correct state
-
 
 ## Usage in Redwood
 


### PR DESCRIPTION
**Fixes**
In commit https://github.com/redwoodjs/redwood/commit/7e8ebbc60af8f05fe073255ec1ec229a1300934e auth Provider 'magic-link' was changed to 'magicLink', and thus `yarn rw generate auth magic-link` won't work. 

```
Invalid values:
  Argument: provider, Given: "magic-link", Choices: "auth0", "firebase", "magicLink", "netlify"
```

**Additional Information**]
I noticed that `goTrue` was added as Auth Provider in the same commit. Two points here;
1. As `goTrue` is part of Netify, would it make it sense to prefix this Auth provider with e.g. `netifyGoTrue`?
2. In the [Auth documentation overview](https://github.com/redwoodjs/redwood/tree/main/packages/auth#authentication) I suggest that this can be re-ordered, e.g. having 1. Netify, 2. Netify GoTrue, 3. Auth0 4. ...

Thanks for the great work!