### PR TITLE
(rw setup): Add command to setup webpack.config.js for web

### DIFF
--- a/packages/cli/src/commands/setup/webpack/templates/webpack.config.js.template
+++ b/packages/cli/src/commands/setup/webpack/templates/webpack.config.js.template
@@ -1,0 +1,13 @@
+module.exports = (config, { env }) => {
+  if (env === 'development') {
+    // Add dev plugin
+  }
+
+  // Add custom rules for your project
+  // config.module.rules.push(YOUR_RULE)
+
+  // Add custom plugins for your project
+  // config.plugins.push(YOUR_PLUGIN)
+
+  return config
+}

--- a/packages/cli/src/commands/setup/webpack/webpack.js
+++ b/packages/cli/src/commands/setup/webpack/webpack.js
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import Listr from 'listr'
+import path from 'path'
+import terminalLink from 'terminal-link'
+
+import c from 'src/lib/colors'
+import { getPaths, writeFile } from 'src/lib'
+
+export const command = 'webpack'
+export const description =
+  'Setup webpack in your project so you can add custom config'
+export const builder = (yargs) => {
+  yargs.option('force', {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing configuration',
+    type: 'boolean',
+  })
+}
+
+export const handler = async ({ force }) => {
+  const tasks = new Listr([
+    {
+      title: 'Adding webpack file to your web folder...',
+      task: () => {
+        const webpackConfigFile = `${getPaths().web.config}/webpack.config.js`
+
+        return writeFile(
+          webpackConfigFile,
+          fs
+            .readFileSync(
+              path.resolve(__dirname, 'templates', 'webpack.config.js.template')
+            )
+            .toString(),
+          { overwriteExisting: force }
+        )
+      },
+    },
+    {
+      title: 'One more thing...',
+      task: (_ctx, task) => {
+        task.title = `One more thing...\n
+          ${c.green(
+            'Quick link to the docs on configuring custom webpack config:'
+          )}\n
+          ${terminalLink(
+            'https://redwoodjs.com/docs/webpack-configuration#configuring-webpack'
+          )}
+        `
+      },
+    },
+  ])
+
+  try {
+    await tasks.run()
+  } catch (e) {
+    console.log(c.error(e.message))
+  }
+}

--- a/packages/cli/src/commands/setup/webpack/webpack.js
+++ b/packages/cli/src/commands/setup/webpack/webpack.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import Listr from 'listr'
 import path from 'path'
-import terminalLink from 'terminal-link'
+import chalk from 'chalk'
 
 import c from 'src/lib/colors'
 import { getPaths, writeFile } from 'src/lib'

--- a/packages/cli/src/commands/setup/webpack/webpack.js
+++ b/packages/cli/src/commands/setup/webpack/webpack.js
@@ -42,8 +42,8 @@ export const handler = async ({ force }) => {
         task.title = `One more thing...\n
           ${c.green(
             'Quick link to the docs on configuring custom webpack config:'
-          )}\n
-          ${terminalLink(
+          )}
+          ${chalk.hex('#e8e8e8')(
             'https://redwoodjs.com/docs/webpack-configuration#configuring-webpack'
           )}
         `


### PR DESCRIPTION
## What?
Simple command to setup the webpack config for the web side at the right place.

## Why?
Beyond "hello world" projects, you probably want to setup custom webpack plugins, resolvers or rules.