### PR TITLE
pr/setup-offline - New setup command for offline raw init.

### DIFF
--- a/packages/cli/src/commands/setup/serviceworker/serviceworker.ts
+++ b/packages/cli/src/commands/setup/serviceworker/serviceworker.ts
@@ -38,8 +38,8 @@ const writeTemplatesTo = (
     force?: boolean
 ): void => files.forEach((file) => writeTemplateTo(file, dir, force))
 
-async function updateIndex(INDEX_PATH: string): Promise<void> {
-  let index = await fs.readFileSync(INDEX_PATH)
+function updateIndex(INDEX_PATH: string): void {
+  let index = fs.readFileSync(INDEX_PATH).toString()
 
   const manifestString = `
   <link href="/manifest.json" rel="manifest"/>

--- a/packages/cli/src/commands/setup/serviceworker/serviceworker.ts
+++ b/packages/cli/src/commands/setup/serviceworker/serviceworker.ts
@@ -20,25 +20,25 @@ export const builder = (yargs) => {
 const writeTemplateTo = (
     filename: string,
     dir: string = getPaths().web.public,
-    force: boolean = false
-) : void => writeFile(
-  path.join(dir, filename),
-  fs
-    .readFileSync(
-      path.resolve(__dirname, 'templates', `${filename}.template`)
+    force = false
+): void =>
+    writeFile(
+        path.join(dir, filename),
+        fs
+            .readFileSync(
+                path.resolve(__dirname, 'templates', `${filename}.template`)
+            )
+            .toString(),
+        { overwriteExisting: force }
     )
-    .toString(),
-  { overwriteExisting: force }
-)
 
 const writeTemplatesTo = (
     files: string[],
     dir?: string,
     force?: boolean
-) : void => files
-    .forEach( file => writeTemplateTo( file, dir, force ) )
+): void => files.forEach((file) => writeTemplateTo(file, dir, force))
 
-async function updateIndex(INDEX_PATH: string) : Promise<void> {
+async function updateIndex(INDEX_PATH: string): Promise<void> {
   let index = await fs.readFileSync(INDEX_PATH)
 
   const manifestString = `
@@ -63,22 +63,33 @@ async function updateIndex(INDEX_PATH: string) : Promise<void> {
 export const handler = async ({ force }: { force: boolean }) => {
   const INDEX_PATH = path.join(getPaths().web.src, 'index.html')
 
-  const tasks = new Listr([{
-    title: `Copying template files to ${getPaths().web.public}`,
-    task: () => writeTemplatesTo( ['manifest.json', 'offline.html', 'sw.js'], getPaths().web.public, force )
-  }, {
-    title: `Updating ${getPaths().web.src}/index.html`,
-    task: () => updateIndex( INDEX_PATH )
-  }, {
-    title: 'One more thing...',
-    task: (_ctx: unknown, task: unknown) => {
-      task.title = `One more thing...\n
-          ${c.green('Quick link to some seriously helping post for a first timer:')}\n
-          ${chalk.hex('#e8e8e8')(
-          'https://gomakethings.com/writing-your-first-service-worker-with-vanilla-js/'
-      )}`
+  const tasks = new Listr([
+    {
+      title: `Copying template files to ${getPaths().web.public}`,
+      task: () =>
+          writeTemplatesTo(
+              ['manifest.json', 'offline.html', 'sw.js'],
+              getPaths().web.public,
+              force
+          ),
     },
-  }])
+    {
+      title: `Updating ${getPaths().web.src}/index.html`,
+      task: () => updateIndex(INDEX_PATH),
+    },
+    {
+      title: 'One more thing...',
+      task: (_ctx: unknown, task: unknown) => {
+        task.title = `One more thing...\n
+          ${c.green(
+            'Quick link to some seriously helping post for a first timer:'
+        )}\n
+          ${chalk.hex('#e8e8e8')(
+            'https://gomakethings.com/writing-your-first-service-worker-with-vanilla-js/'
+        )}`
+      },
+    },
+  ])
 
   try {
     await tasks.run()

--- a/packages/cli/src/commands/setup/serviceworker/serviceworker.ts
+++ b/packages/cli/src/commands/setup/serviceworker/serviceworker.ts
@@ -1,0 +1,88 @@
+import fs from 'fs'
+import path from 'path'
+import Listr from 'listr'
+import chalk from 'chalk'
+import { getPaths, writeFile } from 'src/lib'
+import c from 'src/lib/colors'
+
+export const command = 'serviceworker'
+export const description = 'Setup serviceworker for offline support'
+
+export const builder = (yargs) => {
+  yargs.option('force', {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing configuration',
+    type: 'boolean',
+  })
+}
+
+const writeTemplateTo = (
+    filename: string,
+    dir: string = getPaths().web.public,
+    force: boolean = false
+) : void => writeFile(
+  path.join(dir, filename),
+  fs
+    .readFileSync(
+      path.resolve(__dirname, 'templates', `${filename}.template`)
+    )
+    .toString(),
+  { overwriteExisting: force }
+)
+
+const writeTemplatesTo = (
+    files: string[],
+    dir?: string,
+    force?: boolean
+) : void => files
+    .forEach( file => writeTemplateTo( file, dir, force ) )
+
+async function updateIndex(INDEX_PATH: string) : Promise<void> {
+  let index = await fs.readFileSync(INDEX_PATH)
+
+  const manifestString = `
+  <link href="/manifest.json" rel="manifest"/>
+</head>`
+
+  const serviceWorkerString = `
+<script>
+  // Initialize the service worker
+  if (navigator && navigator.serviceWorker) {
+    navigator.serviceWorker.register('/sw.js')
+  }
+</script>
+</body>`
+
+  index = index.replace('</head>', manifestString)
+  index = index.replace('</body>', serviceWorkerString)
+
+  fs.writeFileSync(INDEX_PATH, index)
+}
+
+export const handler = async ({ force }: { force: boolean }) => {
+  const INDEX_PATH = path.join(getPaths().web.src, 'index.html')
+
+  const tasks = new Listr([{
+    title: `Copying template files to ${getPaths().web.public}`,
+    task: () => writeTemplatesTo( ['manifest.json', 'offline.html', 'sw.js'], getPaths().web.public, force )
+  }, {
+    title: `Updating ${getPaths().web.src}/index.html`,
+    task: () => updateIndex( INDEX_PATH )
+  }, {
+    title: 'One more thing...',
+    task: (_ctx: unknown, task: unknown) => {
+      task.title = `One more thing...\n
+          ${c.green('Quick link to some seriously helping post for a first timer:')}\n
+          ${chalk.hex('#e8e8e8')(
+          'https://gomakethings.com/writing-your-first-service-worker-with-vanilla-js/'
+      )}`
+    },
+  }])
+
+  try {
+    await tasks.run()
+  } catch (e) {
+    console.log(c.error(e.message))
+  }
+}

--- a/packages/cli/src/commands/setup/serviceworker/templates/manifest.json.template
+++ b/packages/cli/src/commands/setup/serviceworker/templates/manifest.json.template
@@ -1,0 +1,21 @@
+{
+  "Scope": "/",
+  "author": "John Doe",
+  "contributors": ["Jane Doe"],
+  "description": "A RedwoodJS Application",
+  "display": "fullscreen",
+  "icons": [
+  {
+    "src": "favicon.png",
+    "sizes": "144x144",
+    "type": "image/png"
+  }
+],
+  "main": "index.js",
+  "manifest_version": "0.0.1",
+  "name": "RedwoodJS Application",
+  "orientation": "portrait",
+  "short_name": "RWJS App",
+  "start_url": "/",
+  "version": "0.0.1"
+}

--- a/packages/cli/src/commands/setup/serviceworker/templates/offline.html.template
+++ b/packages/cli/src/commands/setup/serviceworker/templates/offline.html.template
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <link href="/manifest.json" rel="manifest"/>
+    <link href="/favicon.png" rel="icon" type="image/png"/>
+    <script>
+      // Initialize the service worker
+      if (navigator && navigator.serviceWorker) {
+        navigator.serviceWorker.register('/sw.js')
+      }
+    </script>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+</head>
+<body>
+<p>Thanks a lot for your visit, you're a peach - an <strong>offline</strong> peach.</p>
+</body>
+</html>

--- a/packages/cli/src/commands/setup/serviceworker/templates/sw.js.template
+++ b/packages/cli/src/commands/setup/serviceworker/templates/sw.js.template
@@ -1,0 +1,32 @@
+// On install, cache some stuff
+addEventListener('install', function (event) {
+  event.waitUntil(
+    caches.open('core').then(function (cache) {
+      cache.addAll([
+        'offline.html',
+        /** Add other files to cache here. */
+      ])
+      return
+    })
+  )
+})
+
+// listen for requests
+addEventListener('fetch', function (event) {
+  // Get the request
+  var request = event.request
+
+  // HTML files
+  // Network-first
+  if (request.headers.get('Accept').includes('text/html')) {
+    event.respondWith(
+      fetch(request)
+        .then(function (response) {
+          return response
+        })
+        .catch(function (error) {
+          return caches.match('offline.html')
+        })
+    )
+  }
+})


### PR DESCRIPTION
Since I had just added some bare support for an offline init on my project I thought I should share - there's some interest on the broader topic ( #1319 force instance )

Copies some templates to `web/public`:
- manifest.json
- offline.html
- sw.js

Modifies `web/public/index.html` to add calls to `manifest.json` & `sw.js`.