### PR TITLE
Improve CLI speed

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -10,20 +10,20 @@ import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 import { handler as generatePrismaClient } from 'src/commands/dbCommands/generate'
 
-const apiExists = fs.existsSync(getPaths().api.src)
-const webExists = fs.existsSync(getPaths().web.src)
-
-const optionDefault = (apiExists, webExists) => {
-  let options = []
-  if (apiExists) options.push('api')
-  if (webExists) options.push('web')
-  return options
-}
-
 export const command = 'build [side..]'
 export const description = 'Build for production'
 
 export const builder = (yargs) => {
+  const apiExists = fs.existsSync(getPaths().api.src)
+  const webExists = fs.existsSync(getPaths().web.src)
+
+  const optionDefault = (apiExists, webExists) => {
+    let options = []
+    if (apiExists) options.push('api')
+    if (webExists) options.push('web')
+    return options
+  }
+
   yargs
     .positional('side', {
       choices: ['api', 'web'],

--- a/packages/cli/src/commands/check.js
+++ b/packages/cli/src/commands/check.js
@@ -1,5 +1,3 @@
-import { printDiagnostics, DiagnosticSeverity } from '@redwoodjs/structure'
-
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
@@ -9,11 +7,15 @@ export const description =
   'Get structural diagnostics for a Redwood project (experimental)'
 
 export const handler = async () => {
-  printDiagnostics(getPaths().base, { getSeverityLabel })
-}
+  const { printDiagnostics, DiagnosticSeverity } = await import(
+    '@redwoodjs/structure'
+  )
 
-function getSeverityLabel(severity) {
-  if (severity === DiagnosticSeverity.Error) return c.error('error')
-  if (severity === DiagnosticSeverity.Warning) return c.warning('warning')
-  return c.info('info')
+  printDiagnostics(getPaths().base, {
+    getSeverityLabel: (severity) => {
+      if (severity === DiagnosticSeverity.Error) return c.error('error')
+      if (severity === DiagnosticSeverity.Warning) return c.warning('warning')
+      return c.info('info')
+    },
+  })
 }

--- a/packages/cli/src/commands/deploy/api/api.js
+++ b/packages/cli/src/commands/deploy/api/api.js
@@ -8,14 +8,14 @@ import Listr from 'listr'
 import c from 'src/lib/colors'
 import { getPaths } from 'src/lib'
 
-const SUPPORTED_PROVIDERS = fs
-  .readdirSync(path.resolve(__dirname, 'providers'))
-  .map((file) => path.basename(file, '.js'))
-  .filter((file) => file !== 'README.md')
-
 export const command = 'api <provider>'
 export const description = 'Deploy the API using the selected provider'
 export const builder = (yargs) => {
+  const SUPPORTED_PROVIDERS = fs
+    .readdirSync(path.resolve(__dirname, 'providers'))
+    .map((file) => path.basename(file, '.js'))
+    .filter((file) => file !== 'README.md')
+
   yargs
     .positional('provider', {
       choices: SUPPORTED_PROVIDERS,

--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
@@ -19,12 +19,12 @@ let singleWordFiles,
   kebabCaseWordFiles,
   camelCaseWordFiles
 
-beforeAll(() => {
-  singleWordFiles = cell.files({ name: 'User' })
-  multiWordFiles = cell.files({ name: 'UserProfile' })
-  snakeCaseWordFiles = cell.files({ name: 'user_profile' })
-  kebabCaseWordFiles = cell.files({ name: 'user-profile' })
-  camelCaseWordFiles = cell.files({ name: 'userProfile' })
+beforeAll(async () => {
+  singleWordFiles = await cell.files({ name: 'User' })
+  multiWordFiles = await cell.files({ name: 'UserProfile' })
+  snakeCaseWordFiles = await cell.files({ name: 'user_profile' })
+  kebabCaseWordFiles = await cell.files({ name: 'user-profile' })
+  camelCaseWordFiles = await cell.files({ name: 'userProfile' })
 })
 
 // Single Word Scenario: User

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,5 +1,4 @@
 import pascalcase from 'pascalcase'
-import { getProject } from '@redwoodjs/structure'
 
 import {
   templateForComponentFile,
@@ -9,7 +8,9 @@ import {
 const COMPONENT_SUFFIX = 'Cell'
 const REDWOOD_WEB_PATH_NAME = 'components'
 
-const getCellOperationNames = () => {
+const getCellOperationNames = async () => {
+  const { getProject } = await import('@redwoodjs/structure')
+
   return getProject()
     .cells.map((x) => {
       return x.queryOperationName
@@ -17,20 +18,22 @@ const getCellOperationNames = () => {
     .filter(Boolean)
 }
 
-const uniqueOperationName = (name, index = 1) => {
+const uniqueOperationName = async (name, index = 1) => {
   let operationName =
     index <= 1
       ? `${pascalcase(name)}Query`
       : `${pascalcase(name)}Query_${index}`
-  if (!getCellOperationNames().includes(operationName)) {
+
+  const cellOperationNames = await getCellOperationNames()
+  if (!cellOperationNames.includes(operationName)) {
     return operationName
   }
   return uniqueOperationName(name, index + 1)
 }
 
-export const files = ({ name }) => {
+export const files = async ({ name }) => {
   // Create a unique operation name.
-  const operationName = uniqueOperationName(name)
+  const operationName = await uniqueOperationName(name)
 
   const cellFile = templateForComponentFile({
     name,

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -1,6 +1,5 @@
 import execa from 'execa'
 import terminalLink from 'terminal-link'
-import { getProject } from '@redwoodjs/structure'
 import { ensurePosixPath } from '@redwoodjs/internal'
 
 import { getPaths } from 'src/lib'
@@ -27,7 +26,8 @@ function isInMercurialRepository() {
 
 export const command = 'test [side..]'
 export const description = 'Run Jest tests. Defaults to watch mode'
-export const builder = (yargs) => {
+export const builder = async (yargs) => {
+  const { getProject } = await import('@redwoodjs/structure')
   yargs
     .choices('side', getProject().sides)
     .option('watch', {


### PR DESCRIPTION
I've noticed that it takes 1.5 seconds to run and exit `yarn rw`

Digging deeper I found that we're executing code outside function blocks - so when they're directly imported.

Fixes #1135 

I've lazily imported @rwjs/structure and moved a bunch of the logic into the builder functions so that they're not run when files are imported.

