### PR TITLE
Upgrade Prisma v2.9.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.8.1",
+    "@prisma/client": "2.9.0",
     "@redwoodjs/internal": "^0.19.4",
     "apollo-server-lambda": "2.18.2",
     "core-js": "3.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.8.1",
+    "@prisma/sdk": "2.9.0",
     "@redwoodjs/internal": "^0.19.4",
     "@redwoodjs/structure": "^0.19.4",
     "boxen": "^4.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime-corejs3": "^7.11.2",
-    "@prisma/cli": "2.8.1",
+    "@prisma/cli": "2.9.0",
     "@redwoodjs/cli": "^0.19.4",
     "@redwoodjs/dev-server": "^0.19.4",
     "@redwoodjs/eslint-config": "^0.19.4",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.8.1",
+    "@prisma/sdk": "2.9.0",
     "@redwoodjs/internal": "^0.19.4",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,33 +3117,33 @@
   resolved "https://registry.yarnpkg.com/@prisma/ci-info/-/ci-info-2.1.2.tgz#3da64f54584bde0aaf4b42f298a6c63f025aeb3f"
   integrity sha512-RhAHY+wp6Nqu89Tp3zfUVkpGfqk4TfngeOWaMGgmhP7mB2ASDtOl8dkwxHmI8eN4edo+luyjPmbJBC4kST321A==
 
-"@prisma/cli@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.8.1.tgz#fdfeb56857f2fb08ec9769537279745749effcf7"
-  integrity sha512-mEGJplClGnXI5ki4R0Xq8nq62zcyu7Wzdhybege+cFPZFUbFj0petaPZl/tqta9o5neDyvpU/lDgOwef6mwySg==
+"@prisma/cli@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.9.0.tgz#c6f6652890783b899f266537e90e69c3481f5474"
+  integrity sha512-wPk4ehyTtVM7ZarWs16MhOc6kwLV/gZFardMvUeh46rlBwrklMdKtNChzzPa3wurrUPQ5KTbuRBz5Mgf7AdD/w==
 
-"@prisma/client@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.8.1.tgz#6fe87968eed42901cf76c623985222ebc318c292"
-  integrity sha512-apt6ioi2euOZA1O9mPA8AMRjPoPECsva76gMCcHCVgHvhkMNpFkcbn+UTkErJYrTgcRR7CPQt4D+fw8pkAHfjA==
+"@prisma/client@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.9.0.tgz#acfaca0c5695d7f439e5af54b7cd0f7fb5926340"
+  integrity sha512-VLXw6s13xakIrV9Z8Ftw0j+mbXuvbRkxYv3X5hRZdPN1NAwgeXJmrrTK9MS2HDvW8eGZL7P8OaUSNQ3Sfgvr/Q==
   dependencies:
     pkg-up "^3.1.0"
 
-"@prisma/debug@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.8.1.tgz#ab6006fe8c669bfa3f806fab6949af13cdf0d8f9"
-  integrity sha512-MX7zIz0hP4JvL/WxBFTrpBsjb/pQSMBrJFiwCmpBzJeCI/CMpLnca7pEI9OHs/LVtoJBplhz05kLcrX2hMhN4w==
+"@prisma/debug@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.9.0.tgz#6b2d176f3ae587499bea5eef0e304181d7561775"
+  integrity sha512-Z76oG/vKC8ohdcBSwLt0eu09h+AAEam0lj0JGD9Ijx6NfsdKj+gTZ8CH+IR7+f4aWB38QRzkJRs33jzQDT41Jw==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.8.1.tgz#2384649aaed9ba7f9ebc314b20a1337b4421a051"
-  integrity sha512-aHE9DhJagYFzfIBuGt2GdNx0fL9IvekNDnjx97Ys6WiT/MskZf1RiLD2Sfarc7nBKx8BdSS1BHHGYm5sBOQzlg==
+"@prisma/engine-core@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.9.0.tgz#f8a29c4835afce977446a626636454002c42aa0c"
+  integrity sha512-lDMmoDcSbgAbEyegXtRdDm9Xtj4eprOIEULsx1ZdEBHpr1XGmiKRWOEulU8axNfHfAluFmXMPN/9Ipwi5kM+Fw==
   dependencies:
-    "@prisma/debug" "2.8.1"
-    "@prisma/generator-helper" "2.8.1"
-    "@prisma/get-platform" "2.8.1"
+    "@prisma/debug" "2.9.0"
+    "@prisma/generator-helper" "2.9.0"
+    "@prisma/get-platform" "2.9.0"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
@@ -3152,15 +3152,15 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "2.0.5"
+    undici "2.0.7"
 
-"@prisma/fetch-engine@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.8.1.tgz#4e424961edc9b6900c38bca88fabf038f8f08555"
-  integrity sha512-mJ3vj6dhs5Ez4rb6BpAKlEv2yiKjEmxF/hETGG6PG++v5GILnmironZHNpr5Z2+HDBdvQTjsxAZIE+6AwtAa0w==
+"@prisma/fetch-engine@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.9.0.tgz#38c689c98544bcd28ac2132972b087b356834d26"
+  integrity sha512-Y/tlcWa66P/IPd9x5STcL8Rltn0NNAO8NEOXFTStUOZxDnsLjEnzKZn6swTSj3EFJD7bRJAMnqB/GR4Ort43SQ==
   dependencies:
-    "@prisma/debug" "2.8.1"
-    "@prisma/get-platform" "2.8.1"
+    "@prisma/debug" "2.9.0"
+    "@prisma/get-platform" "2.9.0"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -3178,44 +3178,45 @@
     temp-dir "^2.0.0"
     tempy "^0.7.0"
 
-"@prisma/generator-helper@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.8.1.tgz#8858f2cd9ef23ec55d5bafe38532e05472f46e5c"
-  integrity sha512-f9rgTvrFpjSn3Ity2zPfFv5khiQZ7F+eBr4+pL0eFmm+ffJBAsdGUv1Xl4qEgSfMzQEOmVnVUgtCMcUQgwNfXg==
+"@prisma/generator-helper@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.9.0.tgz#0ad15b9e4513a3b2f1aecee78c611eb831ef6e4e"
+  integrity sha512-Qxpv8OC3fjyVCRo7E369Z1sT+QFxlb590Iva+hr6GhtyQuIncifgZ3+laYrtElDFti6o36gY5JxyXvPznJWitg==
   dependencies:
-    "@prisma/debug" "2.8.1"
+    "@prisma/debug" "2.9.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.8.1.tgz#bcb78b8fae0a4a7190565c3da1fd372e585c64fb"
-  integrity sha512-CW7S7nM03Po+N6w8g6AcR8k/u4CLFaecL2Hm7k12j/Ns1F2lX0F1mRKxoTccg0b11t3lM/vjakia4L5ogDS8KA==
+"@prisma/get-platform@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.9.0.tgz#1e2eb9d5af850941f15dd4930018aebacd9830ce"
+  integrity sha512-Sp83D2txjMqyk+lqVUH/syiS6v6ZXFz8C15eqGDDq6aqstsqzKZ3+sx0bqfepbzJcvvddd6qbr/R034yKM7lzw==
   dependencies:
-    "@prisma/debug" "2.8.1"
+    "@prisma/debug" "2.9.0"
 
-"@prisma/sdk@2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.8.1.tgz#7edb228b98906afc42a267a6b38cf5dc8e8ec753"
-  integrity sha512-xoeuWnP8+jke4VfIfU0zv92ACKJ85CmXLUnkWmRdYS0GndRWDpe/mRkA+RNBpDFA62R9lYVW1sPT3KaUGokEUA==
+"@prisma/sdk@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.9.0.tgz#eb2fedade0d017398dfabc4a9b396a9323be3893"
+  integrity sha512-GzcWlzgjhTcBIGhmHpCOO0vKeEbZ6g8ejVe1166hyjhT0mkrfScBmhSwcuatm7UrYYcfJt28SGrJURf5vivoZg==
   dependencies:
-    "@prisma/debug" "2.8.1"
-    "@prisma/engine-core" "2.8.1"
-    "@prisma/fetch-engine" "2.8.1"
-    "@prisma/generator-helper" "2.8.1"
-    "@prisma/get-platform" "2.8.1"
+    "@prisma/debug" "2.9.0"
+    "@prisma/engine-core" "2.9.0"
+    "@prisma/fetch-engine" "2.9.0"
+    "@prisma/generator-helper" "2.9.0"
+    "@prisma/get-platform" "2.9.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^4.1.3"
     chalk "4.1.0"
-    checkpoint-client "1.1.12"
+    checkpoint-client "1.1.13"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^4.0.0"
     global-dirs "^2.0.1"
     globby "^11.0.0"
     has-yarn "^2.1.0"
+    is-ci "^2.0.0"
     make-dir "^3.0.2"
     node-fetch "2.6.1"
     p-map "^4.0.0"
@@ -6753,10 +6754,10 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-checkpoint-client@1.1.12:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.12.tgz#406fb898a95c2911235aa3e3bf4564de66cb6d8d"
-  integrity sha512-YbQMJe28YfLWBst/YvQhrh12afZGy67J7Uo/q9U0OfrFXZq3D8OyDPgjZkc+zRRK3wppC28SiCQ0fbgalsmCqA==
+checkpoint-client@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.13.tgz#9ee0941d7f82aa24bfd243c5be5da7b1fdb870ed"
+  integrity sha512-/GONVFkUAbwIRpuIl6LR7/lohoCP0RFmzb+gbXU72OJ9GaSzhqJ/yiMmoRPcuH2aF4OAWfvrVaTzS7/K8ZJh3g==
   dependencies:
     "@prisma/ci-info" "2.1.2"
     cross-spawn "7.0.3"
@@ -18011,10 +18012,10 @@ undefsafe@^2.0.2:
   dependencies:
     debug "^2.2.0"
 
-undici@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-2.0.5.tgz#b604e203184002d2ecf6524581ac994346700a09"
-  integrity sha512-KluDT7X78oGS+/3bxwGE06e/4x4wbuK7TNmTMLPJNmEOkzrLGBMwAnWMxm3PukR9BnB7k20IzOpGjl90AltwFQ==
+undici@2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-2.0.7.tgz#3804cffa4c64bc6ae71e6b0f4d85054ea6b0fb91"
+  integrity sha512-3YoSJEva11i4iW+nUfo+r5EP+piSO667SU57hfNeW3kPG5ACl7IgHzhT+bT23j0v1lgs+vIHfxQfTGK32HEPIQ==
 
 unfetch@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/1313

Tested deploy via manual project upgrade. Will test using canary once merged and published.

Prisma [v2.9.0 Release Notes](https://github.com/prisma/prisma/releases/tag/2.9.0)