### PR TITLE
Upgrade Prisma v2.8.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.7.1",
+    "@prisma/client": "2.8.1",
     "@redwoodjs/internal": "^0.19.2",
     "apollo-server-lambda": "2.17.0",
     "core-js": "3.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.7.1",
+    "@prisma/sdk": "2.8.1",
     "@redwoodjs/internal": "^0.19.2",
     "@redwoodjs/structure": "^0.19.2",
     "boxen": "^4.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime-corejs3": "^7.11.2",
-    "@prisma/cli": "2.7.1",
+    "@prisma/cli": "2.8.1",
     "@redwoodjs/cli": "^0.19.2",
     "@redwoodjs/dev-server": "^0.19.2",
     "@redwoodjs/eslint-config": "^0.19.2",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.7.1",
+    "@prisma/sdk": "2.8.1",
     "@redwoodjs/internal": "^0.19.2",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,33 +3117,33 @@
   resolved "https://registry.yarnpkg.com/@prisma/ci-info/-/ci-info-2.1.2.tgz#3da64f54584bde0aaf4b42f298a6c63f025aeb3f"
   integrity sha512-RhAHY+wp6Nqu89Tp3zfUVkpGfqk4TfngeOWaMGgmhP7mB2ASDtOl8dkwxHmI8eN4edo+luyjPmbJBC4kST321A==
 
-"@prisma/cli@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.7.1.tgz#98f2cb434bb931341e6c6292c7bab601e5f842f8"
-  integrity sha512-0uA+gWkNQ35DveVHDPltiTCTr4wcXtEhnPs463IEM+Xn8dTv9x0gtZiYHSuQM3t7uwlOxj1rurBsqSbiljynfQ==
+"@prisma/cli@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.8.1.tgz#fdfeb56857f2fb08ec9769537279745749effcf7"
+  integrity sha512-mEGJplClGnXI5ki4R0Xq8nq62zcyu7Wzdhybege+cFPZFUbFj0petaPZl/tqta9o5neDyvpU/lDgOwef6mwySg==
 
-"@prisma/client@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.7.1.tgz#0a37ddff7fe80ae3a86dfa620c1141c8607be6c2"
-  integrity sha512-IEWDCuvIaQTira8/jAyf+uY+AuPPUFDIXMSN4zEA/gvoJv2woq7RmkaubS+NQVgDbbyOR6F3UcXLiFTYQDzZkQ==
+"@prisma/client@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.8.1.tgz#6fe87968eed42901cf76c623985222ebc318c292"
+  integrity sha512-apt6ioi2euOZA1O9mPA8AMRjPoPECsva76gMCcHCVgHvhkMNpFkcbn+UTkErJYrTgcRR7CPQt4D+fw8pkAHfjA==
   dependencies:
     pkg-up "^3.1.0"
 
-"@prisma/debug@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.7.1.tgz#8ac51f9735fe07bc5e29ef247ff18625ccb96c4a"
-  integrity sha512-qF9xBjNWtf7yZBAKtHJB+Sp0kxdF/K5rUyVk9VoMNNgTrIFkaOcDY68DUlldxh+txjydUT4YacR5P4qXZocsqg==
+"@prisma/debug@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.8.1.tgz#ab6006fe8c669bfa3f806fab6949af13cdf0d8f9"
+  integrity sha512-MX7zIz0hP4JvL/WxBFTrpBsjb/pQSMBrJFiwCmpBzJeCI/CMpLnca7pEI9OHs/LVtoJBplhz05kLcrX2hMhN4w==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.7.1.tgz#87dd6deba49508e3475bc668c3ede2060d782b31"
-  integrity sha512-vbNeKBl6Nl1KJuwCCwva8v4BXuv/jydA/Yl5Jnrf11KGM3BSCRavDGj4N1rxdxXpnp+L4Icb2OkxXYgdEWKPdA==
+"@prisma/engine-core@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.8.1.tgz#2384649aaed9ba7f9ebc314b20a1337b4421a051"
+  integrity sha512-aHE9DhJagYFzfIBuGt2GdNx0fL9IvekNDnjx97Ys6WiT/MskZf1RiLD2Sfarc7nBKx8BdSS1BHHGYm5sBOQzlg==
   dependencies:
-    "@prisma/debug" "2.7.1"
-    "@prisma/generator-helper" "2.7.1"
-    "@prisma/get-platform" "2.7.1"
+    "@prisma/debug" "2.8.1"
+    "@prisma/generator-helper" "2.8.1"
+    "@prisma/get-platform" "2.8.1"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
@@ -3152,15 +3152,15 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+    undici "2.0.5"
 
-"@prisma/fetch-engine@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.7.1.tgz#855a32cdcb22e3c105b5f10e5490e25b7a96d02a"
-  integrity sha512-BmJW8RGQCMAtYSgmCOH3X4trdzzejum4yuutruDKJQDP67fPmd8Waq/SRlnDcjhDs+2ZI6lKMaj6qTCU9Qd+MQ==
+"@prisma/fetch-engine@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.8.1.tgz#4e424961edc9b6900c38bca88fabf038f8f08555"
+  integrity sha512-mJ3vj6dhs5Ez4rb6BpAKlEv2yiKjEmxF/hETGG6PG++v5GILnmironZHNpr5Z2+HDBdvQTjsxAZIE+6AwtAa0w==
   dependencies:
-    "@prisma/debug" "2.7.1"
-    "@prisma/get-platform" "2.7.1"
+    "@prisma/debug" "2.8.1"
+    "@prisma/get-platform" "2.8.1"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -3176,40 +3176,40 @@
     progress "^2.0.3"
     rimraf "^3.0.2"
     temp-dir "^2.0.0"
-    tempy "^0.6.0"
+    tempy "^0.7.0"
 
-"@prisma/generator-helper@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.7.1.tgz#31158537cb79777f42ec2b15e71943edd6c39924"
-  integrity sha512-gG2BRDefyIIXSx6uMFTof8Nd0jkZjPs6ExvTcra7xi36+oqkdgjOmq1vp6x3+VfC+EXzY1qReBZViuZZSFH4Cg==
+"@prisma/generator-helper@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.8.1.tgz#8858f2cd9ef23ec55d5bafe38532e05472f46e5c"
+  integrity sha512-f9rgTvrFpjSn3Ity2zPfFv5khiQZ7F+eBr4+pL0eFmm+ffJBAsdGUv1Xl4qEgSfMzQEOmVnVUgtCMcUQgwNfXg==
   dependencies:
-    "@prisma/debug" "2.7.1"
+    "@prisma/debug" "2.8.1"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.7.1.tgz#3da81ad3ea96c7ff8bed7cb3a4058c1f919dd123"
-  integrity sha512-2G/dbvIUC8rC4pKR+MX9jdcqnTbdSvYvhTLhc99y5Z2pI2dV+/vb3dWSXHWqmLWsmY482n9X+HngxQGnX4V4bQ==
+"@prisma/get-platform@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.8.1.tgz#bcb78b8fae0a4a7190565c3da1fd372e585c64fb"
+  integrity sha512-CW7S7nM03Po+N6w8g6AcR8k/u4CLFaecL2Hm7k12j/Ns1F2lX0F1mRKxoTccg0b11t3lM/vjakia4L5ogDS8KA==
   dependencies:
-    "@prisma/debug" "2.7.1"
+    "@prisma/debug" "2.8.1"
 
-"@prisma/sdk@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.7.1.tgz#cb3f33ef74e335dc0741dcc0b89fbb4c8c8508e0"
-  integrity sha512-vXPxcoxVuxXkNcMOx9+Bx89uiTfTDSJ/dOiNjWKV3Y7NaQj5kphik7wdt76QQees7Zu3cG6MwHRY7Awbkc6ZLw==
+"@prisma/sdk@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.8.1.tgz#7edb228b98906afc42a267a6b38cf5dc8e8ec753"
+  integrity sha512-xoeuWnP8+jke4VfIfU0zv92ACKJ85CmXLUnkWmRdYS0GndRWDpe/mRkA+RNBpDFA62R9lYVW1sPT3KaUGokEUA==
   dependencies:
-    "@prisma/debug" "2.7.1"
-    "@prisma/engine-core" "2.7.1"
-    "@prisma/fetch-engine" "2.7.1"
-    "@prisma/generator-helper" "2.7.1"
-    "@prisma/get-platform" "2.7.1"
+    "@prisma/debug" "2.8.1"
+    "@prisma/engine-core" "2.8.1"
+    "@prisma/fetch-engine" "2.8.1"
+    "@prisma/generator-helper" "2.8.1"
+    "@prisma/get-platform" "2.8.1"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^4.1.3"
     chalk "4.1.0"
-    checkpoint-client "1.1.11"
+    checkpoint-client "1.1.12"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^4.0.0"
@@ -3228,7 +3228,7 @@
     tar "^6.0.1"
     temp-dir "^2.0.0"
     temp-write "^4.0.0"
-    tempy "^0.6.0"
+    tempy "^0.7.0"
     terminal-link "^2.1.1"
     tmp "0.2.1"
     url-parse "^1.4.7"
@@ -6764,10 +6764,10 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-checkpoint-client@1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.11.tgz#992818640b9ef12d66304bf973d993760b1e6926"
-  integrity sha512-p+eDmbuKlP6oHgknetUoqWTHnQsWfSbDlaMlKgwNh8RiEdLQVZ5z1rcU4+0iBynZe2z8sJHHSdWo9VQTmGWRLw==
+checkpoint-client@1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.12.tgz#406fb898a95c2911235aa3e3bf4564de66cb6d8d"
+  integrity sha512-YbQMJe28YfLWBst/YvQhrh12afZGy67J7Uo/q9U0OfrFXZq3D8OyDPgjZkc+zRRK3wppC28SiCQ0fbgalsmCqA==
   dependencies:
     "@prisma/ci-info" "2.1.2"
     cross-spawn "7.0.3"
@@ -6775,8 +6775,8 @@ checkpoint-client@1.1.11:
     fast-write-atomic "0.2.1"
     make-dir "3.1.0"
     ms "2.1.2"
-    node-fetch "2.6.0"
-    uuid "8.1.0"
+    node-fetch "2.6.1"
+    uuid "8.3.0"
 
 chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
@@ -8052,6 +8052,20 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+del@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
+  integrity sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==
+  dependencies:
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
+    slash "^3.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -11434,7 +11448,7 @@ is-observable@^1.1.0:
   dependencies:
     symbol-observable "^1.1.0"
 
-is-path-cwd@^2.0.0:
+is-path-cwd@^2.0.0, is-path-cwd@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
@@ -11453,7 +11467,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-path-inside@^3.0.1:
+is-path-inside@^3.0.1, is-path-inside@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
   integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
@@ -17487,11 +17501,12 @@ temp-write@^4.0.0:
     temp-dir "^1.0.0"
     uuid "^3.3.2"
 
-tempy@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.6.0.tgz#65e2c35abc06f1124a97f387b08303442bde59f3"
-  integrity sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==
+tempy@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.7.1.tgz#5a654e6dbd1747cdd561efb112350b55cd9c1d46"
+  integrity sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==
   dependencies:
+    del "^6.0.0"
     is-stream "^2.0.0"
     temp-dir "^2.0.0"
     type-fest "^0.16.0"
@@ -18002,9 +18017,10 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-"undici@git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744":
-  version "1.3.1"
-  resolved "git://github.com/nodejs/undici.git#e76f6a37836537f08c2d9b7d8805d6ff21d1e744"
+undici@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-2.0.5.tgz#b604e203184002d2ecf6524581ac994346700a09"
+  integrity sha512-KluDT7X78oGS+/3bxwGE06e/4x4wbuK7TNmTMLPJNmEOkzrLGBMwAnWMxm3PukR9BnB7k20IzOpGjl90AltwFQ==
 
 unfetch@^4.1.0:
   version "4.1.0"
@@ -18273,10 +18289,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
-  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+uuid@8.3.0, uuid@^8.0.0, uuid@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
+  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
@@ -18287,11 +18303,6 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
-
-uuid@^8.0.0, uuid@^8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
-  integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Tested locally.

Needs deploy testing.

Release Notes:
- v2.8.0: https://github.com/prisma/prisma/releases/tag/2.8.0
    - `findFirst`
     - Case insensitive filters for PostgreSQL are now stable
- v2.8.1: https://github.com/prisma/prisma/releases/tag/2.8.1
    - misc fixes