### PR TITLE
Fixes DB Generators failing when a schema path includes spaces or other problematic characters

### DIFF
--- a/packages/cli/src/commands/__tests__/build.test.js
+++ b/packages/cli/src/commands/__tests__/build.test.js
@@ -25,7 +25,7 @@ import { handler } from '../build'
 test('The build command runs the correct commands.', async () => {
   await handler({})
   expect(runCommandTask.mock.results[0].value[0]).toEqual(
-    'yarn prisma generate --schema=../../__fixtures__/example-todo-main/api/prisma'
+    'yarn prisma generate --schema="../../__fixtures__/example-todo-main/api/prisma"'
   )
 
   expect(execa.mock.results[0].value).toEqual(

--- a/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
+++ b/packages/cli/src/commands/dbCommands/__tests__/dbCommands.test.js
@@ -37,27 +37,27 @@ describe('db commands', () => {
   it('runs the command as expected', async () => {
     await up.handler({ dbClient: true, schema })
     expect(runCommandTask.mock.results[0].value).toEqual([
-      `yarn prisma migrate up --experimental --create-db --schema=${schema}`,
+      `yarn prisma migrate up --experimental --create-db --schema="${schema}"`,
     ])
 
     await up.handler({ dbClient: true, autoApprove: true, schema })
     expect(runCommandTask.mock.results[1].value).toEqual([
-      `yarn prisma migrate up --experimental --create-db --auto-approve --schema=${schema}`,
+      `yarn prisma migrate up --experimental --create-db --auto-approve --schema="${schema}"`,
     ])
 
     await down.handler({ schema })
     expect(runCommandTask.mock.results[2].value).toEqual([
-      `yarn prisma migrate down --experimental --schema=${schema}`,
+      `yarn prisma migrate down --experimental --schema="${schema}"`,
     ])
 
     await save.handler({ name: 'my-migration', schema })
     expect(runCommandTask.mock.results[3].value).toEqual([
-      `yarn prisma migrate save --name "my-migration" --create-db --experimental --schema=${schema}`,
+      `yarn prisma migrate save --name "my-migration" --create-db --experimental --schema="${schema}"`,
     ])
 
     await introspect.handler({ schema })
     expect(runCommandTask.mock.results[4].value).toEqual([
-      `yarn prisma introspect --schema=${schema}`,
+      `yarn prisma introspect --schema="${schema}"`,
     ])
 
     await seed.handler({})

--- a/packages/cli/src/commands/dbCommands/down.js
+++ b/packages/cli/src/commands/dbCommands/down.js
@@ -24,7 +24,7 @@ export const handler = async ({ decrement, verbose = true, schema }) => {
           'migrate down',
           decrement && `${decrement}`,
           '--experimental',
-          schema && `--schema=${schema}`,
+          schema && `--schema="${schema}"`,
         ].filter(Boolean),
       },
     ],

--- a/packages/cli/src/commands/dbCommands/generate.js
+++ b/packages/cli/src/commands/dbCommands/generate.js
@@ -48,7 +48,7 @@ export const handler = async ({ verbose = true, force = true, schema }) => {
       {
         title: 'Generating the Prisma client...',
         cmd: 'yarn prisma',
-        args: ['generate', schema && `--schema=${schema}`],
+        args: ['generate', schema && `--schema="${schema}"`],
       },
     ],
     {

--- a/packages/cli/src/commands/dbCommands/introspect.js
+++ b/packages/cli/src/commands/dbCommands/introspect.js
@@ -17,7 +17,7 @@ export const handler = async ({ verbose = true, schema }) => {
       {
         title: 'Introspecting your database...',
         cmd: 'yarn prisma',
-        args: ['introspect', schema && `--schema=${schema}`],
+        args: ['introspect', schema && `--schema="${schema}"`],
         opts: { cwd: getPaths().api.db },
       },
     ],

--- a/packages/cli/src/commands/dbCommands/save.js
+++ b/packages/cli/src/commands/dbCommands/save.js
@@ -30,7 +30,7 @@ export const handler = async ({
           name.length && `--name "${name}"`,
           '--create-db',
           '--experimental',
-          schema && `--schema=${schema}`,
+          schema && `--schema=\"${schema}\"`,
         ].filter(Boolean),
       },
     ],

--- a/packages/cli/src/commands/dbCommands/save.js
+++ b/packages/cli/src/commands/dbCommands/save.js
@@ -30,7 +30,7 @@ export const handler = async ({
           name.length && `--name "${name}"`,
           '--create-db',
           '--experimental',
-          schema && `--schema=\"${schema}\"`,
+          schema && `--schema="${schema}"`,
         ].filter(Boolean),
       },
     ],

--- a/packages/cli/src/commands/dbCommands/studio.js
+++ b/packages/cli/src/commands/dbCommands/studio.js
@@ -31,7 +31,7 @@ export const handler = async ({ schema }) => {
       {
         title: 'Starting Prisma Studio...',
         cmd: 'yarn prisma',
-        args: ['studio', schema && `--schema=${schema}`],
+        args: ['studio', schema && `--schema="${schema}"`],
       },
     ],
     { verbose: true }

--- a/packages/cli/src/commands/dbCommands/up.js
+++ b/packages/cli/src/commands/dbCommands/up.js
@@ -44,7 +44,7 @@ export const handler = async ({
           '--experimental',
           '--create-db',
           autoApprove && '--auto-approve',
-          schema && `--schema=\"${schema}\"`,
+          schema && `--schema="${schema}"`,
         ].filter(Boolean),
       },
     ],

--- a/packages/cli/src/commands/dbCommands/up.js
+++ b/packages/cli/src/commands/dbCommands/up.js
@@ -44,7 +44,7 @@ export const handler = async ({
           '--experimental',
           '--create-db',
           autoApprove && '--auto-approve',
-          schema && `--schema=${schema}`,
+          schema && `--schema=\"${schema}\"`,
         ].filter(Boolean),
       },
     ],


### PR DESCRIPTION
Issue:

If your RedwoodJS project path includes characters like spaces or other problematic characters like ( or ), then the schema cannot be found and all the `db`-related generators like save, up, etc fail like:

```
yarn rw db save                                           
yarn run v1.22.10
$ '/Users/username/Dropbox (Personal)/projects/redwoodjs/pectin/node_modules/.bin/rw' db save
Creating database migration... [started]
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `yarn prisma migrate save --name "migration" --create-db --experimental --schema=/Users/username/Dropbox (Personal)/projects/redwoodjs/pectin/api/db/schema.prisma'
Creating database migration... [failed]
→ Command failed with exit code 2: yarn prisma migrate save --name "migration" --create-db --experimental --schema=/Users/username/Dropbox (Personal)/projects/redwoodjs/pectin/api/db/schema.prisma
Command failed with exit code 2: yarn prisma migrate save --name "migration" --create-db --experimental --schema=/Users/username/Dropbox (Personal)/projects/redwoodjs/pectin/api/db/schema.prisma
✨  Done in 2.42s.
```

This PT addresses this issue by enclosing the schema option in double quotes:

```
schema && `--schema=\"${schema}\"`,
```