### PR TITLE
Make scaffold use @redwoodjs/forms

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
@@ -8,7 +8,7 @@ import {
   NumberField,
   TextAreaField,
   Submit,
-} from '@redwoodjs/web'
+} from '@redwoodjs/forms'
 
 const PostForm = (props) => {
   const onSubmit = (data) => {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -5,7 +5,7 @@ import {
   Label,
   ${fieldsToImport.join(',\n  ')},
   Submit,
-} from '@redwoodjs/web'
+} from '@redwoodjs/forms'
 
 const ${singularPascalName}Form = (props) => {
   const onSubmit = (data) => {

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -38,14 +38,14 @@ export const builder = (yargs) => {
 }
 
 const rwPackages =
-  '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router @redwoodjs/auth'
+  '@redwoodjs/core @redwoodjs/api @redwoodjs/web @redwoodjs/router @redwoodjs/auth @redwoodjs/forms'
 
 // yarn upgrade-interactive does not allow --tags, so we resort to this mess
 // @redwoodjs/auth may not be installed so we add check
 const installTags = (tag, isAuth) => {
   const mainString = `yarn upgrade @redwoodjs/core@${tag} \
   && yarn workspace api upgrade @redwoodjs/api@${tag} \
-  && yarn workspace web upgrade @redwoodjs/web@${tag} @redwoodjs/router@${tag}`
+  && yarn workspace web upgrade @redwoodjs/web@${tag} @redwoodjs/router@${tag} @redwoodjs/forms@${tag}`
 
   const authString = ` @redwoodjs/auth@${tag}`
 

--- a/packages/web/src/form/index.js
+++ b/packages/web/src/form/index.js
@@ -1,9 +1,11 @@
 export * from '@redwoodjs/forms'
 
+import { Form as RealForm } from '@redwoodjs/forms'
+
 /**
  * @deprecated Please import from "@redwoodjs/forms"
  */
-export const Form = () => {
+export const Form = (props) => {
   console.warn(`
   Deprecation notice, forms have moved:
     Pleas use:
@@ -11,5 +13,5 @@ export const Form = () => {
     instead of:
     'import { Form } from "@redwoodjs/web"'
   `)
-  return Form
+  return <RealForm {...props} />
 }


### PR DESCRIPTION
I recently moved the forms from `@redwoodjs/web` into `@redwoodjs/forms`. You are still able to reference them via `@redwoodjs/web`, but I didn't export them properly. This fixes that and a bunch of things I didn't fully appreciate below:
- [x] Make upgrade command aware of the forms package
- [x] Fix web exports
- [x] Make scaffold generator use `@redwoodjs/forms`

Fixes #901