### PR TITLE
Add deploy command for api with aws_serverless provider

### DIFF
--- a/packages/cli/src/commands/deploy.js
+++ b/packages/cli/src/commands/deploy.js
@@ -1,0 +1,14 @@
+export const command = 'deploy <command>'
+export const description = 'Deploy your Redwood project.'
+import terminalLink from 'terminal-link'
+
+export const builder = (yargs) =>
+  yargs
+    .commandDir('./deploy', { recurse: true })
+    .demandCommand()
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#deploy'
+      )}`
+    )

--- a/packages/cli/src/commands/deploy/api/__tests__/api.test.js
+++ b/packages/cli/src/commands/deploy/api/__tests__/api.test.js
@@ -1,0 +1,8 @@
+global.__dirname = __dirname
+// import { loadGeneratorFixture } from 'src/lib/test'
+
+// import * as api from '../api'
+
+test('true', () => {
+  expect(true).toEqual(true)
+})

--- a/packages/cli/src/commands/deploy/api/api.js
+++ b/packages/cli/src/commands/deploy/api/api.js
@@ -89,5 +89,6 @@ export const handler = async ({ provider }) => {
     await deploy
   } catch (e) {
     console.log(c.error(e.message))
+    process.exit(1)
   }
 }

--- a/packages/cli/src/commands/deploy/api/api.js
+++ b/packages/cli/src/commands/deploy/api/api.js
@@ -1,0 +1,93 @@
+import fs from 'fs'
+import path from 'path'
+
+import terminalLink from 'terminal-link'
+import execa from 'execa'
+import Listr from 'listr'
+
+import c from 'src/lib/colors'
+import { getPaths } from 'src/lib'
+
+const SUPPORTED_PROVIDERS = fs
+  .readdirSync(path.resolve(__dirname, 'providers'))
+  .map((file) => path.basename(file, '.js'))
+  .filter((file) => file !== 'README.md')
+
+export const command = 'api <provider>'
+export const description = 'Deploy the API using the selected provider'
+export const builder = (yargs) => {
+  yargs
+    .positional('provider', {
+      choices: SUPPORTED_PROVIDERS,
+      description: 'API Deploy provider to configure',
+      type: 'string',
+    })
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/reference/command-line-interface#deploy-api'
+      )}`
+    )
+}
+
+export const handler = async ({ provider }) => {
+  const BASE_DIR = getPaths().base
+  const providerData = await import(`./providers/${provider}`)
+
+  const tasks = new Listr(
+    [
+      providerData.preRequisites &&
+        providerData.preRequisites.length > 0 && {
+          title: 'Checking pre-requisites',
+          task: () =>
+            new Listr(
+              providerData.preRequisites.map((preReq) => {
+                return {
+                  title: preReq.title,
+                  task: async () => {
+                    try {
+                      await execa(...preReq.command)
+                    } catch (error) {
+                      error.message =
+                        error.message + '\n' + preReq.errorMessage.join(' ')
+                      throw error
+                    }
+                  },
+                }
+              })
+            ),
+        },
+      {
+        title: 'Building and Packaging...',
+        task: () =>
+          new Listr(
+            providerData.buildCommands.map((commandDetail) => {
+              return {
+                title: commandDetail.title,
+                task: async () => {
+                  await execa(...commandDetail.command, {
+                    cwd: BASE_DIR,
+                  })
+                },
+              }
+            }),
+            { collapse: false }
+          ),
+      },
+    ].filter(Boolean),
+    { collapse: false }
+  )
+
+  try {
+    await tasks.run()
+
+    console.log(c.green(providerData.deployCommand.title))
+    const deploy = execa(...providerData.deployCommand.command, {
+      cwd: BASE_DIR,
+    })
+    deploy.stdout.pipe(process.stdout)
+    await deploy
+  } catch (e) {
+    console.log(c.error(e.message))
+  }
+}

--- a/packages/cli/src/commands/deploy/api/providers/aws_serverless.js
+++ b/packages/cli/src/commands/deploy/api/providers/aws_serverless.js
@@ -1,0 +1,34 @@
+export const preRequisites = [
+  {
+    title: 'Checking if serverless is installed...',
+    command: ['serverless', ['--version']],
+    errorMessage: [
+      'Looks like serverless is not installed.',
+      'Please follow the steps at https://www.serverless.com/framework/docs/providers/aws/guide/installation/ to install serverless.',
+    ],
+  },
+  {
+    title: 'Checking if @netlify/zip-it-and-ship-it is installed...',
+    command: ['yarn', ['zip-it-and-ship-it', '--version']],
+    errorMessage: [
+      'Looks like @netlify/zip-it-and-ship-it is not installed.',
+      'Either run `yarn rw g deploy aws_serverless` or add it seperately as a dev dependency in the api workspace.',
+    ],
+  },
+]
+
+export const buildCommands = [
+  { title: 'Building API...', command: ['yarn', ['rw', 'build', 'api']] },
+  {
+    title: 'Packaging API...',
+    command: [
+      'yarn',
+      ['zip-it-and-ship-it', 'api/dist/functions/', 'api/dist/zipball'],
+    ],
+  },
+]
+
+export const deployCommand = {
+  title: 'Deploying...',
+  command: ['serverless', ['deploy']],
+}


### PR DESCRIPTION
## Ideally this PR should be merged after https://github.com/redwoodjs/redwood/pull/976

Addresses part 2 of https://github.com/redwoodjs/redwood/issues/431#issuecomment-676357234

For the last deploy command, we need to stream the output of the `serverless` command because it will contain the outputs of the serverless functions and also other important information. I tried streaming the output in `listr` and looked around as well, but it doesn't allow easy streaming of stdout. So I added the deploy command separately at the end. Let me know if someone has a better suggestion.