### PR TITLE
Limit dependabot to Fridays. So much noise.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    versioning-strategy: "increase"
     directory: "/"
     schedule:
-      interval: daily
-      time: "09:00"
-      timezone: America/New_York
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 20


### PR DESCRIPTION
Also make it update the `package.json` files rather than the lockfiles. I don't know if that's reasonable, but it seems reasonable to me.