### PR TITLE
Disable SDL parameter type checking

### DIFF
--- a/packages/structure/src/model/RWServiceFunction.ts
+++ b/packages/structure/src/model/RWServiceFunction.ts
@@ -60,7 +60,7 @@ export class RWServiceFunction extends BaseNode {
         const locationNode = this.node.getParameters()[0] ?? this.node
         const { uri, range } = Location_fromNode(locationNode)
         const message = `Parameter mismatch between SDL and implementation ("${p1}" !== "${p2}")`
-        yield {
+        const diagnostic = {
           uri,
           diagnostic: {
             range,
@@ -75,6 +75,8 @@ export class RWServiceFunction extends BaseNode {
             ],
           },
         } as ExtendedDiagnostic
+        // comment out for now (see https://github.com/redwoodjs/redwood/issues/943)
+        if (false) yield diagnostic // eslint-disable-line
       }
 
       // TODO: check that types match


### PR DESCRIPTION
This PR disables SDL parameter type checking, which resulted in errors being shown when parameters were actually valid. 
The implementation was naive. We need to work on this and re-enable the diagnostic check. See #943.