### PR TITLE
fix CI runner Windows cache false positive

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -15,8 +15,9 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
-    if: github.event.pull_request.merged == 'false'
     steps:
+      - if: github.event.pull_request.merged == 'false'
+        
       - uses: actions/checkout@v2
 
       - name: Setup node

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -40,6 +40,10 @@ jobs:
           powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
             "'-Command Set-MpPreference -DisableRealtimeMonitoring \$true'";
 
+      - name: Set Windows package registry
+        if: matrix.os == 'windows-latest'
+        run: yarn config set registry "http://registry.npmjs.org"     
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   all:
-    if: github.event.pull_request.merged == 'false'
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
@@ -16,6 +15,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
+    if: github.event.pull_request.merged == false
     steps:        
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -30,10 +30,16 @@ jobs:
           path: '**/node_modules'
           key: node_modules_${{ runner.os }}_${{ hashFiles('**/yarn.lock') }}
       
-      - name: Set Windows Yarn Registry
+      - name: Disable Windows Defender Realtime Monitoring
         if: matrix.os == 'windows-latest'
-        run: yarn config set registry "http://registry.npmjs.org"
-        
+        run: |
+          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
+            "'-Command Set-MpPreference -DisableArchiveScanning \$true'";
+          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
+            "'-Command Set-MpPreference -DisableBehaviorMonitoring \$true'";
+          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
+            "'-Command Set-MpPreference -DisableRealtimeMonitoring \$true'";
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
+    if: github.event.pull_request.merged == 'false'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   all:
-    if: github.event.pull_request.merged == false
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
@@ -16,6 +15,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
+    if: github.event.pull_request.merged == 'false'
     steps:
       - uses: actions/checkout@v2
 
@@ -26,10 +26,15 @@ jobs:
 
       - name: Cache "node_modules"
         uses: actions/cache@v2
+        if: matrix.os == 'ubuntu-latest'
         with:
           path: '**/node_modules'
           key: node_modules_${{ runner.os }}_${{ hashFiles('**/yarn.lock') }}
-
+      
+      - name: Set Windows Yarn Registry
+        if: matrix.os == 'windows-latest'
+        run: yarn config set registry "http://registry.npmjs.org"
+        
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
-    if: github.event.pull_request.merged == 'false'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -28,21 +28,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           path: '**/node_modules'
-          key: node_modules_${{ runner.os }}_${{ hashFiles('**/yarn.lock') }}
-      
-      - name: Disable Windows Defender Realtime Monitoring
-        if: matrix.os == 'windows-latest'
-        run: |
-          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
-            "'-Command Set-MpPreference -DisableArchiveScanning \$true'";
-          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
-            "'-Command Set-MpPreference -DisableBehaviorMonitoring \$true'";
-          powershell Start-Process -PassThru -Wait PowerShell -ArgumentList \
-            "'-Command Set-MpPreference -DisableRealtimeMonitoring \$true'";
-
-      - name: Set Windows package registry
-        if: matrix.os == 'windows-latest'
-        run: yarn config set registry "http://registry.npmjs.org"     
+          key: node_modules_${{ runner.os }}_${{ hashFiles('**/yarn.lock') }}  
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   all:
+    if: github.event.pull_request.merged == 'false'
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
@@ -15,9 +16,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest
-    steps:
-      - if: github.event.pull_request.merged == 'false'
-        
+    steps:        
       - uses: actions/checkout@v2
 
       - name: Setup node


### PR DESCRIPTION
Attempting three adjustments:
- runner is still triggering on merge; moved conditional and updated syntax
- set cache to be conditional to skip Windows
- attempting a fix to Windows long running yarn install

Cache is still having false positives on Windows, which results in failed CI due to missing packages.

Cache or no cache, the Windows runner takes about 10 min largely due to the warning "There appears to be trouble with your network connection. Retrying..." during yarn install. I'm trying the yarn config registry workaround here: https://github.com/yarnpkg/yarn/issues/5259#issuecomment-670972053

**SUMMARY**
- I was not able to work around the Windows runner "...trouble with network connection..."
- The runner is now skipping caching for Widows
- The "is merged PR" conditional wasn't working. I moved position and will check if it correctly skips when merging this PR