### PR TITLE
Ignore coercion for unsupported form fields

### DIFF
--- a/packages/web/src/form/coercion.js
+++ b/packages/web/src/form/coercion.js
@@ -26,7 +26,10 @@ export const useCoercion = () => {
   const coercionContext = React.useContext(CoercionContext)
 
   const coerce = React.useCallback(
-    (name, value) => coercionContext.coercions[name](value),
+    (name, value) =>
+      coercionContext.coercions[name]
+        ? coercionContext.coercions[name](value)
+        : value,
     [coercionContext.coercions]
   )
 


### PR DESCRIPTION
As an example, using a `<SelectField />`  in a form breaks the submit action with the following error:

> coercion.js:67 Uncaught (in promise) TypeError: coercionContext.coercions[name] is not a function
>     at coercion.js:67
>     at form.js:161
>     at Array.forEach (<anonymous>)
>     at coerceValues (form.js:160)
>     at form.js:183
>     at react-hook-form.es.js:1215