### PR TITLE
redirectTo a url on login after authenticated

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -239,7 +239,7 @@ When using the Auth0 client, `login` and `logout` take `options` that can be use
 * `returnTo`: a permitted logout url set in Auth0
 * `redirectTo`: a target url after login
 
-The latter is helpful when an unauthenticated user visits a Private route, but then is redirected to the `unauthenticated` route. The Redwood router will place the previous requested path in the pathname as a `redirectTo` parameter which can be extracted and set in the Auth0 `appState`. That way, after successfully loggin in, the user will be directed to this `targetUrl` rather than the config's callback.
+The latter is helpful when an unauthenticated user visits a Private route, but then is redirected to the `unauthenticated` route. The Redwood router will place the previous requested path in the pathname as a `redirectTo` parameter which can be extracted and set in the Auth0 `appState`. That way, after successfully logging in, the user will be directed to this `targetUrl` rather than the config's callback.
 
 ```js
 const UserAuthTools = () => {

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -232,6 +232,43 @@ const UserAuthTools = () => {
 }
 ```
 
+### Auth0 Login an Logout Options
+
+When using the Auth0 client, `login` and `logout` take `options` that can be used to override the client config:
+
+* `returnTo`: a permitted logout url set in Auth0
+* `redirectTo`: a target url after login
+
+The latter is helpful when an unauthenticated user visits a Private route, but then is redirected to the `unauthenticated` route. The Redwood router will place the previous requested path in the pathname as a `redirectTo` parameter which can be extracted and set in the Auth0 `appState`. That way, after successfully loggin in, the user will be directed to this `targetUrl` rather than the config's callback.
+
+```js
+const UserAuthTools = () => {
+  const { loading, isAuthenticated, logIn, logOut } = useAuth()
+
+  if (loading) {
+    // auth is rehydrating
+    return null
+  }
+
+  return (
+    <Button
+      onClick={async () => {
+        if (isAuthenticated) {
+          await logOut({ returnTo: process.env.AUTH0_REDIRECT_URI })
+        } else {
+          const searchParams = new URLSearchParams(window.location.search)
+          await logIn({
+            appState: { targetUrl: searchParams.get('redirectTo') },
+          })
+        }
+      }}
+    >
+      {isAuthenticated ? 'Log out' : 'Log in'}
+    </Button>
+  )
+}
+```
+
 ## API
 
 The following values are available from the `useAuth` hook:
@@ -367,8 +404,8 @@ const mapAuthClientAuth0 = (client: Auth0): AuthClientAuth0 => {
         )
       }
     },
-    logIn: async () => client.loginWithRedirect(),
-    logOut: () => client.logout(),
+    logIn: async (options?) => client.loginWithRedirect(options),
+    logOut: (options?) => client.logout(options),
     getToken: async () => client.getTokenSilently(),
     currentUser: async () => {
       const user = await client.getUser()

--- a/packages/auth/src/authClients/auth0.ts
+++ b/packages/auth/src/authClients/auth0.ts
@@ -25,7 +25,7 @@ export const auth0 = (client: Auth0): AuthClientAuth0 => {
         )
       }
     },
-    login: async () => client.loginWithRedirect(),
+    login: async (options?) => client.loginWithRedirect(options),
     logout: (options?) => client.logout(options),
     getToken: async () => client.getTokenSilently(),
     getUserMetadata: async () => {

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -46,7 +46,7 @@ Some pages should only be visible to authenticated users.
 
 All `Routes` nested in `<Private>` require authentication.
 When a user is not authenticated and attempts to visit this route,
-they will be redirected to the route passed as the `unauthenticated` prop.
+they will be redirected to the route passed as the `unauthenticated` prop and the orignally requested route's path will be added to the querystring in a `redirectTo` param. This lets you send the user to the originally requested once logged in.
 
 ```js
 // Routes.js

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -33,12 +33,7 @@ Private.propTypes = {
   unauthenticated: PropTypes.string.isRequired,
 }
 
-const PrivatePageLoader = ({
-  useAuth,
-  unauthenticatedRoute,
-  redirectTo,
-  children,
-}) => {
+const PrivatePageLoader = ({ useAuth, unauthenticatedRoute, children }) => {
   const { loading, isAuthenticated } = useAuth()
 
   if (loading) {
@@ -49,7 +44,9 @@ const PrivatePageLoader = ({
     return children
   } else {
     return (
-      <Redirect to={`${unauthenticatedRoute()}?redirectTo=${redirectTo}`} />
+      <Redirect
+        to={`${unauthenticatedRoute()}?redirectTo=${window.location.pathname}`}
+      />
     )
   }
 }
@@ -110,7 +107,6 @@ const RouterImpl = ({
         return React.Children.toArray(children).map((route) =>
           React.cloneElement(route, {
             private: true,
-            redirectTo: null,
             unauthenticatedRedirect: unauthenticated,
           })
         )
@@ -173,7 +169,6 @@ const RouterImpl = ({
               unauthenticatedRoute={
                 namedRoutes[route.props.unauthenticatedRedirect]
               }
-              redirectTo={route.props.path}
             >
               <Loaders />
             </PrivatePageLoader>

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -33,7 +33,12 @@ Private.propTypes = {
   unauthenticated: PropTypes.string.isRequired,
 }
 
-const PrivatePageLoader = ({ useAuth, unauthenticatedRoute, children }) => {
+const PrivatePageLoader = ({
+  useAuth,
+  unauthenticatedRoute,
+  redirectTo,
+  children,
+}) => {
   const { loading, isAuthenticated } = useAuth()
 
   if (loading) {
@@ -43,7 +48,9 @@ const PrivatePageLoader = ({ useAuth, unauthenticatedRoute, children }) => {
   if (isAuthenticated) {
     return children
   } else {
-    return <Redirect to={unauthenticatedRoute()} />
+    return (
+      <Redirect to={`${unauthenticatedRoute()}?redirectTo=${redirectTo}`} />
+    )
   }
 }
 
@@ -103,6 +110,7 @@ const RouterImpl = ({
         return React.Children.toArray(children).map((route) =>
           React.cloneElement(route, {
             private: true,
+            redirectTo: null,
             unauthenticatedRedirect: unauthenticated,
           })
         )
@@ -165,6 +173,7 @@ const RouterImpl = ({
               unauthenticatedRoute={
                 namedRoutes[route.props.unauthenticatedRedirect]
               }
+              redirectTo={route.props.path}
             >
               <Loaders />
             </PrivatePageLoader>


### PR DESCRIPTION
# Overview
See: https://community.redwoodjs.com/t/accessing-the-target-url-from-the-unauthenticated-redirect/913

# Background

bennet asked the RW Community

> Would it be possible to add the ability to access the url the user was trying to reach if they are blocked by a Private route? It would be nice if there was an easy way to redirect the user back to the url they were trying to access once they successfully authenticate. Even if we just had access to the name of the original target url after being redirected to the unauthenticated route I think that would be enough.

# Proposed Solution

I found that

https://community.redwoodjs.com/t/accessing-the-target-url-from-the-unauthenticated-redirect/913/9

* the Auth0 client `restoreAuthState` already had a mechanism in place to redirect to a `targerUrl`, it simply needed to. be set as part of the `appState` when

```
await logIn({
  appState: { targetUrl: searchParams.get('redirectTo') },
})
```

* @peterp suggested 

> What if we added it as a query part to the url? http://localhost:8910/login/?redirectTo=/admin/ (escaped)

* so, have added `redirectTo` to the Router and PrivatePageLoader

Now using Auth0:

1. As a not logged in user
2. Visit private route, say `/profile`
3. Get redirected to the `unauthenticatedRoute`: `http://localhost:8910/` (aka `home`)
4. This appends the denied route into the search component of the url querystring

`http://localhost:8910/?redirectTo=/profile`

5. Login and set the `targetUrl`

```js
    <Button
      onClick={async () => {
        if (isAuthenticated) {
          await logOut({ returnTo: process.env.AUTH0_REDIRECT_URI })
        } else {
          const searchParams = new URLSearchParams(window.location.search)
          await logIn({
            appState: { targetUrl: searchParams.get('redirectTo') },
          })
        }
      }}
    >
      {isAuthenticated ? 'Log out' : 'Log in'}
    </Button>
```

5. On successful login, now directed to the /profile route/page (not the default set in client config, aka the callback)

# Considerations

* I want to add test(s)
* `<Redirect to={`${unauthenticatedRoute()}?redirectTo=${redirectTo}`} />` is a little ugly
* Not sure how will/can be implemented with other clients than Auth0, but probably `fetch path` and `navigate(redirectUrl)`

Looking for feedback. Thanks.