### PR TITLE
Add prisma studio via db studio command

### DIFF
--- a/packages/cli/src/commands/dbCommands/ide.js
+++ b/packages/cli/src/commands/dbCommands/ide.js
@@ -1,0 +1,44 @@
+import path from 'path'
+import fs from 'fs'
+
+import terminalLink from 'terminal-link'
+
+import { runCommandTask, getPaths } from 'src/lib'
+import c from 'src/lib/colors'
+
+export const command = 'ide'
+export const description = 'Start Prisma Studio'
+
+export const builder = (yargs) => {
+  yargs.epilogue(
+    `Also see the ${terminalLink(
+      'Redwood CLI Reference',
+      'https://redwoodjs.com/reference/command-line-interface#db-ide'
+    )}`
+  )
+}
+
+export const handler = async () => {
+  // No database, no migrations, no IDE.
+  const FILE_DB = path.join(getPaths().api.db, 'dev.db')
+  const DIR_MIGRATIONS = path.join(getPaths().api.db, 'migrations')
+
+  if (!fs.existsSync(FILE_DB) && !fs.existsSync(DIR_MIGRATIONS)) {
+    console.log(
+      // eslint-disable-next-line
+      `${c.warning('[warning]')} your app doesn't have a database (${c.info('api/prisma/dev.db')}) and/or migrations (${c.info('api/prisma/migrations')}). ${c.green('Save and up')} before starting the IDE.`
+    )
+    return
+  }
+
+  await runCommandTask(
+    [
+      {
+        title: 'Migrate database up...',
+        cmd: 'yarn prisma',
+        args: ['studio', '--experimental'],
+      },
+    ],
+    { verbose: true }
+  )
+}

--- a/packages/cli/src/commands/dbCommands/ide.js
+++ b/packages/cli/src/commands/dbCommands/ide.js
@@ -34,7 +34,7 @@ export const handler = async () => {
   await runCommandTask(
     [
       {
-        title: 'Migrate database up...',
+        title: 'Starting Prisma Studio...',
         cmd: 'yarn prisma',
         args: ['studio', '--experimental'],
       },

--- a/packages/cli/src/commands/dbCommands/studio.js
+++ b/packages/cli/src/commands/dbCommands/studio.js
@@ -6,27 +6,27 @@ import terminalLink from 'terminal-link'
 import { runCommandTask, getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
-export const command = 'ide'
+export const command = 'studio'
 export const description = 'Start Prisma Studio'
 
 export const builder = (yargs) => {
   yargs.epilogue(
     `Also see the ${terminalLink(
       'Redwood CLI Reference',
-      'https://redwoodjs.com/reference/command-line-interface#db-ide'
+      'https://redwoodjs.com/reference/command-line-interface#db-studio'
     )}`
   )
 }
 
 export const handler = async () => {
-  // No database, no migrations, no IDE.
+  // No database, no migrations, no studio.
   const FILE_DB = path.join(getPaths().api.db, 'dev.db')
   const DIR_MIGRATIONS = path.join(getPaths().api.db, 'migrations')
 
   if (!fs.existsSync(FILE_DB) && !fs.existsSync(DIR_MIGRATIONS)) {
     console.log(
       // eslint-disable-next-line
-      `${c.warning('[warning]')} your app doesn't have a database (${c.info('api/prisma/dev.db')}) and/or migrations (${c.info('api/prisma/migrations')}). ${c.green('Save and up')} before starting the IDE.`
+      `${c.warning('[warning]')} your app doesn't have a Database (${c.info('api/prisma/dev.db')}) and/or Migrations (${c.info('api/prisma/migrations')}). ${c.green('Save and up')} before starting Studio.`
     )
     return
   }


### PR DESCRIPTION
This PR adds a new db command: `ide`. It starts Prisma Studio.

```
yarn rw db ide
```

Note that you have to have a `dev.db` and a `migrations` directory in `api/prisma` for this to work. If either are missing, the command outputs:

```terminal
[warning] your app doesn't have a database (api/prisma/dev.db) and/or migrations (api/prisma/migrations). Save and up before starting the IDE.
```

### Design Question:

Should this actually just be a flag on dev like @thedavidprice suggested in #467?

```
yarn rw dev --prismastudio
```

I'm open to anything, I just finally got it to work this way and wanted to reopen the discussion with a working spike.

> **NOTE:** I accidentally kind of overwrote #467, otherwise I would've just reopened that one.

### Priority

Before attempting to write any kind of Prisma primer, I think we should get this one figured out. As Siddhant Sinha [demoed](https://youtu.be/Jq2ZR-3NYVg?t=302) on Prisma Day, you can use Prisma Studio as a playground for your Prisma Client&mdash;basically the equivalent of GraphiQL for GraphQL, which is super awesome.

