### PR TITLE
Fix  #883 - Cell Operation Names not PascalCased

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
@@ -13,13 +13,21 @@ jest.mock('@redwoodjs/structure', () => {
 
 import * as cell from '../cell'
 
-let singleWordFiles, multiWordFiles
+let singleWordFiles,
+  multiWordFiles,
+  snakeCaseWordFiles,
+  kebabCaseWordFiles,
+  camelCaseWordFiles
 
 beforeAll(() => {
   singleWordFiles = cell.files({ name: 'User' })
   multiWordFiles = cell.files({ name: 'UserProfile' })
+  snakeCaseWordFiles = cell.files({ name: 'user_profile' })
+  kebabCaseWordFiles = cell.files({ name: 'user-profile' })
+  camelCaseWordFiles = cell.files({ name: 'userProfile' })
 })
 
+// Single Word Scenario: User
 test('returns exactly 4 files', () => {
   expect(Object.keys(singleWordFiles).length).toEqual(4)
 })
@@ -62,6 +70,7 @@ test('creates a cell mock with a single word name', () => {
   ).toEqual(loadGeneratorFixture('cell', 'singleWordCell.mock.js'))
 })
 
+// Multi Word Scenario: UserProfile
 test('creates a cell component with a multi word name', () => {
   expect(
     multiWordFiles[
@@ -100,4 +109,127 @@ test('creates a cell mock with a multi word name', () => {
       )
     ]
   ).toEqual(loadGeneratorFixture('cell', 'multiWordCell.mock.js'))
+})
+
+// SnakeCase Word Scenario: user_profile
+test('creates a cell component with a snakeCase word name', () => {
+  expect(
+    snakeCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'snakeCaseWordCell.js'))
+})
+
+test('creates a cell test with a snakeCase word name', () => {
+  expect(
+    snakeCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.test.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'snakeCaseWordCell.test.js'))
+})
+
+test('creates a cell stories with a snakeCase word name', () => {
+  expect(
+    snakeCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.stories.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'snakeCaseWordCell.stories.js'))
+})
+
+test('creates a cell mock with a snakeCase word name', () => {
+  expect(
+    snakeCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.mock.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'snakeCaseWordCell.mock.js'))
+})
+
+// KebabCase Word Scenario: user-profile
+test('creates a cell component with a kebabCase word name', () => {
+  expect(
+    kebabCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'kebabCaseWordCell.js'))
+})
+
+test('creates a cell test with a kebabCase word name', () => {
+  expect(
+    kebabCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.test.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'kebabCaseWordCell.test.js'))
+})
+
+test('creates a cell stories with a kebabCase word name', () => {
+  expect(
+    kebabCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.stories.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'kebabCaseWordCell.stories.js'))
+})
+
+test('creates a cell mock with a kebabCase word name', () => {
+  expect(
+    kebabCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.mock.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'kebabCaseWordCell.mock.js'))
+})
+
+// camelCase Word Scenario: user-profile
+test('creates a cell component with a camelCase word name', () => {
+  expect(
+    camelCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'camelCaseWordCell.js'))
+})
+
+test('creates a cell test with a camelCase word name', () => {
+  expect(
+    camelCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.test.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'camelCaseWordCell.test.js'))
+})
+
+test('creates a cell stories with a camelCase word name', () => {
+  expect(
+    camelCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.stories.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'camelCaseWordCell.stories.js'))
+})
+
+test('creates a cell mock with a camelCase word name', () => {
+  expect(
+    camelCaseWordFiles[
+      path.normalize(
+        '/path/to/project/web/src/components/UserProfileCell/UserProfileCell.mock.js'
+      )
+    ]
+  ).toEqual(loadGeneratorFixture('cell', 'camelCaseWordCell.mock.js'))
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.js
@@ -1,0 +1,17 @@
+export const QUERY = gql`
+  query UserProfileQuery {
+    userProfile {
+      id
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => <div>Error: {error.message}</div>
+
+export const Success = ({ userProfile }) => {
+  return JSON.stringify(userProfile)
+}

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.mock.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.mock.js
@@ -1,0 +1,6 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  userProfile: {
+    id: 42,
+  },
+})

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.stories.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.stories.js
@@ -1,0 +1,20 @@
+import { Loading, Empty, Failure, Success } from './UserProfileCell'
+import { standard } from './UserProfileCell.mock'
+
+export const loading = () => {
+  return Loading ? <Loading /> : null
+}
+
+export const empty = () => {
+  return Empty ? <Empty /> : null
+}
+
+export const failure = () => {
+  return Failure ? <Failure error={new Error('Oh no')} /> : null
+}
+
+export const success = () => {
+  return Success ? <Success {...standard()} /> : null
+}
+
+export default { title: 'Cells/UserProfileCell' }

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.test.js
@@ -1,0 +1,30 @@
+import { render, screen } from '@redwoodjs/testing'
+
+import { Loading, Empty, Failure, Success } from './UserProfileCell'
+
+describe('UserProfileCell', () => {
+  it('Loading renders successfully', () => {
+    render(<Loading />)
+    // Use screen.debug() to see output.
+    expect(screen.queryByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('Empty renders successfully', () => {
+    render(<Empty />)
+    expect(screen.queryByText('Empty')).toBeInTheDocument()
+  })
+
+  it('Failure renders successfully', () => {
+    render(<Failure error={{ message: 'Oh no!' }} />)
+    expect(screen.queryByText('Error: Oh no!')).toBeInTheDocument()
+  })
+
+  it('Success renders successfully', () => {
+    render(
+      <Success userExample={{ userProfile: { objectKey: 'objectValue' } }} />
+    )
+    expect(
+      screen.queryByText('{"userProfile":{"objectKey":"objectValue"}}')
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.js
@@ -1,0 +1,17 @@
+export const QUERY = gql`
+  query UserProfileQuery {
+    userProfile {
+      id
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => <div>Error: {error.message}</div>
+
+export const Success = ({ userProfile }) => {
+  return JSON.stringify(userProfile)
+}

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.mock.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.mock.js
@@ -1,0 +1,6 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  userProfile: {
+    id: 42,
+  },
+})

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.stories.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.stories.js
@@ -1,0 +1,20 @@
+import { Loading, Empty, Failure, Success } from './UserProfileCell'
+import { standard } from './UserProfileCell.mock'
+
+export const loading = () => {
+  return Loading ? <Loading /> : null
+}
+
+export const empty = () => {
+  return Empty ? <Empty /> : null
+}
+
+export const failure = () => {
+  return Failure ? <Failure error={new Error('Oh no')} /> : null
+}
+
+export const success = () => {
+  return Success ? <Success {...standard()} /> : null
+}
+
+export default { title: 'Cells/UserProfileCell' }

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.test.js
@@ -1,0 +1,30 @@
+import { render, screen } from '@redwoodjs/testing'
+
+import { Loading, Empty, Failure, Success } from './UserProfileCell'
+
+describe('UserProfileCell', () => {
+  it('Loading renders successfully', () => {
+    render(<Loading />)
+    // Use screen.debug() to see output.
+    expect(screen.queryByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('Empty renders successfully', () => {
+    render(<Empty />)
+    expect(screen.queryByText('Empty')).toBeInTheDocument()
+  })
+
+  it('Failure renders successfully', () => {
+    render(<Failure error={{ message: 'Oh no!' }} />)
+    expect(screen.queryByText('Error: Oh no!')).toBeInTheDocument()
+  })
+
+  it('Success renders successfully', () => {
+    render(
+      <Success userExample={{ userProfile: { objectKey: 'objectValue' } }} />
+    )
+    expect(
+      screen.queryByText('{"userProfile":{"objectKey":"objectValue"}}')
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.js
@@ -1,0 +1,17 @@
+export const QUERY = gql`
+  query UserProfileQuery {
+    userProfile {
+      id
+    }
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => <div>Error: {error.message}</div>
+
+export const Success = ({ userProfile }) => {
+  return JSON.stringify(userProfile)
+}

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.mock.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.mock.js
@@ -1,0 +1,6 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  userProfile: {
+    id: 42,
+  },
+})

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.stories.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.stories.js
@@ -1,0 +1,20 @@
+import { Loading, Empty, Failure, Success } from './UserProfileCell'
+import { standard } from './UserProfileCell.mock'
+
+export const loading = () => {
+  return Loading ? <Loading /> : null
+}
+
+export const empty = () => {
+  return Empty ? <Empty /> : null
+}
+
+export const failure = () => {
+  return Failure ? <Failure error={new Error('Oh no')} /> : null
+}
+
+export const success = () => {
+  return Success ? <Success {...standard()} /> : null
+}
+
+export default { title: 'Cells/UserProfileCell' }

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.test.js
@@ -1,0 +1,30 @@
+import { render, screen } from '@redwoodjs/testing'
+
+import { Loading, Empty, Failure, Success } from './UserProfileCell'
+
+describe('UserProfileCell', () => {
+  it('Loading renders successfully', () => {
+    render(<Loading />)
+    // Use screen.debug() to see output.
+    expect(screen.queryByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('Empty renders successfully', () => {
+    render(<Empty />)
+    expect(screen.queryByText('Empty')).toBeInTheDocument()
+  })
+
+  it('Failure renders successfully', () => {
+    render(<Failure error={{ message: 'Oh no!' }} />)
+    expect(screen.queryByText('Error: Oh no!')).toBeInTheDocument()
+  })
+
+  it('Success renders successfully', () => {
+    render(
+      <Success userExample={{ userProfile: { objectKey: 'objectValue' } }} />
+    )
+    expect(
+      screen.queryByText('{"userProfile":{"objectKey":"objectValue"}}')
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,3 +1,4 @@
+import pascalcase from 'pascalcase'
 import { getProject } from '@redwoodjs/structure'
 
 import {
@@ -17,7 +18,10 @@ const getCellOperationNames = () => {
 }
 
 const uniqueOperationName = (name, index = 1) => {
-  let operationName = index <= 1 ? `${name}Query` : `${name}Query_${index}`
+  let operationName =
+    index <= 1
+      ? `${pascalcase(name)}Query`
+      : `${pascalcase(name)}Query_${index}`
   if (!getCellOperationNames().includes(operationName)) {
     return operationName
   }


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/883

As of v0.14.0, cell queries now get an operation name to work with Storybook:

See: #867

Example:

```js
export const QUERY = gql`
- query {
+ query TestQuery {
    userProfile {
     id
   }
  }
`
```

I created a cell via the generator:

`yarn rw g cell my_sites`

and

```
✔ Generating cell files...
    ✔ Writing 
`./web/src/components/MySitesCell/MySitesCell.mock.j
s`...
    ✔ Writing 
`./web/src/components/MySitesCell/MySitesCell.storie
s.js`...
    ✔ Writing 
`./web/src/components/MySitesCell/MySitesCell.test.j
s`...
    ✔ Writing `./web/src/components/MySitesCell/MySi
tesCell.js`...
✨  Done in 1.57s.
```

the files, used the MySite upper camelCasing (aka Pascal Case).

However, my query operation name is

```js
export const QUERY = gql`
  query my_sitesQuery {
    mySites {
      id
    }
  }
`
```

This PR:

* pascal cases the operation name
* adds test for snakeCase file name input: `user_profile`
* adds test for kebabCase file name input: `user-profile`
* adds test for camelCase file name input: `userProfile`

that all expect the `UserProfileQuery` operation name.