### PR TITLE
Add alias sb for storybook command

### DIFF
--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -2,6 +2,7 @@ import execa from 'execa'
 import { getPaths } from '@redwoodjs/internal'
 
 export const command = 'storybook'
+export const aliases = ['sb']
 export const description =
   'Launch Storybook, an isolated component development environment'
 


### PR DESCRIPTION
This PR closes #816 by adding the alias `sb` to the storybook command. So now you can run it like:

```
yarn rw sb
```