### PR TITLE
Fix cwd in getConfigPath to actual cwd

### DIFF
--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -69,7 +69,7 @@ const PATH_WEB_DIR_CONFIG_POSTCSS = 'web/config/postcss.config.js'
 /**
  * Search the parent directories for the Redwood configuration file.
  */
-export const getConfigPath = (cwd: string = __dirname): string => {
+export const getConfigPath = (cwd: string = process.cwd()): string => {
   const configPath = findUp(CONFIG_FILE_NAME, { cwd })
   if (!configPath) {
     throw new Error(


### PR DESCRIPTION
This fixes a config locating error for users of `yarn link` 