### PR TITLE
Add graphQL mocks to jest

### DIFF
--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -88,7 +88,7 @@ export const handler = async ({
 
   try {
     // Create a test database
-    if (side.includes('api')) {
+    if (sides.includes('api')) {
       const cacheDirDb = `file:${ensurePosixPath(CACHE_DIR)}/test.db`
       const DATABASE_URL = process.env.TEST_DATABASE_URL || cacheDirDb
       await execa.command(`yarn rw db up`, {

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -6,11 +6,6 @@ import { ensurePosixPath } from '@redwoodjs/internal'
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
-const jest = require('jest')
-
-// TODO: Get from redwood.toml
-const sides = getProject().sides
-
 // https://github.com/facebook/create-react-app/blob/cbad256a4aacfc3084be7ccf91aad87899c63564/packages/react-scripts/scripts/test.js#L39
 function isInGitRepository() {
   try {
@@ -34,15 +29,22 @@ export const command = 'test [side..]'
 export const description = 'Run Jest tests'
 export const builder = (yargs) => {
   yargs
-    .choices('side', sides)
+    .choices('side', getProject().sides)
     .option('watch', {
       type: 'boolean',
+      default: false,
     })
     .option('watchAll', {
       type: 'boolean',
+      default: false,
     })
     .option('collectCoverage', {
       type: 'boolean',
+      default: false,
+    })
+    .option('clearCache', {
+      type: 'boolean',
+      default: false,
     })
     .epilogue(
       `Also see the ${terminalLink(
@@ -52,7 +54,12 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ side, watch, watchAll, collectCoverage }) => {
+export const handler = async ({
+  side,
+  watch = false,
+  watchAll = false,
+  collectCoverage = false,
+}) => {
   const { cache: CACHE_DIR } = getPaths()
   const sides = [].concat(side).filter(Boolean)
 
@@ -63,37 +70,42 @@ export const handler = async ({ side, watch, watchAll, collectCoverage }) => {
     watchAll && '--watchAll',
   ].filter(Boolean)
 
-  // Watch unless on CI or explicitly running all tests
+  // If you don't pass any arguments we enter "watch mode" as the default.
   if (!process.env.CI && !watchAll && !collectCoverage) {
     // https://github.com/facebook/create-react-app/issues/5210
     const hasSourceControl = isInGitRepository() || isInMercurialRepository()
     args.push(hasSourceControl ? '--watch' : '--watchAll')
   }
 
-  const jestConfigLocation = require.resolve(
-    '@redwoodjs/core/config/jest.config.js'
+  args.push(
+    '--config',
+    require.resolve('@redwoodjs/core/config/jest.config.js')
   )
-  args.push('--config', jestConfigLocation)
 
   if (sides.length > 0) {
     args.push('--projects', ...sides)
   }
 
   try {
-    /**
-     * Migrate test database. This should be moved to somehow be done on a
-     * per-side basis if possible.
-     */
-    const cacheDirDb = `file:${ensurePosixPath(CACHE_DIR)}/test.db`
-    const DATABASE_URL = process.env.TEST_DATABASE_URL || cacheDirDb
+    // Create a test database
+    if (side.includes('api')) {
+      const cacheDirDb = `file:${ensurePosixPath(CACHE_DIR)}/test.db`
+      const DATABASE_URL = process.env.TEST_DATABASE_URL || cacheDirDb
+      await execa.command(`yarn rw db up`, {
+        stdio: 'inherit',
+        shell: true,
+        env: { DATABASE_URL },
+      })
+    }
 
-    await execa.command(`yarn rw db up`, {
-      stdio: 'inherit',
+    // **NOTE** There is no official way to run Jest programatically,
+    // so we're running it via execa, since `jest.run()` is a bit unstable.
+    // https://github.com/facebook/jest/issues/5048
+    execa('yarn jest', args, {
+      cwd: getPaths().base,
       shell: true,
-      env: { DATABASE_URL },
+      stdio: 'inherit',
     })
-
-    jest.run(args)
   } catch (e) {
     console.log(c.error(e.message))
   }

--- a/packages/core/src/configs/browser/jest.createConfig.ts
+++ b/packages/core/src/configs/browser/jest.createConfig.ts
@@ -12,11 +12,8 @@ export default function getBrowserJestConfig() {
   return {
     displayName: {
       color: 'blueBright',
-
-      // TODO: Detect which side this is and name it that instead
-      name: 'browser',
+      name: 'web',
     },
-
     resolver: 'jest-directory-named-resolver',
     // NOTE: We run the tests with a `cwd` argument that's `getPaths().web.base`
     // testMatch,
@@ -24,7 +21,6 @@ export default function getBrowserJestConfig() {
       __REDWOOD__: true,
       __REDWOOD__API_PROXY_PATH: '/',
     },
-    // transform: { '\\.js$': ['babel-jest', { rootMode: 'upward' }] },
     setupFilesAfterEnv: [path.resolve(__dirname, './jest.setup.js')],
     moduleNameMapper: {
       /**

--- a/packages/core/src/configs/browser/jest.setup.js
+++ b/packages/core/src/configs/browser/jest.setup.js
@@ -1,12 +1,14 @@
 require('@testing-library/jest-dom')
 require('whatwg-fetch')
 
-const { server } = require('@redwoodjs/testing')
+const { startMSW, SERVER_INSTANCE } = require('@redwoodjs/testing')
+
+// TODO: Import all mock files.
 
 beforeAll(() => {
-  server.listen()
+  startMSW()
 })
 
 afterAll(() => {
-  server.close()
+  SERVER_INSTANCE?.close()
 })

--- a/packages/core/src/configs/browser/jest.setup.js
+++ b/packages/core/src/configs/browser/jest.setup.js
@@ -9,8 +9,8 @@ const {
   mockGraphQLQuery,
 } = require('@redwoodjs/testing')
 
-globalThis.mockGraphQLQuery = mockGraphQLQuery
-globalThis.mockGraphQLMutation = mockGraphQLMutation
+global.mockGraphQLQuery = mockGraphQLQuery
+global.mockGraphQLMutation = mockGraphQLMutation
 
 beforeEach(async () => {
   // Import the global mocks.

--- a/packages/core/src/configs/browser/jest.setup.js
+++ b/packages/core/src/configs/browser/jest.setup.js
@@ -1,14 +1,22 @@
 require('@testing-library/jest-dom')
 require('whatwg-fetch')
 
-const { startMSW, SERVER_INSTANCE } = require('@redwoodjs/testing')
+const { getProject } = require('@redwoodjs/structure')
+const {
+  startMSW,
+  setupRequestHandlers,
+  mockGraphQLMutation,
+  mockGraphQLQuery,
+} = require('@redwoodjs/testing')
 
-// TODO: Import all mock files.
+globalThis.mockGraphQLQuery = mockGraphQLQuery
+globalThis.mockGraphQLMutation = mockGraphQLMutation
 
-beforeAll(() => {
-  startMSW()
-})
-
-afterAll(() => {
-  SERVER_INSTANCE?.close()
+beforeEach(async () => {
+  // Import the global mocks.
+  for (const m of getProject().mocks) {
+    require(m)
+  }
+  await startMSW()
+  setupRequestHandlers() // reset the handlers in each test.
 })

--- a/packages/core/src/configs/node/jest.createConfig.ts
+++ b/packages/core/src/configs/node/jest.createConfig.ts
@@ -4,9 +4,7 @@ export default function getNodeJestConfig() {
   return {
     displayName: {
       color: 'redBright',
-
-      // TODO: Detect which side this is and name it that instead
-      name: 'node',
+      name: 'api',
     },
 
     resolver: 'jest-directory-named-resolver',

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -158,6 +158,11 @@ export class RWProject extends BaseNode {
     return ['web', 'api']
   }
 
+  // TODO: Wrap these in a real model.
+  @lazy() get mocks() {
+    return this.host.globSync(this.pathHelper.web.base + '/**/*.mock.{js,ts}')
+  }
+
   /**
    * A "Cell" is a component that ends in `Cell.{js, jsx, tsx}`, but does not
    * have a default export AND does not export `QUERY`

--- a/packages/testing/src/mockRequests.ts
+++ b/packages/testing/src/mockRequests.ts
@@ -6,7 +6,7 @@ import * as msw from 'msw'
 // a queue that is drained once the server is started.
 let REQUEST_HANDLER_QUEUE: msw.RequestHandler[] = []
 
-let SERVER_INSTANCE: any
+export let SERVER_INSTANCE: any
 
 /**
  * This will import the correct runtime (node/ browser) of MSW,

--- a/packages/testing/src/mockRequests.ts
+++ b/packages/testing/src/mockRequests.ts
@@ -6,7 +6,7 @@ import * as msw from 'msw'
 // a queue that is drained once the server is started.
 let REQUEST_HANDLER_QUEUE: msw.RequestHandler[] = []
 
-export let SERVER_INSTANCE: any
+let SERVER_INSTANCE: any
 
 /**
  * This will import the correct runtime (node/ browser) of MSW,
@@ -23,12 +23,13 @@ export const startMSW = async () => {
   if (typeof global.process === 'undefined') {
     const { setupWorker } = require('msw')
     SERVER_INSTANCE = setupWorker()
+    await SERVER_INSTANCE.start()
   } else {
     const { setupServer } = require('msw/node')
     SERVER_INSTANCE = setupServer()
+    await SERVER_INSTANCE.listen()
   }
 
-  await SERVER_INSTANCE.start()
   setupRequestHandlers()
   return SERVER_INSTANCE
 }


### PR DESCRIPTION
This introduces the ability to mock network requests via the `*.mock.js` files on the testing side. It has the identical API to storybook, so the mocks that you declare during development of storybook are also automatically declared in Jest.

You can overwrite the global mocks.

Fixes #892
Fixes #872