### PR TITLE
Use structure to extract operation name from Cell's QUERY

### DIFF
--- a/__fixtures__/example-todo-main-with-errors/web/src/components/TodoListCell/TodoListCell.js
+++ b/__fixtures__/example-todo-main-with-errors/web/src/components/TodoListCell/TodoListCell.js
@@ -3,7 +3,7 @@ import TodoItem from 'src/components/TodoItem'
 import { useMutation } from '@redwoodjs/web'
 
 export const QUERY = gql`
-  query Q {
+  {
     todos {
       id
       body

--- a/__fixtures__/example-todo-main/web/src/components/TodoListCell/TodoListCell.js
+++ b/__fixtures__/example-todo-main/web/src/components/TodoListCell/TodoListCell.js
@@ -3,7 +3,7 @@ import TodoItem from 'src/components/TodoItem'
 import { useMutation } from '@redwoodjs/web'
 
 export const QUERY = gql`
-  {
+  query TodoListCell_GetTodos {
     todos {
       id
       body

--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -84,6 +84,13 @@ export class RWCell extends RWComponent {
       }
     } catch (e) {
       // Maybe the AST has a syntax error...
+      yield {
+        uri: this.uri,
+        diagnostic: {
+          message: e.message,
+          severity: DiagnosticSeverity.Error,
+        },
+      }
     }
 
     // TODO: check that exported QUERY is semantically valid GraphQL (fields exist)

--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -18,6 +18,50 @@ export class RWCell extends RWComponent {
     return !this.hasDefaultExport && this.exportedSymbols.has('QUERY')
   }
 
+  // TODO: Move to RWCellQuery
+  @lazy() get queryStringNode() {
+    const i = this.sf.getVariableDeclaration('QUERY')?.getInitializer()
+    if (!i) {
+      return undefined
+    }
+    // TODO: do we allow other kinds of strings? or just tagged literals?
+    if (tsm.Node.isTaggedTemplateExpression(i)) {
+      const t = i.getTemplate()
+      if (tsm.Node.isNoSubstitutionTemplateLiteral(t)) {
+        return t
+      }
+    }
+    return undefined
+  }
+
+  // TODO: Move to RWCellQuery
+  @lazy() get queryString(): string | undefined {
+    return this.queryStringNode?.getLiteralText()
+  }
+
+  // TODO: Move to RWCellQuery
+  @lazy() get queryAst() {
+    const qs = this.queryString
+    if (!qs) {
+      return undefined
+    }
+    return parseGraphQL(qs)
+  }
+
+  // TODO: Move to RWCellQuery
+  @lazy() get queryOperationName(): string | undefined {
+    const ast = this.queryAst
+    if (!ast) {
+      return undefined
+    }
+    for (const def of ast.definitions) {
+      if (def.kind == 'OperationDefinition') {
+        return def?.name?.value
+      }
+    }
+    return undefined
+  }
+
   *diagnostics() {
     // check that QUERY and Success are exported
     if (!this.exportedSymbols.has('QUERY')) {
@@ -27,31 +71,21 @@ export class RWCell extends RWComponent {
       )
     }
 
-    // TODO: This could very likely be added into RWCellQUERY
-    for (const d of this.sf.getDescendantsOfKind(
-      tsm.SyntaxKind.VariableDeclaration
-    )) {
-      if (d.isExported() && d.getName() === 'QUERY') {
-        // Check that exported QUERY is syntactically valid GraphQL.
-        const gqlNode = d
-          .getDescendantsOfKind(tsm.SyntaxKind.TaggedTemplateExpression)[0]
-          .getChildAtIndex(1)
-        const gqlText = gqlNode.getText().replace(/\`/g, '')
-        try {
-          parseGraphQL(gqlText)
-        } catch (e) {
-          // TODO: Make this point to the exact location included in the error.
-          yield {
-            uri: this.uri,
-            diagnostic: {
-              range: Range_fromNode(gqlNode),
-              message: e.message,
-              severity: DiagnosticSeverity.Error,
-            },
-          } as ExtendedDiagnostic
+    try {
+      if (!this.queryOperationName) {
+        yield {
+          uri: this.uri,
+          diagnostic: {
+            range: Range_fromNode(this.queryStringNode!),
+            message: 'We recommend that you name your query operation',
+            severity: DiagnosticSeverity.Warning,
+          },
         }
       }
+    } catch (e) {
+      // Maybe the AST has a syntax error...
     }
+
     // TODO: check that exported QUERY is semantically valid GraphQL (fields exist)
     if (!this.exportedSymbols.has('Success')) {
       yield err(

--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -87,6 +87,8 @@ export class RWCell extends RWComponent {
       yield {
         uri: this.uri,
         diagnostic: {
+          // TODO: Try to figure out if we can point directly to the syntax error.
+          range: Range_fromNode(this.sf.getVariableDeclaration('QUERY')!),
           message: e.message,
           severity: DiagnosticSeverity.Error,
         },

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -2,7 +2,7 @@ import { getDMMF } from '@prisma/sdk'
 // TODO: re-implement a higher quality version of these in ./project
 import { getPaths, processPagesDir } from '@redwoodjs/internal/dist/paths'
 import { join } from 'path'
-import { URL_file } from 'src/x/URL'
+import { URL_file } from '../x/URL'
 import { BaseNode, Host } from '../ide'
 import { lazy, memo } from '../x/decorators'
 import {

--- a/packages/structure/src/model/RWRouter.ts
+++ b/packages/structure/src/model/RWRouter.ts
@@ -1,4 +1,4 @@
-import { URL_file } from 'src/x/URL'
+import { URL_file } from '../x/URL'
 import * as tsm from 'ts-morph'
 import {
   CodeAction,

--- a/packages/structure/src/model/RWSDLField.ts
+++ b/packages/structure/src/model/RWSDLField.ts
@@ -2,7 +2,7 @@ import {
   FieldDefinitionNode,
   ObjectTypeDefinitionNode,
 } from 'graphql/language/ast'
-import { URL_file } from 'src/x/URL'
+import { URL_file } from '../x/URL'
 import {
   CodeAction,
   DiagnosticSeverity,

--- a/packages/structure/src/model/__tests__/model.test.ts
+++ b/packages/structure/src/model/__tests__/model.test.ts
@@ -53,7 +53,7 @@ describe('Redwood Project Model', () => {
   })
 })
 
-describe.only('Cells', () => {
+describe('Cells', () => {
   it('Correctly determines a Cell component vs a normal component', () => {
     const projectRoot = getFixtureDir('example-todo-main-with-errors')
     const project = new RWProject({ projectRoot, host: new DefaultHost() })
@@ -67,7 +67,20 @@ describe.only('Cells', () => {
   it('Can get the operating name of the QUERY', () => {
     const projectRoot = getFixtureDir('example-todo-main')
     const project = new RWProject({ projectRoot, host: new DefaultHost() })
-    expect(project.cells[0].queryOperationName).toMatch('TodoListCell_GetTodos')
+    const cell = project.cells.find((x) => x.uri.endsWith('TodoListCell.js'))
+    expect(cell.queryOperationName).toMatch('TodoListCell_GetTodos')
+  })
+
+  it('Warns you when you do not supply a name to QUERY', async (done) => {
+    const projectRoot = getFixtureDir('example-todo-main-with-errors')
+    const project = new RWProject({ projectRoot, host: new DefaultHost() })
+
+    const cell = project.cells.find((x) => x.uri.endsWith('TodoListCell.js'))
+    const x = await cell.collectDiagnostics()
+    expect(x.map((e) => e.diagnostic.message)).toContain(
+      'We recommend that you name your query operation'
+    )
+    done()
   })
 })
 

--- a/packages/structure/src/model/__tests__/model.test.ts
+++ b/packages/structure/src/model/__tests__/model.test.ts
@@ -64,7 +64,7 @@ describe('Cells', () => {
     )
   })
 
-  it('Can get the operating name of the QUERY', () => {
+  it('Can get the operation name of the QUERY', () => {
     const projectRoot = getFixtureDir('example-todo-main')
     const project = new RWProject({ projectRoot, host: new DefaultHost() })
     const cell = project.cells.find((x) => x.uri.endsWith('TodoListCell.js'))

--- a/packages/structure/src/model/__tests__/model.test.ts
+++ b/packages/structure/src/model/__tests__/model.test.ts
@@ -52,7 +52,8 @@ describe('Redwood Project Model', () => {
     expect(dss.length).toBeGreaterThan(0)
   })
 })
-describe('Cells', () => {
+
+describe.only('Cells', () => {
   it('Correctly determines a Cell component vs a normal component', () => {
     const projectRoot = getFixtureDir('example-todo-main-with-errors')
     const project = new RWProject({ projectRoot, host: new DefaultHost() })
@@ -61,6 +62,12 @@ describe('Cells', () => {
     expect(cells.map((cell) => basename(cell.filePath))).not.toContain(
       'TableCell.js'
     )
+  })
+
+  it('Can get the operating name of the QUERY', () => {
+    const projectRoot = getFixtureDir('example-todo-main')
+    const project = new RWProject({ projectRoot, host: new DefaultHost() })
+    expect(project.cells[0].queryOperationName).toMatch('TodoListCell_GetTodos')
   })
 })
 


### PR DESCRIPTION
We want to make mocking data in Storybook and Jest super simple. In order to achieve that we need to be able to get the operation name from a QUERY export in a Cell:
```js
export const QUERY = gql`query <i.want.this.operation.value> { invoices { id } }`
```

- [x] Add a way to get the operation name of the QUERY export in a Cell.
- [x] Add diagnostic to recommend that a user should name their QUERY operation in a Cell.
- [x] Throw an diagnostic if the template literal cannot be parser.

/cc @aldonline 