### PR TITLE
Add `yarn rw dev` option to pass any Webpack config as a string

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -19,10 +19,10 @@ export const builder = (yargs) => {
       description: 'Which dev server(s) to start',
       type: 'array',
     })
-    .positional('webpackConfig', {
-      alias: 'wpc',
+    .positional('forward', {
+      alias: 'fwd',
       description:
-        'Optional string of Webpack DevServer config options, e.g. `--wpc="--port=1234"`',
+        'String of one or more Webpack DevServer config options, for example: `--fwd="--port=1234 --open=false"`',
       type: 'string',
     })
     .epilogue(
@@ -33,10 +33,7 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({
-  side = ['api', 'web'],
-  webpackConfig = '',
-}) => {
+export const handler = async ({ side = ['api', 'web'], forward = '' }) => {
   // We use BASE_DIR when we need to effectively set the working dir
   const BASE_DIR = getPaths().base
   // For validation, e.g. dirExists?, we use these
@@ -83,7 +80,7 @@ export const handler = async ({
       command: `cd "${path.join(
         BASE_DIR,
         'web'
-      )}" && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js ${webpackConfig}`,
+      )}" && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js ${forward}`,
       prefixColor: 'blue',
       runWhen: () => fs.existsSync(WEB_DIR_SRC),
     },

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -19,6 +19,12 @@ export const builder = (yargs) => {
       description: 'Which dev server(s) to start',
       type: 'array',
     })
+    .positional('webpackConfig', {
+      alias: 'wpc',
+      description:
+        'Optional string of Webpack DevServer config options, e.g. `--wpc="--port=1234"`',
+      type: 'string',
+    })
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
@@ -27,7 +33,10 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ side = ['api', 'web'] }) => {
+export const handler = async ({
+  side = ['api', 'web'],
+  webpackConfig = '',
+}) => {
   // We use BASE_DIR when we need to effectively set the working dir
   const BASE_DIR = getPaths().base
   // For validation, e.g. dirExists?, we use these
@@ -74,7 +83,7 @@ export const handler = async ({ side = ['api', 'web'] }) => {
       command: `cd "${path.join(
         BASE_DIR,
         'web'
-      )}" && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js`,
+      )}" && yarn webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js ${webpackConfig}`,
       prefixColor: 'blue',
       runWhen: () => fs.existsSync(WEB_DIR_SRC),
     },


### PR DESCRIPTION
Fix #890

This is an alternate, mutual approach to #891 We could merge both and add to CLI docs for `yarn rw dev`

@peterp My approach here is to add a string option to the Yargs command, which could be used to pass any+all Webpack DevServer config options, which will override `webpack.development.js`.

Most importantly --> What do you this of this approach?

Secondarly --> does the code implementation pass your PPSniffTest™?

**edit:** Oh, one question. Should the name of the option be `webpack-config` or `webpackConfig` for CLI option?