### PR TITLE
[WIP] Add directory-named-babel-plugin

### DIFF
--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -140,5 +140,16 @@ module.exports = () => ({
       test: ['./web/src/Routes.js', './web/src/Routes.tsx'],
       plugins: [require('../dist/babel-plugin-redwood-routes-auto-loader')],
     },
+    /**
+     * Automatically import services
+     * So we can do
+     *   import { contacts } from 'src/services/contacts
+     * Instead of:
+     *   import { contacts } from 'src/services/contacts/contacts
+     */
+    // {
+    // test: //
+    // plugins: [require('../dist/babel-plugin-directory-named')]
+    // }
   ],
 })

--- a/packages/core/src/babel-plugin-directory-named.ts
+++ b/packages/core/src/babel-plugin-directory-named.ts
@@ -1,0 +1,4 @@
+/**
+ * Placeholder; goal is to implement https://github.com/chatterbugapp/babel-plugin-directory-named
+ * but in TypeScript.
+ */


### PR DESCRIPTION
This PR stubs out some of what adding the [directory-named-babel-plugin](https://github.com/chatterbugapp/babel-plugin-directory-named) (plan of attack in #641) would entail. 

Once added, given two services, `contacts` and `notes`, we can import from the directory instead of the file. Here's a diff of the actual vs the intended behavior:
```diff
// api/src/services/notes/notes.js

-import { contacts } from 'src/services/contacts/contacts
+import { contacts } from 'src/services/contacts'
```

Related issues:
- #641 
- #804