### PR TITLE
Add "api-server" package

### DIFF
--- a/packages/api-server/.babelrc.js
+++ b/packages/api-server/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = { extends: '../../babel.config.js' }

--- a/packages/api-server/ambient.d.ts
+++ b/packages/api-server/ambient.d.ts
@@ -1,0 +1,14 @@
+declare module '@babel/register' {
+  export default function (options: any): void
+}
+
+declare module 'youch' {
+  export default class {
+    constructor(error: Error)
+    toJSON(): object
+  }
+}
+
+declare module 'youch-terminal' {
+  export default function (json: object): string
+}

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@redwoodjs/api-server",
+  "description": "Redwood's HTTP server for Serverless Functions",
+  "version": "0.15.3",
+  "bin": {
+    "api-server": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@babel/register": "^7.9.0",
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "morgan": "^1.10.0",
+    "qs": "^6.9.3",
+    "require-dir": "^1.2.0",
+    "yargs": "^15.3.1",
+    "youch": "^2.0.10",
+    "youch-terminal": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.46",
+    "@types/express": "^4.17.3",
+    "@types/morgan": "^1.9.0",
+    "@types/qs": "^6.9.1",
+    "@types/require-dir": "^1.0.1"
+  },
+  "scripts": {
+    "build": "yarn build:js",
+    "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
+    "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
+    "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\""
+  },
+  "gitHead": "1cb7c8d1085147787209af423c33a9c91c3e6517"
+}

--- a/packages/api-server/src/error.ts
+++ b/packages/api-server/src/error.ts
@@ -1,0 +1,10 @@
+import Youch from 'youch'
+import forTerminal from 'youch-terminal'
+
+/**
+ * This function will print a pretty version of an error in the terminal.
+ */
+export const handleError = async (error: Error): Promise<string> => {
+  const output = await new Youch(error).toJSON()
+  return forTerminal(output)
+}

--- a/packages/api-server/src/http.ts
+++ b/packages/api-server/src/http.ts
@@ -1,0 +1,56 @@
+import type { Response, Request } from 'express'
+import express from 'express'
+import morgan from 'morgan'
+import bodyParser from 'body-parser'
+
+export interface Lambdas {
+  [path: string]: any
+}
+let LAMBDA_FUNCTIONS: Lambdas = {}
+export const setLambdaFunctions = (functions: Lambdas): void => {
+  LAMBDA_FUNCTIONS = functions
+}
+
+export const server = ({
+  requestHandler,
+}: {
+  requestHandler: (req: Request, res: Response, lambdaFunction: any) => void
+}): any => {
+  const app = express()
+  app.use(
+    bodyParser.text({
+      type: ['text/*', 'application/json', 'multipart/form-data'],
+    })
+  )
+  app.use(bodyParser.raw({ type: '*/*' }))
+  app.use(morgan('dev'))
+
+  app.all('/', (_, res) => {
+    return res.send(`
+      <p>The following serverless Functions are available:</p>
+      <ol>
+        ${Object.keys(LAMBDA_FUNCTIONS)
+          .sort()
+          .map((name) => `<li><a href="/${name}">/${name}</a></li>`)
+          .join('')}
+      </ol>
+    `)
+  })
+
+  const lambdaHandler = async (req: Request, res: Response): Promise<void> => {
+    const { routeName } = req.params
+    const lambdaFunction = LAMBDA_FUNCTIONS[routeName]
+    if (!lambdaFunction) {
+      const errorMessage = `Function "${routeName}" was not found.`
+      console.error(errorMessage)
+      res.status(404).send(errorMessage)
+      return
+    }
+    await requestHandler(req, res, lambdaFunction)
+  }
+
+  app.all('/:routeName', lambdaHandler)
+  app.all('/:routeName/*', lambdaHandler)
+
+  return app
+}

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import path from 'path'
+import yargs from 'yargs'
+import requireDir from 'require-dir'
+
+import { server, setLambdaFunctions } from './http'
+import { requestHandler } from './requestHandlers/awsLambda'
+
+const { port, functions } = yargs
+  .option('port', { default: 8911, type: 'number' })
+  .option('functions', {
+    alias: 'f',
+    required: true,
+    type: 'string',
+    desc: 'The path where your Serverless Functions are stored',
+  }).argv
+
+if (process.env.NODE_ENV !== 'production') {
+  console.info(`NODE_ENV ${process.env.NODE_ENV}`)
+  // Transpile files during development,
+  // this command has to be run from the "api" directory.
+  const babelRequireHook = require('@babel/register')
+  babelRequireHook({
+    extends: path.join(process.cwd(), '.babelrc.js'),
+    extensions: ['.js', '.ts'],
+    only: [process.cwd()],
+    ignore: ['node_modules'],
+    cache: false,
+  })
+}
+
+const serverlessFunctions = requireDir(path.join(process.cwd(), functions), {
+  recurse: false,
+  extensions: ['.js', '.ts'],
+})
+
+try {
+  server({ requestHandler }).listen(port, () => {
+    console.log(`http://localhost:${port}`)
+    setLambdaFunctions(serverlessFunctions)
+  })
+} catch (e) {
+  console.error(e)
+  process.exit(1)
+}

--- a/packages/api-server/src/requestHandlers/awsLambda.ts
+++ b/packages/api-server/src/requestHandlers/awsLambda.ts
@@ -1,0 +1,129 @@
+import type { APIGatewayProxyResult, APIGatewayProxyEvent } from 'aws-lambda'
+import type { Response, Request } from 'express'
+import qs from 'qs'
+
+import { handleError } from '../error'
+
+export const parseBody = (rawBody: string | Buffer) => {
+  if (typeof rawBody === 'string') {
+    return { body: rawBody, isBase64Encoded: false }
+  }
+  if (rawBody instanceof Buffer) {
+    return { body: rawBody.toString('base64'), isBase64Encoded: true }
+  }
+  return { body: '', isBase64Encoded: false }
+}
+
+const lambdaEventForExpressRequest = (
+  request: Request
+): APIGatewayProxyEvent => {
+  return {
+    httpMethod: request.method,
+    headers: request.headers,
+    path: request.path,
+    queryStringParameters: qs.parse(request.url.split(/\?(.+)/)[1]),
+    requestContext: {
+      identity: {
+        sourceIp: request.ip,
+      },
+    },
+    ...parseBody(request.body), // adds `body` and `isBase64Encoded`
+  } as APIGatewayProxyEvent
+}
+
+const expressResponseForLambdaResult = (
+  expressResFn: Response,
+  lambdaResult: APIGatewayProxyResult
+) => {
+  const { statusCode = 200, headers, body = '' } = lambdaResult
+
+  if (headers) {
+    Object.keys(headers).forEach((headerName) => {
+      const headerValue: any = headers[headerName]
+      expressResFn.setHeader(headerName, headerValue)
+    })
+  }
+  expressResFn.status(statusCode)
+
+  // We're using this to log GraphQL errors, this isn't the right place.
+  // I can't seem to get the express middleware to play nicely.
+  if (statusCode === 400) {
+    try {
+      const b = JSON.parse(body)
+      if (b?.errors?.[0]) {
+        const { message } = b.errors[0]
+        const e = new Error(message)
+        e.stack = ''
+        handleError(e).then(console.log)
+      }
+    } catch (e) {
+      // do nothing
+    }
+  }
+
+  // The AWS lambda docs specify that the response object must be
+  // compatible with `JSON.stringify`, but the type definition specifices that
+  // it must be a string.
+  if (typeof body === 'string') {
+    expressResFn.send(body)
+  } else {
+    expressResFn.json(body)
+  }
+}
+
+const expressResponseForLambdaError = (
+  expressResFn: Response,
+  error: Error
+) => {
+  handleError(error).then(console.log)
+  expressResFn.status(500).send()
+}
+
+export const requestHandler = async (
+  req: Request,
+  res: Response,
+  lambdaFunction: any
+) => {
+  const { routeName } = req.params
+  const { handler } = lambdaFunction
+
+  // TODO: Move this to http.
+  if (typeof handler !== 'function') {
+    const errorMessage = `"${routeName}" does not export a function named "handler"`
+    console.error(errorMessage)
+    res.status(500).send(errorMessage)
+  }
+
+  // We take the express request object and convert it into a lambda function event.
+  const event = lambdaEventForExpressRequest(req)
+
+  const handlerCallback = (expressResFn: Response) => (
+    error: Error,
+    lambdaResult: APIGatewayProxyResult
+  ) => {
+    if (error) {
+      expressResponseForLambdaError(expressResFn, error)
+      return
+    }
+
+    expressResponseForLambdaResult(expressResFn, lambdaResult)
+  }
+
+  // Execute the lambda function.
+  // https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html
+  const handlerPromise = handler(
+    event,
+    {}, // TODO: Add support for context: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/0bb210867d16170c4a08d9ce5d132817651a0f80/types/aws-lambda/index.d.ts#L443-L467
+    handlerCallback(res)
+  )
+
+  // In this case the handlerCallback should not be called.
+  if (handlerPromise && typeof handlerPromise.then === 'function') {
+    try {
+      const lambaResponse = await handlerPromise
+      return expressResponseForLambdaResult(res, lambaResponse)
+    } catch (error) {
+      return expressResponseForLambdaError(res, error)
+    }
+  }
+}

--- a/packages/api-server/tsconfig.json
+++ b/packages/api-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.compilerOption.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "outDir": "dist",
+  },
+  "include": ["src", "ambient.d.ts"],
+  "references": [{ "path": "../internal" }]
+}

--- a/packages/cli/src/redwood-tools.js
+++ b/packages/cli/src/redwood-tools.js
@@ -14,6 +14,7 @@ const RW_BINS = {
   'redwood-tools': 'cli/dist/redwood-tools.js',
   rwt: 'cli/dist/redwood-tools.js',
   'dev-server': 'dev-server/dist/main.js',
+  'api-server': 'api-server/dist/index.js',
 }
 
 export const resolveFrameworkPath = (RW_PATH) => {

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -3,7 +3,6 @@
   "description": "Redwood's HTTP server for serverless Functions",
   "version": "0.16.0",
   "bin": {
-    "redwood-http-server": "./dist/main.js",
     "dev-server": "./dist/main.js"
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "packages/testing" },
     { "path": "packages/api" },
     { "path": "packages/dev-server" },
+    { "path": "packages/api-server" },
     { "path": "packages/auth" },
   ],
   "files": []


### PR DESCRIPTION
We're getting ready to split apart the concept of the "dev-server" which watches the api side for changes and reloads the serverless functions when a change is detected. 

Splitting these two concepts will give us greater abilities to generate code, and give people the ability to self-host Redwood projects on their own infrastructure.

So, we'll create two separate processes : one for watching files and performing actions in response to a change, and another for serving serverless functions over http (`api-server`).

