### PR TITLE
Document behavior of named route function route params not defined on route

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -134,10 +134,18 @@ If a route has route parameters, then its named route function will take an obje
 
 ```js
 // SomePage.js
-<Link to={routes.user({ id: 7 })} />
+<Link to={routes.user({ id: 7 })} />...</Link>
 ```
 
 All parameters will be converted to strings before being inserted into the generated URL. If you don't like the default JavaScript behavior of how this conversion happens, make sure to convert to a string before passing it into the named route function.
+
+If you specify parameters to the named route function that do not correspond to parameters defined on the route, they will be appended to the end of the generated URL as search params in `key=val` format:
+
+```js
+// SomePage.js
+<Link to={routes.users({ sort: 'desc', filter: 'all' })}>...</Link>
+// => "/users?sort=desc&filter=all"
+```
 
 ## Route parameter types
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -134,7 +134,7 @@ If a route has route parameters, then its named route function will take an obje
 
 ```js
 // SomePage.js
-<Link to={routes.user({ id: 7 })} />...</Link>
+<Link to={routes.user({ id: 7 })}>...</Link>
 ```
 
 All parameters will be converted to strings before being inserted into the generated URL. If you don't like the default JavaScript behavior of how this conversion happens, make sure to convert to a string before passing it into the named route function.


### PR DESCRIPTION
In the Router docs we never say what happens to params you give to a named route function that don't have corresponding params defined on the route. They end up as search params appended to the URL, so let's document that!