### PR TITLE
Fix FetchConfigProvider to reprise handling no auth

### DIFF
--- a/packages/web/src/components/FetchConfigProvider.tsx
+++ b/packages/web/src/components/FetchConfigProvider.tsx
@@ -21,7 +21,8 @@ export const FetchConfigProvider: React.FunctionComponent<{
   useAuth?: () => AuthContextInterface
   renderLoading?: () => React.ReactElement
 }> = ({
-  useAuth = window.__REDWOOD__USE_AUTH,
+  useAuth = window.__REDWOOD__USE_AUTH ??
+    (() => ({ loading: false, isAuthenticated: false })),
   renderLoading = () => null,
   ...rest
 }) => {
@@ -38,10 +39,6 @@ export const FetchConfigProvider: React.FunctionComponent<{
 
   const fetchConfigValue: FetchConfig = {
     uri: `${window.__REDWOOD__API_PROXY_PATH}/graphql`,
-  }
-
-  if (typeof useAuth === 'undefined') {
-    return <FetchConfigContext.Provider value={fetchConfigValue} {...rest} />
   }
 
   // We block all rendering until auth has booted up.


### PR DESCRIPTION
**Edit**: originally I tried to reprise the control flow of RedwoodProvider; now we just default `loading` and `isAuthenticated` to false.

---

Right now the `FetchConfigProvider` tries to invoke the `useAuth` hook immediately (line 28; the check to see if `useAuth` is defined is 15 lines later at 43):

https://github.com/redwoodjs/redwood/blob/a78cfe80d852ff53ce108face446db869ddba9b6/packages/web/src/components/FetchConfigProvider.tsx#L20-L45

This a problem for no-auth Redwood apps; they get this error on `yarn rw dev`:

![image](https://user-images.githubusercontent.com/32992335/100196869-5cbcdb00-2eae-11eb-93d3-238bee837168.png)

This PR reprises the control flow similar to the `RedwoodProvider` in v0.21.0, which checks to see if `useAuth` is defined and returns a provider appropriately:

https://github.com/redwoodjs/redwood/blob/53349fd121f9198a8fdb5c0217cec8c4f8b6badd/packages/web/src/components/RedwoodProvider.tsx#L85-L108
