### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ Before interacting with the Redwood community, please read and understand our [C
   - [Releases](#releases)
     - [Troubleshooting](#troubleshooting)
   - [CLI Reference: `redwood-tools`](#cli-reference-redwood-tools)
-    - [redwood-tools (alias rwt)](#redwood-tools-alias-rwt)
     - [copy (alias cp)](#copy-alias-cp)
     - [copy:watch (alias cpw)](#copywatch-alias-cpw)
     - [fix-bins (alias fix)](#fix-bins-alias-fix)
@@ -193,22 +192,13 @@ If something went wrong you can use `yarn lerna publish from-package` to publish
 
 ## CLI Reference: `redwood-tools`
 
-This CLI Reference section covers the `redwood-tools` command options. For `redwood` options, see the [CLI Reference on redwoodjs.com](https://redwoodjs.com/reference/command-line-interface).
-
-### redwood-tools (alias rwt)
-
-Redwood's companion CLI development tool. You'll be using this if you're contributing to Redwood.
+This CLI Reference section covers the `redwood-tools` command options:
 
 ```
 yarn rwt <command>
 ```
 
-|Command | Description|
-|:-|:-|
-|`copy` | Copy the Redwood Framework path to this project.|
-|`copy:watch` | Watch the Redwood Framework path for changes and copy them over to this project.|
-|`fix-bins` | Fix Redwood symlinks and permissions.|
-|`install` | Install a package from your local NPM registry.|
+For `redwood` options, see the [CLI Reference on redwoodjs.com](https://redwoodjs.com/reference/command-line-interface).
 
 ### copy (alias cp)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,8 @@ Then, in your local copy of the Redwood Framework, run:
 
 This starts Verdaccio (http://localhost:4873) with our configuration file.
 
+> Note for Windows users: you will need to use WSL 2 for the above to work.
+
 #### Publishing a Package
 
 To build, unpublish, and publish all the Redwood packages to your local NPM registry with a "dev" tag, run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,8 +176,6 @@ If you would like to test against the packages specified in `/__fixtures__/new-p
 ./tasks/test-tutorial --no-local
 ```
 
-The command for this is written in bash and will not work on Windows.
-
 ## Releases
 
 To publish a new version of Redwood to NPM run the following commands:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ We offer two workflows for making this possible: "copy and watch", which has som
 
 ### Copy and Watch
 
-> Unfortunately you can't use "copy and watch". You'll have to manually run `yarn rwt cp ../path/to/redwood` when you've made changes to the Redwood Framework (this is tracked in [issue #701](https://github.com/redwoodjs/redwood/issues/701)).
+> Note for Windows users: there is an ongoing issue with `yarn rwt copy:watch`, more details available in [#701](https://github.com/redwoodjs/redwood/issues/701).
 
 First, build-and-watch files in the Redwood Framework for changes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ For example, if you've made changes to the `@redwoodjs/dev-server` package, you 
 
 #### Installing Published Packages in Your Redwood App
 
-The last step is to install the package into your Redwood App. The CLI command `redwood-tools` (alias `rwt`) makes installing local NPM packages easy:
+The last step is to install the package into your Redwood App.
 
 ```terminal
 yarn rwt install @redwoodjs/dev-server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,15 +73,13 @@ Now any changes made in the framework will be copied into your app!
 
 You can create a `RW_PATH` environment variable so you don't have to specify the path in the `copy:watch` command.
 
-_On Linux_
-
 Add the following line to your `~/.bashrc`:
 
 ```terminal
 export RW_PATH="$HOME/path/to/redwood/framework"
 ```
 
-Where /path/to/redwood/framework is replaced by the path to your local copy of the Redwood Framework.
+Where `/path/to/redwood/framework` is replaced by the path to your local copy of the Redwood Framework.
 
 Then, in your Redwood App or example app, you can just run:
 
@@ -91,23 +89,6 @@ yarn rwt copy:watch
 
 And see your changes copied!
 
-_On Mac_
-
-Add the following line to your `~/.bash_profile`:
-
-```terminal
-export RW_PATH="$HOME/path/to/redwood/framework"
-```
-
-Where /path/to/redwood/framework is replaced by the path to your local copy of the Redwood Framework.
-
-Then, in your Redwood App or example app, you can just run:
-
-```terminal
-yarn rwt copy:watch
-```
-
-And see your changes copied!
 
 ### Local Package Registry Emulation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ We offer two workflows for making this possible: "copy and watch", which has som
 
 **How to choose which one to use?** If you've installed or upgraded a dependency, use the "local package registry emulation" workflow; otherwise, use "copy and watch".
 
-> Both workflows use `redwood-tools` (alias `rwt`), Redwood's companion CLI development tool.
+> Both workflows use `redwood-tools` (alias `rwt`), Redwood's companion CLI development tool, which is included in `@redwoodjs/core`.
 
 ### Copy and Watch
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,6 @@ yarn rwt copy:watch
 
 And see your changes copied!
 
-_On Windows_
-[Todo: please contribute a PR if you can help add instructions here.]
-
 ### Local Package Registry Emulation
 
 Sometimes you'll want to test the full package-development workflow: building, publishing, and installing in your Redwood App. We facilitate this using a local NPM registry called [Verdaccio](https://github.com/verdaccio/verdaccio).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ We offer two workflows for making this possible: "copy and watch", which has som
 
 ### Copy and Watch
 
-> Are you on Windows? If so, you most likely first have to [install rsync](https://tlundberg.com/blog/2020-06-15/installing-rsync-on-windows/). Also, unfortunately you can't use "copy and watch". You'll have to manually run `yarn rwt cp ../path/to/redwood` when you've made changes to the Redwood Framework (this is tracked in [issue #701](https://github.com/redwoodjs/redwood/issues/701)).
+> Unfortunately you can't use "copy and watch". You'll have to manually run `yarn rwt cp ../path/to/redwood` when you've made changes to the Redwood Framework (this is tracked in [issue #701](https://github.com/redwoodjs/redwood/issues/701)).
 
 First, build-and-watch files in the Redwood Framework for changes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Here we'll call this codebase a "Redwood App"--it’s the fullstack-to-Jamstack 
 As a contributor, you'll have to gain familiarity with one more codebase: the Redwood Framework.
 The Redwood Framework lives in the monorepo redwoodjs/redwood; it contains all the packages that make Redwood Apps work the way they do.
 
+If you don't want to create any custom app for sake of working on Redwood's core you can use one of example apps: [invoice](https://github.com/redwoodjs/example-invoice), [blog](https://github.com/redwoodjs/example-blog), [todo](https://github.com/redwoodjs/example-todo).
+
 ### Building the app
 You can build the Redwood Framework using:
 ```terminal

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Love Redwood and want to get involved? You’re in the right place!
 
-Before interacting with the Redwood community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md).
+Before interacting with the Redwood community, please check our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md) first.
 
 **Table of Contents**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Here we'll call this codebase a "Redwood App"--it’s the fullstack-to-Jamstack 
 As a contributor, you'll have to gain familiarity with one more codebase: the Redwood Framework.
 The Redwood Framework lives in the monorepo redwoodjs/redwood; it contains all the packages that make Redwood Apps work the way they do.
 
-While you'll be making most of your changes in the Redwood Framework, you'll probably want to see your changes “running live" in one of your own Redwood Apps or in one of our example apps.
+While you'll be making most of your changes in the Redwood Framework, you'll probably want to see your changes "running live" in one of your own Redwood Apps or in one of our example apps.
 We offer two workflows for making this possible: "copy and watch", which has some restrictions, and "local package registry emulation", which doesn't.
 
 **How to choose which one to use?** If you've installed or upgraded a dependency, use the "local package registry emulation" workflow; otherwise, use "copy and watch".
@@ -78,7 +78,7 @@ _On Linux_
 Add the following line to your `~/.bashrc`:
 
 ```terminal
-export RW_PATH=”$HOME/path/to/redwood/framework”
+export RW_PATH="$HOME/path/to/redwood/framework"
 ```
 
 Where /path/to/redwood/framework is replaced by the path to your local copy of the Redwood Framework.
@@ -96,7 +96,7 @@ _On Mac_
 Add the following line to your `~/.bash_profile`:
 
 ```terminal
-export RW_PATH=”$HOME/path/to/redwood/framework”
+export RW_PATH="$HOME/path/to/redwood/framework"
 ```
 
 Where /path/to/redwood/framework is replaced by the path to your local copy of the Redwood Framework.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,26 +68,6 @@ building file list ... done
 
 Now any changes made in the framework will be copied into your app!
 
-#### Specifying a RW_PATH
-
-You can create a `RW_PATH` environment variable so you don't have to specify the path in the `copy:watch` command.
-
-Add the following line to your `~/.bashrc`:
-
-```terminal
-export RW_PATH="$HOME/path/to/redwood/framework"
-```
-
-Where `/path/to/redwood/framework` is replaced by the path to your local copy of the Redwood Framework.
-
-Then, in your Redwood App or example app, you can just run:
-
-```terminal
-yarn rwt copy:watch
-```
-
-And see your changes copied!
-
 
 ### Local Package Registry Emulation
 
@@ -199,6 +179,22 @@ yarn rwt <command>
 ```
 
 For `redwood` options, see the [CLI Reference on redwoodjs.com](https://redwoodjs.com/reference/command-line-interface).
+
+##### Specifying a RW_PATH
+
+You can create a `RW_PATH` environment variable so you don't have to pass the path explicitely each time you run a command.
+
+Add the following line to your `~/.bashrc`:
+
+```terminal
+export RW_PATH="$HOME/path/to/redwood/framework"
+```
+
+With the above you can run:
+
+```terminal
+yarn rwt copy:watch
+```
 
 ### copy (`cp`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,14 @@ Before interacting with the Redwood community, please read and understand our [C
 **Table of Contents**
 
 - [Contributing](#contributing)
-  - [Local Development](#local-development)
-    - [Copy and Watch](#copy-and-watch)
-      - [Specifying a RW_PATH](#specifying-a-rw_path)
-    - [Local Package Registry Emulation](#local-package-registry-emulation)
-      - [Setting Up and Running a Local NPM Registry](#setting-up-and-running-a-local-npm-registry)
-      - [Publishing a Package](#publishing-a-package)
-      - [Installing Published Packages in Your Redwood App](#installing-published-packages-in-your-redwood-app)
-  - [Running Your Redwood App's Local Server(s)](#running-your-redwood-apps-local-servers)
+  - [Local development](#local-development)
+    - [Building the app](#building-the-app)
+    - [Installing local Redwood in your app](#installing-local-redwood-in-your-app)
+      - [Copy on source change](#copy-on-source-change)
+      - [Local package registry emulation](#local-package-registry-emulation)
+        - [Publishing a package](#publishing-a-package)
+        - [Installing published packages in your app](#installing-published-packages-in-your-app)
+  - [Running your Redwood app](#running-your-redwood-app)
   - [Integration tests](#integration-tests)
   - [Releases](#releases)
     - [Troubleshooting](#troubleshooting)
@@ -24,7 +24,7 @@ Before interacting with the Redwood community, please read and understand our [C
     - [fix-bins (`fix`)](#fix-bins-fix)
     - [install (`i`)](#install-i)
 
-## Local Development
+## Local development
 
 As a Redwood user, you're already familiar with the codebase `yarn create redwood-app` creates.
 Here we'll call this codebase a "Redwood App"--it’s the fullstack-to-Jamstack solution you already know and love.
@@ -32,48 +32,53 @@ Here we'll call this codebase a "Redwood App"--it’s the fullstack-to-Jamstack 
 As a contributor, you'll have to gain familiarity with one more codebase: the Redwood Framework.
 The Redwood Framework lives in the monorepo redwoodjs/redwood; it contains all the packages that make Redwood Apps work the way they do.
 
-While you'll be making most of your changes in the Redwood Framework, you'll probably want to see your changes "running live" in one of your own Redwood Apps or in one of our example apps.
-We offer two workflows for making this possible: "copy and watch", which has some restrictions, and "local package registry emulation", which doesn't.
+### Building the app
+You can build the Redwood Framework using:
+```terminal
+cd redwood
+yarn build
+```
 
-**How to choose which one to use?** If you've installed or upgraded a dependency, use the "local package registry emulation" workflow; otherwise, use "copy and watch".
-
-> Both workflows use `redwood-tools` (alias `rwt`), Redwood's companion CLI development tool, which is included in `@redwoodjs/core`.
-
-### Copy and Watch
-
-> Note for Windows users: there is an ongoing issue with `yarn rwt copy:watch`, more details available in [#701](https://github.com/redwoodjs/redwood/issues/701).
-
-First, build-and-watch files in the Redwood Framework for changes:
+Or you can trigger the building process on source files' change:
 
 ```terminal
 cd redwood
 yarn build:watch
-
+```
+Which is equivilant to running:
+```
 @redwoodjs/api: $ nodemon --watch src -e ts,js --ignore dist --exec 'yarn build'
 @redwoodjs/core: $ nodemon --ignore dist --exec 'yarn build'
 create-redwood-app: $ nodemon --ignore dist --exec 'yarn build'
 @redwoodjs/eslint-plugin-redwood: $ nodemon --ignore dist --exec 'yarn build'
 ```
 
-Then, copy-and-watch those changes into your Redwood App or example app (here, [example-invoice](https://github.com/redwoodjs/example-invoice)):
+### Installing local Redwood in your app
+
+While you'll be making most of your changes in the Redwood Framework, you'll probably want to see your changes "running live" in one of your own Redwood Apps or in one of our example apps.
+
+We offer two workflows for making this possible. **How to choose which one to use?**
+
+If you've installed or upgraded a dependency, use the "[local package registry emulation](#local-package-registry-emulation)" workflow; otherwise, use "[copy on source change](#copy-on-source-change)".
+
+> Both workflows use `redwood-tools` (alias `rwt`), Redwood's companion CLI development tool, which is included in `@redwoodjs/core`.
+
+#### Copy on source change
+
+> Note for Windows users: there is an ongoing issue with `yarn rwt copy:watch`, more details available in [#701](https://github.com/redwoodjs/redwood/issues/701).
+
+You can make Redwood watch changes in the source code to trigger build automatically:
 
 ```terminal
-cd example-invoice
+cd redwood-app
 yarn rwt copy:watch ../path/to/redwood
-
-Redwood Framework Path:  /Users/peterp/Personal/redwoodjs/redwood
-Trigger event:  add
-building file list ... done
 ```
 
 Now any changes made in the framework will be copied into your app!
 
-
-### Local Package Registry Emulation
+#### Local package registry emulation
 
 Sometimes you'll want to test the full package-development workflow: building, publishing, and installing in your Redwood App. We facilitate this using a local NPM registry called [Verdaccio](https://github.com/verdaccio/verdaccio).
-
-#### Setting Up and Running a Local NPM Registry
 
 First, install Verdaccio:
 
@@ -91,45 +96,44 @@ This starts Verdaccio (http://localhost:4873) with our configuration file.
 
 > Note for Windows users: you will need to use WSL 2 for the above to work.
 
-#### Publishing a Package
+##### Publishing a package
 
-To build, unpublish, and publish all the Redwood packages to your local NPM registry with a "dev" tag, run:
+To push all the Redwood's core packages to your local NPM registry run:
 
 ```terminal
 ./tasks/publish-local
 ```
 
-> Note: this script is equivalent to running:
->
-> ```terminal
-> npm unpublish --tag dev --registry http://localhost:4873/ --force
-> npm publish --tag dev --registry http://localhost:4873/ --force
-> ```
-
-You can build a particular package by specifying the path to the package: `./tasks/publish-local ./packages/api`.
-
-For example, if you've made changes to the `@redwoodjs/dev-server` package, you would run:
+Which is equivalent to running:
 
 ```terminal
-./tasks/publish-local ./packages/dev-server
+npm unpublish --tag dev --registry http://localhost:4873/ --force
+npm publish --tag dev --registry http://localhost:4873/ --force
 ```
 
-#### Installing Published Packages in Your Redwood App
-
-The last step is to install the package into your Redwood App.
+You can also publish a specific package by passing the package path to `publish-local`:
 
 ```terminal
+./tasks/publish-local ./packages/api
+```
+
+##### Installing published packages in your app
+
+The last step is to install the package into your Redwood App. If you want to install multiple packages you need to do this one by one.
+
+```terminal
+cd redwood-app
 yarn rwt install @redwoodjs/dev-server
 ```
 
-> Note: this is equivalent to running:
->
-> ```terminal
-> rm -rf <APP_PATH>/node_modules/@redwoodjs/dev-server
-> yarn upgrade @redwoodjs/dev-server@dev --no-lockfile --registry http://localhost:4873/
-> ```
+Which is equivalent to running:
 
-## Running Your Redwood App's Local Server(s)
+```terminal
+rm -rf ./node_modules/@redwoodjs/dev-server
+yarn upgrade @redwoodjs/dev-server@dev --no-lockfile --registry http://localhost:4873/
+```
+
+## Running your Redwood app
 
 When developing Redwood Apps, you’re probably used to running both the API and Web servers with `yarn rw dev` and seeing your changes included immediately.
 But for local package development, your changes won’t be included automatically--you'll need to manually stop/start the respective server to include them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,11 @@ Before interacting with the Redwood community, please read and understand our [C
   - [Integration tests](#integration-tests)
   - [Releases](#releases)
     - [Troubleshooting](#troubleshooting)
-  - [CLI Reference: `redwood-tools`](#cli-reference-redwood-tools)
-    - [copy (alias cp)](#copy-alias-cp)
-    - [copy:watch (alias cpw)](#copywatch-alias-cpw)
-    - [fix-bins (alias fix)](#fix-bins-alias-fix)
-    - [install (alias i)](#install-alias-i)
+  - [CLI Reference: `redwood-tools` (alias `rwt`)](#cli-reference-redwood-tools-alias-rwt)
+    - [copy (`cp`)](#copy-cp)
+    - [copy:watch (`cpw`)](#copywatch-cpw)
+    - [fix-bins (`fix`)](#fix-bins-fix)
+    - [install (`i`)](#install-i)
 
 ## Local Development
 
@@ -190,7 +190,7 @@ The changes the version of **all the packages** (even those that haven't changed
 
 If something went wrong you can use `yarn lerna publish from-package` to publish the packages that aren't already in the registry.
 
-## CLI Reference: `redwood-tools`
+## CLI Reference: `redwood-tools` (alias `rwt`)
 
 This CLI Reference section covers the `redwood-tools` command options:
 
@@ -200,7 +200,7 @@ yarn rwt <command>
 
 For `redwood` options, see the [CLI Reference on redwoodjs.com](https://redwoodjs.com/reference/command-line-interface).
 
-### copy (alias cp)
+### copy (`cp`)
 
 Copy the Redwood Framework path to this project.
 
@@ -210,7 +210,7 @@ yarn rwt cp [RW_PATH]
 
 You can avoid having to provide `RW_PATH` by defining an environment variable on your system. See [Specifying a RW_PATH](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#specifying-a-rw_path).
 
-### copy:watch (alias cpw)
+### copy:watch (`cpw`)
 
 Watch the Redwood Framework path for changes and copy them over to this project.
 
@@ -220,7 +220,7 @@ yarn rwt cpw [RW_PATH]
 
 You can avoid having to provide `RW_PATH` by defining an environment variable on your system. See [Specifying a RW_PATH](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#specifying-a-rw_path).
 
-### fix-bins (alias fix)
+### fix-bins (`fix`)
 
 Fix Redwood symlinks and permissions.
 
@@ -238,7 +238,7 @@ The Redwood CLI has the following binaries:
 
 When you're contributing, the permissions of these binaries can sometimes get mixed up. This makes them executable again.
 
-### install (alias i)
+### install (`i`)
 
 Install a package from your local NPM registry.
 


### PR DESCRIPTION
I followed the guide on Windows so I thought I would update the `CONTRIBUTING.md` a bit. 

I tried to make readable, small commits, but I'm just adding my reasoning since commit names length is limited:
- document mentioned 2 processes to use (copy on file change/use local registry) for working with Redwood, but only the `copy:watch` one included informations about actual building process of Redwood,
  - so I've reworked on the whole section to make clear distinction for build process in the beginning (since it's same for both "approaches") to make a separate instructions afterwards,
- `rwt` was mentioned in multiple sections duplicating similar informations,
  - so I aggregated all of these and moved them to already existing section for `rwt`
- the `please read and understand our CoC` had a passive aggresive vibe to it,
  - so I rephrase it to `please check our CoC first`
- Windows-related informations were needlessly worrisome since apart from the https://github.com/redwoodjs/redwood/issues/701 I consider setting up the Redwood's monorepo on Windows a pleasant experience,
  - I've added information about upgrading to WSL 2 since WSL 1 didn't support `lsof` and would cause issues with, e.g. [tasks/publish-local#L11](https://github.com/redwoodjs/redwood/blob/main/tasks/publish-local#L11),
  - I've rephrased overly expressive information about Windows' `copy:watch` issue (linked issue with a short description is enough and it's contents shouldn't be copied onto the contributions docs)
  - I've removed the "you may need rsync" information as most popular distros, including those supported by WSL, already include rsync by default,
- Information for setting `RW_PATH` env variable was weirdly duplicated onto separate Linux and Mac sections even though it were basically same informations,
  - so I unified this and removed request for adding similar entry for Windows since setting these while using WSL is the same process as in any linux (even though I would argue if section for explaining how to add env variables is needed at all)
- `rwt` command was listed on the same level of nesting as `rwt copy` implicating that `rwt` a command of the same category/group as `rwt copy` which is untrue,
  - so I fixed the nested headers to make explicit distinction between `rwt` in general and it's commands

And: fixed a a few typos, errors (e.g. untrue information that `publish-local` builds the app), inconsistencies (upper/lower cases, phrasings, quotes etc) and needlessly repeated terminal outputs for example or two.