### PR TITLE
remote deprecated argument from prisma studio call

### DIFF
--- a/packages/cli/src/commands/dbCommands/studio.js
+++ b/packages/cli/src/commands/dbCommands/studio.js
@@ -37,7 +37,7 @@ export const handler = async () => {
       {
         title: 'Starting Prisma Studio...',
         cmd: 'yarn prisma',
-        args: ['studio', '--experimental'],
+        args: ['studio'],
       },
     ],
     { verbose: true }


### PR DESCRIPTION
Hi all, 

  `--experimental` is no longer needed in currently shipping prisma
  studio. this drops the warning shown bellow when calling
  `yarn rw db studio`

  ```
  $ /Users/am/hacks/osmium/node_modules/.bin/prisma studio --experimental
  warn --experimental is no longer required for this command
  Starting Prisma Studio ...
  ```


first contrib here, excuse me in advance if i missed something obvious :-) 

All the best && keep the great work!