### PR TITLE
Deploy Generator: fix regex match to skip text in comments

### DIFF
--- a/packages/cli/src/commands/generate/deploy/deploy.js
+++ b/packages/cli/src/commands/generate/deploy/deploy.js
@@ -19,7 +19,7 @@ const updateProxyPath = (newProxyPath) => {
 
   if (redwoodToml.match(/apiProxyPath/)) {
     newRedwoodToml = newRedwoodToml.replace(
-      /apiProxyPath.*/,
+      /apiProxyPath =.*/,
       `apiProxyPath = "${newProxyPath}"`
     )
   } else if (redwoodToml.match(/\[web\]/)) {

--- a/packages/cli/src/commands/generate/deploy/deploy.js
+++ b/packages/cli/src/commands/generate/deploy/deploy.js
@@ -19,7 +19,7 @@ const updateProxyPath = (newProxyPath) => {
 
   if (redwoodToml.match(/apiProxyPath/)) {
     newRedwoodToml = newRedwoodToml.replace(
-      /apiProxyPath =.*/,
+      /apiProxyPath.*/g,
       `apiProxyPath = "${newProxyPath}"`
     )
   } else if (redwoodToml.match(/\[web\]/)) {


### PR DESCRIPTION
Generator currently matches the text in comments above the config. E.g:
<img width="1150" alt="Screen Shot 2020-08-18 at 6 15 01 PM" src="https://user-images.githubusercontent.com/2951/90581737-d1ca9700-e180-11ea-82f3-bad0583c1a21.png">

I've removed that comment line from the CRWA file, but currently installed projects will still have the text and could run into issues if they want to test on Vercel.

