### PR TITLE
Make MockRouter also map private routes.

### DIFF
--- a/packages/router/src/index.d.ts
+++ b/packages/router/src/index.d.ts
@@ -25,7 +25,7 @@ declare module '@redwoodjs/router' {
      * they will be redirected to the route name passed to `unauthenticated`.
      */
     unauthenticated: namedRoute
-    children: typeof Route[]
+    children: Array<typeof Route>
   }>
 
   const Router: React.FunctionComponent<{

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,6 +24,8 @@
     "build:js": "yarn cross-env NODE_ENV=production babel src -d dist --extensions \".js,.ts,.tsx\" --delete-dir-on-start",
     "build:types": "tsc --build --clean && tsc --build",
     "prepublishOnly": "yarn build",
-    "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'"
+    "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'",
+    "test": "jest",
+    "test:watch": "yarn test --watch"
   }
 }

--- a/packages/testing/src/MockProviders.tsx
+++ b/packages/testing/src/MockProviders.tsx
@@ -1,16 +1,13 @@
 /**
- * NOTE! This file is imported by Storybook, so it cannot contain any nodejs modules.
+ * NOTE: This module should not contain any nodejs functionality,
+ * because it's also used by Storybook in the browser.
  */
 import React from 'react'
-// ts-ignore
 import { RedwoodProvider } from '@redwoodjs/web'
 
-// Import the user's Router from `./web/src/Router.js`,
-// we pass the `children` from the user's Router in `./MockRouter.Router`,
-// so that we can populate the `routes object` in tests.
-
-// We need to make this work in the context of the browser
-// eslint-disable-next-line no-undef
+// Import the user's Router from `./web/src/Router.{tsx,js}`,
+// we pass the `children` from the user's Router to `./MockRouter.Router`
+// so that we can populate the `routes object` in Storybook and tests.
 const {
   default: UserRouterWithRoutes,
 } = require('~__REDWOOD__USER_ROUTES_FOR_MOCK')

--- a/packages/testing/src/MockRouter.tsx
+++ b/packages/testing/src/MockRouter.tsx
@@ -1,21 +1,32 @@
 import React from 'react'
-// We're bypassing the `main` field in `package.json` because we're
-// replacing imports of `@redwoodjs/router` with this file, and not doing so
-// would cause an infinite loop.
+// Bypass the `main` field in `package.json` because we alias `@redwoodjs/router`
+// for jest and Storybook. Not doing so would cause an infinite loop.
 // See: ./packages/core/config/jest.config.web.js
+import { Private, Route } from '@redwoodjs/router/dist/index'
 export * from '@redwoodjs/router/dist/index'
 
 export const routes: { [routeName: string]: () => string } = {}
 
+const getPrivateRoutes = (children) =>
+  React.Children.toArray(children)
+    .filter((child) => child.type === Private)
+    .map((child) => child.props.children)
+    .flat(Infinity)
+
 /**
- * This is used in place of the real router during tests.
+ * We overwrite the default `Router` export.
  * It populates the `routes.<pagename>()` utility object.
  */
 export const Router: React.FunctionComponent = ({ children }) => {
-  for (const route of React.Children.toArray(
-    children
-  ) as React.ReactElement[]) {
-    const { name } = route.props
+  // get all children from <Private> blocks.
+  const privateRoutes = getPrivateRoutes(children)
+
+  const normalRoutes = React.Children.toArray(children).filter(
+    (child) => child.type === Route
+  )
+
+  for (const child of [...privateRoutes, ...normalRoutes]) {
+    const { name } = child.props
     routes[name] = () => name
   }
   return <></>

--- a/packages/testing/src/MockRouter.tsx
+++ b/packages/testing/src/MockRouter.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 // Bypass the `main` field in `package.json` because we alias `@redwoodjs/router`
 // for jest and Storybook. Not doing so would cause an infinite loop.
 // See: ./packages/core/config/jest.config.web.js
+// @ts-ignore
 import { Private, Route } from '@redwoodjs/router/dist/index'
 export * from '@redwoodjs/router/dist/index'
 
 export const routes: { [routeName: string]: () => string } = {}
 
-const getPrivateRoutes = (children) =>
-  React.Children.toArray(children)
+const getPrivateRoutes = (children: React.ReactNode) =>
+  (React.Children.toArray(children) as React.ReactElement[])
     .filter((child) => child.type === Private)
     .map((child) => child.props.children)
     .flat(Infinity)
@@ -21,9 +22,9 @@ export const Router: React.FunctionComponent = ({ children }) => {
   // get all children from <Private> blocks.
   const privateRoutes = getPrivateRoutes(children)
 
-  const normalRoutes = React.Children.toArray(children).filter(
-    (child) => child.type === Route
-  )
+  const normalRoutes = (React.Children.toArray(
+    children
+  ) as React.ReactElement[]).filter((child) => child.type === Route)
 
   for (const child of [...privateRoutes, ...normalRoutes]) {
     const { name } = child.props

--- a/packages/testing/src/__tests__/MockRouter.test.tsx
+++ b/packages/testing/src/__tests__/MockRouter.test.tsx
@@ -20,6 +20,8 @@ describe('MockRouter', () => {
       </Router>
     )
 
-    expect(Object.keys(routes)).toEqual(['a', 'b', 'c', 'd'])
+    expect(Object.keys(routes)).toEqual(
+      expect.arrayContaining(['a', 'b', 'c', 'd'])
+    )
   })
 })

--- a/packages/testing/src/__tests__/MockRouter.test.tsx
+++ b/packages/testing/src/__tests__/MockRouter.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Route, Private } from '@redwoodjs/router'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+
+import { routes, Router } from '../MockRouter'
+
+const FakePage = () => <></>
+
+describe('MockRouter', () => {
+  it('should correctly map routes', () => {
+    render(
+      <Router>
+        <Route name="a" path="/a" page={<FakePage />} />
+        <Route name="b" path="/b" page={<FakePage />} />
+        <Private unauthenticated="a">
+          <Route name="c" path="/c" page={<FakePage />} />
+          <Route name="d" path="/d" page={<FakePage />} />
+        </Private>
+      </Router>
+    )
+
+    expect(Object.keys(routes)).toEqual(['a', 'b', 'c', 'd'])
+  })
+})


### PR DESCRIPTION
Fix `MockRouter` not correctly mapping `Routes` nested in `Private`.

- [x] Add test.