### PR TITLE
Warn instead of error on "prettier" deviations

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -96,7 +96,7 @@ module.exports = {
     mockGraphQLMutation: 'readonly',
   },
   rules: {
-    'prettier/prettier': 'error',
+    'prettier/prettier': 'warn',
     'no-console': 'off',
     'prefer-object-spread': 'warn',
     'prefer-spread': 'warn',


### PR DESCRIPTION
The "error" for Prettier is distracting while editing code . You're typing along and get a red underline for something you could can ignore _entirely_ because when you hit save it resolves automatically.

E.g. here I omitted a space,
<img width="310" alt="Screen Shot 2020-08-09 at 11 53 17 AM" src="https://user-images.githubusercontent.com/21505/89739639-337b5a80-da37-11ea-9a6f-14bdac58761e.png">

And there's this dense error in the Problems pane too,
<img width="726" alt="Screen Shot 2020-08-09 at 11 53 22 AM" src="https://user-images.githubusercontent.com/21505/89739644-42faa380-da37-11ea-8c24-ec56cc847f8e.png">

This PR drops it to a warning to be less demanding of attention. I wish it could simply be turned "off" and still be autofixed within ESlint but I don't think that's supported. Another option is to remove it as a "linting" concern entirely (which it isn't really) and move to hooks like `formatOnSave` and a "style" validation adjacent to whenever ESlint is run. I can file an issue if that's a direction the maintainers are open to.