### PR TITLE
Add .idea/ dir for Jetbrains IDE's config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 node_modules
 dist

--- a/__fixtures__/example-todo-main-with-errors/.gitignore
+++ b/__fixtures__/example-todo-main-with-errors/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 dist
 yarn-error.log

--- a/__fixtures__/example-todo-main/.gitignore
+++ b/__fixtures__/example-todo-main/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 dist
 yarn-error.log

--- a/__fixtures__/new-project/.gitignore
+++ b/__fixtures__/new-project/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .env
 .netlify


### PR DESCRIPTION
I've noticed `.vscode` directories merged in repository so I assumed it would be okay to put Jetbrain's `.idea` to gitignore to avoid constant flow of:


![idea](https://user-images.githubusercontent.com/1573875/87877148-e7f80280-c9dc-11ea-86ed-cdabb4a65fd0.png)
