### PR TITLE
Addition of redirectUrl parameter to netlify auth login function

### DIFF
--- a/packages/auth/src/authClients/netlify.ts
+++ b/packages/auth/src/authClients/netlify.ts
@@ -8,7 +8,7 @@ export const netlify = (client: NetlifyIdentity): AuthClient => {
   return {
     type: 'netlify',
     client,
-    login: () => {
+    login: (redirectUrl) => {
       return new Promise((resolve, reject) => {
         let autoClosedModal = false
         client.open('login')
@@ -16,6 +16,9 @@ export const netlify = (client: NetlifyIdentity): AuthClient => {
           // This closes the modal which pops-up immediately after you login.
           autoClosedModal = true
           client.close()
+          if (typeof redirectUrl != "undefined" && redirectUrl != null) {
+            window.location.href = redirectUrl;
+          }
           return resolve(user)
         })
         client.on('close', () => {


### PR DESCRIPTION
I am using Netlify Identity for user authentication and had a use case where I wanted to re-direct the user after a successful login to the member "dashboard" of my app.  Instead of the login modal just closing and the user needing to click to the dashboard I've added a "redirectUrl" parameter to the login function.

An example use case would be calling the login function like this:

import { useAuth } from '@redwoodjs/auth'

  const { logIn, logOut, isAuthenticated } = useAuth()
  const redirectUrl = '/members'

  function doLogin() {
    logIn(redirectUrl)
  }