### PR TITLE
Use original prisma schema path.

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -44,7 +44,11 @@ export const handler = async ({ side = ['api', 'web'], forward = '' }) => {
   if (side.includes('api')) {
     try {
       // This command will check if the api side has a `prisma.schema` file.
-      await generatePrismaClient({ verbose: false, force: false })
+      await generatePrismaClient({
+        verbose: false,
+        force: false,
+        schema: getPaths().api.dbSchema,
+      })
     } catch (e) {
       console.error(c.error(e.message))
     }

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -13,7 +13,7 @@ describe('getConfig', () => {
           "host": "localhost",
           "path": "./api",
           "port": 8911,
-          "schemaPath": "./api/db/schema.prisma",
+          "schemaPath": "./api/prisma/schema.prisma",
           "target": "node",
         },
         "browser": Object {

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -57,7 +57,7 @@ const DEFAULT_CONFIG: Config = {
     port: 8911,
     path: './api',
     target: TargetEnum.NODE,
-    schemaPath: './api/db/schema.prisma',
+    schemaPath: './api/prisma/schema.prisma',
   },
   browser: {
     open: false,


### PR DESCRIPTION
We've introduced a new `redwood.toml` configuration option that allows you to change the default prisma schema path. It's now `./api/db` instead of `./api/prisma` when you create a new project.

This sets the default value for existing projects back to the default so that upgrading the the latest version