### PR TITLE
Convert LocationProvider to function component and add cleanup effects

### DIFF
--- a/packages/router/src/location.js
+++ b/packages/router/src/location.js
@@ -2,35 +2,29 @@ import { createNamedContext, gHistory } from './internal'
 
 const LocationContext = createNamedContext('Location')
 
-class LocationProvider extends React.Component {
-  static defaultProps = {
-    location: window.location,
-  }
-
-  state = {
-    context: this.getContext(),
-  }
-
-  getContext() {
-    const { pathname, search, hash } = this.props.location
+const LocationProvider = ({ location = window.location, children }) => {
+  const getContext = React.useCallback(() => {
+    const { pathname, search, hash } = location
     return { pathname, search, hash }
-  }
+  }, [location])
 
-  componentDidMount() {
+  const [context, setContext] = React.useState(getContext())
+
+  React.useEffect(() => {
+    let isMounted = true
     gHistory.listen(() => {
-      this.setState(() => ({ context: this.getContext() }))
+      if (isMounted) setContext(() => getContext())
     })
-  }
+    return () => {
+      isMounted = false
+    }
+  }, [getContext])
 
-  render() {
-    let { children } = this.props
-    let { context } = this.state
-    return (
-      <LocationContext.Provider value={context}>
-        {typeof children === 'function' ? children(context) : children || null}
-      </LocationContext.Provider>
-    )
-  }
+  return (
+    <LocationContext.Provider value={context}>
+      {typeof children === 'function' ? children(context) : children || null}
+    </LocationContext.Provider>
+  )
 }
 
 const Location = ({ children }) => (


### PR DESCRIPTION
This PR converts the Router package LocationProvider component to a function component and adds cleanup duty to the useEffect hook. This should fix the setState memory leak and related warnings in cases where the router is unmounted (like auth state change).