### PR TITLE
Add Scaffold generator CLI warning when model contains @relation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "@prisma/sdk": "2.4.0",
     "@redwoodjs/internal": "^0.16.0",
     "@redwoodjs/structure": "^0.16.0",
+    "boxen": "^4.2.0",
     "camelcase": "^5.3.1",
     "chalk": "^3.0.0",
     "concurrently": "^5.1.0",

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -8,6 +8,8 @@ import pluralize from 'pluralize'
 import { paramCase } from 'param-case'
 import humanize from 'humanize-string'
 import terminalLink from 'terminal-link'
+import boxen from 'boxen'
+import chalk from 'chalk'
 
 import {
   generateTemplate,
@@ -449,8 +451,26 @@ export const handler = async ({
   const { model, path } = splitPathAndModel(modelArg)
 
   const t = tasks({ model, path, force, typescript, javascript })
+  const schema = await getSchema(pascalcase(pluralize.singular(model)))
+  const line1 =
+    chalk.bold.yellow('WARNING') +
+    `: Because the data model "${pascalcase(model)}" contains a`
+  const line2 = 'Prisma @relation, the generated CRUD code must be manually'
+  const line3 = 'modified to work correctly. See this doc for more info:'
+  const line4 = chalk.underline.blue(
+    'https://redwoodjs.com/docs/schema-relations'
+  )
   try {
     await t.run()
+    if (relationsForModel(schema).length) {
+      console.log(
+        boxen(line1 + '\n' + line2 + '\n' + line3 + '\n' + line4, {
+          padding: 1,
+          margin: 1,
+          borderStyle: 'single',
+        })
+      )
+    }
   } catch (e) {
     console.log(c.error(e.message))
   }


### PR DESCRIPTION
I've added a new doc about Schema Relations, which explains how to manually modify the code generated by Scaffold when the model is relational:
https://redwoodjs.com/docs/schema-relations

This PR attempts the following:
- In the case of `rw g scaffold <model>`, checks if the model is relational
- If it is relational, a Warning is given after the generator CLI output.

The Warning states manual code modification is required and provides a link to the doc.
<img width="500" alt="Screen Shot 2020-08-21 at 12 07 48 AM" src="https://user-images.githubusercontent.com/2951/90862496-5b759280-e342-11ea-818b-6915d99a92be.png">

What say you @peterp? I'm open to any/all suggestions. This isn't meant to be a fix — just trying to smooth out the bumps in the near-term.
