### PR TITLE
Pins postcss-loader & autoprefixer for tailwindcss

### DIFF
--- a/packages/cli/src/commands/generate/util/tailwind/tailwind.js
+++ b/packages/cli/src/commands/generate/util/tailwind/tailwind.js
@@ -50,9 +50,9 @@ export const handler = async ({ force }) => {
           'web',
           'add',
           '-D',
-          'postcss-loader',
+          'postcss-loader@4.0.2',
           'tailwindcss',
-          'autoprefixer',
+          'autoprefixer@9.8.6',
         ])
       },
     },


### PR DESCRIPTION
Fixes Issue https://github.com/redwoodjs/redwood/issues/1170

This PR pins postcss-loader and autoprefixers such that when setting up tailwindcss, it is compatible with PostCSS v7 (the version currently used by RedwoodJS).

```
'postcss-loader@4.0.2',
'autoprefixer@9.8.6',
```

The current, latest version of autoprefixer is v10.0.0 and this requires PostCSS v8. Installing that version in the setup causes errors seen in the [issue](https://github.com/redwoodjs/redwood/issues/1170) above.