### PR TITLE
Replace <tt> HTML elements with semantic <code> HTML elements

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -13,10 +13,10 @@ const FooBarPage = () => {
     <>
       <h1>FooBarPage</h1>
       <p>
-        Find me in <tt>./web/src/pages/FooBarPage/FooBarPage.js</tt>
+        Find me in <code>./web/src/pages/FooBarPage/FooBarPage.js</code>
       </p>
       <p>
-        My default route is named <tt>fooBar</tt>, link to me with \`
+        My default route is named <code>fooBar</code>, link to me with \`
         <Link to={routes.fooBar()}>FooBar</Link>\`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/multiWordPage.js
@@ -5,10 +5,10 @@ const ContactUsPage = () => {
     <>
       <h1>ContactUsPage</h1>
       <p>
-        Find me in <tt>./web/src/pages/ContactUsPage/ContactUsPage.js</tt>
+        Find me in <code>./web/src/pages/ContactUsPage/ContactUsPage.js</code>
       </p>
       <p>
-        My default route is named <tt>contactUs</tt>, link to me with `
+        My default route is named <code>contactUs</code>, link to me with `
         <Link to={routes.contactUs()}>ContactUs</Link>`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/paramPage.js
@@ -5,10 +5,10 @@ const PostPage = ({ id }) => {
     <>
       <h1>PostPage</h1>
       <p>
-        Find me in <tt>./web/src/pages/PostPage/PostPage.js</tt>
+        Find me in <code>./web/src/pages/PostPage/PostPage.js</code>
       </p>
       <p>
-        My default route is named <tt>post</tt>, link to me with `
+        My default route is named <code>post</code>, link to me with `
         <Link to={routes.post({ id: '42' })}>Post 42</Link>`
       </p>
       <p>The parameter passed to me is {id}</p>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/pluralWordPage.js
@@ -5,10 +5,10 @@ const CatsPage = () => {
     <>
       <h1>CatsPage</h1>
       <p>
-        Find me in <tt>./web/src/pages/CatsPage/CatsPage.js</tt>
+        Find me in <code>./web/src/pages/CatsPage/CatsPage.js</code>
       </p>
       <p>
-        My default route is named <tt>cats</tt>, link to me with `
+        My default route is named <code>cats</code>, link to me with `
         <Link to={routes.cats()}>Cats</Link>`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
+++ b/packages/cli/src/commands/generate/page/__tests__/fixtures/singleWordPage.js
@@ -5,10 +5,10 @@ const HomePage = () => {
     <>
       <h1>HomePage</h1>
       <p>
-        Find me in <tt>./web/src/pages/HomePage/HomePage.js</tt>
+        Find me in <code>./web/src/pages/HomePage/HomePage.js</code>
       </p>
       <p>
-        My default route is named <tt>home</tt>, link to me with `
+        My default route is named <code>home</code>, link to me with `
         <Link to={routes.home()}>Home</Link>`
       </p>
     </>

--- a/packages/cli/src/commands/generate/page/templates/page.js.template
+++ b/packages/cli/src/commands/generate/page/templates/page.js.template
@@ -4,9 +4,9 @@ const ${pascalName}Page = (${propParam}) => {
   return (
     <>
       <h1>${pascalName}Page</h1>
-      <p>Find me in <tt>${outputPath}</tt></p>
+      <p>Find me in <code>${outputPath}</code></p>
       <p>
-        My default route is named <tt>${camelName}</tt>, link to me with `
+        My default route is named <code>${camelName}</code>, link to me with `
         <Link to={routes.${camelName}(${ argumentParam })}>${pascalName}<%= argumentParam !== '' ? ' 42' : '' %></Link>`
       </p><% if (paramName !== '') { %>
       <p>


### PR DESCRIPTION
The Teletype Text element `<tt>` is obsolete in HTML 5.2 W3C recommandation. Where the `<tt>` element would have been used for marking up keyboard input, [it is now advised to use the `<code>` element for computer code](https://www.w3.org/TR/html52/obsolete.html#elementdef-tt).