### PR TITLE
Remove dev.db/migrations check in db studio

### DIFF
--- a/packages/cli/src/commands/dbCommands/studio.js
+++ b/packages/cli/src/commands/dbCommands/studio.js
@@ -19,14 +19,15 @@ export const builder = (yargs) => {
 }
 
 export const handler = async () => {
-  // No database, no migrations, no studio.
-  const FILE_DB = path.join(getPaths().api.db, 'dev.db')
-  const DIR_MIGRATIONS = path.join(getPaths().api.db, 'migrations')
-
-  if (!fs.existsSync(FILE_DB) && !fs.existsSync(DIR_MIGRATIONS)) {
+  // No schema, no studio.
+  if (!fs.existsSync(getPaths().api.dbSchema)) {
     console.log(
-      // eslint-disable-next-line
-      `${c.warning('[warning]')} your app doesn't have a Database (${c.info('api/prisma/dev.db')}) and/or Migrations (${c.info('api/prisma/migrations')}). ${c.green('Save and up')} before starting Studio.`
+      `${c.warning(
+        '[warning]'
+      )} cannot start Prisma Studio; schema missing (${c.info(
+        // So we're not hard coding schema.prisma's relative location
+        path.relative(getPaths().base, getPaths().api.dbSchema)
+      )}).`
     )
     return
   }


### PR DESCRIPTION
The `yarn rw db studio` command would check for the presence of a `dev.db` and `migrations` file before starting. This PR removes those checks and replaces it with a check for only the `schema.prisma` file.