### PR TITLE
Proposal: Update cell tests to just test that nothing is thrown

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.test.js
@@ -4,19 +4,21 @@ import { standard } from './UserProfileCell.mock'
 
 describe('UserProfileCell', () => {
   test('Loading renders successfully', () => {
-    render(<Loading />)
-    // Use screen.debug() to see output
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
   })
 
   test('Empty renders successfully', async () => {
-    render(<Empty />)
-    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
   })
 
   test('Failure renders successfully', async () => {
-    render(<Failure error={new Error('Oh no')} />)
-    expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
   })
 
   // When you're ready to test the actual output of your component render

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/camelCaseWordCell.test.js
@@ -19,8 +19,14 @@ describe('UserProfileCell', () => {
     expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
   })
 
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  //   expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
   test('Success renders successfully', async () => {
-    render(<Success userProfile={standard().userProfile} />)
-    expect(screen.getByText(/42/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Success userProfile={standard().userProfile} />)
+    }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.test.js
@@ -4,19 +4,21 @@ import { standard } from './UserProfileCell.mock'
 
 describe('UserProfileCell', () => {
   test('Loading renders successfully', () => {
-    render(<Loading />)
-    // Use screen.debug() to see output
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
   })
 
   test('Empty renders successfully', async () => {
-    render(<Empty />)
-    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
   })
 
   test('Failure renders successfully', async () => {
-    render(<Failure error={new Error('Oh no')} />)
-    expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
   })
 
   // When you're ready to test the actual output of your component render

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/kebabCaseWordCell.test.js
@@ -19,8 +19,14 @@ describe('UserProfileCell', () => {
     expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
   })
 
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  //   expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
   test('Success renders successfully', async () => {
-    render(<Success userProfile={standard().userProfile} />)
-    expect(screen.getByText(/42/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Success userProfile={standard().userProfile} />)
+    }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/multiWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/multiWordCell.test.js
@@ -4,19 +4,21 @@ import { standard } from './UserProfileCell.mock'
 
 describe('UserProfileCell', () => {
   test('Loading renders successfully', () => {
-    render(<Loading />)
-    // Use screen.debug() to see output
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
   })
 
   test('Empty renders successfully', async () => {
-    render(<Empty />)
-    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
   })
 
   test('Failure renders successfully', async () => {
-    render(<Failure error={new Error('Oh no')} />)
-    expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
   })
 
   // When you're ready to test the actual output of your component render

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/multiWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/multiWordCell.test.js
@@ -19,8 +19,14 @@ describe('UserProfileCell', () => {
     expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
   })
 
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  //   expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
   test('Success renders successfully', async () => {
-    render(<Success userProfile={standard().userProfile} />)
-    expect(screen.getByText(/42/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Success userProfile={standard().userProfile} />)
+    }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/singleWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/singleWordCell.test.js
@@ -19,8 +19,14 @@ describe('UserCell', () => {
     expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
   })
 
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  //   expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
   test('Success renders successfully', async () => {
-    render(<Success user={standard().user} />)
-    expect(screen.getByText(/42/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Success user={standard().user} />)
+    }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/singleWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/singleWordCell.test.js
@@ -4,19 +4,21 @@ import { standard } from './UserCell.mock'
 
 describe('UserCell', () => {
   test('Loading renders successfully', () => {
-    render(<Loading />)
-    // Use screen.debug() to see output
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
   })
 
   test('Empty renders successfully', async () => {
-    render(<Empty />)
-    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
   })
 
   test('Failure renders successfully', async () => {
-    render(<Failure error={new Error('Oh no')} />)
-    expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
   })
 
   // When you're ready to test the actual output of your component render

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.test.js
@@ -4,19 +4,21 @@ import { standard } from './UserProfileCell.mock'
 
 describe('UserProfileCell', () => {
   test('Loading renders successfully', () => {
-    render(<Loading />)
-    // Use screen.debug() to see output
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
   })
 
   test('Empty renders successfully', async () => {
-    render(<Empty />)
-    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
   })
 
   test('Failure renders successfully', async () => {
-    render(<Failure error={new Error('Oh no')} />)
-    expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
   })
 
   // When you're ready to test the actual output of your component render

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/snakeCaseWordCell.test.js
@@ -19,8 +19,14 @@ describe('UserProfileCell', () => {
     expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
   })
 
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  //   expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
   test('Success renders successfully', async () => {
-    render(<Success userProfile={standard().userProfile} />)
-    expect(screen.getByText(/42/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Success userProfile={standard().userProfile} />)
+    }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/templates/test.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/test.js.template
@@ -21,6 +21,11 @@ describe('${pascalName}Cell', () => {
     }).not.toThrow()
   })
 
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  //   expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
   test('Success renders successfully', async () => {
     expect(() => {
       render(<Success ${camelName}={standard().${camelName}} />)

--- a/packages/cli/src/commands/generate/cell/templates/test.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/test.js.template
@@ -4,23 +4,26 @@ import { standard } from './${pascalName}Cell.mock'
 
 describe('${pascalName}Cell', () => {
   test('Loading renders successfully', () => {
-    render(<Loading />)
-    // Use screen.debug() to see output
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
   })
 
   test('Empty renders successfully', async () => {
-    render(<Empty />)
-    expect(screen.getByText('Empty')).toBeInTheDocument()
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
   })
 
   test('Failure renders successfully', async () => {
-    render(<Failure error={new Error('Oh no')} />)
-    expect(screen.getByText(/Oh no/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
   })
 
   test('Success renders successfully', async () => {
-    render(<Success ${camelName}={standard().${camelName}} />)
-    expect(screen.getByText(/42/i)).toBeInTheDocument()
+    expect(() => {
+      render(<Success ${camelName}={standard().${camelName}} />)
+    }).not.toThrow()
   })
 })


### PR DESCRIPTION
Right now the cell tests are testing very specific (sometimes the exact) text output from each state (Loading, Empty, Failure, Success). As soon as you change anything in any of these functions, the test fails. I feel like this is not ideal for new developers, or new-to-Redwood developers—a failing test inherently signals to you that you did something "bad" but in this case you just started building out your real functionality. Why should they be "punished" for that?

I propose that the default Cell tests follow the lead of the default Component, Page and Layout tests: just check that no errors are raised. Once you get your component/cell dialed in you can update your test to target specific output, but when you're just building them out the safest thing to check is that no errors are raised:

```javascript
test('Success renders successfully', async () => {
  expect(() => {
    render(<Success posts={standard().posts} />)
  }).not.toThrow()
})
```

It still uses the mocks, and passes them to the components for rendering, but the expectation is just that you didn't horrifically break anything.

I think we can agree that having a Page test that tested for the presence of the default "Find me in web/src/pages/HomePage/HomePage.js" since will pass once or, if they don't bother running the suite, never! Users are guaranteed to change it, and break the test, and have to change that as well. So let's not force them to do extra work just to get started in a Cell either.

We're seeing this cause issues specifically during the tutorial—by the time you finish, if you were to run the test suite, you'd get failures in all of your cells. I don't think this is a good first experience for users. I would love, at the end of part 1 of the tutorial, to tell the reader:

> By the way, run `yarn rw test`—you've got a full test suite! Now check out part 2 to learn about writing your own tests...

Before I could start on part 2 of the tutorial I had to update the test suite so that I could start out new users with everything being green. Let's default them to the happy path and then explain to them the virtues of adding tests and keeping them up-to-date with their component code.

/cc @mojombo @RobertBroersma 