### PR TITLE
support passing coercion functions to form fields

### DIFF
--- a/packages/forms/src/__tests__/form.test.js
+++ b/packages/forms/src/__tests__/form.test.js
@@ -150,4 +150,28 @@ describe('Form', () => {
       expect(input).toHaveFocus()
     })
   })
+
+  it('lets users pass custom coercion functions', async () => {
+    const mockFn = jest.fn()
+    const coercionFunction = (value) => parseInt(value.replace('_', ''), 10)
+
+    render(
+      <Form onSubmit={mockFn}>
+        <TextField
+          name="tf"
+          defaultValue="123_456"
+          dataType={coercionFunction}
+        />
+        <Submit>Save</Submit>
+      </Form>
+    )
+
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(mockFn).toHaveBeenCalledTimes(1))
+    expect(mockFn).toBeCalledWith(
+      { tf: 123456 },
+      expect.anything() // event that triggered the onSubmit call
+    )
+  })
 })

--- a/packages/forms/src/__tests__/form.test.js
+++ b/packages/forms/src/__tests__/form.test.js
@@ -26,11 +26,11 @@ describe('Form', () => {
       <Form onSubmit={onSubmit}>
         <TextField name="tf" defaultValue="text" />
         <NumberField name="nf" defaultValue="42" />
-        <TextField name="ff" defaultValue="3.14" dataType="Float" />
+        <TextField name="ff" defaultValue="3.14" transformValue="Float" />
         <CheckboxField name="cf" defaultChecked={true} />
         <TextAreaField
           name="jf"
-          dataType="Json"
+          transformValue="Json"
           defaultValue={`
             {
               "key_one": "value1",
@@ -63,7 +63,11 @@ describe('Form', () => {
       <Form onSubmit={onSubmit}>
         <p>Some text</p>
         <div className="field">
-          <TextField name="wrapped-ff" defaultValue="3.14" dataType="Float" />
+          <TextField
+            name="wrapped-ff"
+            defaultValue="3.14"
+            transformValue="Float"
+          />
         </div>
         <NumberFieldsWrapper />
         <Submit>Save</Submit>
@@ -160,7 +164,7 @@ describe('Form', () => {
         <TextField
           name="tf"
           defaultValue="123_456"
-          dataType={coercionFunction}
+          transformValue={coercionFunction}
         />
         <Submit>Save</Submit>
       </Form>
@@ -173,5 +177,27 @@ describe('Form', () => {
       { tf: 123456 },
       expect.anything() // event that triggered the onSubmit call
     )
+  })
+
+  it('supports "dataType" prop on input fields with deprecation warning', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {})
+    const mockFn = jest.fn()
+
+    render(
+      <Form onSubmit={mockFn}>
+        <TextField name="tf" defaultValue="3.14" dataType="Float" />
+        <Submit>Save</Submit>
+      </Form>
+    )
+
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(console.warn).toHaveBeenCalledTimes(1))
+    expect(console.warn).toBeCalledWith(
+      'Using the "dataType" prop on form input fields is deprecated. Use "transformValue" instead.'
+    )
+    expect(mockFn).toHaveBeenCalledTimes(1)
+    expect(mockFn).toBeCalledWith({ tf: 3.14 }, expect.anything())
+    spy.mockRestore()
   })
 })

--- a/packages/forms/src/coercion.js
+++ b/packages/forms/src/coercion.js
@@ -36,9 +36,14 @@ export const useCoercion = () => {
 
   const setCoercion = React.useCallback(
     ({ name, type, dataType }) => {
-      const coercionFunction =
-        COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
-        ((value) => value)
+      let coercionFunction
+      if (typeof dataType === 'function') {
+        coercionFunction = dataType
+      } else {
+        coercionFunction =
+          COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
+          ((value) => value)
+      }
 
       coercionContext.setCoercions.call(null, (coercions) => ({
         ...coercions,

--- a/packages/forms/src/coercion.js
+++ b/packages/forms/src/coercion.js
@@ -35,14 +35,15 @@ export const useCoercion = () => {
   )
 
   const setCoercion = React.useCallback(
-    ({ name, type, dataType }) => {
+    ({ name, type, transformValue }) => {
       let coercionFunction
-      if (typeof dataType === 'function') {
-        coercionFunction = dataType
+      if (typeof transformValue === 'function') {
+        coercionFunction = transformValue
       } else {
         coercionFunction =
-          COERCION_FUNCTIONS[dataType || inputTypeToDataTypeMapping[type]] ||
-          ((value) => value)
+          COERCION_FUNCTIONS[
+            transformValue || inputTypeToDataTypeMapping[type]
+          ] || ((value) => value)
       }
 
       coercionContext.setCoercions.call(null, (coercions) => ({

--- a/packages/forms/src/index.js
+++ b/packages/forms/src/index.js
@@ -72,8 +72,9 @@ const inputTagProps = (props) => {
     }
   }
 
-  // dataType shouldn't be passed to the underlying HTML element
+  // dataType/transformValue shouldn't be passed to the underlying HTML element
   delete tagProps.dataType
+  delete tagProps.transformValue
 
   return tagProps
 }
@@ -228,8 +229,16 @@ const TextAreaField = forwardRef((props, ref) => {
   const { setCoercion } = useCoercion()
 
   React.useEffect(() => {
-    setCoercion({ name: props.name, dataType: props.dataType })
-  }, [setCoercion, props.name, props.dataType])
+    if (process.env.NODE_ENV !== 'production' && props.dataType !== undefined) {
+      console.warn(
+        'Using the "dataType" prop on form input fields is deprecated. Use "transformValue" instead.'
+      )
+    }
+    setCoercion({
+      name: props.name,
+      transformValue: props.transformValue || props.dataType,
+    })
+  }, [setCoercion, props.name, props.transformValue, props.dataType])
 
   const tagProps = inputTagProps(props)
 
@@ -274,14 +283,24 @@ const Submit = forwardRef((props, ref) => (
 const InputField = forwardRef((props, ref) => {
   const { register } = useFormContext()
   const { setCoercion } = useCoercion()
-
   React.useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && props.dataType !== undefined) {
+      console.warn(
+        'Using the "dataType" prop on form input fields is deprecated. Use "transformValue" instead.'
+      )
+    }
     setCoercion({
       name: props.name,
       type: props.type,
-      dataType: props.dataType,
+      transformValue: props.transformValue || props.dataType,
     })
-  }, [setCoercion, props.name, props.type, props.dataType])
+  }, [
+    setCoercion,
+    props.name,
+    props.type,
+    props.transformValue,
+    props.dataType,
+  ])
 
   const tagProps = inputTagProps(props)
 


### PR DESCRIPTION
regarding Forms Roadmap: redwoodjs/redwoodjs.com#239

This might be a naive approach, but this PR lets you provide a custom coercion function for a form field. 

Do I need to integrate this with validation error handling somehow?
Thanks!