### PR TITLE
Fix jest module alias resolution

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -59,7 +59,12 @@ module.exports = {
   overrides: [
     // ** WEB PACKAGES **
     {
-      test: ['./packages/router', './packages/web/', './packages/auth/'],
+      test: [
+        './packages/router',
+        './packages/web/',
+        './packages/auth/',
+        './packages/forms/',
+      ],
       presets: [
         [
           '@babel/preset-env',

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -5,6 +5,8 @@
 const { getPaths } = require('@redwoodjs/internal')
 
 const TARGETS_NODE = '12.16.1'
+// Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
+// because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env
 // Warning! Recommended to specify used minor core-js version, like corejs: '3.6',
 // instead of corejs: 3, since with corejs: 3 will not be injected modules which

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -8,159 +8,158 @@ const TARGETS_NODE = '12.16.1'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env
-// Warning! Recommended to specify used minor core-js version, like corejs: '3.6',
-// instead of corejs: 3, since with corejs: 3 will not be injected modules which
-// were added in minor core-js releases.
 const CORE_JS_VERSION = '3.6'
 
-module.exports = () => ({
-  presets: ['@babel/preset-react', '@babel/preset-typescript'],
-  plugins: [
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    'babel-plugin-macros',
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#core-js-aliasing
-        // Setting the version here also requires `@babel/runtime-corejs3`
-        corejs: { version: 3, proposals: true },
-        // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#version
-        // Transform-runtime assumes that @babel/runtime@7.0.0 is installed.
-        // Specifying the version can result in a smaller bundle size.
-        // TODO: Grab version for package.json
-        version: '^7.8.3',
-      },
-    ],
-    ['babel-plugin-graphql-tag'],
-  ],
-  overrides: [
-    // ** API **
-    {
-      test: './api/',
-      presets: [
-        [
-          '@babel/preset-env',
-          {
-            targets: {
-              node: TARGETS_NODE,
-            },
-            useBuiltIns: 'usage',
-            corejs: {
-              version: CORE_JS_VERSION,
-              // List of supported proposals: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#ecmascript-proposals
-              proposals: true,
-            },
-          },
-        ],
+module.exports = () => {
+  return {
+    presets: ['@babel/preset-react', '@babel/preset-typescript'],
+    plugins: [
+      ['@babel/plugin-proposal-class-properties', { loose: true }],
+      'babel-plugin-macros',
+      [
+        '@babel/plugin-transform-runtime',
+        {
+          // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#core-js-aliasing
+          // Setting the version here also requires `@babel/runtime-corejs3`
+          corejs: { version: 3, proposals: true },
+          // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#version
+          // Transform-runtime assumes that @babel/runtime@7.0.0 is installed.
+          // Specifying the version can result in a smaller bundle size.
+          // TODO: Grab version for package.json
+          version: '^7.8.3',
+        },
       ],
-      plugins: [
-        [
-          'babel-plugin-module-resolver',
-          {
-            alias: {
+      ['babel-plugin-graphql-tag'],
+    ],
+    overrides: [
+      // ** API **
+      {
+        test: './api/',
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              targets: {
+                node: TARGETS_NODE,
+              },
+              useBuiltIns: 'usage',
+              corejs: {
+                version: CORE_JS_VERSION,
+                // List of supported proposals: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#ecmascript-proposals
+                proposals: true,
+              },
+            },
+          ],
+        ],
+        plugins: [
+          [
+            'babel-plugin-module-resolver',
+            {
+              alias: {
                 src:
                   // Jest monorepo and multi project runner is not correctly determining
                   // the `cwd`: https://github.com/facebook/jest/issues/7359
                   process.env.NODE_ENV !== 'test'
                     ? './src'
                     : getPaths().api.src,
-            },
-          },
-        ],
-        [
-          'babel-plugin-auto-import',
-          {
-            declarations: [
-              {
-                // import { context } from '@redwoodjs/api'
-                members: ['context'],
-                path: '@redwoodjs/api',
               },
-              {
-                default: 'gql',
-                path: 'graphql-tag',
-              },
-            ],
-          },
-        ],
-        [require('../dist/babel-plugin-redwood-import-dir')],
-      ],
-    },
-    // ** WEB **
-    {
-      test: './web',
-      presets: [
-        [
-          '@babel/preset-env',
-          {
-            // the targets are set in web/package.json
-            useBuiltIns: 'usage',
-            corejs: {
-              version: CORE_JS_VERSION,
-              proposals: true,
             },
-          },
+          ],
+          [
+            'babel-plugin-auto-import',
+            {
+              declarations: [
+                {
+                  // import { context } from '@redwoodjs/api'
+                  members: ['context'],
+                  path: '@redwoodjs/api',
+                },
+                {
+                  default: 'gql',
+                  path: 'graphql-tag',
+                },
+              ],
+            },
+          ],
+          [require('../dist/babel-plugin-redwood-import-dir')],
         ],
-      ],
-      plugins: [
-        [
-          'babel-plugin-module-resolver',
-          {
-            alias: {
+      },
+      // ** WEB **
+      {
+        test: './web',
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              // the targets are set in web/package.json
+              useBuiltIns: 'usage',
+              corejs: {
+                version: CORE_JS_VERSION,
+                proposals: true,
+              },
+            },
+          ],
+        ],
+        plugins: [
+          [
+            'babel-plugin-module-resolver',
+            {
+              alias: {
                 src:
                   // Jest monorepo and multi project runner is not correctly determining
                   // the `cwd`: https://github.com/facebook/jest/issues/7359
                   process.env.NODE_ENV !== 'test'
                     ? './src'
                     : getPaths().web.src,
+              },
             },
-          },
+          ],
+          [
+            'babel-plugin-auto-import',
+            {
+              declarations: [
+                {
+                  // import { React } from 'react'
+                  default: 'React',
+                  path: 'react',
+                },
+                {
+                  // import PropTypes from 'prop-types'
+                  default: 'PropTypes',
+                  path: 'prop-types',
+                },
+                {
+                  // import gql from 'graphql-tag'
+                  default: 'gql',
+                  path: 'graphql-tag',
+                },
+                {
+                  // import { mockGraphQLQuery, mockGraphQLMutation } from '@redwoodjs/testing'
+                  members: ['mockGraphQLQuery', 'mockGraphQLMutation'],
+                  path: '@redwoodjs/testing',
+                },
+              ],
+            },
+          ],
         ],
-        [
-          'babel-plugin-auto-import',
-          {
-            declarations: [
-              {
-                // import { React } from 'react'
-                default: 'React',
-                path: 'react',
-              },
-              {
-                // import PropTypes from 'prop-types'
-                default: 'PropTypes',
-                path: 'prop-types',
-              },
-              {
-                // import gql from 'graphql-tag'
-                default: 'gql',
-                path: 'graphql-tag',
-              },
-              {
-                // import { mockGraphQLQuery, mockGraphQLMutation } from '@redwoodjs/testing'
-                members: ['mockGraphQLQuery', 'mockGraphQLMutation'],
-                path: '@redwoodjs/testing',
-              },
-            ],
-          },
-        ],
-      ],
-    },
-    // ** Files ending in `Cell.[js,ts]` **
-    {
-      test: /.+Cell.(js|tsx)$/,
-      plugins: [require('../dist/babel-plugin-redwood-cell')],
-    },
-    // Automatically import files in `./web/src/pages/*` in to
-    // the `./web/src/Routes.[ts|jsx]` file.
-    {
-      test: ['./web/src/Routes.js', './web/src/Routes.tsx'],
-      plugins: [require('../dist/babel-plugin-redwood-routes-auto-loader')],
-    },
-    // ** Files ending in `Cell.mock.[js,ts]` **
-    // Automatically determine keys for saving and retrieving mock data.
-    {
-      test: /.+Cell.mock.(js|ts)$/,
-      plugins: [require('../dist/babel-plugin-redwood-mock-cell-data')],
-    },
-  ],
-})
+      },
+      // ** Files ending in `Cell.[js,ts]` **
+      {
+        test: /.+Cell.(js|tsx)$/,
+        plugins: [require('../dist/babel-plugin-redwood-cell')],
+      },
+      // Automatically import files in `./web/src/pages/*` in to
+      // the `./web/src/Routes.[ts|jsx]` file.
+      {
+        test: ['./web/src/Routes.js', './web/src/Routes.tsx'],
+        plugins: [require('../dist/babel-plugin-redwood-routes-auto-loader')],
+      },
+      // ** Files ending in `Cell.mock.[js,ts]` **
+      // Automatically determine keys for saving and retrieving mock data.
+      {
+        test: /.+Cell.mock.(js|ts)$/,
+        plugins: [require('../dist/babel-plugin-redwood-mock-cell-data')],
+      },
+    ],
+  }
+}

--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -2,8 +2,7 @@
  * This is the babel preset used `create-redwood-app`
  */
 
-// TODO: Determine what to do different during development, test, and production
-// TODO: Take a look at create-react-app. They've dropped a ton of knowledge.
+const { getPaths } = require('@redwoodjs/internal')
 
 const TARGETS_NODE = '12.16.1'
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env
@@ -57,7 +56,12 @@ module.exports = () => ({
           'babel-plugin-module-resolver',
           {
             alias: {
-              src: './src',
+                src:
+                  // Jest monorepo and multi project runner is not correctly determining
+                  // the `cwd`: https://github.com/facebook/jest/issues/7359
+                  process.env.NODE_ENV !== 'test'
+                    ? './src'
+                    : getPaths().api.src,
             },
           },
         ],
@@ -101,7 +105,12 @@ module.exports = () => ({
           'babel-plugin-module-resolver',
           {
             alias: {
-              src: './src',
+                src:
+                  // Jest monorepo and multi project runner is not correctly determining
+                  // the `cwd`: https://github.com/facebook/jest/issues/7359
+                  process.env.NODE_ENV !== 'test'
+                    ? './src'
+                    : getPaths().web.src,
             },
           },
         ],

--- a/packages/core/src/configs/browser/jest.createConfig.ts
+++ b/packages/core/src/configs/browser/jest.createConfig.ts
@@ -4,19 +4,16 @@ const path = require('path')
 
 const { getPaths } = require('@redwoodjs/internal')
 
-const redwoodPaths = getPaths()
-
-const NODE_MODULES_PATH = path.join(redwoodPaths.base, 'node_modules')
-
 export default function getBrowserJestConfig() {
+  const redwoodPaths = getPaths()
+  const NODE_MODULES_PATH = path.join(redwoodPaths.base, 'node_modules')
+
   return {
     displayName: {
       color: 'blueBright',
       name: 'web',
     },
     resolver: 'jest-directory-named-resolver',
-    // NOTE: We run the tests with a `cwd` argument that's `getPaths().web.base`
-    // testMatch,
     globals: {
       __REDWOOD__: true,
       __REDWOOD__API_PROXY_PATH: '/',

--- a/packages/core/src/configs/browser/jest.setup.js
+++ b/packages/core/src/configs/browser/jest.setup.js
@@ -12,9 +12,11 @@ const {
 global.mockGraphQLQuery = mockGraphQLQuery
 global.mockGraphQLMutation = mockGraphQLMutation
 
+const project = getProject()
+
 beforeEach(async () => {
   // Import the global mocks.
-  for (const m of getProject().mocks) {
+  for (const m of project.mocks) {
     require(m)
   }
   await startMSW()


### PR DESCRIPTION
This circumvents a bug where jest and babel module aliases could not directly determine their paths.

This code was not release, but if you're running canary, then please clear your jest cache before running tests again: `yarn test --clearCache`

Fixes #872 