### PR TITLE
Fix scaffold mutation

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/editCell.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/editCell.js
@@ -23,6 +23,16 @@ const UPDATE_POST_MUTATION = gql`
   mutation UpdatePostMutation($id: Int!, $input: UpdatePostInput!) {
     updatePost(id: $id, input: $input) {
       id
+      title
+      slug
+      author
+      body
+      image
+      isPinned
+      readTime
+      rating
+      postedAt
+      metadata
     }
   }
 `

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/edit.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/edit.js
@@ -18,6 +18,8 @@ const UPDATE_USER_PROFILE_MUTATION = gql`
   ) {
     updateUserProfile(id: $id, input: $input) {
       id
+      username
+      userId
     }
   }
 `

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
@@ -11,8 +11,8 @@ export const QUERY = gql`
 `
 const UPDATE_${singularConstantName}_MUTATION = gql`
   mutation Update${singularPascalName}Mutation($id: ${idType}!, $input: Update${singularPascalName}Input!) {
-    update${singularPascalName}(id: $id, input: $input) {
-      id
+    update${singularPascalName}(id: $id, input: $input) {<% columns.forEach(column => { %>
+      <%= column.name %><% }) %>
     }
   }
 `


### PR DESCRIPTION
I'm trying to make the cypress e2e tutorial tests a bit more robust and noticed that modifying a post didn't update the list of items:

![Kapture 2020-10-13 at 22 36 08](https://user-images.githubusercontent.com/44849/95915439-66c7c600-0da7-11eb-947b-eeb24dac0a15.gif)

Wacky!

So, I read the docs, and noticed this:

> If a mutation updates a single existing entity, Apollo Client can automatically update that entity's value in its cache when the mutation returns. To do so, the mutation must return the id of the modified entity, **along with the values of the fields that were modified.**

This is something that we didn't pick up in the Apollo v3 upgrade.



