### PR TITLE
Fix windows related path and file-uri errors in redwoodjs/structure

### DIFF
--- a/packages/structure/src/language_server/RWLanguageServer.ts
+++ b/packages/structure/src/language_server/RWLanguageServer.ts
@@ -1,4 +1,4 @@
-import { normalize } from 'path'
+import { URL_toFile } from 'src/x/URL'
 import {
   createConnection,
   InitializeParams,
@@ -59,7 +59,7 @@ export class RWLanguageServer {
       const folders = await connection.workspace.getWorkspaceFolders()
       if (folders) {
         for (const folder of folders) {
-          this.projectRoot = normalize(folder.uri.substr(7)) // remove file://
+          this.projectRoot = URL_toFile(folder.uri)
         }
       }
     })

--- a/packages/structure/src/language_server/RWLanguageServer.ts
+++ b/packages/structure/src/language_server/RWLanguageServer.ts
@@ -1,4 +1,3 @@
-import { URL_toFile } from 'src/x/URL'
 import {
   createConnection,
   InitializeParams,
@@ -11,6 +10,7 @@ import { CodeAction } from 'vscode-languageserver-types'
 import { HostWithDocumentsStore, IDEInfo } from '../ide'
 import { RWProject } from '../model'
 import { lazy, memo } from '../x/decorators'
+import { URL_toFile } from '../x/URL'
 import { VSCodeWindowMethods_fromConnection } from '../x/vscode'
 import { Connection_suppressErrors } from '../x/vscode-languageserver'
 import {

--- a/packages/structure/src/model/RWPage.ts
+++ b/packages/structure/src/model/RWPage.ts
@@ -14,7 +14,12 @@ export class RWPage extends FileNode {
     super()
   }
   @lazy() get filePath() {
-    return directoryNameResolver(this.path)
+    const f = directoryNameResolver(this.path)
+    if (!f)
+      throw new Error(
+        `could not resolve index filename for directory '${this.path}' using dirname convention`
+      )
+    return f
   }
   @lazy() get route() {
     return this.parent.router.routes.find(

--- a/packages/structure/src/x/URL.ts
+++ b/packages/structure/src/x/URL.ts
@@ -1,5 +1,5 @@
-import { isAbsolute, join, normalize } from 'path'
-import { parse } from 'url'
+import { isAbsolute, join, normalize, sep as path_sep } from 'path'
+
 /**
  * Creates a file:// URL
  * Works with linux and windows paths
@@ -17,14 +17,64 @@ export function URL_file(filePath: string, ...parts: string[]): string {
 /**
  *
  * @param uriOrFilePath
+ * @param sep separator string, defaults to `require('path').sep`
  */
-export function URL_toFile(uriOrFilePath: string): string {
+export function URL_toFile(uriOrFilePath: string, sep = path_sep): string {
   if (typeof uriOrFilePath !== 'string') throw new Error('arg error')
   if (uriOrFilePath.startsWith(FILE_SCHEME))
-    return URL_toFile(parse(uriOrFilePath)!.path!)
+    return fileUriToPath(uriOrFilePath, sep)
   const p = normalize(uriOrFilePath)
-  if (!isAbsolute(p)) throw new Error('absolut path expected: ' + p)
+  if (!isAbsolute(p)) throw new Error('absolute path expected: ' + p)
   return p!
 }
 
 const FILE_SCHEME = 'file://'
+
+/**
+ * based on https://github.com/TooTallNate/file-uri-to-path/blob/master/src/index.ts
+ * main changes:
+ * - modified to work with VSCode Language Server URIs (they encode colons: "file:///c%3A/a/b.c" )
+ * - you can pass "sep", the system separator, (for tests)
+ *
+ * @param uri
+ * @param sep
+ */
+function fileUriToPath(uri: string, sep = path_sep): string {
+  if (
+    typeof uri !== 'string' ||
+    uri.length <= 7 ||
+    uri.substring(0, 7) !== FILE_SCHEME
+  ) {
+    throw new TypeError('must pass in a file:// URI to convert to a file path')
+  }
+
+  const rest = decodeURIComponent(uri.substring(7))
+  const firstSlash = rest.indexOf('/')
+  let host = rest.substring(0, firstSlash)
+  let path = rest.substring(firstSlash + 1)
+
+  // 2.  Scheme Definition
+  // As a special case, <host> can be the string "localhost" or the empty
+  // string; this is interpreted as "the machine from which the URL is
+  // being interpreted".
+  if (host === 'localhost') host = ''
+  if (host) host = sep + sep + host
+
+  // 3.2  Drives, drive letters, mount points, file system root
+  // Drive letters are mapped into the top of a file URI in various ways,
+  // depending on the implementation; some applications substitute
+  // vertical bar ("|") for the colon after the drive letter, yielding
+  // "file:///c|/tmp/test.txt".  In some cases, the colon is left
+  // unchanged, as in "file:///c:/tmp/test.txt".  In other cases, the
+  // colon is simply omitted, as in "file:///c/tmp/test.txt".
+  path = path.replace(/^(.+)\|/, '$1:')
+
+  const parts = path.split('/')
+
+  // if the first segment is NOT a windows drive
+  // we insert an extra empty segment
+  // this will result in an initial slash (unix style)
+  if (!parts[0].includes(':')) parts.unshift('')
+
+  return parts.join(sep)
+}

--- a/packages/structure/src/x/__tests__/URL.test.ts
+++ b/packages/structure/src/x/__tests__/URL.test.ts
@@ -23,4 +23,7 @@ describe('URL_toFile', () => {
     expect(URL_toFile(`/a/b.c`)).toEqual(res)
     expect(URL_toFile(`file:///a/b.c`)).toEqual(res)
   })
+  it('works with urlencoded windows file URLs (vscode language server does it this way)', () => {
+    expect(URL_toFile(`file:///c%3A/a/b.c`, '\\')).toEqual('c:\\a\\b.c')
+  })
 })

--- a/packages/structure/src/x/path.ts
+++ b/packages/structure/src/x/path.ts
@@ -1,11 +1,17 @@
-import { basename, sep, normalize } from 'path'
+import { existsSync } from 'fs'
+import { basename, normalize, sep } from 'path'
 
-export function directoryNameResolver(dirName: string): string {
+export function directoryNameResolver(dirName: string): string | undefined {
   dirName = normalize(dirName)
   const parts = dirName.split(sep)
   const pp = parts[parts.length - 1]
   parts.push(pp)
-  return parts.join(sep) + '.js'
+  const extensions = ['.js', '.jsx', '.ts', '.tsx']
+  const pathNoExt = parts.join(sep)
+  for (const ext of extensions) {
+    const path = pathNoExt + ext
+    if (existsSync(path)) return path
+  }
 }
 
 export function followsDirNameConvention(filePath: string): boolean {

--- a/packages/structure/src/x/path.ts
+++ b/packages/structure/src/x/path.ts
@@ -1,27 +1,32 @@
-import { basename } from 'path'
+import { basename, sep, normalize } from 'path'
 
 export function directoryNameResolver(dirName: string): string {
-  const parts = dirName.split('/')
+  dirName = normalize(dirName)
+  const parts = dirName.split(sep)
   const pp = parts[parts.length - 1]
   parts.push(pp)
-  return parts.join('/') + '.js'
+  return parts.join(sep) + '.js'
 }
 
 export function followsDirNameConvention(filePath: string): boolean {
-  const ending = basenameNoExt(filePath) + '/' + basename(filePath)
+  filePath = normalize(filePath)
+  const ending = basenameNoExt(filePath) + sep + basename(filePath)
   return filePath.endsWith(ending)
 }
 
 export function basenameNoExt(path: string): string {
+  path = normalize(path)
   const parts = basename(path).split('.')
   if (parts.length > 1) parts.pop()
   return parts.join('.')
 }
 
 export function isLayoutFileName(f: string): boolean {
+  f = normalize(f)
   return basenameNoExt(f).endsWith('Layout')
 }
 
 export function isCellFileName(f: string): boolean {
+  f = normalize(f)
   return basenameNoExt(f).endsWith('Cell')
 }


### PR DESCRIPTION
* This PR fixes several bugs related to path and file-uri handling in windows (use `path.sep` and `path.normalize()`, fix some encoding issues with file URIs, etc)
* It should finally solve #1261. I tested it locally on windows
* It also fixes a related issue where we were only looking for ".js" files (it should be "js, jsx, ts, tsx")