### PR TITLE
Fix intermittent connection issues between web and api in devServer

### DIFF
--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -20,9 +20,12 @@ const baseConfig = merge(webpackConfig('development'), {
     port: redwoodConfig.web.port,
     proxy: {
       [redwoodConfig.web.apiProxyPath]: {
-        target: `http://localhost:${redwoodConfig.api.port}`,
+        target: `http://[::1]:${redwoodConfig.api.port}`,
         pathRewrite: {
           [`^${escapeRegExp(redwoodConfig.web.apiProxyPath)}`]: '',
+        },
+        headers: {
+          Connection: 'keep-alive',
         },
       },
     },


### PR DESCRIPTION
See https://github.com/redwoodjs/redwood/issues/923 for more details.

Also adds `Connection: keep-alive` header for better fault tolerance. See https://github.com/webpack/webpack-dev-server/issues/793#issuecomment-444165866