### PR TITLE
Set cwd for generator babel transforms.

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -228,8 +228,11 @@ export const prettierOptions = () => {
  * Convert a generated TS template file into JS.
  */
 export const transformTSToJS = (filename, content) => {
-  const result = babel.transform(content, {
+  const { code } = babel.transform(content, {
     filename,
+    // If you ran `yarn rw generate` in `./web` transformSync would import the `.babelrc.js` file,
+    // in `./web`? despite us setting `configFile: false`.
+    cwd: process.env.NODE_ENV === 'test' ? undefined : getPaths().base,
     configFile: false,
     plugins: [
       [
@@ -241,9 +244,9 @@ export const transformTSToJS = (filename, content) => {
       ],
     ],
     retainLines: true,
-  }).code
+  })
 
-  return prettify(filename.replace(/\.ts$/, '.js'), result)
+  return prettify(filename.replace(/\.ts$/, '.js'), code)
 }
 
 /**


### PR DESCRIPTION
If you ran a generator in the `./web` or `./api` directory the babel transformation code would pick up the `.babelrc.js` file and transpile the code way beyond the typescript -> JS conversion we wanted.

We set the cwd to the base of the project to avoid that.

Fixes #798