### PR TITLE
upgrade to Prisma v2.11.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.9.0",
+    "@prisma/client": "2.11.0",
     "@redwoodjs/internal": "^0.20.0",
     "apollo-server-lambda": "2.18.2",
     "core-js": "3.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.9.0",
+    "@prisma/sdk": "2.11.0",
     "@redwoodjs/internal": "^0.20.0",
     "@redwoodjs/structure": "^0.20.0",
     "boxen": "^4.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime-corejs3": "^7.11.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
-    "@prisma/cli": "2.9.0",
+    "@prisma/cli": "2.11.0",
     "@redwoodjs/cli": "^0.20.0",
     "@redwoodjs/dev-server": "^0.20.0",
     "@redwoodjs/eslint-config": "^0.20.0",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.9.0",
+    "@prisma/sdk": "2.11.0",
     "@redwoodjs/internal": "^0.20.0",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,55 +3028,69 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@prisma/ci-info@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@prisma/ci-info/-/ci-info-2.1.2.tgz#3da64f54584bde0aaf4b42f298a6c63f025aeb3f"
-  integrity sha512-RhAHY+wp6Nqu89Tp3zfUVkpGfqk4TfngeOWaMGgmhP7mB2ASDtOl8dkwxHmI8eN4edo+luyjPmbJBC4kST321A==
+"@prisma/bar@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
+  integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
 
-"@prisma/cli@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.9.0.tgz#c6f6652890783b899f266537e90e69c3481f5474"
-  integrity sha512-wPk4ehyTtVM7ZarWs16MhOc6kwLV/gZFardMvUeh46rlBwrklMdKtNChzzPa3wurrUPQ5KTbuRBz5Mgf7AdD/w==
-
-"@prisma/client@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.9.0.tgz#acfaca0c5695d7f439e5af54b7cd0f7fb5926340"
-  integrity sha512-VLXw6s13xakIrV9Z8Ftw0j+mbXuvbRkxYv3X5hRZdPN1NAwgeXJmrrTK9MS2HDvW8eGZL7P8OaUSNQ3Sfgvr/Q==
+"@prisma/cli@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.11.0.tgz#34bdc5573ac40edae336b65fa73a164cae437622"
+  integrity sha512-RphW+1SPrEKgpuE5RFM0mv3BeVTF8MCRIyBt35Z9Z/E4YI30qgEWfZu6VfsNDarHRsFiJRKC73wx/aMQ2rLp4g==
   dependencies:
-    pkg-up "^3.1.0"
+    "@prisma/bar" "0.0.1"
+    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
 
-"@prisma/debug@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.9.0.tgz#6b2d176f3ae587499bea5eef0e304181d7561775"
-  integrity sha512-Z76oG/vKC8ohdcBSwLt0eu09h+AAEam0lj0JGD9Ijx6NfsdKj+gTZ8CH+IR7+f4aWB38QRzkJRs33jzQDT41Jw==
+"@prisma/client@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.11.0.tgz#574c1aa3b571ea01c0fa8dca348c6ba5db41dcc9"
+  integrity sha512-BF7K/yi5fAnrt7MelQqUueJyl06IGmIxf+7f5RxFSvyO6xZMbOYxhW21kV2wt10mOIS0khQbo0xY6w/8jViJuQ==
+  dependencies:
+    "@prisma/engines-version" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+
+"@prisma/debug@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.11.0.tgz#cfb9b2c331efacbf3018afc4b83e895c12cacd75"
+  integrity sha512-qOk2HrbvFCZ8VDwBvHOIdj2uw665CNAFql5qh+AS/SZjO5B6dDyvznK3EzUp5DxOLfkhx+HJ+j+Te76nAS+I0Q==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.9.0.tgz#f8a29c4835afce977446a626636454002c42aa0c"
-  integrity sha512-lDMmoDcSbgAbEyegXtRdDm9Xtj4eprOIEULsx1ZdEBHpr1XGmiKRWOEulU8axNfHfAluFmXMPN/9Ipwi5kM+Fw==
+"@prisma/engine-core@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.11.0.tgz#b1ddda8f0827671e0da6dff04e0ebd1267e05b67"
+  integrity sha512-duxmMScKNtXugKmNN7pqm5WRvX8Vp2rD3v8knTpZyYHdIa0/ww7dbfJagA2RlB8bKXnlKL08lXDC7eEvb/r8LQ==
   dependencies:
-    "@prisma/debug" "2.9.0"
-    "@prisma/generator-helper" "2.9.0"
-    "@prisma/get-platform" "2.9.0"
+    "@prisma/debug" "2.11.0"
+    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+    "@prisma/generator-helper" "2.11.0"
+    "@prisma/get-platform" "2.11.0"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
-    get-stream "^5.1.0"
+    get-stream "^6.0.0"
     indent-string "^4.0.0"
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "2.0.7"
+    undici "2.1.1"
 
-"@prisma/fetch-engine@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.9.0.tgz#38c689c98544bcd28ac2132972b087b356834d26"
-  integrity sha512-Y/tlcWa66P/IPd9x5STcL8Rltn0NNAO8NEOXFTStUOZxDnsLjEnzKZn6swTSj3EFJD7bRJAMnqB/GR4Ort43SQ==
+"@prisma/engines-version@2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918":
+  version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#840bb5ca8707ed3b852d250c1bac9c75098682ee"
+  integrity sha512-qlkW4dKoW1dUnperWPuhFriZ/NTHlsKLhBbebxRa8qMuD3o37SvWIDGLjFOQx1N0Eb4H04rI3XxgjkWLFVlZCw==
+
+"@prisma/engines@2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918":
+  version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#5f02f311ce48297ef3fa9861dcab5ec3e52f1371"
+  integrity sha512-0WaUybWM7J5zQuG/zYLbV+ZKx9/nzS7Ruu7Y0K2lXJKy3Z9koeVttq+Xt7tVmUX9TLgI1Rwhb9R2e1JMNDWbsw==
+
+"@prisma/fetch-engine@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.11.0.tgz#f038475f3de4d6951edc77b965eb7f7c0b588cbe"
+  integrity sha512-shkriv/kdR5ihjAOoxJb5/ZBIRjySOYcA+dFhhzbopsFf1cTivB7cKntog9Uc1oE87aftgNXRelITPqvbbYQ6w==
   dependencies:
-    "@prisma/debug" "2.9.0"
-    "@prisma/get-platform" "2.9.0"
+    "@prisma/debug" "2.11.0"
+    "@prisma/get-platform" "2.11.0"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -3092,43 +3106,45 @@
     progress "^2.0.3"
     rimraf "^3.0.2"
     temp-dir "^2.0.0"
-    tempy "^0.7.0"
+    tempy "^1.0.0"
 
-"@prisma/generator-helper@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.9.0.tgz#0ad15b9e4513a3b2f1aecee78c611eb831ef6e4e"
-  integrity sha512-Qxpv8OC3fjyVCRo7E369Z1sT+QFxlb590Iva+hr6GhtyQuIncifgZ3+laYrtElDFti6o36gY5JxyXvPznJWitg==
+"@prisma/generator-helper@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.11.0.tgz#4f8aa14e6c0f7dd7ebc76016ce0aff29c3912249"
+  integrity sha512-R+l8ZQlbcv+0xgzDQwUU7M2+mSs8jBIAeyVKbNJQWoump8+vhGKlyDn+cdTCkJM83e9QlM1K5/i8weYqB/6y7Q==
   dependencies:
-    "@prisma/debug" "2.9.0"
+    "@prisma/debug" "2.11.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.9.0.tgz#1e2eb9d5af850941f15dd4930018aebacd9830ce"
-  integrity sha512-Sp83D2txjMqyk+lqVUH/syiS6v6ZXFz8C15eqGDDq6aqstsqzKZ3+sx0bqfepbzJcvvddd6qbr/R034yKM7lzw==
+"@prisma/get-platform@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.11.0.tgz#e90593c4b904d0613969a2ea94c9357b477282ed"
+  integrity sha512-VNx7/hYqKJm+r8cEsX7Tff/NDoiB+MwTCqOu+T5En4F9rxhxxGEuzCyTTdP+tFqmqvd7WGKtmO2qrMgw3bIylw==
   dependencies:
-    "@prisma/debug" "2.9.0"
+    "@prisma/debug" "2.11.0"
 
-"@prisma/sdk@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.9.0.tgz#eb2fedade0d017398dfabc4a9b396a9323be3893"
-  integrity sha512-GzcWlzgjhTcBIGhmHpCOO0vKeEbZ6g8ejVe1166hyjhT0mkrfScBmhSwcuatm7UrYYcfJt28SGrJURf5vivoZg==
+"@prisma/sdk@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.11.0.tgz#8eb3972a4e93ce1fc026bff8c770c95e169adc48"
+  integrity sha512-a9sU9lSVNQhoMwlRV26KHbu7m1CrEv+Mz0ZwD05S6zm3Ax+KBozGM5irnMnlNlfBaM9pS6bagv3hieS5ija4/w==
   dependencies:
-    "@prisma/debug" "2.9.0"
-    "@prisma/engine-core" "2.9.0"
-    "@prisma/fetch-engine" "2.9.0"
-    "@prisma/generator-helper" "2.9.0"
-    "@prisma/get-platform" "2.9.0"
+    "@prisma/debug" "2.11.0"
+    "@prisma/engine-core" "2.11.0"
+    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+    "@prisma/fetch-engine" "2.11.0"
+    "@prisma/generator-helper" "2.11.0"
+    "@prisma/get-platform" "2.11.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^4.1.3"
     chalk "4.1.0"
-    checkpoint-client "1.1.13"
+    checkpoint-client "1.1.14"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^4.0.0"
+    find-up "5.0.0"
     global-dirs "^2.0.1"
     globby "^11.0.0"
     has-yarn "^2.1.0"
@@ -3145,7 +3161,7 @@
     tar "^6.0.1"
     temp-dir "^2.0.0"
     temp-write "^4.0.0"
-    tempy "^0.7.0"
+    tempy "^1.0.0"
     terminal-link "^2.1.1"
     tmp "0.2.1"
     url-parse "^1.4.7"
@@ -6629,12 +6645,12 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-checkpoint-client@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.13.tgz#9ee0941d7f82aa24bfd243c5be5da7b1fdb870ed"
-  integrity sha512-/GONVFkUAbwIRpuIl6LR7/lohoCP0RFmzb+gbXU72OJ9GaSzhqJ/yiMmoRPcuH2aF4OAWfvrVaTzS7/K8ZJh3g==
+checkpoint-client@1.1.14:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.14.tgz#45d58ae4f9d24c029fb35f5afc8cd6cacfed4e36"
+  integrity sha512-/3wj7LeYK/J/e4pF+WG1JNpRZ3GggoXelgdY8I4VSzmlrlRUe9vJhJQySqYdVrCGe7O6VlfJ1GVlnmw7p8XAKg==
   dependencies:
-    "@prisma/ci-info" "2.1.2"
+    ci-info "2.0.0"
     cross-spawn "7.0.3"
     env-paths "2.2.0"
     fast-write-atomic "0.2.1"
@@ -6699,7 +6715,7 @@ ci-env@^1.4.0:
   resolved "https://registry.yarnpkg.com/ci-env/-/ci-env-1.16.0.tgz#e97f3b5001a8daf7da6e46f418bc6892a238704d"
   integrity sha512-ucF9caQEX5wQlY449KZBIJPx91+kRg9tJ3tWSc4+KzrvC5KNiPm/3g1noP8VhdI3046+Vw3jLmKAD0fjCRJTmw==
 
-ci-info@^2.0.0:
+ci-info@2.0.0, ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
@@ -9370,6 +9386,14 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -9819,6 +9843,11 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
+  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 get-them-args@1.3.2:
   version "1.3.2"
@@ -12612,6 +12641,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash-decorators@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/lodash-decorators/-/lodash-decorators-6.0.1.tgz#f5347811ee7792eba4719042354541578142273d"
@@ -14280,6 +14316,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -17371,10 +17414,10 @@ temp-write@^4.0.0:
     temp-dir "^1.0.0"
     uuid "^3.3.2"
 
-tempy@^0.7.0:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.7.1.tgz#5a654e6dbd1747cdd561efb112350b55cd9c1d46"
-  integrity sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==
+tempy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-1.0.0.tgz#4f192b3ee3328a2684d0e3fc5c491425395aab65"
+  integrity sha512-eLXG5B1G0mRPHmgH2WydPl5v4jH35qEn3y/rA/aahKhIa91Pn119SsU7n7v/433gtT9ONzC8ISvNHIh2JSTm0w==
   dependencies:
     del "^6.0.0"
     is-stream "^2.0.0"
@@ -17878,10 +17921,10 @@ undefsafe@^2.0.3:
   dependencies:
     debug "^2.2.0"
 
-undici@2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-2.0.7.tgz#3804cffa4c64bc6ae71e6b0f4d85054ea6b0fb91"
-  integrity sha512-3YoSJEva11i4iW+nUfo+r5EP+piSO667SU57hfNeW3kPG5ACl7IgHzhT+bT23j0v1lgs+vIHfxQfTGK32HEPIQ==
+undici@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-2.1.1.tgz#4b7a938bd49fe5f45c5f5398aa4a3c5f2e0cd2d4"
+  integrity sha512-4HVo2WQ0Mg98UwFKauN7UCqWtQcYZiApv9LeqUPzKQEZhZDnnz/PkM0B+1KU2ytFUSrUqlQZ7X0BqyQJskvNnA==
 
 unfetch@^4.1.0:
   version "4.2.0"


### PR DESCRIPTION
- [x] test and deploy on Netlify and Vercel
- [x] confirm binaryTarget `rhel...` is no longer needed

[2.11.0](https://github.com/prisma/prisma/releases/tag/2.11.0)
- Native database types in the Prisma schema (Preview)
- New types in the Prisma schema: BigInt, Bytes and Decimal (Preview)
- Set foreign keys directly (Preview)

[2.10.2](https://github.com/prisma/prisma/releases/tag/2.10.2)

[2.10.1](https://github.com/prisma/prisma/releases/tag/2.10.1)

[2.10.0](https://github.com/prisma/prisma/releases/tag/2.10.0)
- Support for Microsoft SQL Server (Preview)
- Single-command schema changes for prototyping `prisma db push` (Preview)
