### PR TITLE
Put migration name in quotes

### DIFF
--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -50,7 +50,7 @@ describe('db commands', () => {
 
     await save.handler({ name: 'my-migration' })
     expect(runCommandTask.mock.results[3].value).toEqual([
-      'yarn prisma migrate save --name my-migration --create-db --experimental',
+      'yarn prisma migrate save --name "my-migration" --create-db --experimental',
     ])
 
     await introspect.handler({})

--- a/packages/cli/src/commands/dbCommands/save.js
+++ b/packages/cli/src/commands/dbCommands/save.js
@@ -33,7 +33,7 @@ export const handler = async ({ name = 'migration', verbose = true }) => {
         cmd: 'yarn prisma',
         args: [
           'migrate save',
-          name.length && `--name ${name}`,
+          name.length && `--name "${name}"`,
           '--create-db',
           '--experimental',
         ].filter(Boolean),


### PR DESCRIPTION
Resolves #1120 

Here are my local testing results:

```bash
❯ yarn rw db save "test name"
yarn run v1.22.4
$ /Users/amorriscode/dev/test-app/node_modules/.bin/rw db save 'test name'
Creating database migration... [started]
$ /Users/amorriscode/dev/test-app/node_modules/.bin/prisma migrate save --name 'test name' --create-db --experimental
📼  migrate save --name test name
....

Prisma Migrate just created your migration 20200909230629-test-name in

migrations/
  └─ 20200909230629-test-name/
    └─ steps.json
    └─ schema.prisma
    └─ README.md

Run yarn prisma migrate up --experimental to apply the migration

Creating database migration... [completed]
✨  Done in 3.05s.
```