### PR TITLE
Run Jest tests in sequence

### DIFF
--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -66,6 +66,7 @@ export const handler = async ({
   const args = [
     '--passWithNoTests',
     collectCoverage && '--collectCoverage',
+    '--runInBand'
   ].filter(Boolean)
   
   // If the user wants to watch, set the proper watch flag based on what kind of repo this is

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -66,7 +66,6 @@ export const handler = async ({
   const args = [
     '--passWithNoTests',
     collectCoverage && '--collectCoverage',
-    '--runInBand'
   ].filter(Boolean)
   
   // If the user wants to watch, set the proper watch flag based on what kind of repo this is
@@ -80,7 +79,11 @@ export const handler = async ({
   if (!sides.length) {
     getProject().sides.forEach(side => sides.push(side))
   }
-
+  
+  if (sides.includes('api')) {
+    args.push('--runInBand')
+  }
+  
   args.push(
     '--config',
     require.resolve('@redwoodjs/core/config/jest.config.js')


### PR DESCRIPTION
Jest will run all test files simultaneously by default. This means it's impossible to test services—any database records created in them can potentially be overwritten or wiped out by another file running at the same time.

This PR adds the `--runInBand` flag that makes Jest run each file one after the other. It's too bad we can't do this just for the api side but I don't see any way to specify that only certain files should run in band and not others.

Strangely enough this actually makes the services tests *feel* faster since you see them running and completing in sequence, instead of nothing happening for a couple of seconds and then them all completing at the same time.