### PR TITLE
Add flags to generators to skip tests and story files

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
@@ -17,7 +17,10 @@ let singleWordFiles,
   multiWordFiles,
   snakeCaseWordFiles,
   kebabCaseWordFiles,
-  camelCaseWordFiles
+  camelCaseWordFiles,
+  withoutTestFiles,
+  withoutStoryFiles,
+  withoutTestAndStoryFiles
 
 beforeAll(async () => {
   singleWordFiles = await cell.files({ name: 'User' })
@@ -25,6 +28,13 @@ beforeAll(async () => {
   snakeCaseWordFiles = await cell.files({ name: 'user_profile' })
   kebabCaseWordFiles = await cell.files({ name: 'user-profile' })
   camelCaseWordFiles = await cell.files({ name: 'userProfile' })
+  withoutTestFiles = await cell.files({ name: 'User', tests: false })
+  withoutStoryFiles = await cell.files({ name: 'User', stories: false })
+  withoutTestAndStoryFiles = await cell.files({
+    name: 'User',
+    tests: false,
+    stories: false,
+  })
 })
 
 // Single Word Scenario: User
@@ -232,4 +242,34 @@ test('creates a cell mock with a camelCase word name', () => {
       )
     ]
   ).toEqual(loadGeneratorFixture('cell', 'camelCaseWordCell.mock.js'))
+})
+
+test("doesn't include test file when --tests is set to false", () => {
+  expect(Object.keys(withoutTestFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/components/UserCell/UserCell.mock.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/components/UserCell/UserCell.stories.js'
+    ),
+    path.normalize('/path/to/project/web/src/components/UserCell/UserCell.js'),
+  ])
+})
+
+test("doesn't include storybook file when --stories is set to false", () => {
+  expect(Object.keys(withoutStoryFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/components/UserCell/UserCell.mock.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/components/UserCell/UserCell.test.js'
+    ),
+    path.normalize('/path/to/project/web/src/components/UserCell/UserCell.js'),
+  ])
+})
+
+test("doesn't include storybook and test files when --stories and --tests is set to false", () => {
+  expect(Object.keys(withoutTestAndStoryFiles)).toEqual([
+    path.normalize('/path/to/project/web/src/components/UserCell/UserCell.js'),
+  ])
 })

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -31,7 +31,7 @@ const uniqueOperationName = async (name, index = 1) => {
   return uniqueOperationName(name, index + 1)
 }
 
-export const files = async ({ name }) => {
+export const files = async ({ name, tests = true, stories = true }) => {
   // Create a unique operation name.
   const operationName = await uniqueOperationName(name)
 
@@ -70,20 +70,31 @@ export const files = async ({ name }) => {
     templatePath: 'mock.js.template',
   })
 
+  const files = [cellFile]
+
+  if (stories) {
+    files.push(storiesFile)
+  }
+
+  if (tests) {
+    files.push(testFile)
+  }
+
+  if (stories || tests) {
+    files.push(mockFile)
+  }
+
   // Returns
   // {
   //    "path/to/fileA": "<<<template>>>",
   //    "path/to/fileB": "<<<template>>>",
   // }
-  return [cellFile, testFile, storiesFile, mockFile].reduce(
-    (acc, [outputPath, content]) => {
-      return {
-        [outputPath]: content,
-        ...acc,
-      }
-    },
-    {}
-  )
+  return files.reduce((acc, [outputPath, content]) => {
+    return {
+      [outputPath]: content,
+      ...acc,
+    }
+  }, {})
 }
 
 export const {

--- a/packages/cli/src/commands/generate/component/__tests__/component.test.ts
+++ b/packages/cli/src/commands/generate/component/__tests__/component.test.ts
@@ -9,7 +9,9 @@ import * as component from '../component'
 let singleWordDefaultFiles,
   multiWordDefaultFiles,
   javascriptFiles,
-  typescriptFiles
+  typescriptFiles,
+  withoutTestFiles,
+  withoutStoryFiles
 
 beforeAll(() => {
   singleWordDefaultFiles = component.files({ name: 'User' })
@@ -21,6 +23,16 @@ beforeAll(() => {
   typescriptFiles = component.files({
     name: 'TypescriptUser',
     typescript: true,
+  })
+  withoutTestFiles = component.files({
+    name: 'withoutTests',
+    javascript: true,
+    tests: false
+  })
+  withoutStoryFiles = component.files({
+    name: 'withoutStories',
+    javascript: true,
+    stories: false
   })
 })
 
@@ -118,4 +130,26 @@ test('creates TS component files if typescript = true', () => {
       )
     ]
   ).not.toBeUndefined()
+})
+
+test("doesn't include storybook file when --stories is set to false", () => {
+  expect(Object.keys(withoutStoryFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/components/WithoutStories/WithoutStories.test.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/components/WithoutStories/WithoutStories.js'
+    ),
+  ])
+})
+
+test("doesn't include test file when --tests is set to false", () => {
+  expect(Object.keys(withoutTestFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/components/WithoutTests/WithoutTests.stories.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/components/WithoutTests/WithoutTests.js'
+    ),
+  ])
 })

--- a/packages/cli/src/commands/generate/component/component.js
+++ b/packages/cli/src/commands/generate/component/component.js
@@ -7,7 +7,7 @@ import {
 
 const REDWOOD_WEB_PATH_NAME = 'components'
 
-export const files = ({ name, ...options }) => {
+export const files = ({ name, tests = true, stories = true, ...options }) => {
   const isJavascript = options.javascript && !options.typescript
   const componentFile = templateForComponentFile({
     name,
@@ -31,24 +31,30 @@ export const files = ({ name, ...options }) => {
     templatePath: 'stories.tsx.template',
   })
 
+  const files = [componentFile]
+  if (stories) {
+    files.push(storiesFile)
+  }
+
+  if (tests) {
+    files.push(testFile)
+  }
+
   // Returns
   // {
   //    "path/to/fileA": "<<<template>>>",
   //    "path/to/fileB": "<<<template>>>",
   // }
-  return [componentFile, testFile, storiesFile].reduce(
-    (acc, [outputPath, content]) => {
-      const template = isJavascript
-        ? transformTSToJS(outputPath, content)
-        : content
+  return files.reduce((acc, [outputPath, content]) => {
+    const template = isJavascript
+      ? transformTSToJS(outputPath, content)
+      : content
 
-      return {
-        [outputPath]: template,
-        ...acc,
-      }
-    },
-    {}
-  )
+    return {
+      [outputPath]: template,
+      ...acc,
+    }
+  }, {})
 }
 
 export const description = 'Generate a component'

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -93,6 +93,16 @@ export const createYargsForComponentGeneration = ({
             `https://redwoodjs.com/reference/command-line-interface#generate-${componentName}`
           )}`
         )
+        .option('tests', {
+          description: 'Generate test files',
+          type: 'boolean',
+          default: true,
+        })
+        .option('stories', {
+          description: 'Generate storybook files',
+          type: 'boolean',
+          default: true,
+        })
       Object.entries(builderObj).forEach(([option, config]) => {
         yargs.option(option, config)
       })

--- a/packages/cli/src/commands/generate/layout/__tests__/layout.test.ts
+++ b/packages/cli/src/commands/generate/layout/__tests__/layout.test.ts
@@ -8,7 +8,9 @@ import * as layout from '../layout'
 let singleWordDefaultFiles,
   multiWordDefaultFiles,
   javascriptFiles,
-  typescriptFiles
+  typescriptFiles,
+  withoutTestFiles,
+  withoutStoryFiles
 
 beforeAll(() => {
   singleWordDefaultFiles = layout.files({ name: 'App' })
@@ -20,6 +22,16 @@ beforeAll(() => {
   typescriptFiles = layout.files({
     name: 'TypescriptPage',
     typescript: true,
+  })
+  withoutTestFiles = layout.files({
+    name: 'withoutTests',
+    javascript: true,
+    tests: false
+  })
+  withoutStoryFiles = layout.files({
+    name: 'withoutStories',
+    javascript: true,
+    stories: false
   })
 })
 
@@ -117,4 +129,26 @@ test('creates TS layout components if typescript = true', () => {
       )
     ]
   ).not.toBeUndefined()
+})
+
+test("doesn't include storybook file when --stories is set to false", () => {
+  expect(Object.keys(withoutStoryFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/layouts/WithoutStoriesLayout/WithoutStoriesLayout.test.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/layouts/WithoutStoriesLayout/WithoutStoriesLayout.js'
+    ),
+  ])
+})
+
+test("doesn't include test file when --tests is set to false", () => {
+  expect(Object.keys(withoutTestFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/layouts/WithoutTestsLayout/WithoutTestsLayout.stories.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/layouts/WithoutTestsLayout/WithoutTestsLayout.js'
+    ),
+  ])
 })

--- a/packages/cli/src/commands/generate/layout/layout.js
+++ b/packages/cli/src/commands/generate/layout/layout.js
@@ -8,7 +8,7 @@ import {
 const COMPONENT_SUFFIX = 'Layout'
 const REDWOOD_WEB_PATH_NAME = 'layouts'
 
-export const files = ({ name, ...options }) => {
+export const files = ({ name, tests = true, stories = true, ...options }) => {
   // TODO: Replace with check from https://github.com/redwoodjs/redwood/pull/633
   const isJavascript = options.javascript && !options.typescript
   const layoutFile = templateForComponentFile({
@@ -36,24 +36,30 @@ export const files = ({ name, ...options }) => {
     templatePath: 'stories.tsx.template',
   })
 
+  const files = [layoutFile]
+  if (stories) {
+    files.push(storyFile)
+  }
+
+  if (tests) {
+    files.push(testFile)
+  }
+
   // Returns
   // {
   //    "path/to/fileA": "<<<template>>>",
   //    "path/to/fileB": "<<<template>>>",
   // }
-  return [layoutFile, testFile, storyFile].reduce(
-    (acc, [outputPath, content]) => {
-      const template = isJavascript
-        ? transformTSToJS(outputPath, content)
-        : content
+  return files.reduce((acc, [outputPath, content]) => {
+    const template = isJavascript
+      ? transformTSToJS(outputPath, content)
+      : content
 
-      return {
-        [outputPath]: template,
-        ...acc,
-      }
-    },
-    {}
-  )
+    return {
+      [outputPath]: template,
+      ...acc,
+    }
+  }, {})
 }
 
 export const {

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -46,24 +46,49 @@ import { getPaths } from 'src/lib'
 import { pathName } from '../../helpers'
 import * as page from '../page'
 
-let singleWordFiles, multiWordFiles, pluralWordFiles, paramFiles
+let singleWordFiles,
+  multiWordFiles,
+  pluralWordFiles,
+  paramFiles,
+  noTestsFiles,
+  noStoriesFiles
 
 beforeAll(() => {
   singleWordFiles = page.files({
     name: 'Home',
+    tests: true,
+    stories: true,
     ...page.paramVariants(pathName(undefined, 'home')),
   })
   multiWordFiles = page.files({
     name: 'ContactUs',
+    tests: true,
+    stories: true,
     ...page.paramVariants(pathName(undefined, 'contact-us')),
   })
   pluralWordFiles = page.files({
     name: 'Cats',
+    tests: true,
+    stories: true,
     ...page.paramVariants(pathName(undefined, 'cats')),
   })
   paramFiles = page.files({
     name: 'Post',
+    tests: true,
+    stories: true,
     ...page.paramVariants(pathName('{id}', 'post')),
+  })
+  noTestsFiles = page.files({
+    name: 'NoTests',
+    tests: false,
+    stories: true,
+    ...page.paramVariants(pathName(undefined, 'no-tests')),
+  })
+  noStoriesFiles = page.files({
+    name: 'NoStories',
+    tests: true,
+    stories: false,
+    ...page.paramVariants(pathName(undefined, 'no-stories')),
   })
 })
 
@@ -149,6 +174,26 @@ test('creates a test for page component with params', () => {
       path.normalize('/path/to/project/web/src/pages/PostPage/PostPage.test.js')
     ]
   ).toEqual(loadGeneratorFixture('page', 'paramPage.test.js'))
+})
+
+test('doesnt create a test for page component when tests=false', () => {
+  expect(Object.keys(noTestsFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/pages/NoTestsPage/NoTestsPage.stories.js'
+    ),
+    path.normalize('/path/to/project/web/src/pages/NoTestsPage/NoTestsPage.js'),
+  ])
+})
+
+test('doesnt create a story for page component when stories=false', () => {
+  expect(Object.keys(noStoriesFiles)).toEqual([
+    path.normalize(
+      '/path/to/project/web/src/pages/NoStoriesPage/NoStoriesPage.test.js'
+    ),
+    path.normalize(
+      '/path/to/project/web/src/pages/NoStoriesPage/NoStoriesPage.js'
+    ),
+  ])
 })
 
 test('creates a single-word route name', () => {

--- a/packages/cli/src/commands/generate/service/__tests__/service.test.js
+++ b/packages/cli/src/commands/generate/service/__tests__/service.test.js
@@ -266,3 +266,17 @@ describe('in typescript mode', () => {
   itCreatesASingleWordServiceFileWithABelongsToRelation(baseArgs)
   itCreatesASingleWordServiceFileWithMultipleRelations(baseArgs)
 })
+
+test("doesn't include test file when --tests is set to false", async () => {
+  const baseArgs = { ...getDefaultArgs(service.defaults), javascript: true }
+
+  const files = await service.files({
+    ...baseArgs,
+    name: 'User',
+    tests: false,
+  })
+
+  expect(Object.keys(files)).toEqual([
+    path.normalize('/path/to/project/api/src/services/users/users.js'),
+  ])
+})

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -11,6 +11,7 @@ import {
 
 export const files = async ({
   name,
+  tests = true,
   relations,
   javascript,
   typescript,
@@ -37,12 +38,17 @@ export const files = async ({
     templateVars: { relations: relations || [], ...rest },
   })
 
+  const files = [serviceFile]
+  if (tests) {
+    files.push(testFile)
+  }
+
   // Returns
   // {
   //    "path/to/fileA": "<<<template>>>",
   //    "path/to/fileB": "<<<template>>>",
   // }
-  return [serviceFile, testFile].reduce((acc, [outputPath, content]) => {
+  return files.reduce((acc, [outputPath, content]) => {
     if (javascript && !typescript) {
       content = transformTSToJS(outputPath, content)
       outputPath = outputPath.replace('.ts', '.js')
@@ -57,6 +63,11 @@ export const files = async ({
 
 export const defaults = {
   ...yargsDefaults,
+  tests: {
+    default: true,
+    description: 'Generate test files',
+    type: 'boolean',
+  },
   crud: {
     default: false,
     description: 'Create CRUD functions',


### PR DESCRIPTION
This adds flags to the generator to allow people to skip test generation and story file generation.

List of generators that need to be changed:

- [x] Cell
- [x] Component
- [x] layout
- [x] page
- [x] service

Fixes #1444 