### PR TITLE
Adds an AuthClient for Facebook Login with FB JS SDK

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -10,8 +10,10 @@
   "devDependencies": {
     "@auth0/auth0-spa-js": "^1.7.0",
     "@supabase/supabase-js": "^0.36.4",
+    "@types/facebook-js-sdk": "^3.3.1",
     "@types/netlify-identity-widget": "^1.4.1",
     "@types/react": "16.9.53",
+    "fb-sdk-wrapper": "^1.1.0",
     "firebase": "^7.14.5",
     "firebase-admin": "^9.1.1",
     "gotrue-js": "git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb",

--- a/packages/auth/src/authClients/facebook/fb-sdk-wrapper.d.ts
+++ b/packages/auth/src/authClients/facebook/fb-sdk-wrapper.d.ts
@@ -1,0 +1,134 @@
+declare module 'fb-sdk-wrapper' {
+  import StatusResponse = facebook.StatusResponse
+  import InitParams = facebook.InitParams
+  import LoginOptions = facebook.LoginOptions
+  import ShareOpenGraphDialogParams = facebook.ShareOpenGraphDialogParams
+  import ShareOpenGraphDialogResponse = facebook.ShareOpenGraphDialogResponse
+  import AddPageTabDialogParams = facebook.AddPageTabDialogParams
+  import DialogResponse = facebook.DialogResponse
+  import GameRequestDialogParams = facebook.GameRequestDialogParams
+  import GameRequestDialogResponse = facebook.GameRequestDialogResponse
+  import PayDialogParams = facebook.PayDialogParams
+  import PayDialogResponse = facebook.PayDialogResponse
+  import PaymentsLiteDialogParams = facebook.PaymentsLiteDialogParams
+  import PaymentsLiteDialogResponse = facebook.PaymentsLiteDialogResponse
+  import LiveDialogParams = facebook.LiveDialogParams
+  import LiveDialogResponse = facebook.LiveDialogResponse
+  import SendDialogParams = facebook.SendDialogParams
+  import CreateOfferDialogParams = facebook.CreateOfferDialogParams
+  import CreateOfferDialogResponse = facebook.CreateOfferDialogResponse
+  import LeadgenDialogParams = facebook.LeadgenDialogParams
+  import LeadgenDialogResponse = facebook.LeadgenDialogResponse
+  import InstantExperiencesAdsDialogParams = facebook.InstantExperiencesAdsDialogParams
+  import InstantExperiencesAdsDialogResponse = facebook.InstantExperiencesAdsDialogResponse
+  import InstantExperiencesPreviewDialogParams = facebook.InstantExperiencesPreviewDialogParams
+  import CollectionAdsDialogParams = facebook.CollectionAdsDialogParams
+  import CollectionAdsDialogResponse = facebook.CollectionAdsDialogResponse
+  import ShareDialogParams = facebook.ShareDialogParams
+  import ShareDialogResponse = facebook.ShareDialogResponse
+
+  interface LoadParams {
+    locale?: string
+  }
+
+  export function load(params?: LoadParams): Promise<typeof FB>
+  export function init(params?: Partial<InitParams>): void
+
+  export function getGlobalFB(): typeof FB
+
+  export function api<TResponse>(path: string): Promise<TResponse>
+  export function api<TParams extends object, TResponse>(
+    path: string,
+    params: TParams
+  ): Promise<TResponse>
+  export function api<TParams extends object, TResponse>(
+    path: string,
+    method: 'get' | 'post' | 'delete',
+    params: TParams
+  ): Promise<TResponse>
+
+  export function getLoginStatus(force?: boolean): Promise<StatusResponse>
+  export function login(options?: LoginOptions): Promise<StatusResponse>
+  export function logout(): Promise<StatusResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/sharing/reference/share-dialog
+   */
+  export function ui(params: ShareDialogParams): Promise<ShareDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/sharing/reference/share-dialog
+   */
+  export function ui(
+    params: ShareOpenGraphDialogParams
+  ): Promise<ShareOpenGraphDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/pages/page-tab-dialog
+   */
+  export function ui(params: AddPageTabDialogParams): Promise<DialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/games/services/gamerequests
+   */
+  export function ui(
+    params: GameRequestDialogParams
+  ): Promise<GameRequestDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/payments/reference/paydialog
+   */
+  export function ui(params: PayDialogParams): Promise<PayDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/games_payments/payments_lite
+   */
+  export function ui(
+    params: PaymentsLiteDialogParams
+  ): Promise<PaymentsLiteDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/videos/live-video/exploring-live#golivedialog
+   */
+  export function ui(params: LiveDialogParams): Promise<LiveDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/sharing/reference/send-dialog
+   */
+  export function ui(params: SendDialogParams): Promise<DialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/marketing-api/guides/offer-ads/#create-offer-dialog
+   */
+  export function ui(
+    params: CreateOfferDialogParams
+  ): Promise<CreateOfferDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/marketing-api/guides/lead-ads/create#create-leadgen-dialog
+   */
+  export function ui(
+    params: LeadgenDialogParams
+  ): Promise<LeadgenDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/marketing-api/guides/canvas-ads#canvas-ads-dialog
+   */
+  export function ui(
+    params: InstantExperiencesAdsDialogParams
+  ): Promise<InstantExperiencesAdsDialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/marketing-api/guides/canvas-ads#canvas-preview-dialog
+   */
+  export function ui(
+    params: InstantExperiencesPreviewDialogParams
+  ): Promise<DialogResponse>
+
+  /**
+   * @see https://developers.facebook.com/docs/marketing-api/guides/collection#collection-ads-dialog
+   */
+  export function ui(
+    params: CollectionAdsDialogParams
+  ): Promise<CollectionAdsDialogResponse>
+}

--- a/packages/auth/src/authClients/facebook/index.ts
+++ b/packages/auth/src/authClients/facebook/index.ts
@@ -1,0 +1,49 @@
+import * as FB from 'fb-sdk-wrapper'
+
+export type Facebook = typeof FB
+
+import { AuthClient } from '../'
+
+export type FacebookUser = facebook.AuthResponse
+
+export interface AuthClientFacebook extends AuthClient {
+  login(options?: facebook.LoginOptions): Promise<facebook.StatusResponse>
+  logout(): Promise<facebook.StatusResponse>
+  signup(options?: facebook.LoginOptions): Promise<facebook.StatusResponse>
+  getToken(force?: boolean): Promise<null | string>
+  getUserMetadata(force?: boolean): Promise<null | FacebookUser>
+}
+
+export const facebook = (client: Facebook): AuthClientFacebook => {
+  return {
+    type: 'facebook',
+    client,
+
+    async login(options?) {
+      return await client.login(options)
+    },
+
+    async logout() {
+      return await client.logout()
+    },
+
+    async signup(options?) {
+      return await this.login(options)
+    },
+
+    async getToken(force = false) {
+      const authResponse = await this.getUserMetadata(force)
+      return authResponse?.accessToken || null
+    },
+
+    /** The user's data from the AuthProvider */
+    async getUserMetadata(force = false) {
+      const statusResponse = await client.getLoginStatus(force)
+      if (statusResponse.status === 'connected') {
+        return statusResponse.authResponse
+      } else {
+        return null
+      }
+    },
+  }
+}

--- a/packages/auth/src/authClients/index.ts
+++ b/packages/auth/src/authClients/index.ts
@@ -4,6 +4,7 @@ import type { GoTrue, GoTrueUser } from './goTrue'
 import type { MagicLink, MagicUser } from './magicLink'
 import type { Firebase } from './firebase'
 import type { Supabase, SupabaseUser } from './supabase'
+import { Facebook, FacebookUser } from './facebook'
 import type { Custom } from './custom'
 //
 import { netlify } from './netlify'
@@ -12,6 +13,7 @@ import { goTrue } from './goTrue'
 import { magicLink } from './magicLink'
 import { firebase } from './firebase'
 import { supabase } from './supabase'
+import { facebook } from './facebook'
 import { custom } from './custom'
 
 const typesToClients = {
@@ -21,6 +23,7 @@ const typesToClients = {
   magicLink,
   firebase,
   supabase,
+  facebook,
   /** Don't we support your auth client? No problem, define your own the `custom` type! */
   custom,
 }
@@ -32,6 +35,7 @@ export type SupportedAuthClients =
   | MagicLink
   | Firebase
   | Supabase
+  | Facebook
   | Custom
 
 export type SupportedAuthTypes = keyof typeof typesToClients
@@ -40,12 +44,18 @@ export type { Auth0User }
 export type { GoTrueUser }
 export type { MagicUser }
 export type { SupabaseUser }
-export type SupportedUserMetadata = Auth0User | GoTrueUser | MagicUser | SupabaseUser
+export type { FacebookUser }
+export type SupportedUserMetadata =
+  | Auth0User
+  | GoTrueUser
+  | MagicUser
+  | SupabaseUser
+  | FacebookUser
 
 export interface AuthClient {
   restoreAuthState?(): void | Promise<any>
   login(options?: any): Promise<any>
-  logout(options?: any): void | Promise<void>
+  logout(options?: any): void | Promise<any>
   signup(options?: any): void | Promise<any>
   getToken(): Promise<null | string>
   /** The user's data from the AuthProvider */

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
-    "outDir": "dist",
+    "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3954,6 +3954,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/facebook-js-sdk@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/facebook-js-sdk/-/facebook-js-sdk-3.3.1.tgz#1aec89b8530b9b313f73d9efe088c9d378a716d3"
+  integrity sha512-jRVPdOu237QxDDoBjc9/xzGsDz75FmdvcwVZdCEg1AjHAQxGmXoHfACUyUVtz7DSWA4E+jgj5MQME4snjGwOng==
+
 "@types/findup-sync@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/findup-sync/-/findup-sync-2.0.2.tgz#3fff6e72b8bbec258c64208a8d64c861fec63ea7"
@@ -9161,6 +9166,11 @@ faye-websocket@^0.10.0:
   integrity sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=
   dependencies:
     websocket-driver ">=0.5.1"
+
+fb-sdk-wrapper@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fb-sdk-wrapper/-/fb-sdk-wrapper-1.1.0.tgz#3b47c413aceb67dec10a5c03fa7128cd44ba5005"
+  integrity sha512-66peeFF3epjeQR5l+aaB03aF8bEI+bQf+wMq3fjnUEyQ1d6qR+Z6rGHq9bSxuu2kzEtWG+0PfU5x2SiVEcYy0w==
 
 fb-watchman@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
With one notable change: `logout` return type has been changed to `void | Promise<any>`, as Facebook does return some data upon logging out.

I will also be looking at returning "actual" user metadata once logged in, but it might not be trivial as not the same data will be made available by Facebook depending on the required & user-permitted scopes.

---

Anyway I'm keeping this as a draft for now, as there's something I'd like to discuss/to be solved before I consider it ready.
I encourage you to have a look at the [sister PR](https://github.com/redwoodjs/playground-auth/pull/10) I've just opened on the Auth Playground repo as well.

There, you'll see that the Facebook auth implementation mainly revolves around doing this:

```ts
import * as Facebook from 'fb-sdk-wrapper'

Facebook.load().then(() => Facebook.init({ appId: "my-app-id" }))

export default (props) => {
  return <AuthProvider client={Facebook} type="facebook" {...props}>
}
```

If you setup everything and run the auth playground locally, it will most likely work well and you'll see the Facebook login popup.

However, the initialization of the Facebook SDK **is asynchronous**, and even though the expected client on the `AuthProvider` side is indeed `Facebook`, this client can only be used once both `Facebook.load()` and `Facebook.init()` have resolved.
So if the connection is slow and a user clicks on "login" before the client has been fully loaded/initialized, nothing will work.

So I'd rather do something like this:

```ts
import * as Facebook from 'fb-sdk-wrapper'

const fbLoading = Facebook.load().then(() => {
  Facebook.init({ appId: "my-app-id" })
  return Facebook
)

export default (props) => {
  return <AuthProvider client={fbLoading} type="facebook" {...props}>
}

```

My understanding of the codebase is that there's no support, today, for an "asynchronously available client" provided to the `AuthProvider`.

I can see two ways to add this support:
- either handle this specificity at the AuthClient level, i.e. instead of having:

```ts
export const facebook = (client: Facebook): AuthClientFacebook => {
```

use:

```ts
export const facebook = (client: Promise<Facebook>): AuthClientFacebook => {
```

and handle the promised client within the AuthClient.
I guess that means that `SupportedAuthClients` should be augmented with the promise version of the facebook auth client?

- or handle the possibility of having an asynchronous client higher up in the auth package, probably by making `createAuthClient` async and doing something like this (untested/probably invalid code):

```ts
export const createAuthClient = async (
  client: SupportedAuthClients | Promise<SupportedAuthClients>,
  type: SupportedAuthTypes
): AuthClient => {
  if (!typesToClients[type]) {
    throw new Error(
      `Your client ${type} is not supported, we only support ${Object.keys(
        typesToClients
      ).join(', ')}`
    )
  }
  return typesToClients[type](await Promise.resolve(client))
}
```

Although it makes things more transparent for auth provider implementers, it might have many implications on the codebase and I'm not sure whether it's feasible/viable or not. For one thing, `createAuthClient` is called within the `AuthProvider` constructor, which cannot be made `async`... so there's that 😅 
If we go that way, there will be a pattern to be found to work around that.

Does anyone have some thoughts or pointers about this? ^^