### PR TITLE
Resolve destroy page "propParam is not defined" error

### DIFF
--- a/packages/cli/src/commands/destroy/page/page.js
+++ b/packages/cli/src/commands/destroy/page/page.js
@@ -5,7 +5,10 @@ import { deleteFilesTask, removeRoutesFromRouterTask } from 'src/lib'
 import c from 'src/lib/colors'
 
 import { pathName } from '../../generate/helpers'
-import { files as pageFiles } from '../../generate/page/page'
+import {
+  files as pageFiles,
+  paramVariants as templateVars,
+} from '../../generate/page/page'
 
 export const command = 'page <name> [path]'
 export const description = 'Destroy a page and route component'
@@ -26,7 +29,12 @@ export const tasks = ({ name, path }) =>
       {
         title: 'Destroying page files...',
         task: async () => {
-          const f = pageFiles({ name, path: pathName(path, name) })
+          const p = pathName(path, name)
+          const f = pageFiles({
+            name,
+            path: p,
+            ...templateVars(p),
+          })
           return deleteFilesTask(f)
         },
       },


### PR DESCRIPTION
This PR resolves the `propParam is not defined` error currently thrown when running `yarn rw destroy page PageName`.

When instantiating the list of page files to destroy, not all template variables were being passed in. This caused lodash to throw an exception when attempting to interpolate the page template.

The proposed fix is to include the default page template variables when instantiating the destroy file list to ensure that lodash can successfully interpolate the template.

Closes #1037 

Thanks!