### PR TITLE
@redwoodjs/structure: do not throw if pages dir is empty

### DIFF
--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -90,7 +90,11 @@ export class RWProject extends BaseNode {
     return new RWTOML(join(this.projectRoot, 'redwood.toml'), this)
   }
   @lazy() private get processPagesDir() {
-    return processPagesDir(this.pathHelper.web.pages)
+    try {
+      return processPagesDir(this.pathHelper.web.pages)
+    } catch (e) {
+      return []
+    }
   }
   @lazy() get pages(): RWPage[] {
     return this.processPagesDir.map((p) => new RWPage(p.const, p.path, this))


### PR DESCRIPTION
* Super small fix that should not break anything (just wrapping something with a try/catch)

* @redwoodjs/structure should tolerate all sorts of malformed projects and NOT throw any errors if possible
* This fix adds a try/catch clause to prevent the package from throwing when the "pages" dir is empty.

See [this issue comment](https://github.com/redwoodjs/redwood/issues/1261#issuecomment-703179835) for more details
