### PR TITLE
Add @storybook/react to @redwoodjs/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "@redwoodjs/eslint-config": "^0.12.0",
     "@redwoodjs/internal": "^0.12.0",
     "@redwoodjs/testing": "^0.12.0",
+    "@storybook/react": "^5.3.19",
     "@testing-library/jest-dom": "^5.8.0",
     "@types/jest": "^25.1.4",
     "@types/node": "^13.9.5",


### PR DESCRIPTION
This PR adds the `@storybook/react` package to `@redwood/core`. Let me know if this isn't necessary, but I didn't see storybook as a dependency, even though we require it in [packages/core/config/storybook/preview.js](https://github.com/redwoodjs/redwood/blob/c52fd6620a137012c5db39d8b63170879efb0ea3/packages/core/config/storybook/preview.js#L2):

```js
const { addDecorator } = require('@storybook/react')
```

Also, even when I upgrade one of my local Redwood apps to canary, I have to install it myself (i.e. run `yarn workspace web add -D @storybook/react`). `yarn rw storybook` fails otherwise ("missing command start-storybook"). Maybe this is why?

Last question: ideally it should be a dev dependency in Redwood app's web side right?