### PR TITLE
add GoTrue-JS doc and example code to auth readme

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -72,6 +72,39 @@ ReactDOM.render(
 )
 ```
 
+### For GoTrue-JS
+
+Add GoTrue-JS to the web side:
+
+```terminal
+yarn workspace web add gotrue-js
+```
+
+Then instantiate GoTrue with your configuration and pass it to AuthProvider:
+
+```js
+// web/src/index.js
+import { AuthProvider } from '@redwoodjs/auth'
+import GoTrue from 'GoTrue'
+
+const goTrue = new GoTrue({
+  APIUrl: 'https://MYAPP.netlify.app/.netlify/identity',
+  setCookie: true,
+})
+
+// in your JSX component
+ReactDOM.render(
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <AuthProvider client={goTrue} type="goTrue">
+      <RedwoodProvider>
+        <Routes />
+      </RedwoodProvider>
+    </AuthProvider>
+  </FatalErrorBoundary>,
+  document.getElementById('redwood-app')
+)
+```
+
 ### For Auth0
 
 To get your application keys, only complete the ["Configure Auth0"](https://auth0.com/docs/quickstart/spa/react#get-your-application-keys) section of the SPA Quickstart guide.


### PR DESCRIPTION
This PR adds some some auth instruction and example code for configuring GoTrue-JS to the auth readme.
Probably doesn't quite close [#220 @ redwoodjs.com](https://github.com/redwoodjs/redwoodjs.com/issues/220) but it's a start. :)

@jtoar 