### PR TITLE
Add Automerge to Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
       interval: daily
       time: "09:00"
       timezone: America/New_York
-      ignored_updates:
-      - match:
-          dependency_name: "core-js"
-          dependency_name: "@babel*"
       automerged_updates:
       - match:
           dependency_type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,12 @@ updates:
       interval: daily
       time: "09:00"
       timezone: America/New_York
+      ignored_updates:
+      - match:
+          dependency_name: "core-js"
+          dependency_name: "@babel*"
+      automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:patch"
     open-pull-requests-limit: 20


### PR DESCRIPTION
Fixes #1122

@peterp The config for Dependabot is much more limited than I anticipated. Here's what we can do: 
- Automerge patch updates
- completely ignore `core-js` and `@bable` (will not submit PRs)

I'm not sure how to test this other than to merge and see how it works 😬 

Re: completely ignoring all `core-js` and `@babel*` packages: aren't these two examples we should manually manage? I thought about trying to just ignore them from auto merger using the following, but I wasn't sure if it would work.

```yaml
      - match:
          dependency_name: "!core-js"
          dependency_name: "!@babel*"
```

Thoughts/suggestions about proceeding forward with this?


