### PR TITLE
Add supabase auth provider

### DIFF
--- a/packages/api/src/auth/decoders/index.ts
+++ b/packages/api/src/auth/decoders/index.ts
@@ -12,6 +12,7 @@ const typesToDecoders: Record<SupportedAuthTypes, Function> = {
   goTrue: netlify,
   magicLink: noop,
   firebase: noop,
+  supabase: noop,
   custom: noop,
 }
 

--- a/packages/api/src/functions/authDecoder.test.ts
+++ b/packages/api/src/functions/authDecoder.test.ts
@@ -97,6 +97,15 @@ describe('Uses correct Auth decoder', () => {
     expect(output).toEqual(MOCKED_JWT)
   })
 
+  it('returns undecoded token for supabase', async () => {
+    const output = await decodeToken('supabase', MOCKED_JWT, {
+      event: mockedAPIGatewayProxyEvent,
+      context: {},
+    })
+
+    expect(output).toEqual(MOCKED_JWT)
+  })
+
   it('returns undecoded token for unknown values', async () => {
     const output = await decodeToken('SOMETHING_ELSE!', MOCKED_JWT, {
       event: mockedAPIGatewayProxyEvent,

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,7 +16,8 @@
     "gotrue-js": "git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb",
     "magic-sdk": "^2.5.0",
     "netlify-identity-widget": "1.9.1",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "@supabase/supabase-js": "^0.36.4"
   },
   "bundlesize": [
     {

--- a/packages/auth/src/authClients/index.ts
+++ b/packages/auth/src/authClients/index.ts
@@ -3,6 +3,7 @@ import type { Auth0, Auth0User } from './auth0'
 import type { GoTrue, GoTrueUser } from './goTrue'
 import type { MagicLink, MagicUser } from './magicLink'
 import type { Firebase } from './firebase'
+import type { Supabase, SupabaseUser } from './supabase'
 import type { Custom } from './custom'
 //
 import { netlify } from './netlify'
@@ -10,6 +11,7 @@ import { auth0 } from './auth0'
 import { goTrue } from './goTrue'
 import { magicLink } from './magicLink'
 import { firebase } from './firebase'
+import { supabase } from './supabase'
 import { custom } from './custom'
 
 const typesToClients = {
@@ -18,6 +20,7 @@ const typesToClients = {
   goTrue,
   magicLink,
   firebase,
+  supabase,
   /** Don't we support your auth client? No problem, define your own the `custom` type! */
   custom,
 }
@@ -28,6 +31,7 @@ export type SupportedAuthClients =
   | NetlifyIdentity
   | MagicLink
   | Firebase
+  | Supabase
   | Custom
 
 export type SupportedAuthTypes = keyof typeof typesToClients
@@ -35,7 +39,8 @@ export type SupportedAuthTypes = keyof typeof typesToClients
 export type { Auth0User }
 export type { GoTrueUser }
 export type { MagicUser }
-export type SupportedUserMetadata = Auth0User | GoTrueUser | MagicUser
+export type { SupabaseUser }
+export type SupportedUserMetadata = Auth0User | GoTrueUser | MagicUser | SupabaseUser
 
 export interface AuthClient {
   restoreAuthState?(): void | Promise<any>

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -24,7 +24,6 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
     getToken: async () => {
       const supabaseJson = localStorage.getItem('supabase.auth.token')
       const supabaseData = supabaseJson ? JSON.parse(supabaseJson) : null
-      console.log(supabaseData?.accessToken)
       return supabaseData?.accessToken || null
     },
     getUserMetadata: async () => client.auth.user(),

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -1,0 +1,32 @@
+import type { SupabaseAuthUser, SupabaseClient as Supabase, SupabaseAuthResponse} from '@supabase/supabase-js'
+
+import type { AuthClient } from './index'
+export type SupabaseUser = SupabaseAuthUser
+export type { Supabase }
+
+export interface AuthClientSupabase extends AuthClient {
+  login(options: {
+    email: string
+    password: string
+  }): Promise<SupabaseAuthResponse>
+  client: Supabase
+}
+
+export const supabase = (client: Supabase): AuthClientSupabase => {
+  return {
+    type: 'supabase',
+    client,
+    login: async ({ email, password }) =>
+      client.auth.login(email, password),
+    logout: async () => {
+      return client.auth.logout()
+    },
+    getToken: async () => {
+      const supabaseJson = localStorage.getItem('supabase.auth.token')
+      const supabaseData = supabaseJson ? JSON.parse(supabaseJson) : null
+      console.log(supabaseData?.accessToken)
+      return supabaseData?.accessToken || null
+    },
+    getUserMetadata: async () => client.auth.user(),
+  }
+}

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -16,10 +16,10 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
   return {
     type: 'supabase',
     client,
-    login: async ({ email, password }) =>
+    login: ({ email, password }) =>
       client.auth.login(email, password),
-    logout: async () => {
-      return client.auth.logout()
+    logout: () => {
+      client.auth.logout()
     },
     getToken: async () => {
       const supabaseJson = localStorage.getItem('supabase.auth.token')

--- a/packages/cli/src/commands/generate/auth/providers/supabase.js
+++ b/packages/cli/src/commands/generate/auth/providers/supabase.js
@@ -1,0 +1,22 @@
+// the lines that need to be added to index.js
+export const config = {
+  imports: [`import { createClient } from '@supabase/supabase-js'`],
+  init: `const supabaseClient = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_KEY
+  )`,
+  authProvider: {
+    client: 'supabaseClient',
+    type: 'supabase',
+  },
+}
+
+// required packages to install
+export const webPackages = ['@supabase/supabase-js']
+export const apiPackages = []
+
+// any notes to print out when the job is done
+export const notes = [
+  'You will need to add your Supabase URL and key to your .env file.',
+  'See: https://supabase.io/docs/library/getting-started#reference',
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3670,6 +3670,31 @@
     telejson "^3.2.0"
     util-deprecate "^1.0.2"
 
+"@supabase/postgrest-js@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-0.17.0.tgz#fcf700e731e234ba53ff9fcda679c9740a165dcf"
+  integrity sha512-7Dt7ALli+bOQK51JMolraI08sJg2UweNuGFghr8MrX4nc3WoDwL5PP6fNZwy+j/7f7nvvM6s1OUtqNTvqiW+5Q==
+  dependencies:
+    superagent "^5.2.1"
+
+"@supabase/realtime-js@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-0.9.0.tgz#6dd646f08713f359af160ce6f1b2fb801a53d2d0"
+  integrity sha512-aYkVsD2hNgD7QPPBV+LALJTexNf8pVhIh9qJC13NnOLYZpudtHbof+rg0dgq5+GIhYa8HzqUMdf+OwwlQVJgsw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    query-string "^6.12.1"
+    websocket "^1.0.31"
+
+"@supabase/supabase-js@^0.36.4":
+  version "0.36.4"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-0.36.4.tgz#2f0b2682d8e94d1150fd9870882c51e6958a0b7e"
+  integrity sha512-+qQm0JccYe41xA2fajIBDm83o00YuGRVSmwT1Y/eb/+Dp0LqwLn9KVQ+2nT+dBJI+dAg9LqTeQb1dDuo4twVrQ==
+  dependencies:
+    "@supabase/postgrest-js" "^0.17.0"
+    "@supabase/realtime-js" "^0.9.0"
+    superagent "^5.2.1"
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -6577,6 +6602,13 @@ buffer@^5.1.0, buffer@^5.2.1, buffer@^5.5.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+bufferutil@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.1.tgz#3a177e8e5819a1243fe16b63a199951a7ad8d4a7"
+  integrity sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==
+  dependencies:
+    node-gyp-build "~3.7.0"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -7285,7 +7317,7 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -7526,6 +7558,11 @@ cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
+cookiejar@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -9401,6 +9438,11 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fast-text-encoding@^1.0.0, fast-text-encoding@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
@@ -9807,6 +9849,11 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formidable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
+  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -13493,7 +13540,7 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -13560,7 +13607,7 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.2.0, mime@^2.4.4:
+mime@^2.2.0, mime@^2.4.4, mime@^2.4.6:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
@@ -14017,6 +14064,11 @@ node-forge@^0.9.0, node-forge@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
   integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
+
+node-gyp-build@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-3.7.0.tgz#daa77a4f547b9aed3e2aac779eaf151afd60ec8d"
+  integrity sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==
 
 node-gyp@^5.0.2:
   version "5.1.1"
@@ -15525,7 +15577,7 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.6.0, qs@^6.9.3:
+qs@^6.6.0, qs@^6.9.3, qs@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
@@ -15542,6 +15594,15 @@ query-string@^4.1.0:
   dependencies:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
+
+query-string@^6.12.1:
+  version "6.13.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.1.tgz#d913ccfce3b4b3a713989fe6d39466d92e71ccad"
+  integrity sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -17084,6 +17145,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -17240,6 +17306,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.1"
@@ -17465,6 +17536,23 @@ subscriptions-transport-ws@0.9.17, subscriptions-transport-ws@^0.9.11:
     iterall "^1.2.1"
     symbol-observable "^1.0.4"
     ws "^5.2.0"
+
+superagent@^5.2.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.3.1.tgz#d62f3234d76b8138c1320e90fa83dc1850ccabf1"
+  integrity sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -18419,6 +18507,13 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utf-8-validate@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.2.tgz#63cfbccd85dc1f2b66cf7a1d0eebc08ed056bfb3"
+  integrity sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==
+  dependencies:
+    node-gyp-build "~3.7.0"
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -18864,6 +18959,18 @@ websocket@1.0.31:
     es5-ext "^0.10.50"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
+    yaeti "^0.0.6"
+
+websocket@^1.0.31:
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
+  integrity sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
     yaeti "^0.0.6"
 
 whatwg-encoding@^1.0.5:


### PR DESCRIPTION
I got really excited [by the discussion around supabase](https://community.redwoodjs.com/t/supabase-redwood-experiments/1088/15) and really wanted to use it in my Redwood project. I figured I'd give it a spin. It was much easier than I expected. Looking for feedback to see if we can get this supported as I'd prefer to use supabase over anything else at the moment. 😅 

This PR:
- [x] Adds supabase as an auth provider
- [x] Adds tests for the supabase decoder
- [x] Adds supabase to the CLI tool

~I've marked this PR as a **draft** because I'm not sure if it's worth having Supabase as an auth provider at this point. They are missing key features like password resets, etc.~