### PR TITLE
AuthProvider: cleanup async tasks before unmount

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -84,6 +84,10 @@ export class AuthProvider extends React.Component<
     return this.reauthenticate()
   }
 
+  componentWillUnmount() {
+    this.setState(this.state)
+  }
+
   getCurrentUser = async () => {
     if (this.props.skipFetchCurrentUser) {
       return undefined


### PR DESCRIPTION
This PR gives cleanup duty to the AuthProvider component and puts an end to its memory leak warnings (and memory leaks, for that matter).