### PR TITLE
Improve new Setup command

### DIFF
--- a/packages/cli/src/commands/generate/util.js
+++ b/packages/cli/src/commands/generate/util.js
@@ -2,7 +2,7 @@ import terminalLink from 'terminal-link'
 
 export const command = 'util <util>'
 export const aliases = ['u']
-export const description = 'Quality of life utilities'
+export const description = 'WARNING: deprecated. Use "yarn rw setup" command.'
 
 // ********
 // Deprecated as of September 2020
@@ -16,6 +16,6 @@ export const builder = (yargs) =>
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
-        'https://redwoodjs.com/reference/command-line-interface'
+        'https://redwoodjs.com/reference/command-line-interface#setup'
       )}`
     )

--- a/packages/cli/src/commands/generate/util.js
+++ b/packages/cli/src/commands/generate/util.js
@@ -4,6 +4,11 @@ export const command = 'util <util>'
 export const aliases = ['u']
 export const description = 'Quality of life utilities'
 
+// ********
+// Deprecated as of September 2020
+// Use "setup" command
+// ********
+
 export const builder = (yargs) =>
   yargs
     .commandDir('./util', { recurse: true, exclude: /util.js/ })

--- a/packages/cli/src/commands/generate/util/tailwind/tailwind.js
+++ b/packages/cli/src/commands/generate/util/tailwind/tailwind.js
@@ -23,10 +23,11 @@ export const handler = async ({ force }) => {
     ? 'yarn rw setup tailwind --force'
     : 'yarn rw setup tailwind'
   try {
-    console.log(c.warning('WARNING: deprecated "util" command'))
+    console.log(c.warning('\n' + 'WARNING: deprecated "util" command'))
     console.log(
       c.green('See "setup" command: ') +
-        'https://redwoodjs.com/reference/command-line-interface#setup'
+        'https://redwoodjs.com/reference/command-line-interface#setup' +
+        '\n'
     )
     await execa(cmd, {
       stdio: 'inherit',

--- a/packages/cli/src/commands/generate/util/tailwind/tailwind.js
+++ b/packages/cli/src/commands/generate/util/tailwind/tailwind.js
@@ -1,15 +1,14 @@
-import fs from 'fs'
-import path from 'path'
-
-import Listr from 'listr'
 import execa from 'execa'
-import chalk from 'chalk'
 
 import c from 'src/lib/colors'
-import { getPaths, writeFile } from 'src/lib'
+
+// ********
+// Deprecated as of September 2020
+// Use "setup" command
+// ********
 
 export const command = 'tailwind'
-export const description = 'Setup tailwindcss'
+export const description = 'WARNING: deprecated. Use "yarn rw setup" command.'
 export const builder = (yargs) => {
   yargs.option('force', {
     alias: 'f',
@@ -19,105 +18,20 @@ export const builder = (yargs) => {
   })
 }
 
-const tailwindImportsAndNotes = [
-  '/**',
-  ' * START --- TAILWIND GENERATOR EDIT',
-  ' *',
-  ' * `yarn rw generate util tailwind` placed these imports here',
-  " * to inject Tailwind's styles into your CSS.",
-  ' * For more information, see: https://tailwindcss.com/docs/installation#add-tailwind-to-your-css',
-  ' */',
-  '@import "tailwindcss/base";',
-  '@import "tailwindcss/components";',
-  '@import "tailwindcss/utilities";',
-  '/**',
-  ' * END --- TAILWIND GENERATOR EDIT',
-  ' */\n',
-]
-
-const INDEX_CSS_PATH = path.join(getPaths().web.src, 'index.css')
-
 export const handler = async ({ force }) => {
-  const tasks = new Listr([
-    {
-      title: 'Installing packages...',
-      task: async () => {
-        /**
-         * Install postcss-loader, tailwindcss, and autoprefixer
-         */
-        await execa('yarn', [
-          'workspace',
-          'web',
-          'add',
-          '-D',
-          'postcss-loader@4.0.2',
-          'tailwindcss',
-          'autoprefixer@9.8.6',
-        ])
-      },
-    },
-    {
-      title: 'Configuring PostCSS...',
-      task: () => {
-        /**
-         * Make web/config if it doesn't exist
-         * and write postcss.config.js there
-         */
-        return writeFile(
-          getPaths().web.postcss,
-          fs
-            .readFileSync(
-              path.resolve(__dirname, 'templates', 'postcss.config.js.template')
-            )
-            .toString(),
-          { overwriteExisting: force }
-        )
-      },
-    },
-    {
-      title: 'Initializing Tailwind CSS...',
-      task: async () => {
-        /**
-         * If it doesn't already exist,
-         * initialize tailwind and move tailwind.config.js to web/
-         */
-        const configExists = fs.existsSync(
-          path.join(getPaths().web.base, 'tailwind.config.js')
-        )
-
-        if (!configExists || force) {
-          await execa('yarn', ['tailwindcss', 'init'])
-          /**
-           * Later, when we can tell the vscode extension where to look for the config,
-           * we can put it in web/config/
-           */
-          await execa('mv', ['tailwind.config.js', 'web/'])
-        }
-      },
-    },
-    {
-      title: 'Adding imports to index.css...',
-      task: () => {
-        /**
-         * Add tailwind imports and notes to the top of index.css
-         */
-        let indexCSS = fs.readFileSync(INDEX_CSS_PATH)
-        indexCSS = tailwindImportsAndNotes.join('\n') + indexCSS
-        fs.writeFileSync(INDEX_CSS_PATH, indexCSS)
-      },
-    },
-    {
-      title: 'One more thing...',
-      task: (_ctx, task) => {
-        task.title = `One more thing...\n\n   ${chalk.hex('#bf4722')(
-          'Quick link to the docs: '
-        )}https://tailwindcss.com/\n`
-      },
-    },
-  ])
-
+  const cmd = force
+    ? 'yarn rw setup tailwind --force'
+    : 'yarn rw setup tailwind'
   try {
-    await tasks.run()
+    console.log(c.warning('WARNING: deprecated "util" command'))
+    console.log(
+      c.green('See "setup" command: ') +
+        'https://redwoodjs.com/reference/command-line-interface#setup'
+    )
+    await execa(cmd, {
+      stdio: 'inherit',
+      shell: true,
+    })
   } catch (e) {
     console.log(c.error(e.message))
   }

--- a/packages/cli/src/commands/generate/util/tailwind/templates/postcss.config.js.template
+++ b/packages/cli/src/commands/generate/util/tailwind/templates/postcss.config.js.template
@@ -1,8 +1,0 @@
-const path = require('path')
-
-module.exports = {
-  plugins: [
-    require('tailwindcss')(path.resolve(__dirname, '../tailwind.config.js')),
-    require('autoprefixer'),
-  ],
-}

--- a/packages/cli/src/commands/setup.js
+++ b/packages/cli/src/commands/setup.js
@@ -1,7 +1,6 @@
 import terminalLink from 'terminal-link'
 export const command = 'setup <option>'
-export const description =
-  'Initialize project configuration with one-time setup commands.'
+export const description = 'Initialize project config and install packages'
 
 export const builder = (yargs) =>
   yargs

--- a/packages/cli/src/commands/setup.js
+++ b/packages/cli/src/commands/setup.js
@@ -1,15 +1,17 @@
 import terminalLink from 'terminal-link'
-export const command = 'setup <type>'
-export const description = 'Execute some setup logic'
+export const command = 'setup <option>'
+export const description =
+  'Initialize project configuration with one-time setup commands.'
 
 export const builder = (yargs) =>
   yargs
     .commandDir('./setup', { recurse: true })
+    .choices('i18n', 'tailwind')
     .demandCommand()
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
-        'https://redwoodjs.com/reference/command-line-interface#setting-up'
+        'https://redwoodjs.com/reference/command-line-interface#setup'
       )}`
     )
 

--- a/packages/cli/src/commands/setup/tailwind/tailwind.js
+++ b/packages/cli/src/commands/setup/tailwind/tailwind.js
@@ -44,15 +44,16 @@ export const handler = async ({ force }) => {
       task: async () => {
         /**
          * Install postcss-loader, tailwindcss, and autoprefixer
+         * RedwoodJS currently uses PostCSS v7; postcss-loader and autoprefixers pinned for compatibility
          */
         await execa('yarn', [
           'workspace',
           'web',
           'add',
           '-D',
-          'postcss-loader',
+          'postcss-loader@4.0.2',
           'tailwindcss',
-          'autoprefixer',
+          'autoprefixer@9.8.6',
         ])
       },
     },

--- a/packages/cli/src/commands/setup/tailwind/tailwind.js
+++ b/packages/cli/src/commands/setup/tailwind/tailwind.js
@@ -9,7 +9,7 @@ import c from 'src/lib/colors'
 import { getPaths, writeFile } from 'src/lib'
 
 export const command = 'tailwind'
-export const description = 'Setup tailwindcss'
+export const description = 'Setup tailwindcss and PostCSS'
 export const builder = (yargs) => {
   yargs.option('force', {
     alias: 'f',


### PR DESCRIPTION
continues #1154

- [x] updates setup/tailwind.js to match #1189
    - [ ] ~~Check out --> "initiating your config file with the `-p` flag will also generate a default PostCSS config file for you"~~
- [x] adds deprecation warning to `yarn rw g util tailwind`, which now uses `yarn rw setup tailwind`
- [x] improve description of setup command
- [ ] allow `yarn rw setup [options]` to take an array of commands (not sure if this is possible in Yargs in case of command directory) --> moved to issue #1252

