### PR TITLE
Small Language Server fixes (to get VSCode extension working)

### DIFF
--- a/packages/structure/src/language_server/RWLanguageServer.ts
+++ b/packages/structure/src/language_server/RWLanguageServer.ts
@@ -12,6 +12,7 @@ import { HostWithDocumentsStore, IDEInfo } from '../ide'
 import { RWProject } from '../model'
 import { lazy, memo } from '../x/decorators'
 import { VSCodeWindowMethods_fromConnection } from '../x/vscode'
+import { Connection_suppressErrors } from '../x/vscode-languageserver'
 import {
   ExtendedDiagnostic_findRelevantQuickFixes,
   Range_contains,
@@ -24,12 +25,16 @@ import { XMethodsManager } from './xmethods'
 export class RWLanguageServer {
   initializeParams!: InitializeParams
   documents = new TextDocuments(TextDocument)
-  connection = createConnection(ProposedFeatures.all)
+  @lazy() get connection() {
+    const c = createConnection(ProposedFeatures.all)
+    Connection_suppressErrors(c)
+    return c
+  }
   @memo() start() {
     const { connection, documents } = this
     connection.onInitialize((params) => {
       connection.console.log(
-        `Redwood.js Language Server onInitialize(), PID=${process.pid}`
+        `Redwood Language Server onInitialize(), PID=${process.pid}`
       )
       this.initializeParams = params
       return {
@@ -50,7 +55,7 @@ export class RWLanguageServer {
     })
 
     connection.onInitialized(async () => {
-      connection.console.log('Redwood.js Language Server onInitialized()')
+      connection.console.log('Redwood Language Server onInitialized()')
       const folders = await connection.workspace.getWorkspaceFolders()
       if (folders) {
         for (const folder of folders) {

--- a/packages/structure/src/language_server/RWLanguageServer.ts
+++ b/packages/structure/src/language_server/RWLanguageServer.ts
@@ -57,11 +57,14 @@ export class RWLanguageServer {
           this.projectRoot = normalize(folder.uri.substr(7)) // remove file://
         }
       }
-      this.diagnostics.start()
-      this.commands.start()
-      this.outline.start()
-      this.xmethods.start()
     })
+
+    // initialize these early on to prevent "unhandled methods"
+    // they are smart enough to short-circuit if this.projectRoot is not ready
+    this.diagnostics.start()
+    this.commands.start()
+    this.outline.start()
+    this.xmethods.start()
 
     connection.onImplementation(async ({ textDocument: { uri }, position }) => {
       const info = await this.info(uri, 'Implementation')

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -79,12 +79,19 @@ export class RWProject extends BaseNode {
   }
   // TODO: do we move this to a separate node? (ex: RWDatabase)
   @memo() async prismaDMMF() {
-    return await getDMMF({
-      datamodel: this.host.readFileSync(this.pathHelper.api.dbSchema),
-    })
+    try {
+      // consider case where dmmf doesn't exist (or fails to parse)
+      return await getDMMF({
+        datamodel: this.host.readFileSync(this.pathHelper.api.dbSchema),
+      })
+    } catch (e) {
+      return undefined
+    }
   }
   @memo() async prismaDMMFModelNames() {
-    return (await this.prismaDMMF()).datamodel.models.map((m) => m.name)
+    const dmmf = await this.prismaDMMF()
+    if (!dmmf) return []
+    return dmmf.datamodel.models.map((m) => m.name)
   }
   @lazy() get redwoodTOML(): RWTOML {
     return new RWTOML(join(this.projectRoot, 'redwood.toml'), this)

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -90,7 +90,11 @@ export class RWProject extends BaseNode {
     return new RWTOML(join(this.projectRoot, 'redwood.toml'), this)
   }
   @lazy() private get processPagesDir() {
-    return processPagesDir(this.pathHelper.web.pages)
+    try {
+      return processPagesDir(this.pathHelper.web.pages)
+    } catch (e) {
+      return []
+    }
   }
   @lazy() get pages(): RWPage[] {
     return this.processPagesDir.map((p) => new RWPage(p.const, p.path, this))

--- a/packages/structure/src/outline/outline.ts
+++ b/packages/structure/src/outline/outline.ts
@@ -205,6 +205,7 @@ function _schema(project: RWProject): TreeItem2 {
     ...resourceUriAndCommandFor(project.pathHelper.api.dbSchema),
     async children() {
       const dmmf = await project.prismaDMMF()
+      if (!dmmf) return []
       const models = dmmf.datamodel.models.map((model) => {
         return {
           label: model.name,

--- a/packages/structure/src/x/vscode-languageserver.ts
+++ b/packages/structure/src/x/vscode-languageserver.ts
@@ -1,0 +1,57 @@
+import { Connection } from 'vscode-languageserver'
+
+/**
+ * will monkey patch the connection object
+ * so that any errors thrown by subsequently installed handlers are caught and logged
+ * (ex: connection.onHover(() => throw new Error('oops!')))
+ * this prevents the LSP client, on the other end, to receive errors
+ * which can sometimes cause error messages to pop-up uncontrollably
+ *
+ * @param conn
+ */
+export function Connection_suppressErrors<T extends Connection>(conn: T) {
+  for (const k of Object.keys(conn)) {
+    if (!k.startsWith('on')) continue // only onHover, onCodeLens, etc?
+    const v = conn[k]
+    if (typeof v !== 'function') continue
+    conn[k] = (...args) => {
+      const args2 = args.map((arg) =>
+        typeof arg === 'function'
+          ? with_catch2(arg, (e, fargs) => {
+              const data = {
+                handler: k,
+                handlerInstallParams: args,
+                handlerExecParams: fargs,
+                error: e + '',
+              }
+              const dd = JSON.stringify(data, null, 2)
+              conn.console.error(dd)
+              return null
+            })
+          : arg
+      )
+      return v.apply(conn, args2)
+    }
+  }
+}
+
+type CatchClause = (e?, args?) => unknown
+
+function with_catch2(f, clause: CatchClause) {
+  return (...args) =>
+    catch2(
+      () => f(...args),
+      (e) => clause(e, args)
+    )
+  function catch2(f, clause2) {
+    try {
+      const res = f()
+      if (typeof res?.then === 'function')
+        // promise
+        return res.catch?.(clause2)
+      return res
+    } catch (e) {
+      return clause2(e)
+    }
+  }
+}


### PR DESCRIPTION
* This PR contains a set of minimal changes to the Language Server code
* They are critical for some users who are running into issues when trying to use the VSCode extension (see #1261)
* I am keeping them as small and self-contained as possible so we can release a patch ASAP

# Changes

## Suppress most error responses from the Language Server

* By patching the `lsp.Connection` object (the top-most entry point), we're catching all errors that would otherwise result in VSCode showing a warning (or worse, an information message that doesn't go away)
* This is brute force, but it is still correct (DX-wise). We want the IDE to support all kinds of malformed projects without failing (just suppressing functionality). We're still logging the errors to the Redwood Language Server output channel.
* Eventually, some of the errors that will get logged should be addressed more granularly at the structure/model level

## Improve initialization order of LSP components

* After looking at some usage logs I found sporadic "unhandled method" exceptions (thrown by the LSP client on the VSCode extension side) that were, in some cases, resulting in an empty outline, or in the extension host shutting down the extension altogether. It is hard to understand the race conditions involved, but initializing them as early as possible is a simple, albeit blunt, solution.
* This is a really small fix that changes the initialization sequence of parts of the language server
* It makes sure that several request handlers (commands, outline, etc) are installed as early as possible in the initialization process

## Tolerate certain missing files and folders

* Do not throw if schema.prisma does not exist or cannot be parsed
* Do not throw "pages" folder does not exist (or processPagesDir fails)
* More info in [this issue comment](https://github.com/redwoodjs/redwood/issues/1261#issuecomment-703179835)