### PR TITLE
Move fast refresh to dependencies, instead of dev

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime-corejs3": "^7.11.2",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@prisma/cli": "2.9.0",
     "@redwoodjs/cli": "^0.20.0",
     "@redwoodjs/dev-server": "^0.20.0",
@@ -51,6 +52,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^0.11.0",
     "null-loader": "^4.0.1",
+    "react-refresh": "^0.9.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",
     "typescript": "^4.0.2",
@@ -63,11 +65,9 @@
     "webpack-retry-chunk-load-plugin": "^1.4.0"
   },
   "devDependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "@types/babel-core": "^6.25.6",
     "@types/babel-plugin-tester": "^9.0.0",
     "babel-plugin-tester": "^9.0.1",
-    "react-refresh": "^0.9.0",
     "whatwg-fetch": "^3.0.0"
   },
   "gitHead": "c235e7d7186e5e258764699c0e0e1d5cc0fdd0b5",


### PR DESCRIPTION
Moves fast refresh dependencies to main dependencies instead of dev. It's dev for the user, not for RW