### PR TITLE
Fix #1278 launch Storybook with path w/ spaces

### DIFF
--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -29,7 +29,7 @@ export const handler = ({ open, port }) => {
   const staticAssetsFolder = path.join(getPaths().web.base, 'public')
 
   // Create the `MockServiceWorker.js` file.
-  execa(`yarn msw init ${staticAssetsFolder}`, undefined, {
+  execa(`yarn msw init "${staticAssetsFolder}"`, undefined, {
     stdio: 'inherit',
     shell: true,
     cwd,
@@ -39,7 +39,7 @@ export const handler = ({ open, port }) => {
     '--config-dir ../node_modules/@redwoodjs/core/config/storybook',
     `--port ${port}`, // this should be configurable?
     '--no-version-updates', // we'll handle upgrades
-    `--static-dir ${staticAssetsFolder}`,
+    `--static-dir "${staticAssetsFolder}"`,
   ]
 
   if (!open) {


### PR DESCRIPTION
This PR addresses issue #1278

https://github.com/redwoodjs/redwood/issues/1278

Now, the `yarn rw storybook` command succeeds to:

```
yarn rw storybook     
yarn run v1.22.10
$ '/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/node_modules/.bin/rw' storybook
$ '/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/node_modules/.bin/start-storybook' --config-dir ../node_modules/@redwoodjs/core/config/storybook --port 7910 --no-version-updates --static-dir '/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/web/public' --ci
$ '/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/node_modules/.bin/msw' init '/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/web/public'
Initializing the Mock Service Worker at "/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/web/public"...

Service Worker successfully created!
/Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/web/public/mockServiceWorker.js

Continue by creating a mocking definition module in your application:

  https://mswjs.io/docs/getting-started/mocks

info @storybook/react v5.3.19
info 
info => Loading static files from: /Users/dthyresson/Dropbox (Personal)/projects/redwoodjs/pectin/web/public .
info => Loading presets
info => Loading presets
info => Loading custom babel config as JS
info => Loading custom babel config as JS
info => Loading config/preview file in "../node_modules/@redwoodjs/core/config/storybook".
info => Adding stories defined in "../node_modules/@redwoodjs/core/config/storybook/main.js".
info => Using default Webpack setup.
info => Using base config because react-scripts is not installed.
webpack built 0241b95ed5395d2508cd in 12507ms
╭───────────────────────────────────────────────────╮
│                                                   │
│   Storybook 5.3.19 started                        │
│   12 s for manager and 14 s for preview           │
│                                                   │
│    Local:            http://localhost:7910/       │
│    On your network:  http://192.168.7.53:7910/    │
│                                                   │
```

Note: While this succeeds in finding the paths properly, I am getting a memory error:

```
webpack building...
webpack built d6d6922e94ad11a99e16 in 15683ms
webpack building...
70% building 2/2 modules 0 active
<--- Last few GCs --->

[71095:0x110008000]   183649 ms: Scavenge (reduce) 4031.0 (4100.8) -> 4030.2 (4101.8) MB, 7.0 / 0.0 ms  (average mu = 0.094, current mu = 0.048) allocation failure 
[71095:0x110008000]   183663 ms: Scavenge (reduce) 4031.1 (4100.8) -> 4030.3 (4101.8) MB, 8.6 / 0.0 ms  (average mu = 0.094, current mu = 0.048) allocation failure 
[71095:0x110008000]   183674 ms: Scavenge (reduce) 4031.2 (4100.8) -> 4030.5 (4102.1) MB, 7.0 / 0.0 ms  (average mu = 0.094, current mu = 0.048) allocation failure 


<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 ```

But, I think this may be an unrelated and separate issue that I will investigate and report.