### PR TITLE
Add --build option to `yarn rw storybook`

### DIFF
--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -6,7 +6,7 @@ import { getPaths } from '@redwoodjs/internal'
 export const command = 'storybook'
 export const aliases = ['sb']
 export const description =
-  'Launch Storybook: An isolate component development environment.'
+  'Launch Storybook: An isolated component development environment'
 
 export const builder = (yargs) => {
   yargs

--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -31,7 +31,8 @@ export const handler = ({ open, port, build }) => {
   const cwd = getPaths().web.base
 
   const staticAssetsFolder = path.join(getPaths().web.base, 'public')
-  // Create the `MockServiceWorker.js` file.
+  // Create the `MockServiceWorker.js` file
+  // https://mswjs.io/docs/cli/init
   execa(`yarn msw init "${staticAssetsFolder}"`, undefined, {
     stdio: 'inherit',
     shell: true,
@@ -42,10 +43,10 @@ export const handler = ({ open, port, build }) => {
     `yarn ${build ? 'build' : 'start'}-storybook`,
     [
       '--config-dir ../node_modules/@redwoodjs/core/config/storybook',
-      `--port ${port}`,
-      '--no-version-updates',
+      !build && `--port ${port}`,
+      !build && '--no-version-updates',
       `--static-dir "${staticAssetsFolder}"`,
-      !open && '--ci',
+      open && '--ci',
     ].filter(Boolean),
     {
       stdio: 'inherit',

--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -6,12 +6,17 @@ import { getPaths } from '@redwoodjs/internal'
 export const command = 'storybook'
 export const aliases = ['sb']
 export const description =
-  'Launch Storybook, an isolated component development environment'
+  'Launch Storybook: An isolate component development environment.'
 
 export const builder = (yargs) => {
   yargs
     .option('open', {
       describe: 'Open storybooks in your browser on start',
+      type: 'boolean',
+      default: false,
+    })
+    .option('build', {
+      describe: 'Build Storybook',
       type: 'boolean',
       default: false,
     })
@@ -22,12 +27,10 @@ export const builder = (yargs) => {
     })
 }
 
-export const handler = ({ open, port }) => {
-  const cmd = 'yarn start-storybook'
+export const handler = ({ open, port, build }) => {
   const cwd = getPaths().web.base
 
   const staticAssetsFolder = path.join(getPaths().web.base, 'public')
-
   // Create the `MockServiceWorker.js` file.
   execa(`yarn msw init "${staticAssetsFolder}"`, undefined, {
     stdio: 'inherit',
@@ -35,20 +38,19 @@ export const handler = ({ open, port }) => {
     cwd,
   })
 
-  const options = [
-    '--config-dir ../node_modules/@redwoodjs/core/config/storybook',
-    `--port ${port}`, // this should be configurable?
-    '--no-version-updates', // we'll handle upgrades
-    `--static-dir "${staticAssetsFolder}"`,
-  ]
-
-  if (!open) {
-    options.push('--ci')
-  }
-
-  execa(cmd, options, {
-    stdio: 'inherit',
-    shell: true,
-    cwd,
-  })
+  execa(
+    `yarn ${build ? 'build' : 'start'}-storybook`,
+    [
+      '--config-dir ../node_modules/@redwoodjs/core/config/storybook',
+      `--port ${port}`,
+      '--no-version-updates',
+      `--static-dir "${staticAssetsFolder}"`,
+      !open && '--ci',
+    ].filter(Boolean),
+    {
+      stdio: 'inherit',
+      shell: true,
+      cwd,
+    }
+  )
 }

--- a/packages/core/config/storybook/main.js
+++ b/packages/core/config/storybook/main.js
@@ -9,7 +9,8 @@ module.exports = {
     `${getPaths().web.src}/**/*.stories.{tsx,jsx,js}`.replace(/\\/g, '/'),
   ],
   webpackFinal: (sbConfig, { configType }) => {
-    const isEnvProduction = configType === 'production'
+    // configType is 'PRODUCTION' or 'DEVELOPMENT', why shout?
+    const isEnvProduction = configType?.toLowerCase() === 'production'
 
     const rwConfig = isEnvProduction
       ? require('../webpack.production')
@@ -19,7 +20,7 @@ module.exports = {
     sbConfig.resolve.alias['@redwoodjs/router$'] = path.join(getPaths().base, 'node_modules/@redwoodjs/testing/dist/MockRouter.js')
     sbConfig.resolve.alias['~__REDWOOD__USER_ROUTES_FOR_MOCK'] = getPaths().web.routes
     sbConfig.resolve.alias['~__REDWOOD__USER_WEB_SRC'] = getPaths().web.src
-    
+
     // Determine the default storybook style file to use.
     const supportedStyleIndexFiles = ['index.scss', 'index.sass', 'index.css']
     for (let file of supportedStyleIndexFiles) {
@@ -29,7 +30,7 @@ module.exports = {
         break;
       }
     }
-    
+
     sbConfig.resolve.extensions = rwConfig.resolve.extensions
     sbConfig.resolve.plugins = rwConfig.resolve.plugins // Directory Named Plugin
 


### PR DESCRIPTION
This adds `--build` to the `yarn rw storybook` command, it produces a set of files that can be statically served. Handy during pull-requests.
