### PR TITLE
Fixes setting Prisma Version in root redwood schema

### DIFF
--- a/packages/api/src/makeMergedSchema/rootSchema.ts
+++ b/packages/api/src/makeMergedSchema/rootSchema.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { GlobalContext } from 'src/globalContext'
-import { PrismaClient } from '@prisma/client'
+const { prismaVersion } = require('@prisma/client')
 import gql from 'graphql-tag'
 import {
   DateResolver,
@@ -53,7 +53,7 @@ export const resolvers: Resolvers = {
   Query: {
     redwood: () => ({
       version: apiPackageJson.version,
-      prismaVersion: () => PrismaClient.prismaVersion,
+      prismaVersion: () => prismaVersion.client,
       currentUser: (_args: any, context: GlobalContext) => {
         return context?.currentUser
       },


### PR DESCRIPTION
actually fetch and consume prismaVersion the right way

#1495 solved the crash but didn't solve the root issue which was to actually have #1395
working as intended. (my bad for not testing enough :( ).

this one fixes it (famous last words).

All the best, and sorry for the noise
