### PR TITLE
Form: use context to handle coercions

### DIFF
--- a/packages/web/src/form/__tests__/form.test.js
+++ b/packages/web/src/form/__tests__/form.test.js
@@ -12,6 +12,7 @@ import {
   TextField,
   NumberField,
   CheckboxField,
+  TextAreaField,
   Submit,
 } from 'src/form/form'
 
@@ -23,6 +24,17 @@ describe('Form', () => {
         <NumberField name="nf" defaultValue="42" />
         <TextField name="ff" defaultValue="3.14" dataType="Float" />
         <CheckboxField name="cf" defaultChecked={true} />
+        <TextAreaField
+          name="jf"
+          dataType="Json"
+          defaultValue={`
+            {
+              "key_one": "value1",
+              "key_two": 2,
+              "false": false
+            }
+          `}
+        />
         <Submit>Save</Submit>
       </Form>
     )
@@ -75,6 +87,11 @@ describe('Form', () => {
         nf: 4224, // i.e. NOT "4224"
         ff: 3.141592,
         cf: true,
+        jf: {
+          key_one: 'value1',
+          key_two: 2,
+          false: false,
+        },
       },
       expect.anything() // event that triggered the onSubmit call
     )

--- a/packages/web/src/form/__tests__/form.test.js
+++ b/packages/web/src/form/__tests__/form.test.js
@@ -28,6 +28,18 @@ describe('Form', () => {
     )
   }
 
+  const TestComponentWithWrappedFormElements = ({ onSubmit = () => {} }) => {
+    return (
+      <Form onSubmit={onSubmit}>
+        <p>Some text</p>
+        <div className="field">
+          <TextField name="wrapped-ff" defaultValue="3.14" dataType="Float" />
+        </div>
+        <Submit>Save</Submit>
+      </Form>
+    )
+  }
+
   afterEach(() => {
     cleanup()
   })
@@ -64,6 +76,20 @@ describe('Form', () => {
         ff: 3.141592,
         cf: true,
       },
+      expect.anything() // event that triggered the onSubmit call
+    )
+  })
+
+  it('finds nested form fields to coerce', async () => {
+    const mockFn = jest.fn()
+
+    render(<TestComponentWithWrappedFormElements onSubmit={mockFn} />)
+
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(mockFn).toHaveBeenCalledTimes(1))
+    expect(mockFn).toBeCalledWith(
+      { 'wrapped-ff': 3.14 },
       expect.anything() // event that triggered the onSubmit call
     )
   })

--- a/packages/web/src/form/__tests__/form.test.js
+++ b/packages/web/src/form/__tests__/form.test.js
@@ -40,6 +40,20 @@ describe('Form', () => {
     )
   }
 
+  const NumberFieldsWrapper = () => (
+    <div>
+      <h4>This is a wrapped form field header</h4>
+      <div>
+        <label htmlFor="wrapped-nf-1">Wrapped NumberField</label>
+        <NumberField name="wrapped-nf-1" defaultValue="0101" />
+      </div>
+      <div>
+        <label htmlFor="wrapped-nf-2">Wrapped NumberField</label>
+        <NumberField name="wrapped-nf-2" defaultValue="0102" />
+      </div>
+    </div>
+  )
+
   const TestComponentWithWrappedFormElements = ({ onSubmit = () => {} }) => {
     return (
       <Form onSubmit={onSubmit}>
@@ -47,6 +61,7 @@ describe('Form', () => {
         <div className="field">
           <TextField name="wrapped-ff" defaultValue="3.14" dataType="Float" />
         </div>
+        <NumberFieldsWrapper />
         <Submit>Save</Submit>
       </Form>
     )
@@ -106,7 +121,7 @@ describe('Form', () => {
 
     await waitFor(() => expect(mockFn).toHaveBeenCalledTimes(1))
     expect(mockFn).toBeCalledWith(
-      { 'wrapped-ff': 3.14 },
+      { 'wrapped-ff': 3.14, 'wrapped-nf-1': 101, 'wrapped-nf-2': 102 },
       expect.anything() // event that triggered the onSubmit call
     )
   })

--- a/packages/web/src/form/coercion.js
+++ b/packages/web/src/form/coercion.js
@@ -1,0 +1,50 @@
+const CoercionContext = React.createContext()
+
+export const CoercionContextProvider = ({ children }) => {
+  const [coercions, setCoercions] = React.useState({})
+
+  const setCoercion = React.useCallback(
+    (name, type) => {
+      setCoercions((coercions) => ({ ...coercions, [name]: type }))
+    },
+    [setCoercions]
+  )
+
+  const coerce = React.useCallback((name, value) => coercions[name](value), [
+    coercions,
+  ])
+
+  return (
+    <CoercionContext.Provider value={{ setCoercion, coerce }}>
+      {children}
+    </CoercionContext.Provider>
+  )
+}
+
+const COERCION_FUNCTIONS = {
+  Boolean: (value) => !!value,
+  Float: (value) => parseFloat(value),
+  Int: (value) => parseInt(value, 10),
+  Json: (value) => JSON.parse(value),
+}
+
+const inputTypeToDataTypeMapping = {
+  checkbox: 'Boolean',
+  number: 'Int',
+}
+
+export const useCoercion = () => {
+  const coercionContext = React.useContext(CoercionContext)
+
+  const setCoercion = (name, type, dataType) => {
+    const coercionFunction =
+      COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
+      ((value) => value)
+
+    coercionContext.setCoercion(name, coercionFunction)
+  }
+
+  const coerce = coercionContext.coerce
+
+  return { setCoercion, coerce }
+}

--- a/packages/web/src/form/coercion.js
+++ b/packages/web/src/form/coercion.js
@@ -27,7 +27,7 @@ export const useCoercion = () => {
 
   const coerce = (name, value) => coercionContext.coercions[name](value)
 
-  const setCoercion = (name, type, dataType) => {
+  const setCoercion = ({ name, type, dataType }) => {
     const coercionFunction =
       COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
       ((value) => value)

--- a/packages/web/src/form/coercion.js
+++ b/packages/web/src/form/coercion.js
@@ -3,19 +3,8 @@ const CoercionContext = React.createContext()
 export const CoercionContextProvider = ({ children }) => {
   const [coercions, setCoercions] = React.useState({})
 
-  const setCoercion = React.useCallback(
-    (name, type) => {
-      setCoercions((coercions) => ({ ...coercions, [name]: type }))
-    },
-    [setCoercions]
-  )
-
-  const coerce = React.useCallback((name, value) => coercions[name](value), [
-    coercions,
-  ])
-
   return (
-    <CoercionContext.Provider value={{ setCoercion, coerce }}>
+    <CoercionContext.Provider value={{ coercions, setCoercions }}>
       {children}
     </CoercionContext.Provider>
   )
@@ -36,15 +25,18 @@ const inputTypeToDataTypeMapping = {
 export const useCoercion = () => {
   const coercionContext = React.useContext(CoercionContext)
 
+  const coerce = (name, value) => coercionContext.coercions[name](value)
+
   const setCoercion = (name, type, dataType) => {
     const coercionFunction =
       COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
       ((value) => value)
 
-    coercionContext.setCoercion(name, coercionFunction)
+    coercionContext.setCoercions((coercions) => ({
+      ...coercions,
+      [name]: coercionFunction,
+    }))
   }
 
-  const coerce = coercionContext.coerce
-
-  return { setCoercion, coerce }
+  return { coerce, setCoercion }
 }

--- a/packages/web/src/form/coercion.js
+++ b/packages/web/src/form/coercion.js
@@ -25,18 +25,24 @@ const inputTypeToDataTypeMapping = {
 export const useCoercion = () => {
   const coercionContext = React.useContext(CoercionContext)
 
-  const coerce = (name, value) => coercionContext.coercions[name](value)
+  const coerce = React.useCallback(
+    (name, value) => coercionContext.coercions[name](value),
+    [coercionContext.coercions]
+  )
 
-  const setCoercion = ({ name, type, dataType }) => {
-    const coercionFunction =
-      COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
-      ((value) => value)
+  const setCoercion = React.useCallback(
+    ({ name, type, dataType }) => {
+      const coercionFunction =
+        COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
+        ((value) => value)
 
-    coercionContext.setCoercions((coercions) => ({
-      ...coercions,
-      [name]: coercionFunction,
-    }))
-  }
+      coercionContext.setCoercions.call(null, (coercions) => ({
+        ...coercions,
+        [name]: coercionFunction,
+      }))
+    },
+    [coercionContext.setCoercions]
+  )
 
   return { coerce, setCoercion }
 }

--- a/packages/web/src/form/form.js
+++ b/packages/web/src/form/form.js
@@ -1,6 +1,7 @@
 import { useForm, FormContext, useFormContext } from 'react-hook-form'
 import { useContext, useEffect } from 'react'
 import pascalcase from 'pascalcase'
+import { CoercionContextProvider, useCoercion } from './coercion'
 
 const DEFAULT_MESSAGES = {
   required: 'is required',
@@ -35,13 +36,6 @@ const INPUT_TYPES = [
   'url',
   'week',
 ]
-const COERCION_FUNCTIONS = {
-  Boolean: (value) => !!value,
-  Float: (value) => parseFloat(value),
-  Int: (value) => parseInt(value, 10),
-  Json: (value) => JSON.parse(value),
-  NumberField: (value) => parseInt(value, 10),
-}
 
 // Massages a hash of props depending on whether the given named field has
 // any errors on it
@@ -148,30 +142,14 @@ const FormError = ({
   )
 }
 
-const coerceValues = (data, children) => {
-  const coercedData = { ...data }
-
-  children.forEach((child) => {
-    const childName = child.props.name
-
-    const [componentName] = Object.entries(inputComponents).find(
-      ([_, componentConstructor]) => componentConstructor === child.type
-    ) || [undefined, undefined]
-
-    const coercionFunction =
-      COERCION_FUNCTIONS[child.props?.dataType || componentName]
-
-    if (coercionFunction) {
-      coercedData[childName] = coercionFunction(data[childName])
-    }
-  })
-
-  return coercedData
+const coerceValues = (data, coerce) => {
+  // TODO: ie11 compat?
+  return Object.fromEntries(
+    Object.entries(data).map(([name, value]) => [name, coerce(name, value)])
+  )
 }
 
-// Renders a containing <form> tag with required contexts
-
-const Form = (props) => {
+const FormWithCoercionContext = (props) => {
   // deconstruct some props we care about and keep the remaining `formProps` to
   // pass to the <form> tag
   const {
@@ -182,12 +160,13 @@ const Form = (props) => {
   } = props
   const useFormMethods = useForm(props.validation)
   const formMethods = propFormMethods || useFormMethods
+  const { coerce } = useCoercion()
 
   return (
     <form
       {...formProps}
       onSubmit={formMethods.handleSubmit((data, event) =>
-        onSubmit(coerceValues(data, props.children), event)
+        onSubmit(coerceValues(data, coerce), event)
       )}
     >
       <FieldErrorContext.Provider
@@ -198,6 +177,16 @@ const Form = (props) => {
         <FormContext {...formMethods}>{props.children}</FormContext>
       </FieldErrorContext.Provider>
     </form>
+  )
+}
+
+// Renders a containing <form> tag with required contexts
+
+const Form = (props) => {
+  return (
+    <CoercionContextProvider>
+      <FormWithCoercionContext {...props} />
+    </CoercionContextProvider>
   )
 }
 
@@ -268,6 +257,12 @@ const Submit = React.forwardRef((props, ref) => (
 
 const InputField = (props) => {
   const { register } = useFormContext()
+  const { setCoercion } = useCoercion()
+
+  React.useEffect(() => {
+    setCoercion(props.name, props.type, props.dataType)
+  }, [props.name, props.type, props.dataType])
+
   const tagProps = inputTagProps(props)
 
   return (

--- a/packages/web/src/form/form.js
+++ b/packages/web/src/form/form.js
@@ -221,6 +221,12 @@ const FieldError = (props) => {
 
 const TextAreaField = (props) => {
   const { register } = useFormContext()
+  const { setCoercion } = useCoercion()
+
+  React.useEffect(() => {
+    setCoercion({ name: props.name, dataType: props.dataType })
+  }, [props.name, props.dataType])
+
   const tagProps = inputTagProps(props)
 
   return (
@@ -260,7 +266,11 @@ const InputField = (props) => {
   const { setCoercion } = useCoercion()
 
   React.useEffect(() => {
-    setCoercion(props.name, props.type, props.dataType)
+    setCoercion({
+      name: props.name,
+      type: props.type,
+      dataType: props.dataType,
+    })
   }, [props.name, props.type, props.dataType])
 
   const tagProps = inputTagProps(props)

--- a/packages/web/src/form/form.js
+++ b/packages/web/src/form/form.js
@@ -144,10 +144,13 @@ const FormError = ({
 }
 
 const coerceValues = (data, coerce) => {
-  // TODO: ie11 compat?
-  return Object.fromEntries(
-    Object.entries(data).map(([name, value]) => [name, coerce(name, value)])
-  )
+  const coercedData = {}
+
+  Object.keys(data).forEach((name) => {
+    coercedData[name] = coerce(name, data[name])
+  })
+
+  return coercedData
 }
 
 const FormWithCoercionContext = (props) => {

--- a/packages/web/src/form/form.js
+++ b/packages/web/src/form/form.js
@@ -1,6 +1,7 @@
 import { useForm, FormContext, useFormContext } from 'react-hook-form'
 import { useContext, useEffect } from 'react'
 import pascalcase from 'pascalcase'
+
 import { CoercionContextProvider, useCoercion } from './coercion'
 
 const DEFAULT_MESSAGES = {
@@ -225,7 +226,7 @@ const TextAreaField = (props) => {
 
   React.useEffect(() => {
     setCoercion({ name: props.name, dataType: props.dataType })
-  }, [props.name, props.dataType])
+  }, [setCoercion, props.name, props.dataType])
 
   const tagProps = inputTagProps(props)
 
@@ -271,7 +272,7 @@ const InputField = (props) => {
       type: props.type,
       dataType: props.dataType,
     })
-  }, [props.name, props.type, props.dataType])
+  }, [setCoercion, props.name, props.type, props.dataType])
 
   const tagProps = inputTagProps(props)
 


### PR DESCRIPTION
This is an alternative solution to #826 to handle nested form fields. 

I feel this is a more idiomatic React solution, using Context instead of recursive looping over child elements.

Fixes #825 