### PR TITLE
forms: Improve typings for errors

### DIFF
--- a/packages/forms/src/FormError.tsx
+++ b/packages/forms/src/FormError.tsx
@@ -1,0 +1,109 @@
+import { GraphQLError } from 'graphql'
+
+interface ServerParseError extends Error {
+  response: Response
+  statusCode: number
+  bodyText: string
+}
+
+interface ServerError extends Error {
+  response: Response
+  statusCode: number
+  result: Record<string, any>
+}
+
+interface RWGqlError {
+  message: string
+  graphQLErrors: GraphQLError[]
+  networkError: Error | ServerParseError | ServerError | null
+}
+
+interface FormErrorProps {
+  error?: RWGqlError
+  wrapperClassName?: string
+  wrapperStyle?: React.CSSProperties
+  titleClassName?: string
+  titleStyle?: React.CSSProperties
+  listClassName?: string
+  listStyle?: React.CSSProperties
+  listItemClassName?: string
+  listItemStyle?: React.CSSProperties
+}
+
+/**
+ * Big error message at the top of the page explaining everything that's wrong
+ * with the form fields in this form
+ */
+const FormError = ({
+  error,
+  wrapperClassName,
+  wrapperStyle,
+  titleClassName,
+  titleStyle,
+  listClassName,
+  listStyle,
+  listItemClassName,
+  listItemStyle,
+}: FormErrorProps) => {
+  if (!error) {
+    return null
+  }
+
+  let rootMessage = error.message
+  const messages: string[] = []
+  const hasGraphQLError = !!error.graphQLErrors[0]
+  const hasNetworkError =
+    !!error.networkError && Object.keys(error.networkError).length > 0
+
+  if (hasGraphQLError) {
+    const errors = error.graphQLErrors[0].extensions?.exception.messages
+    rootMessage = error.graphQLErrors[0].message ?? 'Something went wrong.'
+    for (const e in errors) {
+      errors[e].forEach((fieldError: any) => {
+        messages.push(`${e} ${fieldError}`)
+      })
+    }
+  } else if (hasNetworkError) {
+    rootMessage = rootMessage ?? 'An error has occurred'
+    if (Object.prototype.hasOwnProperty.call(error.networkError, 'bodyText')) {
+      const netErr = error.networkError as ServerParseError
+      messages.push(`${netErr.name}: ${netErr.bodyText}`)
+    } else if (
+      Object.prototype.hasOwnProperty.call(error.networkError, 'result')
+    ) {
+      const netErr = error.networkError as ServerError
+      netErr.result.errors?.forEach((error: any) => {
+        if (typeof error.message === 'string') {
+          if (error.message.indexOf(';') >= 0) {
+            messages.push(error.message?.split(';')[1])
+          } else {
+            messages.push(error.message)
+          }
+        }
+      })
+    }
+  }
+
+  if (!rootMessage) {
+    return null
+  }
+
+  return (
+    <div className={wrapperClassName} style={wrapperStyle}>
+      <p className={titleClassName} style={titleStyle}>
+        {rootMessage}
+      </p>
+      {messages.length > 0 && (
+        <ul className={listClassName} style={listStyle}>
+          {messages.map((message: string, index: number) => (
+            <li key={index} className={listItemClassName} style={listItemStyle}>
+              {message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default FormError

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -15,6 +15,7 @@ import {
   TDefinedCoercionFunctions,
   useCoercion,
 } from './coercion'
+import FormError from './FormError'
 
 const DEFAULT_MESSAGES = {
   required: 'is required',
@@ -116,79 +117,6 @@ interface FieldErrorContextProps {
   [key: string]: string
 }
 const FieldErrorContext = React.createContext({} as FieldErrorContextProps)
-
-// Big error message at the top of the page explaining everything that's wrong
-// with the form fields in this form
-
-interface FormErrorProps {
-  error: any
-  wrapperClassName: string
-  wrapperStyle: React.CSSProperties
-  titleClassName: string
-  titleStyle: React.CSSProperties
-  listClassName: string
-  listStyle: React.CSSProperties
-  listItemClassName: string
-  listItemStyle: React.CSSProperties
-}
-
-const FormError = ({
-  error,
-  wrapperClassName,
-  wrapperStyle,
-  titleClassName,
-  titleStyle,
-  listClassName,
-  listStyle,
-  listItemClassName,
-  listItemStyle,
-}: FormErrorProps) => {
-  let rootMessage = null
-  let messages = null
-  const hasGraphQLError = !!error?.graphQLErrors[0]
-  const hasNetworkError = !!error?.networkError?.result?.errors
-
-  if (hasGraphQLError) {
-    const errors = error.graphQLErrors[0].extensions.exception.messages
-    rootMessage = error.graphQLErrors[0].message
-    messages = []
-    for (const e in errors) {
-      errors[e].map((fieldError: any) => {
-        messages.push(`${e} ${fieldError}`)
-      })
-    }
-  } else if (hasNetworkError) {
-    rootMessage = 'An error has occurred'
-    messages = error.networkError.result.errors.map(
-      (error: any) => error.message.split(';')[1]
-    )
-  }
-
-  return (
-    <>
-      {messages && (
-        <div className={wrapperClassName} style={wrapperStyle}>
-          <p className={titleClassName} style={titleStyle}>
-            {rootMessage !== '' ? rootMessage : 'Something went wrong.'}
-          </p>
-          {messages.length > 0 && (
-            <ul className={listClassName} style={listStyle}>
-              {messages.map((message: string, index: number) => (
-                <li
-                  key={index}
-                  className={listItemClassName}
-                  style={listItemStyle}
-                >
-                  {message}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
-    </>
-  )
-}
 
 const coerceValues = (
   data: Record<string, string>,


### PR DESCRIPTION
The `<FormError>` `error` prop was previously typed as `any`. This PR tries to give it some proper typings.

In adapting the code for the types I also made some small implementation changes. I've tried to test things manually, but it's difficult to know what exactly to do to trigger all possible error states. I have, for example, not been able to trigger an error that hits [line 78](https://github.com/redwoodjs/redwood/pull/1510/files#diff-d62339bed2ff80375e94b9f3e929214dfcac60aa1ebad0f49c2cb3870027bcabR78) (That's [line 163](https://github.com/redwoodjs/redwood/pull/1510/files#diff-f22ed6538894aa3d779aa9616f36c5c8343be52cbfae026288a749c3a839e7aaL163) the old code)