### PR TITLE
Implement missing Apollo methods

### DIFF
--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -1,7 +1,10 @@
 import './config'
 
+export { useSubscription } from '@apollo/client/react/hooks/useSubscription'
+export { useLazyQuery } from '@apollo/client/react/hooks/useLazyQuery'
 export { useQuery } from '@apollo/client/react/hooks/useQuery'
 export { useMutation } from '@apollo/client/react/hooks/useMutation'
+export { useApolloClient } from '@apollo/client/react/hooks/useApolloClient'
 
 export { default as FatalErrorBoundary } from 'src/components/FatalErrorBoundary'
 export { default as RedwoodProvider } from 'src/components/RedwoodProvider'


### PR DESCRIPTION
This reimplement missing apollo client hooks that are referenced in the types [here](https://github.com/redwoodjs/redwood/blob/main/packages/web/src/index.d.ts)

closes https://github.com/redwoodjs/redwood/issues/1184