### PR TITLE
Auth RBAC, hasRole accepts a single role or an array of roles

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -31,6 +31,10 @@ const mapAuthClientAuth0 = (client: Auth0): AuthClientAuth0 => {
       const user = await client.getUser()
       return user || null
     },
+    getUserMetadata: async () => {
+      const user = await client.getUser()
+      return user || null
+    },
   }
 }
 ```

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -30,9 +30,11 @@ export interface AuthContextInterface {
   getCurrentUser(): Promise<null | CurrentUser>
   /**
    * Checks if the "currentUser" from the api side
-   * is assigned a role
+   * is assigned a role or one of a list of roles.
+   * If the user is assigned any of the provided list of roles,
+   * the hasRole is considered to be true.
    **/
-  hasRole(role: string): boolean
+  hasRole(role: string | string[]): boolean
   /**
    * Redetermine authentication state and update the state.
    */
@@ -135,8 +137,35 @@ export class AuthProvider extends React.Component<
     }
   }
 
-  hasRole = (role: string): boolean => {
-    return this.state.currentUser?.roles?.includes(role) || false
+  /**
+   * @example
+   * ```js
+   *  hasRole("editor")
+   *  hasRole(["editor"])
+   *  hasRole(["editor", "author"])
+   * ```
+   *
+   * Checks if the "currentUser" from the api side
+   * is assigned a role or one of a list of roles.
+   * If the user is assigned any of the provided list of roles,
+   * the hasRole is considered to be true.
+   */
+  hasRole = (role: string | string[]): boolean => {
+    if (
+      typeof role !== 'undefined' &&
+      this.state.currentUser &&
+      this.state.currentUser.roles
+    ) {
+      if (typeof role === 'string') {
+        return this.state.currentUser.roles?.includes(role) || false
+      }
+
+      if (Array.isArray(role)) {
+        return this.state.currentUser.roles.some((r) => role.includes(r))
+      }
+    }
+
+    return false
   }
 
   reauthenticate = async () => {

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -79,6 +79,11 @@ const AuthConsumer = () => {
           </p>
           <p>Has Admin: {hasRole('admin') ? 'yes' : 'no'}</p>
           <p>Has Super User: {hasRole('superuser') ? 'yes' : 'no'}</p>
+          <p>Has Admin as Array: {hasRole(['admin']) ? 'yes' : 'no'}</p>
+          <p>Has Editor: {hasRole(['editor', 'publisher']) ? 'yes' : 'no'}</p>
+          <p>
+            Has Editor or Author: {hasRole(['editor', 'author']) ? 'yes' : 'no'}
+          </p>
 
           <button onClick={() => reauthenticate()}>Update auth data</button>
         </>
@@ -482,6 +487,271 @@ test('Authenticated user has not been assigned some role access but not others a
 
   expect(screen.getByText('Has Admin: yes')).toBeInTheDocument()
   expect(screen.getByText('Has Super User: no')).toBeInTheDocument()
+
+  // Log out
+  fireEvent.click(screen.getByText('Log Out'))
+  await waitFor(() => screen.getByText('Log In'))
+
+  done()
+})
+
+/**
+ * Check assigned role access when specified as single array element
+ */
+test('Authenticated user has assigned role access as expected', async (done) => {
+  const mockAuthClient: AuthClient = {
+    login: async () => {
+      return true
+    },
+    logout: async () => {},
+    getToken: async () => 'hunter2',
+    getUserMetadata: jest.fn(async () => {
+      return null
+    }),
+    hasRole: jest.fn(async () => {
+      return null
+    }),
+    client: () => {},
+    type: 'custom',
+  }
+
+  CURRENT_USER_DATA = {
+    name: 'Peter Pistorius',
+    email: 'nospam@example.net',
+    roles: ['admin'],
+  }
+
+  render(
+    <AuthProvider client={mockAuthClient} type="custom">
+      <AuthConsumer />
+    </AuthProvider>
+  )
+
+  // We're booting up!
+  expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+  // The user is not authenticated
+  await waitFor(() => screen.getByText('Log In'))
+
+  expect(screen.queryByText('Has Admin:')).not.toBeInTheDocument()
+  expect(screen.queryByText('Has Super User:')).not.toBeInTheDocument()
+
+  // Replace "getUserMetadata" with actual data, and login!
+  mockAuthClient.getUserMetadata = jest.fn(async () => {
+    return {
+      sub: 'abcdefg|123456',
+      username: 'peterp',
+    }
+  })
+  fireEvent.click(screen.getByText('Log In'))
+
+  // Check that you're logged in!
+  await waitFor(() => screen.getByText('Log Out'))
+
+  mockAuthClient.hasRole = jest.fn(async () => {
+    return true
+  })
+
+  expect(screen.getByText('Has Admin as Array: yes')).toBeInTheDocument()
+
+  // Log out
+  fireEvent.click(screen.getByText('Log Out'))
+  await waitFor(() => screen.getByText('Log In'))
+
+  done()
+})
+
+/**
+ * Check assigned role access when specified as array element
+ */
+test('Authenticated user has assigned role access as expected', async (done) => {
+  const mockAuthClient: AuthClient = {
+    login: async () => {
+      return true
+    },
+    logout: async () => {},
+    getToken: async () => 'hunter2',
+    getUserMetadata: jest.fn(async () => {
+      return null
+    }),
+    hasRole: jest.fn(async () => {
+      return null
+    }),
+    client: () => {},
+    type: 'custom',
+  }
+
+  CURRENT_USER_DATA = {
+    name: 'Peter Pistorius',
+    email: 'nospam@example.net',
+    roles: ['admin'],
+  }
+
+  render(
+    <AuthProvider client={mockAuthClient} type="custom">
+      <AuthConsumer />
+    </AuthProvider>
+  )
+
+  // We're booting up!
+  expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+  // The user is not authenticated
+  await waitFor(() => screen.getByText('Log In'))
+
+  expect(screen.queryByText('Has Admin:')).not.toBeInTheDocument()
+  expect(screen.queryByText('Has Super User:')).not.toBeInTheDocument()
+
+  // Replace "getUserMetadata" with actual data, and login!
+  mockAuthClient.getUserMetadata = jest.fn(async () => {
+    return {
+      sub: 'abcdefg|123456',
+      username: 'peterp',
+    }
+  })
+  fireEvent.click(screen.getByText('Log In'))
+
+  // Check that you're logged in!
+  await waitFor(() => screen.getByText('Log Out'))
+
+  mockAuthClient.hasRole = jest.fn(async () => {
+    return true
+  })
+
+  expect(screen.getByText('Has Admin as Array: yes')).toBeInTheDocument()
+
+  // Log out
+  fireEvent.click(screen.getByText('Log Out'))
+  await waitFor(() => screen.getByText('Log In'))
+
+  done()
+})
+
+/**
+ * Check if assigned one of the roles in an array
+ */
+test('Authenticated user has assigned role access as expected', async (done) => {
+  const mockAuthClient: AuthClient = {
+    login: async () => {
+      return true
+    },
+    logout: async () => {},
+    getToken: async () => 'hunter2',
+    getUserMetadata: jest.fn(async () => {
+      return null
+    }),
+    hasRole: jest.fn(async () => {
+      return null
+    }),
+    client: () => {},
+    type: 'custom',
+  }
+
+  CURRENT_USER_DATA = {
+    name: 'Peter Pistorius',
+    email: 'nospam@example.net',
+    roles: ['editor'],
+  }
+
+  render(
+    <AuthProvider client={mockAuthClient} type="custom">
+      <AuthConsumer />
+    </AuthProvider>
+  )
+
+  // We're booting up!
+  expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+  // The user is not authenticated
+  await waitFor(() => screen.getByText('Log In'))
+
+  expect(screen.queryByText('Has Admin:')).not.toBeInTheDocument()
+  expect(screen.queryByText('Has Super User:')).not.toBeInTheDocument()
+
+  // Replace "getUserMetadata" with actual data, and login!
+  mockAuthClient.getUserMetadata = jest.fn(async () => {
+    return {
+      sub: 'abcdefg|123456',
+      username: 'peterp',
+    }
+  })
+  fireEvent.click(screen.getByText('Log In'))
+
+  // Check that you're logged in!
+  await waitFor(() => screen.getByText('Log Out'))
+
+  mockAuthClient.hasRole = jest.fn(async () => {
+    return true
+  })
+
+  expect(screen.getByText('Has Editor: yes')).toBeInTheDocument()
+
+  // Log out
+  fireEvent.click(screen.getByText('Log Out'))
+  await waitFor(() => screen.getByText('Log In'))
+
+  done()
+})
+
+/**
+ * Check if not assigned any of the roles in an array
+ */
+test('Authenticated user has assigned role access as expected', async (done) => {
+  const mockAuthClient: AuthClient = {
+    login: async () => {
+      return true
+    },
+    logout: async () => {},
+    getToken: async () => 'hunter2',
+    getUserMetadata: jest.fn(async () => {
+      return null
+    }),
+    hasRole: jest.fn(async () => {
+      return null
+    }),
+    client: () => {},
+    type: 'custom',
+  }
+
+  CURRENT_USER_DATA = {
+    name: 'Peter Pistorius',
+    email: 'nospam@example.net',
+    roles: ['admin'],
+  }
+
+  render(
+    <AuthProvider client={mockAuthClient} type="custom">
+      <AuthConsumer />
+    </AuthProvider>
+  )
+
+  // We're booting up!
+  expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+  // The user is not authenticated
+  await waitFor(() => screen.getByText('Log In'))
+
+  expect(screen.queryByText('Has Admin:')).not.toBeInTheDocument()
+  expect(screen.queryByText('Has Super User:')).not.toBeInTheDocument()
+
+  // Replace "getUserMetadata" with actual data, and login!
+  mockAuthClient.getUserMetadata = jest.fn(async () => {
+    return {
+      sub: 'abcdefg|123456',
+      username: 'peterp',
+    }
+  })
+  fireEvent.click(screen.getByText('Log In'))
+
+  // Check that you're logged in!
+  await waitFor(() => screen.getByText('Log Out'))
+
+  mockAuthClient.hasRole = jest.fn(async () => {
+    return true
+  })
+  expect(screen.getByText('Has Admin: yes')).toBeInTheDocument()
+  expect(screen.getByText('Has Editor: no')).toBeInTheDocument()
+  expect(screen.getByText('Has Editor or Author: no')).toBeInTheDocument()
 
   // Log out
   fireEvent.click(screen.getByText('Log Out'))

--- a/packages/cli/src/commands/generate/auth/templates/auth.js.template
+++ b/packages/cli/src/commands/generate/auth/templates/auth.js.template
@@ -62,7 +62,7 @@ import { AuthenticationError, ForbiddenError, parseJWT } from '@redwoodjs/api'
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param {string=} role - An optional role
+ * @param {string=, string[]=} role - An optional role
  *
  * @example - No role-based access control.
  *
@@ -106,8 +106,9 @@ export const getCurrentUser = async (decoded, { _token, _type }) => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param {string=} role - An optional role
- *
+ * @param {string=} roles - An optional role or list of roles
+ * @param {string[]=} roles - An optional list of roles
+
  * @example
  *
  * // checks if currentUser is authenticated
@@ -115,9 +116,10 @@ export const getCurrentUser = async (decoded, { _token, _type }) => {
  *
  * @example
  *
- * // checks if currentUser is authenticated and assigned a role
+ * // checks if currentUser is authenticated and assigned one of the given roles
  * requireAuth({ role: 'admin' })
- *
+ * requireAuth({ role: ['editor', 'author'] })
+ * requireAuth({ role: ['publisher'] })
  */
 export const requireAuth = ({ role } = {}) => {
   if (!context.currentUser) {
@@ -126,7 +128,16 @@ export const requireAuth = ({ role } = {}) => {
 
   if (
     typeof role !== 'undefined' &&
+    typeof role === 'string' &&
     !context.currentUser.roles?.includes(role)
+  ) {
+    throw new ForbiddenError("You don't have access to do that.")
+  }
+
+  if (
+    typeof role !== 'undefined' &&
+    Array.isArray(role) &&
+    !context.currentUser.roles?.some((r) => role.includes(r))
   ) {
     throw new ForbiddenError("You don't have access to do that.")
   }

--- a/packages/router/src/index.d.ts
+++ b/packages/router/src/index.d.ts
@@ -26,7 +26,7 @@ declare module '@redwoodjs/router' {
      * they will be redirected to the route name passed to `unauthenticated`.
      */
     unauthenticated: namedRoute
-    role: string | string[]
+    role?: string | string[]
     children: Array<typeof Route>
   }>
 

--- a/packages/router/src/index.d.ts
+++ b/packages/router/src/index.d.ts
@@ -21,10 +21,12 @@ declare module '@redwoodjs/router' {
    */
   const Private: React.FunctionComponent<{
     /**
-     * When a user is not authenticated and attempts to visit a route within private,
+     * When a user is not authenticated or is not assigned a role
+     * and attempts to visit a route within private,
      * they will be redirected to the route name passed to `unauthenticated`.
      */
     unauthenticated: namedRoute
+    role: string | string[]
     children: Array<typeof Route>
   }>
 

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -31,7 +31,7 @@ Private.propTypes = {
    * The page name where a user will be redirected when not authenticated.
    */
   unauthenticated: PropTypes.string.isRequired,
-  role: PropTypes.string,
+  role: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 }
 
 const PrivatePageLoader = ({


### PR DESCRIPTION
This PR addresses https://github.com/redwoodjs/redwood/issues/977

In AuthProvider `hasRole()` now accepts a single string role or an array of strings/

```js
  /**
   * @example
   * ```js
   *  hasRole("editor")
   *  hasRole(["editor"])
   *  hasRole(["editor", "author"])
   * ```
   *
   * Checks if the "currentUser" from the api side
   * is assigned a role or one of a list of roles.
   * If the user is assigned any of the provided list of roles,
   * the hasRole is considered to be true.
   */
```

This can be used in routes:

```js
<Private unauthenticated="home" role="admin">
  <Route path="/admin/users" page={UsersPage} name="users" />
</Private>

<Private unauthenticated="home" role={['admin', 'editor']}>
  <Route path="/settings" page={SettingsPage} name="settings" />
</Private>
```

and in pages, cells, components:

```js
{isAuthenticated &&
  hasRole(['admin', 'author', 'editor', 'publisher']) && (
    <NavLink
...
```

or

```js
{isAuthenticated && hasRole('admin') && (
  <NavLink
```

Change made to:

* AuthProvider
* In Private route
* Auth generator `auth.js` template 

TODO: RedwoodJS.com docs need to be updated