### PR TITLE
CRWA installation success message

### DIFF
--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -52,5 +52,3 @@ node ./dist/create-redwood-app.js /path/to/new/redwood-app
 # Run without installing yarn dependencies
 node ./dist/create-redwood-app.js --no-yarn-install /path/to/new/redwood-app
 ```
-
-_Note: In above example we are creating the app in the parent directory in folder `create-redwood-app-test`._

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -31,23 +31,26 @@ Explains how to contribute by addressing the following three points:
 
 ### How to run create redwood-app script locally
 
-Install [`esm`](https://www.npmjs.com/package/esm);
+Step into the `create-redwood-app` package:
 
 ```bash
-yarn workspace add --dev create-redwood-app
+cd packages/create-redwood-app
 ```
 
-After making changes to `create-redwood-app.js`, do one of the following;
+Watch for changes to the package:
+
+```bash
+yarn build:watch
+```
+
+In a new terminal, when you make a change to e.g. `create-redwood-app.js`, run it:
 
 ```bash
 # Run and install yarn dependencies
-node -r esm ./packages/create-redwood-app/src/create-redwood-app.js ../create-redwood-app-test
+node ./dist/create-redwood-app.js /path/to/new/redwood-app
 
 # Run without installing yarn dependencies
-node -r esm ./packages/create-redwood-app/src/create-redwood-app.js --no-yarn-install ../create-redwood-app-test
-
-# For the lazy; forcefully delete ../create-redwood-app-test and then run without installing yarn dependencies
-rm -rf ../create-redwood-app-test && node -r esm ./packages/create-redwood-app/src/create-redwood-app.js --no-yarn-install ../create-redwood-app-test
+node ./dist/create-redwood-app.js --no-yarn-install /path/to/new/redwood-app
 ```
 
 _Note: In above example we are creating the app in the parent directory in folder `create-redwood-app-test`._

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -8,15 +8,19 @@
 - [FAQ](#FAQ)
 
 ## Purpose and Vision
+
 Summarise the project's values, purpose, and aspirational vision.
 
 ## Package Lead
+
 Identify the decision maker and/or go-to for questions.
 
 ## Roadmap
+
 Similar to Purpose and Vision, but more concrete, comprising near-term priorities and long-term goals.
 
 ## Contributing
+
 Explains how to contribute by addressing the following three points:
 
 1) Core technologies a contributor should be a familiar with.
@@ -27,16 +31,23 @@ Explains how to contribute by addressing the following three points:
 
 ### How to run create redwood-app script locally
 
-After making changes to `create-redwood-app.js`:
+Install [`esm`](https://www.npmjs.com/package/esm);
 
-```
-node -r esm ./redwood/packages/create-redwood-app/src/create-redwood-app.js ../path/to/new-project`
+```bash
+yarn workspace add --dev create-redwood-app
 ```
 
-If running from within the current redwood source directory, be sure your target app path is outside.
+After making changes to `create-redwood-app.js`, do one of the following;
 
-Note: Assumes that
+```bash
+# Run and install yarn dependencies
+node -r esm ./packages/create-redwood-app/src/create-redwood-app.js ../create-redwood-app-test
 
+# Run without installing yarn dependencies
+node -r esm ./packages/create-redwood-app/src/create-redwood-app.js --no-yarn-install ../create-redwood-app-test
+
+# For the lazy; forcefully delete ../create-redwood-app-test and then run without installing yarn dependencies
+rm -rf ../create-redwood-app-test && node -r esm ./packages/create-redwood-app/src/create-redwood-app.js --no-yarn-install ../create-redwood-app-test
 ```
-npm install --save esm
-```
+
+_Note: In above example we are creating the app in the parent directory in folder `create-redwood-app-test`._

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -171,7 +171,7 @@ const style = {
   warning: chalk.keyword('orange'),
   success: chalk.greenBright,
   info: chalk.grey,
-  header: chalk.bold.underline.hex('##e8e8e8'),
+  header: chalk.bold.underline.hex('#e8e8e8'),
   cmd: chalk.hex('#808080'),
   redwood: chalk.hex('#ff845e'),
   love: chalk.redBright,

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -216,7 +216,6 @@ new Listr(
       `${style.redwood(' ⮡  Find a Good First Issue')}: https://redwoodjs.com/good-first-issue`,
       ''
     ].map((item) => console.log(item))
-    console.log()
   })
   .catch((e) => {
     console.log()

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -164,6 +164,97 @@ const installNodeModulesTasks = ({ newAppDir }) => {
   ]
 }
 
+const displaySuccessMessage = () => {
+  const items = displaySuccessMessageItems
+
+  return Object.keys(items).forEach((key) => {
+    const section = items[key]
+
+    if (section.header) {
+      console.log(`\n${section.header}\n`)
+    }
+
+    section.rows.forEach((row) => {
+      const text = row.text
+      const url = typeof row.url !== 'undefined' ? `: ${row.url}` : ''
+
+      console.log(`${text}${url}`)
+    })
+  })
+}
+
+// Inspiration from from @redwood/cli
+// https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/lib/colors.js
+const style = {
+  error: chalk.bold.red,
+  warning: chalk.keyword('orange'),
+  success: chalk.hex('#c3e88d'),
+  info: chalk.grey,
+  header: chalk.bold.underline.hex('##e8e8e8'),
+  cmd: chalk.hex('#808080'),
+  redwood: chalk.hex('#ff845e'),
+  love: chalk.reset.hex('#de1d10'),
+}
+
+const displaySuccessMessageItems = {
+  start: {
+    header: style.success('Thanks for trying out Redwood!'),
+    rows: [
+      {
+        text: `We've created your app in '${style.cmd(newAppDir)}'`,
+      },
+      {
+        text: `Enter the directory and run '${style.cmd(
+          'yarn rw dev'
+        )}' to start the development server.`,
+      },
+    ],
+  },
+  help: {
+    header: style.header('Join the Community and Get Help'),
+    rows: [
+      {
+        text: style.redwood(' ⮡  Join our Forums'),
+        url: 'https://community.redwoodjs.com',
+      },
+      {
+        text: style.redwood(' ⮡  Join our Chat'),
+        url: 'https://discord.gg/redwoodjs',
+      },
+      {
+        text: style.redwood(' ⮡  Read the Documentation'),
+        url: 'https://redwoodjs.com/docs/',
+      },
+    ],
+  },
+  updated: {
+    header: style.header('Keep updated'),
+    rows: [
+      {
+        text: style.redwood(' ⮡  Newsletter signup'),
+        url: 'https://www.redwoodjs.com',
+      },
+      {
+        text: style.redwood(' ⮡  Follow on Twitter'),
+        url: 'https://twitter.com/redwoodjs',
+      },
+    ],
+  },
+  contribute: {
+    header: `${style.header(`Become a Contributor`)} ${style.love('❤')}`,
+    rows: [
+      {
+        text: style.redwood(' ⮡  Learn how to get started'),
+        url: 'https://redwoodjs.com/docs/contributing',
+      },
+      {
+        text: style.redwood(' ⮡  Find a Good First Issue'),
+        url: 'https://redwoodjs.com/good-first-issue',
+      }
+    ],
+  },
+}
+
 new Listr(
   [
     {
@@ -179,33 +270,8 @@ new Listr(
 )
   .run()
   .then(() => {
-    // TODO: show helpful out for next steps.
+    displaySuccessMessage()
     console.log()
-    console.log(
-      `Thanks for trying out Redwood! We've created your app in '${newAppDir}'`
-    )
-    console.log()
-    console.log(
-      'Inside that directory you can run `yarn rw dev` to start the development server.'
-    )
-    console.log()
-    console.log(
-      `${chalk.hex('#bf4722')(
-        '* Join our Discord server'
-      )}: https://discord.gg/jjSYEQd`
-    )
-
-    console.log(
-      `${chalk.hex('#bf4722')(
-        '* Join our Discourse Community'
-      )}: https://community.redwoodjs.com`
-    )
-
-    console.log(
-      `${chalk.hex('#bf4722')(
-        '* Signup to the Newsletter'
-      )}: https://www.redwoodjs.com`
-    )
   })
   .catch((e) => {
     console.log()

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -169,12 +169,12 @@ const installNodeModulesTasks = ({ newAppDir }) => {
 const style = {
   error: chalk.bold.red,
   warning: chalk.keyword('orange'),
-  success: chalk.hex('#c3e88d'),
+  success: chalk.greenBright,
   info: chalk.grey,
   header: chalk.bold.underline.hex('##e8e8e8'),
   cmd: chalk.hex('#808080'),
   redwood: chalk.hex('#ff845e'),
-  love: chalk.reset.hex('#de1d10'),
+  love: chalk.redBright,
 }
 
 new Listr(

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -164,25 +164,6 @@ const installNodeModulesTasks = ({ newAppDir }) => {
   ]
 }
 
-const displaySuccessMessage = () => {
-  const items = displaySuccessMessageItems
-
-  return Object.keys(items).forEach((key) => {
-    const section = items[key]
-
-    if (section.header) {
-      console.log(`\n${section.header}\n`)
-    }
-
-    section.rows.forEach((row) => {
-      const text = row.text
-      const url = typeof row.url !== 'undefined' ? `: ${row.url}` : ''
-
-      console.log(`${text}${url}`)
-    })
-  })
-}
-
 // Inspiration from from @redwood/cli
 // https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/lib/colors.js
 const style = {
@@ -194,65 +175,6 @@ const style = {
   cmd: chalk.hex('#808080'),
   redwood: chalk.hex('#ff845e'),
   love: chalk.reset.hex('#de1d10'),
-}
-
-const displaySuccessMessageItems = {
-  start: {
-    header: style.success('Thanks for trying out Redwood!'),
-    rows: [
-      {
-        text: `We've created your app in '${style.cmd(newAppDir)}'`,
-      },
-      {
-        text: `Enter the directory and run '${style.cmd(
-          'yarn rw dev'
-        )}' to start the development server.`,
-      },
-    ],
-  },
-  help: {
-    header: style.header('Join the Community and Get Help'),
-    rows: [
-      {
-        text: style.redwood(' ⮡  Join our Forums'),
-        url: 'https://community.redwoodjs.com',
-      },
-      {
-        text: style.redwood(' ⮡  Join our Chat'),
-        url: 'https://discord.gg/redwoodjs',
-      },
-      {
-        text: style.redwood(' ⮡  Read the Documentation'),
-        url: 'https://redwoodjs.com/docs/',
-      },
-    ],
-  },
-  updated: {
-    header: style.header('Keep updated'),
-    rows: [
-      {
-        text: style.redwood(' ⮡  Newsletter signup'),
-        url: 'https://www.redwoodjs.com',
-      },
-      {
-        text: style.redwood(' ⮡  Follow on Twitter'),
-        url: 'https://twitter.com/redwoodjs',
-      },
-    ],
-  },
-  contribute: {
-    header: `${style.header(`Become a Contributor`)} ${style.love('❤')}`,
-    rows: [
-      {
-        text: style.redwood(' ⮡  Learn how to get started'),
-        url: 'https://redwoodjs.com/docs/contributing',
-      },
-      {
-        text: style.redwood(' ⮡  Find a Good First Issue'),
-        url: 'https://redwoodjs.com/good-first-issue',
-      }
-    ],
-  },
 }
 
 new Listr(
@@ -270,7 +192,30 @@ new Listr(
 )
   .run()
   .then(() => {
-    displaySuccessMessage()
+    [
+      '',
+      style.success('Thanks for trying out Redwood!'),
+      '',
+      `We've created your app in '${style.cmd(newAppDir)}'`,
+      `Enter the directory and run '${style.cmd("yarn rw dev")}' to start the development server.`,
+      '',
+      style.header('Join the Community and Get Help'),
+      '',
+      `${style.redwood(' ⮡  Join our Forums')}: https://community.redwoodjs.com`,
+      `${style.redwood(' ⮡  Join our Chat')}: https://discord.gg/redwoodjs`,
+      `${style.redwood(' ⮡  Read the Documentation')}: https://redwoodjs.com/docs`,
+      '',
+      style.header('Keep updated'),
+      '',
+      `${style.redwood(' ⮡  Newsletter signup')}: https://www.redwoodjs.com`,
+      `${style.redwood(' ⮡  Follow on Twitter')}: https://twitter.com/redwoodjs`,
+      '',
+      `${style.header(`Become a Contributor`)} ${style.love('❤')}`,
+      '',
+      `${style.redwood(' ⮡  Learn how to get started')}: https://redwoodjs.com/docs/contributing`,
+      `${style.redwood(' ⮡  Find a Good First Issue')}: https://redwoodjs.com/good-first-issue`,
+      ''
+    ].map((item) => console.log(item))
     console.log()
   })
   .catch((e) => {


### PR DESCRIPTION
**Description**
Updates the success message when a Redwood application is created using `yarn create redwood-app`.

**Related**
#1171 Improve final "success" output during CRWA installation

**Questions**
- [X] Would we rather have this change in a series of `console.log`'s (as before) or rendered from an [object](https://github.com/redwoodjs/redwood/pull/1195/commits/7373b0de2374383ddd5d906e0bd67bcba14efc92#diff-bb0a9e2525a05a79a2b81b652eb44480R199) (as of PR)?
- [X] Is it okay to do some refactoring of methods and helpers into separate files? If so, I'll will do this in another PR.
- [X] Is there any lightweight core package that would be suitable in the future to share chalk styles/colors for`@redwood/cli` and `@redwood/create-redwood-app`? (See [this](https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/lib/colors.js) and [this](https://github.com/redwoodjs/redwood/pull/1195/commits/7373b0de2374383ddd5d906e0bd67bcba14efc92#diff-bb0a9e2525a05a79a2b81b652eb44480R188))

**Latest output**
![image](https://user-images.githubusercontent.com/865493/93994352-13f28400-fd90-11ea-9af3-3f22065df3bb.png)
