### PR TITLE
Overwritten DATABASE_URL wasn't being used in actual Jest run

### DIFF
--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -90,10 +90,11 @@ export const handler = async ({
   }
   
   try {
+    const cacheDirDb = `file:${ensurePosixPath(CACHE_DIR)}/test.db`
+    const DATABASE_URL = process.env.TEST_DATABASE_URL || cacheDirDb
+      
     // Create a test database
     if (sides.includes('api')) {
-      const cacheDirDb = `file:${ensurePosixPath(CACHE_DIR)}/test.db`
-      const DATABASE_URL = process.env.TEST_DATABASE_URL || cacheDirDb
       await execa.command(`yarn rw db up`, {
         stdio: 'inherit',
         shell: true,
@@ -107,6 +108,7 @@ export const handler = async ({
       cwd: getPaths().base,
       shell: true,
       stdio: 'inherit',
+      env: { DATABASE_URL },
     })
   } catch (e) {
     console.log(c.error(e.message))


### PR DESCRIPTION
My previous PR fixed it for migrating the database, but the new `DATABASE_URL` wasn't being given to the actual jest run, so that was still overriding the dev database.