### PR TITLE
Move fast-refresh config to work with storybook

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -118,6 +118,7 @@ const getStyleLoaders = (isEnvProduction) => {
   ]
 }
 
+// Shared with storybook, as well as the RW app
 const getSharedPlugins = (isEnvProduction) => {
   const shouldIncludeFastRefresh =
     redwoodConfig.web.experimentalFastRefresh && !isEnvProduction

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -11,6 +11,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
 const { RetryChunkLoadPlugin } = require('webpack-retry-chunk-load-plugin')
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 
 const redwoodConfig = getConfig()
 const redwoodPaths = getPaths()
@@ -118,12 +119,16 @@ const getStyleLoaders = (isEnvProduction) => {
 }
 
 const getSharedPlugins = (isEnvProduction) => {
+  const shouldIncludeFastRefresh =
+    redwoodConfig.web.experimentalFastRefresh && !isEnvProduction
+
   return [
     isEnvProduction &&
       new MiniCssExtractPlugin({
         filename: 'static/css/[name].[contenthash:8].css',
         chunkFilename: 'static/css/[name].[contenthash:8].css',
       }),
+    shouldIncludeFastRefresh && new ReactRefreshWebpackPlugin(),
     new webpack.ProvidePlugin({
       React: 'react',
       PropTypes: 'prop-types',

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -3,8 +3,6 @@ const escapeRegExp = require('lodash.escaperegexp')
 const { getConfig } = require('@redwoodjs/internal')
 const ErrorOverlayPlugin = require('error-overlay-webpack-plugin')
 
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
-
 const webpackConfig = require('./webpack.common')
 
 const { mergeUserWebpackConfig } = webpackConfig
@@ -40,11 +38,7 @@ const baseConfig = merge(webpackConfig('development'), {
     removeEmptyChunks: false,
     splitChunks: false,
   },
-  plugins: [
-    new ErrorOverlayPlugin(),
-    redwoodConfig.web.experimentalFastRefresh &&
-      new ReactRefreshWebpackPlugin(),
-  ].filter(Boolean),
+  plugins: [new ErrorOverlayPlugin()].filter(Boolean),
 })
 
 module.exports = mergeUserWebpackConfig('development', baseConfig)


### PR DESCRIPTION
Moves fast-refresh plugin to `webpack.common.js` as it _can_ be used by storybook.

Storybook doesn't currently use `webpack.development.js` - we should think about renaming these files to be a little bit more explicit perhaps?