### PR TITLE
Fix of TypeError: merge is not a function

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -9,7 +9,7 @@ const CopyPlugin = require('copy-webpack-plugin')
 const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin')
 const Dotenv = require('dotenv-webpack')
 const { getConfig, getPaths } = require('@redwoodjs/internal')
-const merge = require('webpack-merge')
+const { merge } = require('webpack-merge')
 
 const redwoodConfig = getConfig()
 const redwoodPaths = getPaths()


### PR DESCRIPTION
**Issue**
`TypeError: merge is not a function`

**Related commit**
https://github.com/redwoodjs/redwood/commit/fb1e20eff33b2724220445cdcf04e932a50b7da2 - Bump webpack-merge from 4.2.2 to 5.1.2 

> Breaking - `merge` has been moved as a regular import (i.e. `import { merge } from 'webpack-merge'`).

https://github.com/survivejs/webpack-merge/blob/master/CHANGELOG.md#503--2020-07-06

**Related Issue**
https://github.com/redwoodjs/redwood/issues/1174 Fix webpack merge not a function error 

**Error message**

```bash
❯ yarn rw dev
      yarn run v1.22.4
      $ /home/user/redwood-webpack-merge/node_modules/.bin/rw dev
      $ /home/user/redwood-webpack-merge/node_modules/.bin/dev-server
      $ /home/user/redwood-webpack-merge/node_modules/.bin/webpack-dev-server --config ../node_modules/@redwoodjs/core/config/webpack.development.js
      api | Running at 'http://localhost:8911'
      api | Watching files in '/home/user/redwood-webpack-merge/api/src/functions'
      web | /home/user/redwood-webpack-merge/node_modules/@redwoodjs/core/config/webpack.common.js:288
      web |   return merge(baseConfig, userWebpackConfig)
      web |          ^
      web |
      web | TypeError: merge is not a function
      web |     at module.exports.mergeUserWebpackConfig (/home/user/redwood-webpack-merge/node_modules/@redwoodjs/core/config/webpack.common.js:288:10)
      web |     at Object.<anonymous> (/home/user/redwood-webpack-merge/node_modules/@redwoodjs/core/config/webpack.development.js:44:18)
      web |     at Module._compile (internal/modules/cjs/loader.js:1236:30)
      web |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1257:10)
      web |     at Module.load (internal/modules/cjs/loader.js:1085:32)
      web |     at Function.Module._load (internal/modules/cjs/loader.js:950:14)
      web |     at Module.require (internal/modules/cjs/loader.js:1125:19)
      web |     at require (internal/modules/cjs/helpers.js:75:18)
      web |     at WEBPACK_OPTIONS (/home/user/redwood-webpack-merge/node_modules/webpack-cli/bin/utils/convert-argv.js:114:13)
      web |     at requireConfig (/home/user/redwood-webpack-merge/node_modules/webpack-cli/bin/utils/convert-argv.js:116:6)
      web |     at /home/user/redwood-webpack-merge/node_modules/webpack-cli/bin/utils/convert-argv.js:123:17
      web |     at Array.forEach (<anonymous>)
      web |     at module.exports (/home/user/redwood-webpack-merge/node_modules/webpack-cli/bin/utils/convert-argv.js:121:15)
      web |     at Object.<anonymous> (/home/user/redwood-webpack-merge/node_modules/webpack-dev-server/bin/webpack-dev-server.js:84:40)
      web |     at Module._compile (internal/modules/cjs/loader.js:1236:30)
      web |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1257:10)
```

**Redwood version**
`0.19.0`