### PR TITLE
Add cache-and-network fetchPolicy to beforeQuery

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/indexCell.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/indexCell.js
@@ -17,10 +17,6 @@ export const QUERY = gql`
   }
 `
 
-export const beforeQuery = (props) => {
-  return { variables: props, fetchPolicy: 'cache-and-network' }
-}
-
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.js.template
@@ -10,10 +10,6 @@ export const QUERY = gql`
   }
 `
 
-export const beforeQuery = (props) => {
-  return { variables: props, fetchPolicy: 'cache-and-network' }
-}
-
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => {

--- a/packages/web/src/graphql/withCell.js
+++ b/packages/web/src/graphql/withCell.js
@@ -37,7 +37,10 @@ import { Query } from '@apollo/react-components'
  * }
  */
 export const withCell = ({
-  beforeQuery = (props) => ({ variables: props }),
+  beforeQuery = (props) => ({
+    variables: props,
+    fetchPolicy: 'cache-and-network',
+  }),
   QUERY,
   afterQuery = (data) => ({ ...data }),
   Loading = () => 'Loading...',


### PR DESCRIPTION
This PR closes #717 by changing `beforeQuery`'s `fetchPolicy` to `'cache-and-network'` (previously, it didn't have one).

Was working on the Cells doc (https://github.com/redwoodjs/redwoodjs.com/pull/202) and found #717 in the process of documenting. Figured I'd close it out real quick because it seemed simple enough (is it this simple?).

There could also be complementary PRs to remove the export of `beforeQuery` in scaffolds (as it wouldn't differ from just the default after this gets merged). Or is it better to be explicit? 