### PR TITLE
Fix directory named imports

### DIFF
--- a/packages/core/src/babelPlugins/__tests__/babel-plugin-redwood-directory-named-imports.ts
+++ b/packages/core/src/babelPlugins/__tests__/babel-plugin-redwood-directory-named-imports.ts
@@ -66,9 +66,6 @@ describe('directory named imports', () => {
           ],
         ],
       }).code
-      babeled //?
-      output //?
-
       expect(babeled).toMatch(output)
     })
   })

--- a/packages/core/src/babelPlugins/__tests__/babel-plugin-redwood-directory-named-imports.ts
+++ b/packages/core/src/babelPlugins/__tests__/babel-plugin-redwood-directory-named-imports.ts
@@ -1,53 +1,52 @@
 import * as babel from '@babel/core'
-import { ensurePosixPath } from '@redwoodjs/internal'
 
 import namedDirectory from '../babel-plugin-redwood-directory-named-import'
-
-// So tests pass on Windows too
-const POSIX_DIRNAME = ensurePosixPath(__dirname)
 
 const testCases = [
   // Directory named imports
   {
-    input: 'import pew from "./__fixtures__/directory-named-imports/Module"',
-    output: `import pew from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/Module/Module.js";`,
+    input:
+      'import { ImpModule } from "./__fixtures__/directory-named-imports/Module"',
+    output:
+      'import { ImpModule } from "./__fixtures__/directory-named-imports/Module/Module";',
   },
   // Directory named imports TSX
   {
-    input: 'import pew from "./__fixtures__/directory-named-imports/TSX"',
-    output: `import pew from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/TSX/TSX.tsx";`,
+    input:
+      'import { ImpTSX } from "./__fixtures__/directory-named-imports/TSX"',
+    output: `import { ImpTSX } from "./__fixtures__/directory-named-imports/TSX/TSX";`,
   },
   // Directory named exports
   {
     input:
-      'export { pew } from "./__fixtures__/directory-named-imports/Module"',
-    output: `export { pew } from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/Module/Module.js";`,
+      'export { ExpModule } from "./__fixtures__/directory-named-imports/Module"',
+    output: `export { ExpModule } from "./__fixtures__/directory-named-imports/Module/Module";`,
   },
   // Gives preferences to `index.*`
   {
     input:
-      'export { pew } from "./__fixtures__/directory-named-imports/indexModule"',
-    output: `export { pew } from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/indexModule/index.js";`,
+      'export { ExpIndex } from "./__fixtures__/directory-named-imports/indexModule"',
+    output: `export { ExpIndex } from "./__fixtures__/directory-named-imports/indexModule/index";`,
   },
   {
     input:
-      'export { pew } from "./__fixtures__/directory-named-imports/TSWithIndex"',
-    output: `export { pew } from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/TSWithIndex/index.js";`,
+      'export { TSWithIndex } from "./__fixtures__/directory-named-imports/TSWithIndex"',
+    output: `export { TSWithIndex } from "./__fixtures__/directory-named-imports/TSWithIndex/index";`,
   },
   // Supports "*.ts"
   {
     input: 'export { pew } from "./__fixtures__/directory-named-imports/TS"',
-    output: `export { pew } from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/TS/TS.ts";`,
+    output: `export { pew } from "./__fixtures__/directory-named-imports/TS/TS";`,
   },
   // Supports "*.tsx"
   {
     input: 'export { pew } from "./__fixtures__/directory-named-imports/TSX"',
-    output: `export { pew } from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/TSX/TSX.tsx";`,
+    output: `export { pew } from "./__fixtures__/directory-named-imports/TSX/TSX";`,
   },
   // Supports "*.jsx"
   {
     input: 'export { pew } from "./__fixtures__/directory-named-imports/JSX"',
-    output: `export { pew } from "${POSIX_DIRNAME}/__fixtures__/directory-named-imports/JSX/JSX.jsx";`,
+    output: `export { pew } from "./__fixtures__/directory-named-imports/JSX/JSX";`,
   },
 ]
 
@@ -67,6 +66,9 @@ describe('directory named imports', () => {
           ],
         ],
       }).code
+      babeled //?
+      output //?
+
       expect(babeled).toMatch(output)
     })
   })

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -96,7 +96,7 @@ export const getBaseDirFromFile = (file: string) => {
  */
 export const resolveFile = (
   filePath: string,
-  extensions: string[] = ['.tsx', '.ts', '.js', '.jsx']
+  extensions: string[] = ['.js', '.tsx', '.ts', '.jsx']
 ): string | null => {
   for (const extension of extensions) {
     const p = `${filePath}${extension}`


### PR DESCRIPTION
This PR uses a relative path to test if a module exists, but then returns an import-type path for for importing the module.