### PR TITLE
Add refetch queries to create and delete mutations.

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
@@ -2,6 +2,8 @@ import { useMutation, useFlash } from '@redwoodjs/web'
 import { navigate, routes } from '@redwoodjs/router'
 import UserProfileForm from 'src/components/UserProfileForm'
 
+import { QUERY } from 'src/components/UserProfilesCell'
+
 const CREATE_USER_PROFILE_MUTATION = gql`
   mutation CreateUserProfileMutation($input: CreateUserProfileInput!) {
     createUserProfile(input: $input) {
@@ -22,7 +24,7 @@ const NewUserProfile = () => {
       // This refetches the query on the list page. Read more about other ways to
       // update the cache over here:
       // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-      refetchQueries: ['USER_PROFILES'],
+      refetchQueries: [{ query: QUERY }],
       awaitRefetchQueries: true,
     }
   )

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/foreignKeys/new.js
@@ -19,6 +19,11 @@ const NewUserProfile = () => {
         navigate(routes.userProfiles())
         addMessage('UserProfile created.', { classes: 'rw-flash-success' })
       },
+      // This refetches the query on the list page. Read more about other ways to
+      // update the cache over here:
+      // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+      refetchQueries: ['USER_PROFILES'],
+      awaitRefetchQueries: true,
     }
   )
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
@@ -1,6 +1,8 @@
 import { useMutation, useFlash } from '@redwoodjs/web'
 import { Link, routes } from '@redwoodjs/router'
 
+import { QUERY } from 'src/components/PostsCell'
+
 const DELETE_POST_MUTATION = gql`
   mutation DeletePostMutation($id: Int!) {
     deletePost(id: $id) {
@@ -44,13 +46,13 @@ const PostsList = ({ posts }) => {
     // This refetches the query on the list page. Read more about other ways to
     // update the cache over here:
     // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: ['POSTS'],
+    refetchQueries: [{ query: QUERY }],
     awaitRefetchQueries: true,
   })
 
   const onDeleteClick = (id) => {
     if (confirm('Are you sure you want to delete post ' + id + '?')) {
-      deletePost({ variables: { id }, refetchQueries: ['POSTS'] })
+      deletePost({ variables: { id } })
     }
   }
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/index.js
@@ -41,6 +41,11 @@ const PostsList = ({ posts }) => {
     onCompleted: () => {
       addMessage('Post deleted.', { classes: 'rw-flash-success' })
     },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: ['POSTS'],
+    awaitRefetchQueries: true,
   })
 
   const onDeleteClick = (id) => {

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
@@ -2,6 +2,8 @@ import { useMutation, useFlash } from '@redwoodjs/web'
 import { navigate, routes } from '@redwoodjs/router'
 import PostForm from 'src/components/PostForm'
 
+import { QUERY } from 'src/components/PostsCell'
+
 const CREATE_POST_MUTATION = gql`
   mutation CreatePostMutation($input: CreatePostInput!) {
     createPost(input: $input) {
@@ -20,7 +22,7 @@ const NewPost = () => {
     // This refetches the query on the list page. Read more about other ways to
     // update the cache over here:
     // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: ['POSTS'],
+    refetchQueries: [{ query: QUERY }],
     awaitRefetchQueries: true,
   })
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/new.js
@@ -17,6 +17,11 @@ const NewPost = () => {
       navigate(routes.posts())
       addMessage('Post created.', { classes: 'rw-flash-success' })
     },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: ['POSTS'],
+    awaitRefetchQueries: true,
   })
 
   const onSave = (input) => {

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
@@ -36,6 +36,11 @@ const Post = ({ post }) => {
       navigate(routes.posts())
       addMessage('Post deleted.', { classes: 'rw-flash-success' })
     },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: ['POSTS'],
+    awaitRefetchQueries: true,
   })
 
   const onDeleteClick = (id) => {

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/show.js
@@ -1,6 +1,8 @@
 import { useMutation, useFlash } from '@redwoodjs/web'
 import { Link, routes, navigate } from '@redwoodjs/router'
 
+import { QUERY } from 'src/components/PostsCell'
+
 const DELETE_POST_MUTATION = gql`
   mutation DeletePostMutation($id: Int!) {
     deletePost(id: $id) {
@@ -39,7 +41,7 @@ const Post = ({ post }) => {
     // This refetches the query on the list page. Read more about other ways to
     // update the cache over here:
     // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: ['POSTS'],
+    refetchQueries: [{ query: QUERY }],
     awaitRefetchQueries: true,
   })
 

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
@@ -1,6 +1,8 @@
 import { useMutation, useFlash } from '@redwoodjs/web'
 import { Link, routes, navigate } from '@redwoodjs/router'
 
+import { QUERY } from 'src/components/${pluralPascalName}Cell'
+
 const DELETE_${singularConstantName}_MUTATION = gql`
   mutation Delete${singularPascalName}Mutation($id: ${idType}!) {
     delete${singularPascalName}(id: $id) {
@@ -39,7 +41,7 @@ const ${singularPascalName} = ({ ${singularCamelName} }) => {
     // This refetches the query on the list page. Read more about other ways to
     // update the cache over here:
     // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: ['${pluralConstantName}'],
+    refetchQueries: [{ query: QUERY }],
     awaitRefetchQueries: true,
   })
 

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Name.js.template
@@ -36,6 +36,11 @@ const ${singularPascalName} = ({ ${singularCamelName} }) => {
       navigate(routes.${pluralRouteName}())
       addMessage('${singularPascalName} deleted.', { classes: 'rw-flash-success' })
     },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: ['${pluralConstantName}'],
+    awaitRefetchQueries: true,
   })
 
   const onDeleteClick = (id) => {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
@@ -41,6 +41,11 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
     onCompleted: () => {
       addMessage('${singularPascalName} deleted.', { classes: 'rw-flash-success' })
     },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: ['${pluralConstantName}'],
+    awaitRefetchQueries: true,
   })
 
   const onDeleteClick = (id) => {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/Names.js.template
@@ -1,6 +1,8 @@
 import { useMutation, useFlash } from '@redwoodjs/web'
 import { Link, routes } from '@redwoodjs/router'
 
+import { QUERY } from 'src/components/${pluralPascalName}Cell'
+
 const DELETE_${singularConstantName}_MUTATION = gql`
   mutation Delete${singularPascalName}Mutation($id: ${idType}!) {
     delete${singularPascalName}(id: $id) {
@@ -44,13 +46,13 @@ const ${pluralPascalName}List = ({ ${pluralCamelName} }) => {
     // This refetches the query on the list page. Read more about other ways to
     // update the cache over here:
     // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: ['${pluralConstantName}'],
+    refetchQueries: [{ query: QUERY }],
     awaitRefetchQueries: true,
   })
 
   const onDeleteClick = (id) => {
     if (confirm('Are you sure you want to delete ${singularCamelName} ' + id + '?')) {
-      delete${singularPascalName}({ variables: { id }, refetchQueries: ['${pluralConstantName}'] })
+      delete${singularPascalName}({ variables: { id } })
     }
   }
 

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
@@ -2,6 +2,8 @@ import { useMutation, useFlash } from '@redwoodjs/web'
 import { navigate, routes } from '@redwoodjs/router'
 import ${singularPascalName}Form from 'src/components/${pascalScaffoldPath}${singularPascalName}Form'
 
+import { QUERY } from 'src/components/${pluralPascalName}Cell'
+
 const CREATE_${singularConstantName}_MUTATION = gql`
   mutation Create${singularPascalName}Mutation($input: Create${singularPascalName}Input!) {
     create${singularPascalName}(input: $input) {
@@ -20,7 +22,7 @@ const New${singularPascalName} = () => {
     // This refetches the query on the list page. Read more about other ways to
     // update the cache over here:
     // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
-    refetchQueries: ['${pluralConstantName}'],
+    refetchQueries: [{ query: QUERY }],
     awaitRefetchQueries: true,
   })
 

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NewName.js.template
@@ -17,6 +17,11 @@ const New${singularPascalName} = () => {
       navigate(routes.${pluralRouteName}())
       addMessage('${singularPascalName} created.', { classes: 'rw-flash-success' })
     },
+    // This refetches the query on the list page. Read more about other ways to
+    // update the cache over here:
+    // https://www.apollographql.com/docs/react/data/mutations/#making-all-other-cache-updates
+    refetchQueries: ['${pluralConstantName}'],
+    awaitRefetchQueries: true,
   })
 
   const onSave = (input) => {<% if (intForeignKeys.length) { %>


### PR DESCRIPTION
We've changed to the default caching policy in Apollo's client. So now we're require to update our cache manually. This adds a stop-gap solution which reloads the queries.

We're going to evaluate different GraphQL clients, and based on the evaluation, we'll add a more robust cache updating technique or switch libraries.