### PR TITLE
fix: :bug: fix `prisma.disconnect` deprecated warning

### DIFF
--- a/packages/cli/src/commands/dataMigrate/up.js
+++ b/packages/cli/src/commands/dataMigrate/up.js
@@ -156,7 +156,7 @@ export const handler = async () => {
   try {
     await tasks.run()
   } finally {
-    await db.disconnect()
+    await db.$disconnect()
     report(counters)
     process.exit(0)
   }


### PR DESCRIPTION
The `prisma.disconnect` function has been deprecated in favor of `prisma.$disconnect`.  
Fix #1402
