### PR TITLE
fix(auth-decoder): Make auth decoder backwards compatible with 0.12

### DIFF
--- a/packages/api/src/__tests__/authDecoder.test.ts
+++ b/packages/api/src/__tests__/authDecoder.test.ts
@@ -1,0 +1,108 @@
+import mockedAPIGatewayProxyEvent from './fixtures/apiGatewayProxyEvent.fixture'
+import * as auth0Decoder from './../auth/decoders/auth0'
+import * as netlifyDecoder from './../auth/decoders/netlify'
+import { decodeToken } from './../auth/decoders/index'
+
+jest.mock('./../auth/decoders/auth0', () => {
+  return {
+    auth0: jest.fn().mockImplementation(async () => {
+      return { decodedWith: 'auth0', fakeDecodedToken: true }
+    }),
+  }
+})
+
+jest.mock('./../auth/decoders/netlify', () => {
+  return {
+    netlify: jest.fn().mockImplementation(async () => {
+      return { decodedWith: 'netlify', fakeDecodedToken: true }
+    }),
+  }
+})
+
+const MOCKED_JWT = 'xxx.yyy.zzz'
+
+describe('Uses correct Auth decoder', () => {
+  it('handles auth0', async () => {
+    const output = await decodeToken('auth0', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(auth0Decoder.auth0).toHaveBeenCalledWith(
+      MOCKED_JWT,
+      expect.anything()
+    )
+    expect(output).toEqual({
+      decodedWith: 'auth0',
+      fakeDecodedToken: true,
+    })
+  })
+
+  it('decodes goTrue with netlify decoder', async () => {
+    const output = await decodeToken('goTrue', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(netlifyDecoder.netlify).toHaveBeenCalledWith(
+      MOCKED_JWT,
+      expect.anything()
+    )
+    expect(output).toEqual({
+      decodedWith: 'netlify',
+      fakeDecodedToken: true,
+    })
+  })
+
+  it('decodes netlify with netlify decoder', async () => {
+    const output = await decodeToken('netlify', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(netlifyDecoder.netlify).toHaveBeenCalledWith(
+      MOCKED_JWT,
+      expect.anything()
+    )
+    expect(output).toEqual({
+      decodedWith: 'netlify',
+      fakeDecodedToken: true,
+    })
+  })
+
+  it('returns undecoded token for custom', async () => {
+    const output = await decodeToken('custom', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(output).toEqual(MOCKED_JWT)
+  })
+
+  it('returns undecoded token for magicLink', async () => {
+    const output = await decodeToken('magicLink', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(output).toEqual(MOCKED_JWT)
+  })
+
+  it('returns undecoded token for firebase', async () => {
+    const output = await decodeToken('firebase', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(output).toEqual(MOCKED_JWT)
+  })
+
+  it('returns undecoded token for unknown values', async () => {
+    const output = await decodeToken('SOMETHING_ELSE!', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(output).toEqual(MOCKED_JWT)
+  })
+})

--- a/packages/api/src/__tests__/fixtures/apiGatewayProxyEvent.fixture.ts
+++ b/packages/api/src/__tests__/fixtures/apiGatewayProxyEvent.fixture.ts
@@ -1,0 +1,46 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda'
+
+export const mockedAPIGatewayProxyEvent: APIGatewayProxyEvent = {
+  body: 'MOCKED_BODY',
+  headers: {},
+  multiValueHeaders: {},
+  httpMethod: 'POST',
+  isBase64Encoded: false,
+  path: '/MOCK_PATH',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  stageVariables: null,
+  requestContext: {
+    accountId: 'MOCKED_ACCOUNT',
+    apiId: 'MOCKED_API_ID',
+    authorizer: { name: 'MOCKED_AUTHORIZER' },
+    protocol: 'HTTP',
+    identity: {
+      accessKey: null,
+      accountId: null,
+      apiKey: null,
+      apiKeyId: null,
+      caller: null,
+      cognitoAuthenticationProvider: null,
+      cognitoAuthenticationType: null,
+      cognitoIdentityId: null,
+      cognitoIdentityPoolId: null,
+      principalOrgId: null,
+      sourceIp: '123.123.123.123',
+      user: null,
+      userAgent: null,
+      userArn: null,
+    },
+    httpMethod: 'POST',
+    path: '/MOCK_PATH',
+    stage: 'MOCK_STAGE',
+    requestId: 'MOCKED_REQUEST_ID',
+    requestTimeEpoch: 1,
+    resourceId: 'MOCKED_RESOURCE_ID',
+    resourcePath: 'MOCKED_RESOURCE_PATH',
+  },
+  resource: 'MOCKED_RESOURCE',
+}
+
+export default mockedAPIGatewayProxyEvent

--- a/packages/api/src/auth/decoders/index.ts
+++ b/packages/api/src/auth/decoders/index.ts
@@ -24,12 +24,20 @@ export const decodeToken = async (
   }
 ): Promise<null | string | object> => {
   if (!typesToDecoders[type]) {
-    throw new Error(
-      `The auth type "${type}" is not supported, we currently support: ${Object.keys(
-        typesToDecoders
-      ).join(', ')}`
-    )
+    // Make this a warning, instead of a hard error
+    // Allow users to have multiple custom types if they choose to
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(
+        `The auth type "${type}" is not officially supported, we currently support: ${Object.keys(
+          typesToDecoders
+        ).join(', ')}`
+      )
+
+      console.warn(
+        'Please ensure you have handlers for your custom auth in getCurrentUser in src/lib/auth.{js,ts}'
+      )
+    }
   }
-  const decoder = typesToDecoders[type]
+  const decoder = typesToDecoders[type] || noop
   return decoder(token, req)
 }


### PR DESCRIPTION
### What does it do? 
- Allow users to use any type of auth provider without a hard error.
- Add tests for decoder selection to prevent regression in the future!

### Why?
If you have a custom auth setup, you might want multiple different types of custom auth. e.g. in our case they're "jwt" and "cli-token" - this is a string, not a jwt. Although I could use "custom" instead of "jwt" for web, it would mean all the cli clients would break and would need a forced upgrade.

--- 
### Checklist:
- [x]  Tested with RW contribution flow
- [x] All tests pass with `yarn test`
- [x]  Write some tests to prevent regression