### PR TITLE
Remove superfluous comma in web/jsconfig.json

### DIFF
--- a/__fixtures__/new-project/web/jsconfig.json
+++ b/__fixtures__/new-project/web/jsconfig.json
@@ -4,7 +4,7 @@
     "paths": {
       "src/*": ["./src/*"]
     },
-    "jsx": "preserve",
+    "jsx": "preserve"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fix the `web/jsconfig.json` fixtures file by removing the superfluous comma after `"preserve"`**,**<---

Note: I do not know if all the tools using this file are using [relaxedjson](http://www.relaxedjson.org) (where the comma is allowed) or not.

References:
https://code.visualstudio.com/docs/languages/jsconfig
http://json.schemastore.org/jsconfig

Feel free to close this PR if you know for a fact this is not an issue, or if this is required for something.
