### PR TITLE
Improve Language Server

### DIFF
--- a/packages/structure/.vscode/launch.json
+++ b/packages/structure/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}",
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node"
+    }
+  ]
+}

--- a/packages/structure/src/ide.ts
+++ b/packages/structure/src/ide.ts
@@ -4,7 +4,13 @@ import { basename } from 'path'
 import * as tsm from 'ts-morph'
 import { TextDocuments } from 'vscode-languageserver'
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import { CodeLens, Location } from 'vscode-languageserver-types'
+import {
+  CodeLens,
+  DocumentLink,
+  Location,
+  Range,
+  Hover,
+} from 'vscode-languageserver-types'
 import { ArrayLike, ArrayLike_normalize } from './x/Array'
 import { lazy, memo } from './x/decorators'
 import { basenameNoExt } from './x/path'
@@ -31,7 +37,9 @@ export type IDEInfo =
   | Implementation
   | Reference
   | CodeLensX
-  | Hover
+  | HoverX
+  | Decoration
+  | DocumentLinkX
 
 export interface Definition {
   kind: 'Definition'
@@ -57,10 +65,26 @@ export interface CodeLensX {
   codeLens: CodeLens
 }
 
-export interface Hover {
+export interface HoverX {
   kind: 'Hover'
   location: Location
-  text: string
+  hover: Hover
+}
+
+export interface Decoration {
+  kind: 'Decoration'
+  location: Location
+  style:
+    | 'path_punctuation'
+    | 'path_parameter'
+    | 'path_slash'
+    | 'path_parameter_type'
+}
+
+export interface DocumentLinkX {
+  kind: 'DocumentLink'
+  location: Location
+  link: DocumentLink
 }
 
 export abstract class BaseNode {
@@ -119,14 +143,18 @@ export abstract class BaseNode {
 
   @memo()
   async collectIDEInfo(): Promise<IDEInfo[]> {
-    // TODO: catch runtime errors and add them as diagnostics
-    // TODO: we can parallelize this further
-    const d1 = await this._ideInfo()
-    const dd = await Promise.all(
-      (await this._children()).map((c) => c.collectIDEInfo())
-    )
-    const d2 = dd.flat()
-    return [...d1, ...d2]
+    try {
+      const d1 = await this._ideInfo()
+      const dd = await Promise.all(
+        (await this._children()).map((c) => c.collectIDEInfo())
+      )
+      const d2 = dd.flat()
+      return [...d1, ...d2]
+    } catch (e) {
+      // TODO: this diagnostic is also interesting
+      console.log(e)
+      return []
+    }
   }
 
   /**
@@ -137,12 +165,31 @@ export abstract class BaseNode {
   async collectDiagnostics(): Promise<ExtendedDiagnostic[]> {
     // TODO: catch runtime errors and add them as diagnostics
     // TODO: we can parallelize this further
-    const d1 = await this._diagnostics()
-    const dd = await Promise.all(
-      (await this._children()).map((c) => c.collectDiagnostics())
-    )
-    const d2 = dd.flat()
-    return [...d1, ...d2]
+    try {
+      const d1 = await this._diagnostics()
+      const dd = await Promise.all(
+        (await this._children()).map((c) => c.collectDiagnostics())
+      )
+      const d2 = dd.flat()
+      return [...d1, ...d2]
+    } catch (e) {
+      const uri = this.closestContainingUri
+      if (!uri) throw e
+      const range = Range.create(0, 0, 0, 0)
+      return [
+        {
+          uri,
+          diagnostic: { message: e + '', range },
+        },
+      ]
+    }
+  }
+
+  @lazy() get closestContainingUri(): string | undefined {
+    const { uri } = this as any
+    if (uri) return uri
+    if (this.parent) return this.parent.closestContainingUri
+    return undefined
   }
 
   /**

--- a/packages/structure/src/language_server/commands.ts
+++ b/packages/structure/src/language_server/commands.ts
@@ -1,0 +1,106 @@
+import { ExecuteCommandOptions } from 'vscode-languageserver'
+import { command_builder } from '../interactive_cli/command_builder'
+import { redwood_gen_dry_run as dry_run } from '../interactive_cli/dry_run'
+import { RedwoodCommandString } from '../interactive_cli/RedwoodCommandString'
+import { VSCodeWindowUI } from '../interactive_cli/ui'
+import { RWProject } from '../model'
+import { lazy, memo } from '../x/decorators'
+import { URL_toFile } from '../x/URL'
+import {
+  FileSet_fromTextDocuments,
+  WorkspaceEdit_fromFileSet,
+} from '../x/vscode-languageserver-types'
+import { RWLanguageServer } from './RWLanguageServer'
+
+export const redwoodjs_commands = {
+  'redwoodjs.cli': 'redwoodjs.cli',
+}
+
+export type CommandID = keyof typeof redwoodjs_commands
+
+export class CommandsManager {
+  constructor(public server: RWLanguageServer) {}
+
+  @lazy() get options(): ExecuteCommandOptions {
+    return {
+      commands: Object.keys(redwoodjs_commands),
+      workDoneProgress: true,
+    }
+  }
+
+  @memo() start() {
+    const { connection } = this.server
+    connection.onExecuteCommand(async (params) => {
+      if (params.command === redwoodjs_commands['redwoodjs.cli']) {
+        const [cmd, cwd] = params.arguments ?? []
+        await this.command__cli(cmd, cwd)
+      }
+    })
+  }
+
+  // --- start command implementations
+  private async command__cli(cmdString?: string, cwd?: string) {
+    const {
+      vscodeWindowMethods,
+      host,
+      projectRoot,
+      connection,
+      documents,
+    } = this.server
+    cwd = cwd ?? projectRoot
+    if (!cwd) return // we need a cwd to run the CLI
+    // parse the cmd. this will do some checks and throw
+    let cmd = new RedwoodCommandString(cmdString ?? '...')
+
+    if (
+      cmd.processed.startsWith('dev --open') ||
+      cmd.processed.startsWith('storybook --open')
+    ) {
+      vscodeWindowMethods.showInformationMessage(
+        'not implemented yet: $ redwood ' + cmd.processed
+      )
+      return
+    }
+
+    if (!cmd.isComplete) {
+      // if the command is incomplete, we need to build it interactively
+      const project = new RWProject({ projectRoot: cwd, host })
+      // the interactive builder needs a UI to prompt the user
+      // this UI is provided by the client side VSCode extension
+      // (it is not a standard part of the LSP)
+      // we have a convenience wrapper to access it
+      const ui = new VSCodeWindowUI(vscodeWindowMethods)
+      const cmd2 = await command_builder({ cmd, project, ui })
+      if (!cmd2) return // user cancelled the interactive process
+      cmd = cmd2
+    }
+    // run the command
+    if (cmd.isInterceptable) {
+      // TODO: we could use the LSP progress API
+      vscodeWindowMethods.showInformationMessage('redwood ' + cmd.processed)
+      // run using dry_run so we can intercept the generated files
+      const fileOverrides = FileSet_fromTextDocuments(documents)
+      const { stdout, files } = await dry_run({
+        cmd,
+        cwd,
+        fileOverrides,
+      })
+      const edit = WorkspaceEdit_fromFileSet(files, (f) => {
+        if (!host.existsSync(URL_toFile(f))) return undefined
+        return host.readFileSync(URL_toFile(f))
+      })
+      vscodeWindowMethods.showInformationMessage(stdout)
+      await connection.workspace.applyEdit({
+        label: 'redwood ' + cmd.processed,
+        edit,
+      })
+    } else {
+      // if it can't be intercepted, just run in the terminal
+      vscodeWindowMethods.createTerminal2({
+        name: 'Redwood',
+        cwd,
+        cmd: 'yarn redwood ' + cmd.processed,
+      })
+    }
+  }
+}

--- a/packages/structure/src/language_server/diagnostics.ts
+++ b/packages/structure/src/language_server/diagnostics.ts
@@ -1,0 +1,45 @@
+import { debounce, memo } from '../x/decorators'
+import { ExtendedDiagnostic_groupByUri } from '../x/vscode-languageserver-types'
+import { RWLanguageServer } from './RWLanguageServer'
+
+const REFRESH_DIAGNOSTICS_INTERVAL = 5000
+const REFRESH_DIAGNOSTICS_DEBOUNCE = 500
+
+export class DiagnosticsManager {
+  constructor(public server: RWLanguageServer) {}
+
+  @memo() start() {
+    setInterval(() => this.refreshDiagnostics(), REFRESH_DIAGNOSTICS_INTERVAL)
+    // The content of a text document has changed. This event is emitted
+    // when the text document first opened or when its content has changed.
+    const { documents, connection } = this.server
+    documents.onDidChangeContent(() => {
+      this.refreshDiagnostics()
+    })
+    connection.onDidChangeWatchedFiles(() => {
+      this.refreshDiagnostics()
+    })
+  }
+
+  // we need to keep track of URIs so we can "erase" previous diagnostics
+  private previousURIs: string[] = []
+
+  @debounce(REFRESH_DIAGNOSTICS_DEBOUNCE)
+  private async refreshDiagnostics() {
+    const dss = await this.getDiagnosticsGroupedByUri()
+    const newURIs = Object.keys(dss)
+    const allURIs = newURIs.concat(this.previousURIs)
+    this.previousURIs = newURIs
+    for (const uri of allURIs) {
+      const diagnostics = dss[uri] ?? []
+      this.server.connection.sendDiagnostics({ uri, diagnostics })
+    }
+  }
+
+  private async getDiagnosticsGroupedByUri() {
+    const project = this.server.getProject()
+    if (!project) return {}
+    const ds = await project.collectDiagnostics()
+    return ExtendedDiagnostic_groupByUri(ds)
+  }
+}

--- a/packages/structure/src/language_server/outline.ts
+++ b/packages/structure/src/language_server/outline.ts
@@ -1,0 +1,31 @@
+import { getOutline } from '../outline/outline'
+import { memo } from '../x/decorators'
+import {
+  RemoteTreeDataProviderImpl,
+  RemoteTreeDataProvider_publishOverLSPConnection,
+} from '../x/vscode'
+import { RWLanguageServer } from './RWLanguageServer'
+
+export class OutlineManager {
+  constructor(public server: RWLanguageServer) {}
+
+  @memo() start() {
+    const getRoot = () => {
+      const p = this.server.getProject()
+      if (!p)
+        return {
+          async children() {
+            return [{ label: 'No Redwood.js project found...' }]
+          },
+        }
+      return getOutline(p)
+    }
+    const tdp = new RemoteTreeDataProviderImpl(getRoot)
+    const methodPrefix = 'redwoodjs/x-outline-'
+    RemoteTreeDataProvider_publishOverLSPConnection(
+      tdp,
+      this.server.connection,
+      methodPrefix
+    )
+  }
+}

--- a/packages/structure/src/language_server/xmethods.ts
+++ b/packages/structure/src/language_server/xmethods.ts
@@ -1,0 +1,31 @@
+import { memo } from '../x/decorators'
+import { RWLanguageServer } from './RWLanguageServer'
+
+/**
+ * A set of custom methods (not included in the LSP spec) exposed to the client
+ * via the sendRequest/onRequest mechanism.
+ */
+export class XMethodsManager {
+  constructor(public server: RWLanguageServer) {}
+  @memo() start() {
+    const { server } = this
+    const { connection } = server
+    connection.onRequest('redwoodjs/x-getInfo', async (uri: string) => {
+      const node = await server.getProject()?.findNode(uri)
+      if (!node) return undefined
+      return await node.collectIDEInfo()
+    })
+    connection.onRequest(
+      'redwoodjs/x-getFilePathForRoutePath',
+      (routePath: string) => {
+        return server.getProject()?.router.getFilePathForRoutePath(routePath)
+      }
+    )
+    connection.onRequest(
+      'redwoodjs/x-getRoutePathForFilePath',
+      (uri: string) => {
+        return server.getProject()?.router.getRoutePathForFilePath(uri)
+      }
+    )
+  }
+}

--- a/packages/structure/src/model/RWRouter.ts
+++ b/packages/structure/src/model/RWRouter.ts
@@ -1,4 +1,3 @@
-import { URL_file } from '../x/URL'
 import * as tsm from 'ts-morph'
 import {
   CodeAction,
@@ -12,6 +11,7 @@ import { RWError } from '../errors'
 import { CodeLensX, FileNode } from '../ide'
 import { iter } from '../x/Array'
 import { lazy, memo } from '../x/decorators'
+import { URL_file } from '../x/URL'
 import {
   err,
   ExtendedDiagnostic,
@@ -82,7 +82,7 @@ export class RWRouter extends FileNode {
           range: location.range,
           command: Command.create(
             'Create Page...',
-            'redwoodjs/cli',
+            'redwoodjs.cli',
             'generate page...',
             this.parent.projectRoot
           ),

--- a/packages/structure/src/model/util/__tests__/advanced_path_parser.test.ts
+++ b/packages/structure/src/model/util/__tests__/advanced_path_parser.test.ts
@@ -1,0 +1,7 @@
+import { advanced_path_parser } from '../advanced_path_parser'
+describe('advanced_path_parser', () => {
+  test('it works', () => {
+    const route = '/foo/{param1}/bar/{baz:Int}/x'
+    advanced_path_parser(route) //?
+  })
+})

--- a/packages/structure/src/model/util/advanced_path_parser.ts
+++ b/packages/structure/src/model/util/advanced_path_parser.ts
@@ -1,0 +1,21 @@
+/**
+ * A route path parser with positional information.
+ * Used to enable decorations
+ * @param route
+ */
+export function advanced_path_parser(route: string) {
+  const paramRanges: [number, number][] = []
+  const paramTypeRanges: [number, number][] = []
+  for (const param of route.matchAll(/\{([^}]+)\}/g)) {
+    const [paramName, paramType] = param[1].split(':')
+    const index = param.index! + 1
+    paramRanges.push([index, index + paramName.length])
+    if (paramType) {
+      const typeIndex = index + paramName.length + 2
+      paramTypeRanges.push([typeIndex, typeIndex + paramType.length])
+    }
+  }
+  const punctuationIndexes = [...route.matchAll(/[{}:]/g)].map((x) => x.index!)
+  const slashIndexes = [...route.matchAll(/[\/]/g)].map((x) => x.index!)
+  return { punctuationIndexes, slashIndexes, paramRanges, paramTypeRanges }
+}

--- a/packages/structure/src/x/vscode.ts
+++ b/packages/structure/src/x/vscode.ts
@@ -1,4 +1,11 @@
+// vscode is a compile-time only dependency
+// we only use it in type declarations
+// (we can't use "import type" since we need to do use it in some typeof expressions)
 import * as vscode from 'vscode'
+import { Connection as LSPConnection } from 'vscode-languageserver'
+import { Command, Location } from 'vscode-languageserver-types'
+import { lazy, memo } from '../x/decorators'
+import { memoize } from 'lodash'
 
 export type VSCodeWindowMethods = Pick<
   typeof vscode.window,
@@ -34,4 +41,277 @@ class VSCodeWindowMethodsWrapper implements VSCodeWindowMethods {
     // TODO:
     return task()
   }
+}
+
+export type SerializableTreeItem = ReplacePropTypes<
+  vscode.TreeItem,
+  {
+    resourceUri: string
+    collapsibleState: TreeItemCollapsibleState2
+    iconPath: ThemeIcon2
+    command: Command
+  }
+> & {
+  id: string
+} & { menu?: TreeItemMenu }
+
+/**
+ * menus types must be known beforehand.
+ * they are set up by the vscode extension in its package.json
+ */
+type TreeItemMenu = MenuCLI | MenuRoute | MenuGroup | MenuWithDoc
+
+interface MenuCLI {
+  kind: 'cli'
+  doc?: Command
+  run: Command
+}
+
+interface MenuRoute {
+  kind: 'route'
+  openInBrowser?: Command
+  openComponent?: Command
+  openRoute?: Command
+}
+
+interface MenuGroup {
+  kind: 'group'
+  add?: Command
+  doc?: Command
+}
+
+interface MenuWithDoc {
+  kind: 'withDoc'
+  doc?: Command
+}
+
+/**
+ * Based on the actual TreeItem interface provided by VSCode.
+ * It has a few differences.
+ */
+export type TreeItem2 = Partial<SerializableTreeItem> & {
+  key?: string
+  children?(): vscode.ProviderResult<TreeItem2[]>
+}
+
+export class TreeItem2Wrapper {
+  constructor(
+    public item: TreeItem2,
+    public parent?: TreeItem2Wrapper,
+    public indexInParent: number = 0
+  ) {}
+  @lazy() get keys(): string[] {
+    if (!this.parent) return []
+    return [...(this.parent?.keys ?? []), this.key]
+  }
+  @lazy() get key(): string {
+    const {
+      indexInParent,
+      item: { key, label },
+    } = this
+    if (key) return key
+    return (label ?? '') + '-' + indexInParent
+  }
+  @lazy() get id() {
+    return JSON.stringify(this.keys)
+  }
+  @lazy() get collapsibleState() {
+    return (
+      this.item.collapsibleState ??
+      (this.item.children
+        ? TreeItemCollapsibleState2.Collapsed
+        : TreeItemCollapsibleState2.None)
+    )
+  }
+  @memo() async children(): Promise<TreeItem2Wrapper[]> {
+    const cs = await ProviderResult_normalize(this.item.children?.())
+    return (cs ?? []).map((c, i) => new TreeItem2Wrapper(c, this, i))
+  }
+  @memo()
+  async findChild(key: string): Promise<TreeItem2Wrapper | undefined> {
+    for (const c of await this.children()) if (c.key === key) return c
+  }
+  @memo(JSON.stringify)
+  async findChildRec(keys: string[]): Promise<TreeItem2Wrapper | undefined> {
+    if (keys.length === 0) return this
+    const [k, ...rest] = keys
+    return await (await this.findChild(k))?.findChildRec(rest)
+  }
+  @lazy() get serializableTreeItem(): SerializableTreeItem {
+    return {
+      ...this.item,
+      id: this.id,
+      collapsibleState: this.collapsibleState,
+    }
+  }
+}
+
+/**
+ * https://microsoft.github.io/vscode-codicons/dist/codicon.html
+ * plust a few extra icons provided by decoupled studio:
+ * - redwood
+ * - prisma
+ * - graphql
+ * - netlify
+ */
+type ThemeIcon2 = string
+
+/**
+ * A copy of vscode.TreeItemCollapsibleState
+ * we don't want to have a runtime dependency on the vscode package
+ */
+export enum TreeItemCollapsibleState2 {
+  /**
+   * Determines an item can be neither collapsed nor expanded. Implies it has no children.
+   */
+  None = 0,
+  /**
+   * Determines an item is collapsed
+   */
+  Collapsed = 1,
+  /**
+   * Determines an item is expanded
+   */
+  Expanded = 2,
+}
+
+/**
+ * A vscode.TreeDataProvider that uses string IDs as elements
+ * and returns a SerializableTreeItem.
+ */
+type RemoteTreeDataProvider = ReplacePropTypes<
+  vscode.TreeDataProvider<string>,
+  {
+    getTreeItem(id: string): Promise<SerializableTreeItem>
+  }
+>
+
+export class RemoteTreeDataProviderImpl implements RemoteTreeDataProvider {
+  constructor(
+    private getRoot: () => TreeItem2,
+    private refreshInterval = 5000
+  ) {}
+
+  private root!: TreeItem2Wrapper
+
+  private refresh() {
+    this.root = new TreeItem2Wrapper(this.getRoot())
+  }
+
+  @memo()
+  private lazyInit() {
+    this.refresh()
+    setInterval(() => {
+      this.refresh()
+      for (const l of this.listeners) l(undefined)
+    }, this.refreshInterval)
+  }
+
+  // ----- start TreeDataProvider impl
+  private listeners: Array<(e: string | undefined) => void> = []
+  onDidChangeTreeData(listener: (e: string | undefined) => void) {
+    this.lazyInit()
+    this.listeners.push(listener)
+    return null as any // TODO: disposable (we're not using it for now)
+  }
+
+  async getTreeItem(id: string): Promise<SerializableTreeItem> {
+    this.lazyInit()
+    //console.log('getTreeItem', id)
+    const keys = JSON.parse(id)
+    const item = await this.root.findChildRec(keys)
+    if (!item) throw new Error(`item not found for id ${id}`)
+    //console.log('--->', item.treeItemOverTheWire)
+    return item.serializableTreeItem
+  }
+
+  async getChildren(id?: string): Promise<string[]> {
+    this.lazyInit()
+    //console.log('getChildren', id)
+    const keys = id ? JSON.parse(id) : []
+    const self = await this.root.findChildRec(keys)
+    const children = await self?.children()
+    if (!children) return []
+    const res = children?.map((c) => c.id)
+    //console.log('--->', res)
+    return res
+  }
+
+  //   getParent(id: string) {
+  //     return null as any
+  //   }
+
+  // ----- end TreeDataProvider impl
+}
+
+export function RemoteTreeDataProvider_publishOverLSPConnection(
+  tdp: RemoteTreeDataProvider,
+  connection: LSPConnection,
+  methodPrefix: string
+) {
+  const lazyInit = memoize(() => {
+    // we only setup this listener if we receive a call
+    tdp.onDidChangeTreeData?.((id) =>
+      connection.sendRequest(`${methodPrefix}onDidChangeTreeData`, [id])
+    )
+  })
+  connection.onRequest(`${methodPrefix}getChildren`, async (id) => {
+    lazyInit()
+    try {
+      return await ProviderResult_normalize(tdp.getChildren(id))
+    } catch (e) {
+      return []
+    }
+  })
+  connection.onRequest(`${methodPrefix}getTreeItem`, async (id) => {
+    lazyInit()
+    try {
+      return await ProviderResult_normalize(tdp.getTreeItem(id))
+    } catch (e) {
+      return { label: '(project has too many errors)', tooltip: e + '' }
+    }
+  })
+}
+
+export async function ProviderResult_normalize<T>(
+  x: vscode.ProviderResult<T>
+): Promise<T | undefined> {
+  if (isThenable(x)) return await ProviderResult_normalize(await x)
+  if (x === null) return undefined
+  return x
+}
+
+function isThenable(x: unknown): x is Thenable<unknown> {
+  if (typeof x !== 'object') return false
+  if (x === null) return false
+  return typeof x['then'] === 'function'
+}
+
+export function Command_open(uriOrLocation: string | Location): Command {
+  const { uri, range } = Location.is(uriOrLocation)
+    ? uriOrLocation
+    : { uri: uriOrLocation, range: undefined }
+  if (uri.startsWith('https') || uri.startsWith('http')) {
+    return {
+      command: 'vscode.open',
+      arguments: [uri],
+      title: 'open',
+    }
+  }
+  return {
+    command: 'vscode.open',
+    arguments: [uri, { selection: range, preserveFocus: true }],
+    title: 'open',
+  }
+}
+
+export function Command_cli(cmd: string, title = 'run...'): Command {
+  cmd = cmd.trim()
+  if (!(cmd.startsWith('rw') || cmd.startsWith('redwood')))
+    cmd = 'redwood ' + cmd
+  return { command: 'redwoodjs.cli', arguments: [cmd], title }
+}
+
+type ReplacePropTypes<T extends {}, Replacements extends {}> = {
+  [K in keyof T]: K extends keyof Replacements ? Replacements[K] : T[K]
 }


### PR DESCRIPTION
* This PR adds the last critical features to the Language Server
* Once this code is published as part of a redwood release, Decoupled Studio will be updated to rely completely on this Language Server, which will (finally) get us to the point where we can have a great VSCode experience which is coming 100% from the Redwood codebase and can evolve from version to version.
* Some of the features in this PR:
  * Outline
    * Improve the performance of the outline. This was achieved by removing abstractions
    * Make the outline API closely match the [TreeView API (in vscode)](https://code.visualstudio.com/api/extension-guides/tree-view) to remove ambiguities
    * Commands in the outline now follow the command API, which makes it possible to define them 100% in the Redwood codebase.
  * Decorations
    * Decorations for Redwood path syntax are now provided by the Language Server via a non-standard method.