### PR TITLE
Make generated pages use named-route functions

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -5,7 +5,7 @@ import {} from 'src/lib/test'
 
 import * as helpers from '../helpers'
 
-const PAGE_TEMPLATE_OUTPUT = `import { Link } from '@redwoodjs/router'
+const PAGE_TEMPLATE_OUTPUT = `import { Link, routes } from '@redwoodjs/router'
 
 const FooBarPage = () => {
   return (
@@ -14,7 +14,7 @@ const FooBarPage = () => {
       <p>Find me in "./web/src/pages/FooBarPage/FooBarPage.js"</p>
       <p>
         My default route is named "fooBar", link to me with \`
-        <Link to="fooBar">routes.fooBar()</Link>\`
+        <Link to={routes.fooBar()}>routes.fooBar()</Link>\`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const ContactUsPage = () => {
   return (
@@ -7,7 +7,7 @@ const ContactUsPage = () => {
       <p>Find me in "./web/src/pages/ContactUsPage/ContactUsPage.js"</p>
       <p>
         My default route is named "contactUs", link to me with `
-        <Link to="contactUs">routes.contactUs()</Link>`
+        <Link to={routes.contactUs()}>routes.contactUs()</Link>`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const CatsPage = () => {
   return (
@@ -7,7 +7,7 @@ const CatsPage = () => {
       <p>Find me in "./web/src/pages/CatsPage/CatsPage.js"</p>
       <p>
         My default route is named "cats", link to me with `
-        <Link to="cats">routes.cats()</Link>`
+        <Link to={routes.cats()}>routes.cats()</Link>`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const HomePage = () => {
   return (
@@ -7,7 +7,7 @@ const HomePage = () => {
       <p>Find me in "./web/src/pages/HomePage/HomePage.js"</p>
       <p>
         My default route is named "home", link to me with `
-        <Link to="home">routes.home()</Link>`
+        <Link to={routes.home()}>routes.home()</Link>`
       </p>
     </>
   )

--- a/packages/cli/src/commands/generate/page/templates/page.js.template
+++ b/packages/cli/src/commands/generate/page/templates/page.js.template
@@ -1,4 +1,4 @@
-import { Link } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 
 const ${pascalName}Page = () => {
   return (
@@ -7,7 +7,7 @@ const ${pascalName}Page = () => {
       <p>Find me in "${outputPath}"</p>
       <p>
         My default route is named "${camelName}",
-        link to me with `<Link to="${camelName}">routes.${camelName}()</Link>`
+        link to me with `<Link to={routes.${camelName}()}>routes.${camelName}()</Link>`
       </p>
     </>
   )


### PR DESCRIPTION
This PR tweaks the page generator; it changes the Link component's `to` prop from a string to a named-routes function:

```diff
- <Link to="contactUs">routes.contactUs()</Link>`
+ <Link to={routes.contactUs()}>routes.contactUs()</Link>`
```