### PR TITLE
fix prisma version field resolver not working

### DIFF
--- a/packages/api/src/makeMergedSchema/rootSchema.ts
+++ b/packages/api/src/makeMergedSchema/rootSchema.ts
@@ -53,7 +53,7 @@ export const resolvers: Resolvers = {
   Query: {
     redwood: () => ({
       version: apiPackageJson.version,
-      prismaVersion: PrismaClient.prismaVersion.client,
+      prismaVersion: () => PrismaClient.prismaVersion,
       currentUser: (_args: any, context: GlobalContext) => {
         return context?.currentUser
       },


### PR DESCRIPTION
fixes typo introduced [here](https://github.com/redwoodjs/redwood/commit/0f1a378829fb280e7a2e89f914ce69baf5130f44) which seems to be breaking latest canary revs. 

All the best, 

António