### PR TITLE
Add tailwind generator

### DIFF
--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -5,7 +5,11 @@ import terminalLink from 'terminal-link'
 
 export const builder = (yargs) =>
   yargs
-    .commandDir('./generate', { recurse: true })
+    /**
+     * Like generate, util is an entry point command,
+     * so we can't have generate going through its subdirectories
+     */
+    .commandDir('./generate', { recurse: true, exclude: /\/util\// })
     .demandCommand()
     .epilogue(
       `Also see the ${terminalLink(

--- a/packages/cli/src/commands/generate/util.js
+++ b/packages/cli/src/commands/generate/util.js
@@ -1,0 +1,16 @@
+import terminalLink from 'terminal-link'
+
+export const command = 'util <util>'
+export const aliases = ['u']
+export const description = 'Quality of life utilities'
+
+export const builder = (yargs) =>
+  yargs
+    .commandDir('./util', { recurse: true, exclude: /util.js/ })
+    .demandCommand()
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface'
+      )}`
+    )

--- a/packages/cli/src/commands/generate/util/tailwind/tailwind.js
+++ b/packages/cli/src/commands/generate/util/tailwind/tailwind.js
@@ -1,0 +1,105 @@
+import fs from 'fs'
+import path from 'path'
+
+import Listr from 'listr'
+import execa from 'execa'
+
+import c from 'src/lib/colors'
+import { getPaths, writeFile } from 'src/lib'
+
+export const command = 'tailwind'
+export const description = 'Setup tailwindcss'
+export const builder = (yargs) => {
+  yargs.option('force', {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing configuration',
+    type: 'boolean',
+  })
+}
+
+const notes = [
+  'Add the following directives to your ./web/src/index.css:',
+  '',
+  '@tailwind base;',
+  '@tailwind components;',
+  '@tailwind utilities;',
+  '',
+  "And don't forget to read the docs: https://tailwindcss.com/",
+]
+
+export const handler = async ({ force }) => {
+  const tasks = new Listr([
+    {
+      title: 'Installing packages...',
+      task: async () => {
+        /**
+         * Install postcss-loader, tailwindcss, and autoprefixer
+         */
+        await execa('yarn', [
+          'workspace',
+          'web',
+          'add',
+          '-D',
+          'postcss-loader',
+          'tailwindcss',
+          'autoprefixer',
+        ])
+      },
+    },
+    {
+      title: 'Configuring Postcss...',
+      task: () => {
+        /**
+         * Make web/config if it doesn't exist
+         * and write postcss.config.js there
+         */
+        return writeFile(
+          getPaths().web.postcss,
+          fs
+            .readFileSync(
+              path.resolve(__dirname, 'templates', 'postcss.config.js.template')
+            )
+            .toString(),
+          { overwriteExisting: force }
+        )
+      },
+    },
+    {
+      title: 'Initializing Tailwind...',
+      task: async () => {
+        /**
+         * If it doesn't already exist,
+         * initialize tailwind and move tailwind.config.js to web/
+         */
+        const configExists = fs.existsSync(
+          path.join(getPaths().web.base, 'tailwind.config.js')
+        )
+
+        if (!configExists || force) {
+          await execa('yarn', ['tailwindcss', 'init'])
+          /**
+           * Later, when we can tell the vscode extension where to look for the config,
+           * we can put it in web/config/
+           */
+          await execa('mv', ['tailwind.config.js', 'web/'])
+        }
+      },
+    },
+    {
+      title: 'One more thing...',
+      task: (_ctx, task) => {
+        /**
+         * Instruct users to copy-paste the tailwind directives into web/src/index.css
+         */
+        task.title = `One more thing...\n\n   ${notes.join('\n   ')}\n`
+      },
+    },
+  ])
+
+  try {
+    await tasks.run()
+  } catch (e) {
+    console.log(c.error(e.message))
+  }
+}

--- a/packages/cli/src/commands/generate/util/tailwind/templates/postcss.config.js.template
+++ b/packages/cli/src/commands/generate/util/tailwind/templates/postcss.config.js.template
@@ -1,0 +1,8 @@
+const path = require('path')
+
+module.exports = {
+  plugins: [
+    require('tailwindcss')(__dirname, '../tailwind.config.js')),
+    require('autoprefixer'),
+  ],
+}


### PR DESCRIPTION
This PR adds a generator that adds Tailwind to a Redwood app:

```
yarn rw g tailwind
```

![rw-g-tailwind](https://user-images.githubusercontent.com/32992335/87234076-47716500-c382-11ea-8a8e-5f115f36e4cf.gif)

We do already have the process documented in the doc on [Webpack Configuration](https://redwoodjs.com/docs/webpack-configuration#adding-tailwindcss). But I feel like adding Tailwind to a Redwood app happens often enough to warrant a generator for it. Let me know if you guys think it's extraneous though. And/or if it should be part of a larger "css" generator:

```
yarn rw g css tailwind
```

Right now, adding-directives-to-your-index.css bit is a note at the end, much like the way auth works:

```
const notes = [
  'Add the following directives to your ./web/src/index.css:',
  '',
  '@tailwind base;',
  '@tailwind components;',
  '@tailwind utilities;',
]
```

I thought this was better than just overwriting `index.css` but open to any suggestions there as well.

### To-dos:
- [x] Should this be part of a larger css generator? I.e. just one of many options accessed through `yarn rw g css`
- [x] Should this output a note about adding directives to `index.css` (current behavior), or just overwrite the file?
- [x] Add tests! (skipping for now @peterp )