### PR TITLE
quote paths and keywords with <tt> instead of quotation marks in JSX template generator

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -12,9 +12,11 @@ const FooBarPage = () => {
   return (
     <>
       <h1>FooBarPage</h1>
-      <p>Find me in "./web/src/pages/FooBarPage/FooBarPage.js"</p>
       <p>
-        My default route is named "fooBar", link to me with \`
+        Find me in <tt>./web/src/pages/FooBarPage/FooBarPage.js</tt>
+      </p>
+      <p>
+        My default route is named <tt>fooBar</tt>, link to me with \`
         <Link to={routes.fooBar()}>FooBar</Link>\`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
@@ -4,9 +4,11 @@ const ContactUsPage = () => {
   return (
     <>
       <h1>ContactUsPage</h1>
-      <p>Find me in "./web/src/pages/ContactUsPage/ContactUsPage.js"</p>
       <p>
-        My default route is named "contactUs", link to me with `
+        Find me in <tt>./web/src/pages/ContactUsPage/ContactUsPage.js</tt>
+      </p>
+      <p>
+        My default route is named <tt>contactUs</tt>, link to me with `
         <Link to={routes.contactUs()}>ContactUs</Link>`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
@@ -4,9 +4,11 @@ const PostPage = ({ id }) => {
   return (
     <>
       <h1>PostPage</h1>
-      <p>Find me in "./web/src/pages/PostPage/PostPage.js"</p>
       <p>
-        My default route is named "post", link to me with `
+        Find me in <tt>./web/src/pages/PostPage/PostPage.js</tt>
+      </p>
+      <p>
+        My default route is named <tt>post</tt>, link to me with `
         <Link to={routes.post({ id: '42' })}>Post 42</Link>`
       </p>
       <p>The parameter passed to me is {id}</p>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
@@ -4,9 +4,11 @@ const CatsPage = () => {
   return (
     <>
       <h1>CatsPage</h1>
-      <p>Find me in "./web/src/pages/CatsPage/CatsPage.js"</p>
       <p>
-        My default route is named "cats", link to me with `
+        Find me in <tt>./web/src/pages/CatsPage/CatsPage.js</tt>
+      </p>
+      <p>
+        My default route is named <tt>cats</tt>, link to me with `
         <Link to={routes.cats()}>Cats</Link>`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
@@ -4,9 +4,11 @@ const HomePage = () => {
   return (
     <>
       <h1>HomePage</h1>
-      <p>Find me in "./web/src/pages/HomePage/HomePage.js"</p>
       <p>
-        My default route is named "home", link to me with `
+        Find me in <tt>./web/src/pages/HomePage/HomePage.js</tt>
+      </p>
+      <p>
+        My default route is named <tt>home</tt>, link to me with `
         <Link to={routes.home()}>Home</Link>`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/templates/page.js.template
+++ b/packages/cli/src/commands/generate/page/templates/page.js.template
@@ -4,9 +4,9 @@ const ${pascalName}Page = (${propParam}) => {
   return (
     <>
       <h1>${pascalName}Page</h1>
-      <p>Find me in "${outputPath}"</p>
+      <p>Find me in <tt>${outputPath}</tt></p>
       <p>
-        My default route is named "${camelName}", link to me with `
+        My default route is named <tt>${camelName}</tt>, link to me with `
         <Link to={routes.${camelName}(${ argumentParam })}>${pascalName}<%= argumentParam !== '' ? ' 42' : '' %></Link>`
       </p><% if (paramName !== '') { %>
       <p>


### PR DESCRIPTION
Last time I ran `yarn rw lint` I got [no-unescaped-entities](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md ) errors from the scaffolded pages. I'm not certain this was Redwood's lint config but I figure being robust to that lint rule wouldn't hurt.
