### PR TITLE
add user property to CurrentUser interface

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -10,6 +10,7 @@ import { createAuthClient } from './authClients'
 
 export interface CurrentUser {
   roles?: Array<string>
+  user?: any
 }
 
 export interface AuthContextInterface {


### PR DESCRIPTION
After updating to v0.16.0 I was getting errors in typescript files where I was using currentUser from useAuth hook.
RBAC changes added a roles property to the CurrentUser interface, but not the user property.

This PR fixes that, adding the missing user property to the CurrentUser interface.