### PR TITLE
Add link to Releases in Changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Current and Previous Versions 
+For all changelog information since v0.0.1:
+- [GitHub Releases](https://github.com/redwoodjs/redwood/releases)
+
 ## [0.0.1-alpha.15] - 2020-01-04
 
 ### Changed


### PR DESCRIPTION
@peterp Changelog.md hasn't been used since January. I added a link to GH Releases, but what do you think about simply deleting this file?