### PR TITLE
feat: support styling Flash with style object

### DIFF
--- a/packages/web/src/flash/Flash.js
+++ b/packages/web/src/flash/Flash.js
@@ -25,6 +25,7 @@ const FlashMessage = ({ message, timeout }) => {
   return (
     <div
       className={`rw-flash-message ${message.classes} ${classes}`}
+      style={message.style}
       data-testid="message"
     >
       <div className="rw-flash-message-text">{message.text}</div>

--- a/packages/web/src/flash/FlashReducer.js
+++ b/packages/web/src/flash/FlashReducer.js
@@ -13,6 +13,7 @@ export default (state, action) => {
           {
             id: state.messages.length,
             text: action.payload.text,
+            style: action.payload.style || {},
             classes: action.payload.classes || '',
             persist: action.payload.persist || false,
             viewed: action.payload.viewed || false,

--- a/packages/web/src/flash/__tests__/flash.test.js
+++ b/packages/web/src/flash/__tests__/flash.test.js
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
 import { render, cleanup, fireEvent } from '@testing-library/react'
 // TODO: Remove when jest configs are in place
-import { toHaveClass } from '@testing-library/jest-dom/matchers'
-expect.extend({ toHaveClass })
+import { toHaveClass, toHaveStyle } from '@testing-library/jest-dom/matchers'
+expect.extend({ toHaveClass, toHaveStyle })
 
 import Flash from 'src/flash/Flash'
 import { FlashProvider, useFlash } from 'src/flash/FlashContext'
@@ -59,6 +59,23 @@ describe('Flash', () => {
     expect(getByText(testMessages[0].text)).toBeTruthy()
     expect(queryAllByTestId('message')[0]).toHaveClass(testMessages[0].classes)
     expect(queryAllByTestId('message')[1]).toHaveClass(testMessages[1].classes)
+  })
+
+  it('supports styling messages with a style object', () => {
+    const msg = [
+      {
+        text: 'A basic message',
+        style: { backgroundColor: 'green', color: 'white' },
+      },
+    ]
+    const { getByText, queryByTestId, queryAllByTestId } = render(
+      <FlashProvider>
+        <TestComponent messages={msg} />
+      </FlashProvider>
+    )
+    expect(queryByTestId('flash')).toBeTruthy()
+    expect(getByText(testMessages[0].text)).toBeTruthy()
+    expect(queryAllByTestId('message')[0]).toHaveStyle(msg[0].style)
   })
 
   it('dismisses messages on close button click', () => {


### PR DESCRIPTION
per @cannikin's [suggestion](https://github.com/redwoodjs/redwoodjs.com/pull/344/files/7470e65de34f74bb4b361f2d953f9cfab8bd0543#r486455023), this PR would add the option to style a Flash message with a style object for convenience.