### PR TITLE
fix #1256 router "Create Page..." codelens positon

### DIFF
--- a/packages/structure/src/model/RWRouter.ts
+++ b/packages/structure/src/model/RWRouter.ts
@@ -77,23 +77,20 @@ export class RWRouter extends FileNode {
   *ideInfo() {
     if (this.jsxNode) {
       let location = Location_fromNode(this.jsxNode)
-      if (this.routes.length > 0) {
-        location = Location_fromNode(this.routes[0].jsxNode)
-        const codeLens: CodeLens = {
-          range: location.range,
-          command: Command.create(
-            'Create Page...',
-            'redwoodjs.cli',
-            'generate page...',
-            this.parent.projectRoot
-          ),
-        }
-        yield {
-          kind: 'CodeLens',
-          location,
-          codeLens,
-        } as CodeLensX
+      const codeLens: CodeLens = {
+        range: location.range,
+        command: Command.create(
+          'Create Page...',
+          'redwoodjs.cli',
+          'generate page...',
+          this.parent.projectRoot
+        ),
       }
+      yield {
+        kind: 'CodeLens',
+        location,
+        codeLens,
+      } as CodeLensX
     }
   }
 


### PR DESCRIPTION
Fixes #1256 by modifying the location in which the codelens is rendered. It used to be rendered above the first route and now is rendered on top of the `<Router>` tag instead.
![image](https://user-images.githubusercontent.com/5379019/95667447-a2128c80-0b3c-11eb-9d5d-9f48cb62631e.png)
This also allows for further changes within the structure of router without disrupting the codelens.