### PR TITLE
Export useLazyQuery/useSubscription from @apollo

### DIFF
--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -1,7 +1,13 @@
 import './config'
 
 export { default as gql } from 'graphql-tag'
-export { useQuery, useMutation, useApolloClient } from '@apollo/react-hooks'
+export {
+  useQuery,
+  useLazyQuery,
+  useMutation,
+  useSubscription,
+  useApolloClient,
+} from '@apollo/react-hooks'
 
 export { default as FatalErrorBoundary } from 'src/components/FatalErrorBoundary'
 export { default as RedwoodProvider } from 'src/components/RedwoodProvider'


### PR DESCRIPTION
I tried to use `useLazyQuery` hook and noticed that along with the useSubscription it's not being exported from @web package.