### PR TITLE
Fix auth generator regex

### DIFF
--- a/packages/cli/src/commands/generate/auth/auth.js
+++ b/packages/cli/src/commands/generate/auth/auth.js
@@ -95,7 +95,7 @@ export const addApiConfig = () => {
 
   // add import statement
   content = content.replace(
-    /^(.*importAll.*)$/m,
+    /^(.*services.*)$/m,
     `$1\n\nimport { getCurrentUser } from 'src/lib/auth.js'`
   )
   // add object to handler

--- a/packages/cli/src/commands/generate/auth/auth.js
+++ b/packages/cli/src/commands/generate/auth/auth.js
@@ -96,7 +96,7 @@ export const addApiConfig = () => {
   // add import statement
   content = content.replace(
     /^(.*services.*)$/m,
-    `$1\n\nimport { getCurrentUser } from 'src/lib/auth.js'`
+    `$1\n\nimport { getCurrentUser } from 'src/lib/auth'`
   )
   // add object to handler
   content = content.replace(


### PR DESCRIPTION
This PR closes #830 by fixing the RegExp the auth generator uses to add the `import { getCurrentUser } from 'src/lib/auth.js` statement to the graphql function.

There's probably a better fix than just replacing "importAll" with "services", but this works.
