### PR TITLE
improve(auth): Add multiproviders for firebase auth

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -201,8 +201,10 @@ export class AuthProvider extends React.Component<
   }
 
   logIn = async (options?: any) => {
-    await this.rwClient.login(options)
-    return this.reauthenticate()
+    const loginOutput = await this.rwClient.login(options)
+    await this.reauthenticate()
+
+    return loginOutput
   }
 
   logOut = async (options?: any) => {

--- a/packages/auth/src/authClients/firebase.ts
+++ b/packages/auth/src/authClients/firebase.ts
@@ -4,21 +4,34 @@ export type Firebase = typeof Firebase
 
 import { AuthClient } from './'
 
+// @TODO: Firebase doesn't export a list of providerIds they use
+// But I found them here: https://github.com/firebase/firebase-js-sdk/blob/a5768b0aa7d7ce732279931aa436e988c9f36487/packages/rules-unit-testing/src/api/index.ts
+export type oAuthProvider =
+  | 'google.com'
+  | 'facebook.com'
+  | 'github.com'
+  | 'twitter.com'
+  | 'microsoft.com'
+  | 'apple.com'
+
 export const firebase = (client: Firebase): AuthClient => {
+  // Use a function to allow us to extend for non-oauth providers in the future
+  const getProvider = (providerId: oAuthProvider) => {
+    return new client.auth.OAuthProvider(providerId)
+  }
+
   return {
     type: 'firebase',
     client,
     restoreAuthState: () => client.auth().getRedirectResult(),
-    // TODO: Allow the user to define the `AuthProvider`
-    login: async () => {
-      const provider = new client.auth.GoogleAuthProvider()
-      return client.auth().signInWithRedirect(provider)
+    login: async (usingProvider: oAuthProvider = 'google.com') => {
+      const provider = getProvider(usingProvider)
+      return client.auth().signInWithPopup(provider)
     },
     logout: () => client.auth().signOut(),
-    signup: async () => {
-      const provider = new client.auth.GoogleAuthProvider()
-      return client.auth().signInWithRedirect(provider)
-
+    signup: async (usingProvider: oAuthProvider = 'google.com') => {
+      const provider = getProvider(usingProvider)
+      return client.auth().signInWithPopup(provider)
     },
     getToken: async () => client.auth().currentUser?.getIdToken() ?? null,
     getUserMetadata: async () => client.auth().currentUser,


### PR DESCRIPTION
### a) Adds support for multiple providers using firebase auth
So far this works for me with:
- [x] google
- [x] github
- [x] facebook
- [x] apple

tried microsoft, but couldn't get their oauth config to work.

### b) Fixes login function not returning output
The login function wasn't returning the data from the client login, this may be useful in some cases.

---
**Breaking changes:** none 🤞🏽

@peterp, @dthyresson would love your thoughts, and tips on how to add more tests.
﻿
