### PR TITLE
dataMigrate exits(1) when failing

### DIFF
--- a/packages/cli/src/commands/generate/dataMigration/dataMigration.js
+++ b/packages/cli/src/commands/generate/dataMigration/dataMigration.js
@@ -71,5 +71,6 @@ export const handler = async (args) => {
     await tasks.run()
   } catch (e) {
     console.log(c.error(e.message))
+    process.exit(1)
   }
 }


### PR DESCRIPTION
Adds process.exit(1) to error handling of <code>yarn rw dataMigrate up</code> as suggested in #942,