### PR TITLE
create_pr_package: Unique names per build

### DIFF
--- a/.github/workflows/create_pr_package.yaml
+++ b/.github/workflows/create_pr_package.yaml
@@ -33,6 +33,11 @@ jobs:
           for d in packages/*/ ; do
             (cd "$d" && tgz=$(npm pack) && cp $tgz ../../bin/)
           done
+          cd bin
+          sha="${{ github.event.pull_request.head.sha }}"
+          for f in * ; do
+            mv -- "$f" "${f%.tgz}-${sha:0:7}.tgz"
+          done
 
       - name: copy files to s3
         env:
@@ -55,9 +60,24 @@ jobs:
           msg+="%0AInstall locally with yarn, e.g. \`yarn workspace web add <url>\`"
           echo "::set-output name=msg::$msg"
 
-      - name: Comment on PR
-        uses: mshick/add-pr-comment@v1
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
         with:
-          message: ${{ steps.comment_msg.outputs.msg }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: false # The links don't change (but the file they link to does). So no need to repost
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.number }}
+          body: ${{ steps.comment_msg.outputs.msg }}
+
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: ${{ steps.comment_msg.outputs.msg }}
+          edit-mode: replace


### PR DESCRIPTION
I've included the sha-1 of the commit in the filename to make it more deterministic what package (code) you install and deploy. There is still only one comment from the bot with the filenames. Each time a new commit comes on on the PR the comment is updated. You can always see past comments (with the old filenames) by using the dropdown on the comment, see screenshot. The screenshot also shows that the first 7 characters of the commit sha-1 are included in the package filenames

/cc @jeliasson 

![image](https://user-images.githubusercontent.com/30793/99121050-35d3ee80-25fc-11eb-9e54-321092d5a99d.png)
