### PR TITLE
Generate pages with route parameters

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -4,6 +4,7 @@ global.__dirname = __dirname
 import {} from 'src/lib/test'
 
 import * as helpers from '../helpers'
+import * as page from '../page/page'
 
 const PAGE_TEMPLATE_OUTPUT = `import { Link, routes } from '@redwoodjs/router'
 
@@ -33,6 +34,7 @@ test('templateForComponentFile creates a proper output path for files', () => {
       webPathSection: 'pages',
       generator: 'page',
       templatePath: 'page.js.template',
+      templateVars: page.paramVariants(helpers.pathName(undefined, name)),
     })
 
     expect(output[0]).toEqual(
@@ -48,6 +50,7 @@ test('templateForComponentFile can create a path in /web', () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.js.template',
+    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
   })
 
   expect(output[0]).toEqual(
@@ -62,6 +65,7 @@ test('templateForComponentFile can create a path in /api', () => {
     apiPathSection: 'services',
     generator: 'page',
     templatePath: 'page.js.template',
+    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
   })
 
   expect(output[0]).toEqual(
@@ -76,6 +80,7 @@ test('templateForComponentFile can override generated component name', () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.js.template',
+    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
   })
 
   expect(output[0]).toEqual(
@@ -91,6 +96,7 @@ test('templateForComponentFile can override file extension', () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.js.template',
+    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
   })
 
   expect(output[0]).toEqual(
@@ -120,6 +126,7 @@ test('templateForComponentFile creates a template', () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.js.template',
+    templateVars: page.paramVariants(helpers.pathName(undefined, 'fooBar')),
   })
 
   expect(output[1]).toEqual(PAGE_TEMPLATE_OUTPUT)
@@ -150,15 +157,6 @@ test('pathName supports paths with route params', () => {
   expect(helpers.pathName('/post/{id:Int}/edit', 'EditPost')).toEqual(
     '/post/{id:Int}/edit'
   )
-})
-
-test('getParam returns undefined for no params', () => {
-  expect(helpers.getParam('/')).toEqual(undefined)
-  expect(helpers.getParam('/post/edit')).toEqual(undefined)
-})
-
-test('getParam finds the param in the middle of the path', () => {
-  expect(helpers.getParam('/post/{id:Int}/edit')).toEqual('{id:Int}')
 })
 
 test('relationsForModel returns related field names from a belongs-to relationship', () => {

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -5,7 +5,7 @@ import {} from 'src/lib/test'
 
 import * as helpers from '../helpers'
 
-const PAGE_TEMPLATE_OUTPUT = `import { Link } from '@redwoodjs/router'
+const PAGE_TEMPLATE_OUTPUT = `import { Link, routes } from '@redwoodjs/router'
 
 const FooBarPage = () => {
   return (
@@ -14,7 +14,7 @@ const FooBarPage = () => {
       <p>Find me in "./web/src/pages/FooBarPage/FooBarPage.js"</p>
       <p>
         My default route is named "fooBar", link to me with \`
-        <Link to="fooBar">routes.fooBar()</Link>\`
+        <Link to={routes.fooBar()}>FooBar</Link>\`
       </p>
     </>
   )
@@ -139,6 +139,26 @@ test('pathName creates path based on name if path is null', () => {
   names.forEach((name) => {
     expect(helpers.pathName(null, name)).toEqual('/foo-bar')
   })
+})
+
+test('pathName creates path based on name if path is just a route parameter', () => {
+  expect(helpers.pathName('{id}', 'post')).toEqual('/post/{id}')
+  expect(helpers.pathName('{id:Int}', 'post')).toEqual('/post/{id:Int}')
+})
+
+test('pathName supports paths with route params', () => {
+  expect(helpers.pathName('/post/{id:Int}/edit', 'EditPost')).toEqual(
+    '/post/{id:Int}/edit'
+  )
+})
+
+test('getParam returns undefined for no params', () => {
+  expect(helpers.getParam('/')).toEqual(undefined)
+  expect(helpers.getParam('/post/edit')).toEqual(undefined)
+})
+
+test('getParam finds the param in the middle of the path', () => {
+  expect(helpers.getParam('/post/{id:Int}/edit')).toEqual('{id:Int}')
 })
 
 test('relationsForModel returns related field names from a belongs-to relationship', () => {

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -52,10 +52,25 @@ export const templateForComponentFile = ({
 
 /**
  * Creates a route path, either returning the existing path if passed, otherwise
- * creates one based on the name
+ * creates one based on the name. If the passed path is just a route parameter
+ * a new path based on the name is created, with the parameter appended to it
  */
 export const pathName = (path, name) => {
-  return path ?? `/${paramCase(name)}`
+  let routePath = path
+
+  if (path && path.startsWith('{') && path.endsWith('}')) {
+    routePath = `/${paramCase(name)}/${path}`
+  }
+
+  if (!routePath) {
+    routePath = `/${paramCase(name)}`
+  }
+
+  return routePath
+}
+
+export const getParam = (path) => {
+  return path.match(/(\{[\w:]+\})/)?.[1]
 }
 
 /**

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -37,16 +37,14 @@ export const templateForComponentFile = ({
   const componentOutputPath =
     outputPath ||
     path.join(basePath, outputComponentName, outputComponentName + extension)
-  const content = generateTemplate(
-    path.join(generator, 'templates', templatePath),
-    {
-      name,
-      outputPath: ensurePosixPath(
-        `./${path.relative(getPaths().base, componentOutputPath)}`
-      ),
-      ...templateVars,
-    }
-  )
+  const fullTemplatePath = path.join(generator, 'templates', templatePath)
+  const content = generateTemplate(fullTemplatePath, {
+    name,
+    outputPath: ensurePosixPath(
+      `./${path.relative(getPaths().base, componentOutputPath)}`
+    ),
+    ...templateVars,
+  })
   return [componentOutputPath, content]
 }
 
@@ -67,10 +65,6 @@ export const pathName = (path, name) => {
   }
 
   return routePath
-}
-
-export const getParam = (path) => {
-  return path.match(/(\{[\w:]+\})/)?.[1]
 }
 
 /**

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const ContactUsPage = () => {
   return (
@@ -7,7 +7,7 @@ const ContactUsPage = () => {
       <p>Find me in "./web/src/pages/ContactUsPage/ContactUsPage.js"</p>
       <p>
         My default route is named "contactUs", link to me with `
-        <Link to="contactUs">routes.contactUs()</Link>`
+        <Link to={routes.contactUs()}>ContactUs</Link>`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
@@ -1,0 +1,17 @@
+import { Link, routes } from '@redwoodjs/router'
+
+const PostPage = ({ id }) => {
+  return (
+    <>
+      <h1>PostPage</h1>
+      <p>Find me in "./web/src/pages/PostPage/PostPage.js"</p>
+      <p>
+        My default route is named "post", link to me with `
+        <Link to={routes.post({ id: 42 })}>Post 42</Link>`
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default PostPage

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
@@ -7,7 +7,7 @@ const PostPage = ({ id }) => {
       <p>Find me in "./web/src/pages/PostPage/PostPage.js"</p>
       <p>
         My default route is named "post", link to me with `
-        <Link to={routes.post({ id: 42 })}>Post 42</Link>`
+        <Link to={routes.post({ id: '42' })}>Post 42</Link>`
       </p>
       <p>The parameter passed to me is {id}</p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.stories.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.stories.js
@@ -1,0 +1,7 @@
+import PostPage from './PostPage'
+
+export const generated = () => {
+  return <PostPage />
+}
+
+export default { title: 'Pages/PostPage' }

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.stories.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.stories.js
@@ -1,7 +1,7 @@
 import PostPage from './PostPage'
 
 export const generated = () => {
-  return <PostPage />
+  return <PostPage id="42" />
 }
 
 export default { title: 'Pages/PostPage' }

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.test.js
@@ -5,7 +5,7 @@ import PostPage from './PostPage'
 describe('PostPage', () => {
   it('renders successfully', () => {
     expect(() => {
-      render(<PostPage id={42} />)
+      render(<PostPage id="42" />)
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.test.js
@@ -1,0 +1,11 @@
+import { render } from '@redwoodjs/testing'
+
+import PostPage from './PostPage'
+
+describe('PostPage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<PostPage id={42} />)
+    }).not.toThrow()
+  })
+})

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const CatsPage = () => {
   return (
@@ -7,7 +7,7 @@ const CatsPage = () => {
       <p>Find me in "./web/src/pages/CatsPage/CatsPage.js"</p>
       <p>
         My default route is named "cats", link to me with `
-        <Link to="cats">routes.cats()</Link>`
+        <Link to={routes.cats()}>Cats</Link>`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const HomePage = () => {
   return (
@@ -7,7 +7,7 @@ const HomePage = () => {
       <p>Find me in "./web/src/pages/HomePage/HomePage.js"</p>
       <p>
         My default route is named "home", link to me with `
-        <Link to="home">routes.home()</Link>`
+        <Link to={routes.home()}>Home</Link>`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -5,12 +5,13 @@ import { loadGeneratorFixture } from 'src/lib/test'
 
 import * as page from '../page'
 
-let singleWordFiles, multiWordFiles, pluralWordFiles
+let singleWordFiles, multiWordFiles, pluralWordFiles, paramFiles
 
 beforeAll(() => {
   singleWordFiles = page.files({ name: 'Home' })
   multiWordFiles = page.files({ name: 'ContactUs' })
   pluralWordFiles = page.files({ name: 'Cats' })
+  paramFiles = page.files({ name: 'Post', param: '{id:Int}' })
 })
 
 test('returns exactly 3 files', () => {
@@ -33,7 +34,7 @@ test('creates a page test', () => {
   ).toEqual(loadGeneratorFixture('page', 'singleWordPage.test.js'))
 })
 
-test('creates a page test', () => {
+test('creates a page story', () => {
   expect(
     singleWordFiles[
       path.normalize(
@@ -53,7 +54,7 @@ test('creates a page component', () => {
   ).toEqual(loadGeneratorFixture('page', 'multiWordPage.js'))
 })
 
-test('creates a page test', () => {
+test('creates a test for a component with multiple words for a name', () => {
   expect(
     multiWordFiles[
       path.normalize(
@@ -79,6 +80,22 @@ test('creates a page component with a plural word for name', () => {
       path.normalize('/path/to/project/web/src/pages/CatsPage/CatsPage.js')
     ]
   ).toEqual(loadGeneratorFixture('page', 'pluralWordPage.js'))
+})
+
+test('creates a page component with params', () => {
+  expect(
+    paramFiles[
+      path.normalize('/path/to/project/web/src/pages/PostPage/PostPage.js')
+    ]
+  ).toEqual(loadGeneratorFixture('page', 'paramPage.js'))
+})
+
+test('creates a test for page component with params', () => {
+  expect(
+    paramFiles[
+      path.normalize('/path/to/project/web/src/pages/PostPage/PostPage.test.js')
+    ]
+  ).toEqual(loadGeneratorFixture('page', 'paramPage.test.js'))
 })
 
 test('creates a single-word route name', () => {

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -42,15 +42,28 @@ import fs from 'fs'
 import { loadGeneratorFixture } from 'src/lib/test'
 import { getPaths } from 'src/lib'
 
+import { pathName } from '../../helpers'
 import * as page from '../page'
 
 let singleWordFiles, multiWordFiles, pluralWordFiles, paramFiles
 
 beforeAll(() => {
-  singleWordFiles = page.files({ name: 'Home' })
-  multiWordFiles = page.files({ name: 'ContactUs' })
-  pluralWordFiles = page.files({ name: 'Cats' })
-  paramFiles = page.files({ name: 'Post', param: '{id:Int}' })
+  singleWordFiles = page.files({
+    name: 'Home',
+    ...page.paramVariants(pathName(undefined, 'home')),
+  })
+  multiWordFiles = page.files({
+    name: 'ContactUs',
+    ...page.paramVariants(pathName(undefined, 'contact-us')),
+  })
+  pluralWordFiles = page.files({
+    name: 'Cats',
+    ...page.paramVariants(pathName(undefined, 'cats')),
+  })
+  paramFiles = page.files({
+    name: 'Post',
+    ...page.paramVariants(pathName('{id}', 'post')),
+  })
 })
 
 test('returns exactly 3 files', () => {
@@ -161,6 +174,47 @@ test('creates a path equal to passed path', () => {
   expect(page.routes({ name: 'FooBar', path: 'fooBar-baz' })).toEqual([
     '<Route path="fooBar-baz" page={FooBarPage} name="fooBar" />',
   ])
+})
+
+test('paramVariants returns empty string for no params', () => {
+  expect(page.paramVariants()).toEqual({
+    propParam: '',
+    propValueParam: '',
+    argumentParam: '',
+    paramName: '',
+    paramValue: '',
+  })
+  expect(page.paramVariants('')).toEqual({
+    propParam: '',
+    propValueParam: '',
+    argumentParam: '',
+    paramName: '',
+    paramValue: '',
+  })
+  expect(page.paramVariants('/')).toEqual({
+    propParam: '',
+    propValueParam: '',
+    argumentParam: '',
+    paramName: '',
+    paramValue: '',
+  })
+  expect(page.paramVariants('/post/edit')).toEqual({
+    propParam: '',
+    propValueParam: '',
+    argumentParam: '',
+    paramName: '',
+    paramValue: '',
+  })
+})
+
+test('paramVariants finds the param in the middle of the path', () => {
+  expect(page.paramVariants('/post/{id:Int}/edit')).toEqual({
+    propParam: '{ id }',
+    propValueParam: 'id="42" ',
+    argumentParam: "{ id: '42' }",
+    paramName: 'id',
+    paramValue: ' 42',
+  })
 })
 
 test('file generation', async () => {

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -8,10 +8,33 @@ import terminalLink from 'terminal-link'
 import { writeFilesTask, addRoutesToRouterTask } from 'src/lib'
 import c from 'src/lib/colors'
 
-import { templateForComponentFile, pathName, getParam } from '../helpers'
+import { templateForComponentFile, pathName } from '../helpers'
 
 const COMPONENT_SUFFIX = 'Page'
 const REDWOOD_WEB_PATH_NAME = 'pages'
+
+export const paramVariants = (path) => {
+  const param = path?.match(/(\{[\w:]+\})/)?.[1]
+  const paramName = param?.replace(/:[^}]+/, '').slice(1, -1)
+
+  if (param === undefined) {
+    return {
+      propParam: '',
+      propValueParam: '',
+      argumentParam: '',
+      paramName: '',
+      paramValue: '',
+    }
+  }
+
+  return {
+    propParam: `{ ${paramName} }`,
+    propValueParam: `${paramName}="42" `,
+    argumentParam: `{ ${paramName}: '42' }`,
+    paramName,
+    paramValue: ' 42',
+  }
+}
 
 export const files = ({ name, ...rest }) => {
   const pageFile = templateForComponentFile({
@@ -125,7 +148,7 @@ export const handler = async ({ name, path, force }) => {
         title: 'Generating page files...',
         task: async () => {
           path = pathName(path, name)
-          const f = await files({ name, path, param: getParam(path) })
+          const f = await files({ name, path, ...paramVariants(path) })
           return writeFilesTask(f, { overwriteExisting: force })
         },
       },

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -27,6 +27,8 @@ export const paramVariants = (path) => {
     }
   }
 
+  // "42" is just a value used for demonstrating parameter usage in the
+  // generated page-, test-, and story-files.
   return {
     propParam: `{ ${paramName} }`,
     propValueParam: `${paramName}="42" `,

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -8,7 +8,7 @@ import terminalLink from 'terminal-link'
 import { writeFilesTask, addRoutesToRouterTask } from 'src/lib'
 import c from 'src/lib/colors'
 
-import { templateForComponentFile, pathName } from '../helpers'
+import { templateForComponentFile, pathName, getParam } from '../helpers'
 
 const COMPONENT_SUFFIX = 'Page'
 const REDWOOD_WEB_PATH_NAME = 'pages'
@@ -74,7 +74,7 @@ export const builder = (yargs) => {
       type: 'string',
     })
     .positional('path', {
-      description: 'URL path to the page. Defaults to name',
+      description: 'URL path to the page, or just {param}. Defaults to name',
       type: 'string',
     })
     .option('force', {
@@ -124,7 +124,8 @@ export const handler = async ({ name, path, force }) => {
       {
         title: 'Generating page files...',
         task: async () => {
-          const f = await files({ name, path: pathName(path, name) })
+          path = pathName(path, name)
+          const f = await files({ name, path, param: getParam(path) })
           return writeFilesTask(f, { overwriteExisting: force })
         },
       },

--- a/packages/cli/src/commands/generate/page/templates/page.js.template
+++ b/packages/cli/src/commands/generate/page/templates/page.js.template
@@ -1,14 +1,17 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
-const ${pascalName}Page = () => {
+const ${pascalName}Page = (<%= typeof param !== 'undefined' && param ? param.replace(/:[^}]+/, '') : '' %>) => {
   return (
     <>
       <h1>${pascalName}Page</h1>
       <p>Find me in "${outputPath}"</p>
       <p>
-        My default route is named "${camelName}",
-        link to me with `<Link to="${camelName}">routes.${camelName}()</Link>`
-      </p>
+        My default route is named "${camelName}", link to me with `
+        <Link to={routes.${camelName}(<%= typeof param !== 'undefined' && param ? param.replace(/(:[^}]+)?}/, ': 42 }') : '' %>)}>${pascalName}<%= typeof param !== 'undefined' && param ? ' 42' : '' %></Link>`
+      </p><% if (typeof param !== 'undefined' && param) { %>
+      <p>
+        The parameter passed to me is <%= param.replace(/:[^}]+/, '') %>
+      </p><% } %>
     </>
   )
 }

--- a/packages/cli/src/commands/generate/page/templates/page.js.template
+++ b/packages/cli/src/commands/generate/page/templates/page.js.template
@@ -1,16 +1,16 @@
 import { Link, routes } from '@redwoodjs/router'
 
-const ${pascalName}Page = (<%= typeof param !== 'undefined' && param ? param.replace(/:[^}]+/, '') : '' %>) => {
+const ${pascalName}Page = (${propParam}) => {
   return (
     <>
       <h1>${pascalName}Page</h1>
       <p>Find me in "${outputPath}"</p>
       <p>
         My default route is named "${camelName}", link to me with `
-        <Link to={routes.${camelName}(<%= typeof param !== 'undefined' && param ? param.replace(/(:[^}]+)?}/, ': 42 }') : '' %>)}>${pascalName}<%= typeof param !== 'undefined' && param ? ' 42' : '' %></Link>`
-      </p><% if (typeof param !== 'undefined' && param) { %>
+        <Link to={routes.${camelName}(${ argumentParam })}>${pascalName}<%= argumentParam !== '' ? ' 42' : '' %></Link>`
+      </p><% if (paramName !== '') { %>
       <p>
-        The parameter passed to me is <%= param.replace(/:[^}]+/, '') %>
+        The parameter passed to me is {${ paramName }}
       </p><% } %>
     </>
   )

--- a/packages/cli/src/commands/generate/page/templates/stories.js.template
+++ b/packages/cli/src/commands/generate/page/templates/stories.js.template
@@ -1,7 +1,7 @@
 import ${pascalName}Page from './${pascalName}Page'
 
 export const generated = () => {
-  return <${pascalName}Page />
+  return <${pascalName}Page ${propValueParam}/>
 }
 
 export default { title: 'Pages/${pascalName}Page' }

--- a/packages/cli/src/commands/generate/page/templates/test.js.template
+++ b/packages/cli/src/commands/generate/page/templates/test.js.template
@@ -5,7 +5,7 @@ import ${pascalName}Page from './${pascalName}Page'
 describe('${pascalName}Page', () => {
   it('renders successfully', () => {
     expect(() => {
-      render(<${pascalName}Page />)
+      render(<${pascalName}Page <%= typeof param !== 'undefined' && param ? param.replace(/{([^:}]+)(:[^}]+)?}/, '$1={42} ') : '' %>/>)
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/page/templates/test.js.template
+++ b/packages/cli/src/commands/generate/page/templates/test.js.template
@@ -5,7 +5,7 @@ import ${pascalName}Page from './${pascalName}Page'
 describe('${pascalName}Page', () => {
   it('renders successfully', () => {
     expect(() => {
-      render(<${pascalName}Page <%= typeof param !== 'undefined' && param ? param.replace(/{([^:}]+)(:[^}]+)?}/, '$1={42} ') : '' %>/>)
+      render(<${pascalName}Page ${propValueParam}/>)
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -326,7 +326,7 @@ export const addRoutesToRouterTask = (routes) => {
     if (content.includes(route)) {
       return content
     }
-    return content.replace(/(\s*)\<Router\>/, `$1<Router>$1  ${route}`)
+    return content.replace(/<Router>(\s*)/, `<Router>$1${route}$1`)
   }, routesContent)
   writeFile(redwoodPaths.web.routes, newRoutesContent, {
     overwriteExisting: true,

--- a/packages/cli/src/lib/test.js
+++ b/packages/cli/src/lib/test.js
@@ -65,13 +65,16 @@ export const generatorsRootPath = path.join(
   'generate'
 )
 
-// Loads the fixture for a generator by assuming a lot of the path structure automatically:
-//
-//   loadGeneratorFixture('scaffold', 'NamePage.js')
-//
-// will return the contents of:
-//
-//   cli/src/commands/generate/scaffold/test/fixtures/NamePage.js.fixture
+/**
+ * Loads the fixture for a generator by assuming a lot of the path structure
+ * automatically:
+ *
+ *   `loadGeneratorFixture('scaffold', 'NamePage.js')`
+ *
+ * will return the contents of:
+ *
+ *   `cli/src/commands/generate/scaffold/__tests__/fixtures/NamePage.js`
+ */
 export const loadGeneratorFixture = (generator, name) => {
   return loadFixture(
     path.join(
@@ -87,7 +90,9 @@ export const loadGeneratorFixture = (generator, name) => {
   )
 }
 
-// Returns the contents of a text file suffixed with ".fixture"
+/**
+ * Returns the contents of a text file in a `fixtures` directory
+ */
 export const loadFixture = (filepath) => {
   return fs.readFileSync(filepath).toString()
 }


### PR DESCRIPTION
This PR adds support to the page generator for generating pages with route parameters.

Let's say you want to generate a page for displaying posts. You probably already know from the start that you will have to take the post ID as a route parameter. Now you can directly generate a page for that.

Is this useful? How do you like the syntax? What about the naming of everything? 

The new generator cli syntax looks like this
```bash
$ yarn rw g page post {id}
```

That will give you an entry in your routes like this:
```jsx
<Route path="/post/{id}" page={PostPage} name="post" />
```

and the generated page will look like this:
```jsx
import { Link } from '@redwoodjs/router'

const PostPage = ({ id }) => {
  return (
    <>
      <h1>PostPage</h1>
      <p>Find me in "./web/src/pages/PostPage/PostPage.js"</p>
      <p>
        My default route is named "post", link to me with `
        <Link to={routes.post({ id: 42 })}>Post 42</Link>`
      </p>
      <p>The parameter passed to me is {id}</p>
    </>
  )
}

export default PostPage
```

You'll also get a test that uses a parameter
```jsx
import { render } from '@redwoodjs/testing'

import PostPage from './PostPage'

describe('PostPage', () => {
  it('renders successfully', () => {
    expect(() => {
      render(<PostPage id={42} />)
    }).not.toThrow()
  })
})
```

Other supported generator cli syntaxes

```
$ yarn rw g page post /post/{id}
$ yarn rw g page post {id:Int}
$ yarn rw g page EditPost post/{id}/edit
$ yarn rw g page EditPost post/{id:Int}/edit
```

TODO:
- [x] Determine if this is something we want to add to RW
- [x] Actually launch/run a project that uses the generated pages
- [x] Run the generated tests
- [x] ~Make sure it handles spaces, like in `yarn rw g page post /post/{ id }`~ We don't want to support this (yargs gives a pretty useful error message if someone tries something like this)
- [x] Update docs https://github.com/redwoodjs/redwoodjs.com/issues/260
- [x] Make sure everything can be destroyed with the `destroy` cli command