### PR TITLE
Fix webpack merge TypeError

### DIFF
--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -1,4 +1,4 @@
-const merge = require('webpack-merge')
+const { merge } = require('webpack-merge')
 const escapeRegExp = require('lodash.escaperegexp')
 const { getConfig } = require('@redwoodjs/internal')
 const ErrorOverlayPlugin = require('error-overlay-webpack-plugin')


### PR DESCRIPTION
We just bumped webpack-merge (https://github.com/redwoodjs/redwood/pull/991) and have to change the way we import the merge function now to avoid this TypeError:

```
web | /home/dominic/projects/redwood/redwood-app/node_modules/@redwoodjs/core/config/webpack.development.js:11
web | const baseConfig = merge(webpackConfig('development'), {
web |                    ^
web | 
web | TypeError: merge is not a function
``` 