### PR TITLE
Small http server tweaks

### DIFF
--- a/packages/api-server/src/http.ts
+++ b/packages/api-server/src/http.ts
@@ -22,7 +22,12 @@ export const server = ({
       type: ['text/*', 'application/json', 'multipart/form-data'],
     })
   )
-  app.use(bodyParser.raw({ type: '*/*' }))
+  app.use(
+    bodyParser.raw({
+      type: '*/*',
+      limit: process.env.BODY_PARSER_LIMIT,
+    })
+  )
   app.use(morgan('dev'))
 
   app.all('/', (_, res) => {

--- a/packages/api-server/src/http.ts
+++ b/packages/api-server/src/http.ts
@@ -30,18 +30,6 @@ export const server = ({
   )
   app.use(morgan('dev'))
 
-  app.all('/', (_, res) => {
-    return res.send(`
-      <p>The following serverless Functions are available:</p>
-      <ol>
-        ${Object.keys(LAMBDA_FUNCTIONS)
-          .sort()
-          .map((name) => `<li><a href="/${name}">/${name}</a></li>`)
-          .join('')}
-      </ol>
-    `)
-  })
-
   const lambdaHandler = async (req: Request, res: Response): Promise<void> => {
     const { routeName } = req.params
     const lambdaFunction = LAMBDA_FUNCTIONS[routeName]

--- a/packages/dev-server/src/http.ts
+++ b/packages/dev-server/src/http.ts
@@ -22,7 +22,7 @@ export const server = ({
       type: ['text/*', 'application/json', 'multipart/form-data'],
     })
   )
-  app.use(bodyParser.raw({ type: '*/*' }))
+  app.use(bodyParser.raw({ type: '*/*', limit: process.env.BODY_PARSER_LIMIT }))
   app.use(morgan('dev'))
 
   app.all('/', (_, res) => {

--- a/packages/dev-server/src/http.ts
+++ b/packages/dev-server/src/http.ts
@@ -31,7 +31,7 @@ export const server = ({
       <ol>
         ${Object.keys(LAMBDA_FUNCTIONS)
           .sort()
-          .map((name) => `<li><a href="/${name}">/${name}</a></li>`)
+          .map((name) => `<li><a href="${name}">${name}</a></li>`)
           .join('')}
       </ol>
     `)


### PR DESCRIPTION
I came across a few bugs in the http-servers, both for dev and production. This PR fixes:

- [x] The list of serverless functions have relative paths, so if you visit `http://localhost:8910/.redwood/` and see a list of functions you can actually click on them.
- [x] I'm posting a massive JSON payload to the api-server. I got a `PayloadTooLargeError` error from bodyParser. It turns out you can configure the size, so I've added a `BODY_PARSER_LIMIT` env-var where you can specify the size.
- [x] I no longer show a list of functions in the `api-server` since you probably don't want to bleed that to world in production.