### PR TITLE
Issue #811 after create redwood-app prompt to join

### DIFF
--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -25,4 +25,18 @@ Explains how to contribute by addressing the following three points:
 
 ## FAQ
 
-Answers to frequently asked questions.
+### How to run create redwood-app script locally
+
+After making changes to `create-redwood-app.js`:
+
+```
+node -r esm ./redwood/packages/create-redwood-app/src/create-redwood-app.js ../path/to/new-project`
+```
+
+If running from within the current redwood source directory, be sure your target app path is outside.
+
+Note: Assumes that
+
+```
+npm install --save esm
+```

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -179,6 +179,24 @@ new Listr(
     console.log(
       'Inside that directory you can run `yarn rw dev` to start the development server.'
     )
+    console.log()
+    console.log(
+      `${chalk.hex('#bf4722')(
+        '* Join our Discord server'
+      )}: https://discord.gg/jjSYEQd`
+    )
+
+    console.log(
+      `${chalk.hex('#bf4722')(
+        '* Join our Discourse Community'
+      )}: https://community.redwoodjs.com`
+    )
+
+    console.log(
+      `${chalk.hex('#bf4722')(
+        '* Signup to the Newsletter'
+      )}: https://www.redwoodjs.com`
+    )
   })
   .catch((e) => {
     console.log()


### PR DESCRIPTION
Resolves https://github.com/redwoodjs/redwood/issues/811

@peterp suggested that after someone creates a new redwood app, they are prompted to join in on the community:

```
It would be great if we could invite people to:

* Signup to the newsletter 
* Just our discord and discourse
```

![prompt](https://user-images.githubusercontent.com/1051633/88405983-045dbb80-cd9e-11ea-8e19-46824a5b8049.png)

Notes:

* added a little RW color
* I used the Discord url from the website, though I noticed that `https://discord.gg/redwoodjs` also went to an invite
* The newsletter doesn't have a link or anchor, so just directed to WWW (but could just go to the Mailchimp form, though the url is not terribly friendly: `https://redwoodjs.us19.list-manage.com/subscribe/post?u=0c27354a06a7fdf4d83ce07fc&id=09f634eea4` actually, could setup a Netlify redirect to go there instead: 
`https://www.redwoodjs.com/newsletter` or `https://www.redwoodjs.com/signup`
). That would require a change to the redwoodjs www so outside this PR.


Added some info to the README FAQ to help run ... this was the way I was able to test locally. But, maybe there is another way.