### PR TITLE
Revert to default Apollo fetch policy

### DIFF
--- a/packages/web/src/graphql/withCell.tsx
+++ b/packages/web/src/graphql/withCell.tsx
@@ -61,7 +61,6 @@ export type CellSuccessStateComponent =
 export const withCell = ({
   beforeQuery = (props) => ({
     variables: props,
-    fetchPolicy: 'cache-and-network',
   }),
   QUERY,
   afterQuery = (data) => ({ ...data }),


### PR DESCRIPTION
This PR resolves #1104. I used the [example blog](https://github.com/redwoodjs/example-blog) to test it. It's actually really easy to reproduce the double render issue with `Success` which made it was easy to confirm the fix!