### PR TITLE
Add test script to web

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,9 @@
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production babel src -d dist --delete-dir-on-start",
     "prepublishOnly": "yarn build",
-    "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\""
+    "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
+    "test": "jest",
+    "test:watch": "yarn test --watch"
   },
   "gitHead": "1cb7c8d1085147787209af423c33a9c91c3e6517"
 }


### PR DESCRIPTION
This adds a `test` script to the `web` project, to include it in the main test run executed by GitHub's actions.

So now this is part of the action output:

```
@redwoodjs/web: $ jest --colors
@redwoodjs/router:  PASS  src/__tests__/util.test.js
@redwoodjs/router:  PASS  src/__tests__/links.test.js
@redwoodjs/web:  PASS  src/flash/__tests__/FlashContext.test.js
@redwoodjs/router:  PASS  src/__tests__/location.test.js
@redwoodjs/router: Test Suites: 3 passed, 3 total
@redwoodjs/router: Tests:       43 passed, 43 total
@redwoodjs/router: Snapshots:   0 total
@redwoodjs/router: Time:        4.428s
@redwoodjs/router: Ran all test suites matching /src/i.
@redwoodjs/web:  PASS  src/flash/__tests__/flash.test.js
@redwoodjs/web: Test Suites: 2 passed, 2 total
@redwoodjs/web: Tests:       7 passed, 7 total
@redwoodjs/web: Snapshots:   0 total
@redwoodjs/web: Time:        3.212s
@redwoodjs/web: Ran all test suites.
```

All those @redwoodjs/web lines are new