### PR TITLE
Default sides to all in test command

### DIFF
--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -81,6 +81,10 @@ export const handler = async ({
     const hasSourceControl = isInGitRepository() || isInMercurialRepository()
     args.push(hasSourceControl ? '--watch' : '--watchAll')
   }
+  // if no sides declared with yargs, default to all sides
+  if (!sides.length) {
+    getProject().sides.forEach(side => sides.push(side))
+  }
   args.push(
     '--config',
     require.resolve('@redwoodjs/core/config/jest.config.js')

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -1,6 +1,7 @@
 import execa from 'execa'
 import terminalLink from 'terminal-link'
 import { ensurePosixPath } from '@redwoodjs/internal'
+const { getProject } = require('@redwoodjs/structure')
 
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
@@ -27,7 +28,6 @@ function isInMercurialRepository() {
 export const command = 'test [side..]'
 export const description = 'Run Jest tests. Defaults to watch mode'
 export const builder = (yargs) => {
-  const { getProject } = require('@redwoodjs/structure')
   yargs
     .choices('side', getProject().sides)
     .option('watch', {


### PR DESCRIPTION
@thedavidprice and I got on a call and were trying to figure out why running the test suite with `yarn rw test` would wipe out the dev database. 

Turns out that when you don't specify a side with the command (like `yarn rw test api`) that *no* sides are set, and it skips the DB setup code that sets the `DATABASE_URL` to `TEST_DATABASE_URL`.

/cc @RobertBroersma @peterp 