### PR TITLE
Add "diagnostics" command to CLI

### DIFF
--- a/packages/cli/src/commands/diagnostics.js
+++ b/packages/cli/src/commands/diagnostics.js
@@ -1,0 +1,18 @@
+import { printDiagnostics, DiagnosticSeverity } from '@redwoodjs/structure'
+
+import { getPaths } from 'src/lib'
+import c from 'src/lib/colors'
+
+export const command = 'diagnostics'
+export const description =
+  'Get structural diagnostics for a Redwood project (experimental)'
+
+export const handler = async () => {
+  printDiagnostics(getPaths().base, { getSeverityLabel })
+}
+
+function getSeverityLabel(severity) {
+  if (severity === DiagnosticSeverity.Error) return c.error('error')
+  if (severity === DiagnosticSeverity.Warning) return c.warning('warning')
+  return c.info('info')
+}

--- a/packages/structure/src/index.ts
+++ b/packages/structure/src/index.ts
@@ -2,6 +2,10 @@ export { DefaultHost, Host } from './ide'
 export { RWProject } from './model'
 import { DefaultHost } from './ide'
 import { RWProject } from './model'
+import {
+  ExtendedDiagnostic_format,
+  GetSeverityLabelFunction,
+} from './x/vscode-languageserver-types'
 export { DiagnosticSeverity } from 'vscode-languageserver-types'
 
 export function getProject(projectRoot: string, host = new DefaultHost()) {
@@ -9,4 +13,20 @@ export function getProject(projectRoot: string, host = new DefaultHost()) {
     projectRoot,
     host,
   })
+}
+
+export async function printDiagnostics(
+  projectRoot: string,
+  opts?: { getSeverityLabel?: GetSeverityLabelFunction }
+) {
+  const project = getProject(projectRoot)
+  const formatOpts = { cwd: projectRoot, ...opts }
+  try {
+    for (const d of await project.collectDiagnostics()) {
+      const str = ExtendedDiagnostic_format(d, formatOpts)
+      console.log(str)
+    }
+  } catch (e) {
+    console.log('runtime error: ' + e.message)
+  }
 }

--- a/packages/structure/src/x/__tests__/vscode-languageserver-types-x.test.ts
+++ b/packages/structure/src/x/__tests__/vscode-languageserver-types-x.test.ts
@@ -1,7 +1,13 @@
-import { Position, Range } from 'vscode-languageserver-types'
+import {
+  Position,
+  Range,
+  DiagnosticSeverity,
+} from 'vscode-languageserver-types'
 import {
   Position_compare,
   Range_contains,
+  ExtendedDiagnostic,
+  ExtendedDiagnostic_format,
 } from '../vscode-languageserver-types'
 
 describe('Position_compare', () => {
@@ -36,5 +42,28 @@ describe('Range_contains', () => {
     function x(r: Range, l: number, c: number, res: boolean) {
       expect(Range_contains(r, Position.create(l, c))).toEqual(res)
     }
+  })
+})
+
+describe('ExtendedDiagnostic_format', () => {
+  it('can format diagnostics', async () => {
+    const d: ExtendedDiagnostic = {
+      uri: 'file:///path/to/app/b.ts',
+      diagnostic: {
+        range: Range.create(1, 2, 1, 6),
+        severity: DiagnosticSeverity.Error,
+        message: 'this is a message',
+      },
+    }
+    const str = ExtendedDiagnostic_format(d, { cwd: '/path/to/app/' })
+    expect(str).toEqual('b.ts:2:3: error: this is a message')
+
+    const str2 = ExtendedDiagnostic_format(d)
+    expect(str2).toEqual('/path/to/app/b.ts:2:3: error: this is a message')
+
+    const str3 = ExtendedDiagnostic_format(d, {
+      getSeverityLabel: (s) => `<${s}>`,
+    })
+    expect(str3).toEqual('/path/to/app/b.ts:2:3: <1>: this is a message')
   })
 })


### PR DESCRIPTION
* This PR adds a new command to the CLI called "diagnostics"
* For now all it does is print some diagnostics (with no stats, no summaries, etc)
* It delegates all work to the @redwoodjs/structure package

<img width="1050" alt="Screen Shot 2020-07-14 at 1 04 59 AM" src="https://user-images.githubusercontent.com/154884/87400981-66344f00-c56e-11ea-8e60-7ffbba877100.png">