### PR TITLE
Allow CORS to be passed to AWS Lambda Handler

### DIFF
--- a/packages/api/src/functions/graphql.ts
+++ b/packages/api/src/functions/graphql.ts
@@ -1,5 +1,5 @@
 import type { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
-import type { Config } from 'apollo-server-lambda'
+import type { Config, CreateHandlerOptions } from 'apollo-server-lambda'
 import type { Context, ContextFunction } from 'apollo-server-core'
 import type { GlobalContext } from 'src/globalContext'
 import type { AuthContextPayload } from 'src/auth'
@@ -86,18 +86,14 @@ interface GraphQLHandlerOptions extends Config {
  * export const handler = createGraphQLHandler({ schema, context, getCurrentUser })
  * ```
  */
-export const createGraphQLHandler = (
-  {
-    context,
-    getCurrentUser,
-    onException,
-    ...options
-  }: GraphQLHandlerOptions = {},
-  /**
-   * @deprecated please use onException instead to disconnect your database.
-   * */
-  db?: any
-) => {
+export const createGraphQLHandler = ({
+  context,
+  getCurrentUser,
+  onException,
+  cors,
+  onHealthCheck,
+  ...options
+}: GraphQLHandlerOptions = {}) => {
   const isDevEnv = process.env.NODE_ENV !== 'production'
   const handler = new ApolloServer({
     // Turn off playground, introspection and debug in production.
@@ -134,9 +130,6 @@ export const createGraphQLHandler = (
       handler(event, context, callback)
     } catch (e) {
       onException && onException()
-      // Disconnect from the database (recommended by Prisma), this step will be
-      // removed in future releases.
-      db && db.$disconnect()
       throw e
     }
   }

--- a/packages/api/src/functions/graphql.ts
+++ b/packages/api/src/functions/graphql.ts
@@ -75,6 +75,9 @@ interface GraphQLHandlerOptions extends Config {
    * A callback when an unhandled exception occurs. Use this to disconnect your prisma instance.
    */
   onException?: () => void
+
+  cors?: CreateHandlerOptions['cors']
+  onHealthCheck?: CreateHandlerOptions['onHealthCheck']
 }
 /**
  * Creates an Apollo GraphQL Server.
@@ -120,7 +123,7 @@ export const createGraphQLHandler = (
     // Wrap the user's context function in our own
     context: createContextHandler(context, getCurrentUser),
     ...options,
-  }).createHandler()
+  }).createHandler({ cors, onHealthCheck })
 
   return (
     event: APIGatewayProxyEvent,

--- a/packages/api/src/functions/graphql.ts
+++ b/packages/api/src/functions/graphql.ts
@@ -97,8 +97,9 @@ export const createGraphQLHandler = (
 ) => {
   const isDevEnv = process.env.NODE_ENV !== 'production'
   const handler = new ApolloServer({
-    // Turn off playground in production
+    // Turn off playground, introspection and debug in production.
     debug: isDevEnv,
+    introspection: isDevEnv,
     playground: isDevEnv,
     // Log the errors in the console
     formatError: (error) => {


### PR DESCRIPTION
This allows the user to pass in `cors` and `onHealthCheck` parameters that'll be forwarded to the `createHandler` method.


Fixes #1172