### PR TITLE
Remove heads up about Prisma 2 in readme

### DIFF
--- a/__fixtures__/new-project/README.md
+++ b/__fixtures__/new-project/README.md
@@ -1,5 +1,4 @@
 # Redwood
->**HEADS UP:** RedwoodJS is _NOT_ ready for use in Production. It relies heavily on Prisma2, which is currently in testing with an expected production release coming soon. See status at ["Is Prisma2 Ready?"](https://isprisma2ready.com)
 
 ## Getting Started
 - [Redwoodjs.com](https://redwoodjs.com): home to all things RedwoodJS.


### PR DESCRIPTION
Seems like Prisma 2.0 is ready for production
https://isprisma2ready.com
https://www.prisma.io/blog/announcing-prisma-2-n0v98rzc8br1

2.0.0 was actually released 20+ days ago
https://github.com/prisma/prisma/releases/tag/2.0.0

Does this mean we can remove this warning?
> RedwoodJS is _NOT_ ready for use in Production

