### PR TITLE
Add prismaVersion to redwood graphQL call

### DIFF
--- a/packages/api/src/makeMergedSchema/rootSchema.ts
+++ b/packages/api/src/makeMergedSchema/rootSchema.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { GlobalContext } from 'src/globalContext'
+import { PrismaClient } from '@prisma/client'
 import gql from 'graphql-tag'
 import {
   DateResolver,
@@ -26,6 +27,7 @@ export const schema = gql`
   type Redwood {
     version: String
     currentUser: JSON
+    prismaVersion: String
   }
 
   type Query {
@@ -51,6 +53,7 @@ export const resolvers: Resolvers = {
   Query: {
     redwood: () => ({
       version: apiPackageJson.version,
+      prismaVersion: PrismaClient.prismaVersion.client,
       currentUser: (_args: any, context: GlobalContext) => {
         return context?.currentUser
       },


### PR DESCRIPTION
For easier debugging we want to add PrismaVersion to the `redwood`
graphql call. This can help people easier identify which version of
Prisma is actually running.

Fixes: #1395