### PR TITLE
Reduce bundle size

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 const packageJSON = require('./package.json')
 
 const TARGETS_NODE = '12.16'
-const TARGETS_BROWSERS = 'defaults'
+const TARGETS_BROWSERS = ['defaults', 'not IE 11', 'not IE_Mob 11']
 // Warning! Recommended to specify used minor core-js version, like corejs: '3.6',
 // instead of corejs: '3', since with '3' it will not be injected modules
 // which were added in minor core-js releases.

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -126,7 +126,7 @@ const getSharedPlugins = (isEnvProduction) => {
     new webpack.ProvidePlugin({
       React: 'react',
       PropTypes: 'prop-types',
-      gql: ['@redwoodjs/web', 'gql'],
+      gql: 'graphql-tag',
       mockGraphQLQuery: ['@redwoodjs/testing', 'mockGraphQLQuery'],
       mockGraphQLMutation: ['@redwoodjs/testing', 'mockGraphQLMutation'],
     }),

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -233,6 +233,10 @@ module.exports = (webpackEnv) => {
               ),
               use: 'null-loader',
             },
+            {
+              test: path.join(redwoodPaths.base, 'node_modules/graphql-tag'),
+              use: 'null-loader',
+            },
             // (7)
             {
               test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -148,6 +148,7 @@ const getSharedPlugins = (isEnvProduction) => {
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpack.config.js
 module.exports = (webpackEnv) => {
   const isEnvProduction = webpackEnv === 'production'
+  const isEnvDevelopment = !isEnvProduction
 
   return {
     mode: isEnvProduction ? 'production' : 'development',
@@ -225,6 +226,13 @@ module.exports = (webpackEnv) => {
             },
             // .module.css (3), .css (4), .module.scss (5), .scss (6)
             ...getStyleLoaders(isEnvProduction),
+            isEnvProduction && {
+              test: path.join(
+                redwoodPaths.base,
+                'node_modules/@redwoodjs/router/dist/splash-page'
+              ),
+              use: 'null-loader',
+            },
             // (7)
             {
               test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
@@ -233,7 +241,7 @@ module.exports = (webpackEnv) => {
                 name: 'static/media/[name].[hash:8].[ext]',
               },
             },
-          ],
+          ].filter(Boolean),
         },
       ],
     },

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -148,7 +148,6 @@ const getSharedPlugins = (isEnvProduction) => {
 // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpack.config.js
 module.exports = (webpackEnv) => {
   const isEnvProduction = webpackEnv === 'production'
-  const isEnvDevelopment = !isEnvProduction
 
   return {
     mode: isEnvProduction ? 'production' : 'development',

--- a/packages/router/src/internal.js
+++ b/packages/router/src/internal.js
@@ -1,7 +1,6 @@
 export * from './util'
 export * from './history'
 export * from './location'
-export * from './splash-page'
 export * from './named-routes'
 export * from './router'
 export * from './params'

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -9,10 +9,11 @@ import {
   ParamsContext,
   navigate,
   mapNamedRoutes,
-  SplashPage,
   PageLoader,
   Redirect,
 } from './internal'
+
+import { SplashPage } from './splash-page'
 
 const Route = () => {
   return null

--- a/packages/web/src/graphql/index.js
+++ b/packages/web/src/graphql/index.js
@@ -1,4 +1,5 @@
-import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
+import { ApolloClient, InMemoryCache } from '@apollo/client'
+import { ApolloProvider } from '@apollo/client/react'
 
 export { withCell } from './withCell'
 

--- a/packages/web/src/graphql/withCell.js
+++ b/packages/web/src/graphql/withCell.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Query } from '@apollo/client/react/components'
+import { Query } from '@apollo/client/react/components/Query'
 
 /**
  * Is a higher-order-component that executes a GraphQL query and automatically

--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -1,6 +1,7 @@
 import './config'
 
-export * from '@apollo/client'
+export { useQuery } from '@apollo/client/react/hooks/useQuery'
+export { useMutation } from '@apollo/client/react/hooks/useMutation'
 
 export { default as FatalErrorBoundary } from 'src/components/FatalErrorBoundary'
 export { default as RedwoodProvider } from 'src/components/RedwoodProvider'


### PR DESCRIPTION
My goal is to get the bundle size under 500 KB

- [x] Drop support for IE 11, and IE 11 mobile. Closes #1082
- [x] Do not bundle `SplashPage`, from @redwoodjs/router, in Production. Closes #64 
- [x] _Really_ exclude `graphql-tag`