### PR TITLE
Fix tailwind generator

### DIFF
--- a/packages/cli/src/commands/generate/util/tailwind/templates/postcss.config.js.template
+++ b/packages/cli/src/commands/generate/util/tailwind/templates/postcss.config.js.template
@@ -2,7 +2,7 @@ const path = require('path')
 
 module.exports = {
   plugins: [
-    require('tailwindcss')(__dirname, '../tailwind.config.js')),
+    require('tailwindcss')(path.resolve(__dirname, '../tailwind.config.js')),
     require('autoprefixer'),
   ],
 }


### PR DESCRIPTION
This PR fixes the tailwind utility generator. I forgot to add `path.resolve` to postcss.config.js. @thedavidprice I'm going to do the appending-the-directives-to-index.css in another PR because this fix is a matter of the generator being broken or not.