### PR TITLE
Only stop rendering on Private routes

### DIFF
--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -9,7 +9,7 @@ import type { AuthClient } from '../authClients'
 import { AuthProvider } from '../AuthProvider'
 import { useAuth } from '../useAuth'
 
-let CURRENT_USER_DATA = {
+let CURRENT_USER_DATA: { name: string; email: string; roles?: string[] } = {
   name: 'Peter Pistorius',
   email: 'nospam@example.net',
 }
@@ -41,6 +41,7 @@ const AuthConsumer = () => {
   const {
     loading,
     isAuthenticated,
+    authToken,
     logOut,
     logIn,
     userMetadata,
@@ -72,6 +73,7 @@ const AuthConsumer = () => {
       {isAuthenticated && (
         <>
           <p>userMetadata: {JSON.stringify(userMetadata)}</p>
+          <p>authToken: {authToken}</p>
           <p>
             currentUser:{' '}
             {(currentUser && JSON.stringify(currentUser)) ||
@@ -100,6 +102,7 @@ test('Authentication flow (logged out -> login -> logged in -> logout) works as 
     login: async () => {
       return true
     },
+    signup: async () => {},
     logout: async () => {},
     getToken: async () => 'hunter2',
     getUserMetadata: jest.fn(async () => {
@@ -144,6 +147,7 @@ test('Authentication flow (logged out -> login -> logged in -> logout) works as 
       'currentUser: {"name":"Peter Pistorius","email":"nospam@example.net"}'
     )
   ).toBeInTheDocument()
+  expect(screen.getByText('authToken: hunter2')).toBeInTheDocument()
 
   // Log out
   fireEvent.click(screen.getByText('Log Out'))
@@ -157,6 +161,7 @@ test('Fetching the current user can be skipped', async (done) => {
     login: async () => {
       return true
     },
+    signup: async () => {},
     logout: async () => {},
     getToken: async () => 'hunter2',
     getUserMetadata: jest.fn(async () => {
@@ -206,6 +211,7 @@ test('A user can be reauthenticated to update the "auth state"', async (done) =>
     login: async () => {
       return true
     },
+    signup: async () => {},
     logout: async () => {},
     getToken: async () => 'hunter2',
     getUserMetadata: jest.fn(async () => {
@@ -267,6 +273,7 @@ test('When the current user cannot be fetched the user is not authenticated', as
     login: async () => {
       return true
     },
+    signup: async () => {},
     logout: async () => {},
     getToken: async () => 'hunter2',
     getUserMetadata: jest.fn(async () => {
@@ -302,6 +309,7 @@ test('Authenticated user has assigned role access as expected', async (done) => 
     login: async () => {
       return true
     },
+    signup: async () => {},
     logout: async () => {},
     getToken: async () => 'hunter2',
     getUserMetadata: jest.fn(async () => {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -9,6 +9,7 @@
   "types": "src/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "@redwoodjs/auth": "^0.21.0",
     "core-js": "3.6.5",
     "lodash.isequal": "^4.5.0"
   },

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -1,6 +1,8 @@
 // The guts of the router implementation.
 import PropTypes from 'prop-types'
 
+import { useAuth as useAuthHook } from '@redwoodjs/auth'
+
 import {
   Location,
   parseSearch,
@@ -113,7 +115,7 @@ const RouterImpl = ({
   paramTypes,
   pageLoadingDelay = DEFAULT_PAGE_LOADING_DELAY,
   children,
-  useAuth = window.__REDWOOD__USE_AUTH,
+  useAuth = useAuthHook,
 }) => {
   const routes = React.useMemo(() => {
     // Find `Private` components, mark their children `Route` components as private,

--- a/packages/router/src/router.js
+++ b/packages/router/src/router.js
@@ -40,12 +40,13 @@ const PrivatePageLoader = ({
   useAuth,
   unauthenticatedRoute,
   role,
+  whileLoading = () => null,
   children,
 }) => {
   const { loading, isAuthenticated, hasRole } = useAuth()
 
   if (loading) {
-    return null
+    return whileLoading()
   }
 
   if (
@@ -190,6 +191,7 @@ const RouterImpl = ({
               unauthenticatedRoute={
                 namedRoutes[route.props.unauthenticatedRedirect]
               }
+              whileLoading={route.props.whileLoading}
               role={route.props.role}
             >
               <Loaders

--- a/packages/testing/src/MockProviders.tsx
+++ b/packages/testing/src/MockProviders.tsx
@@ -18,6 +18,7 @@ const fakeUseAuth = (): AuthContextInterface => ({
   loading: false,
   isAuthenticated: false,
   currentUser: null,
+  authToken: null,
   userMetadata: null,
   logIn: async () => undefined,
   logOut: async () => undefined,

--- a/packages/web/src/components/FetchConfigProvider.test.tsx
+++ b/packages/web/src/components/FetchConfigProvider.test.tsx
@@ -39,7 +39,7 @@ describe('FetchConfigProvider', () => {
           ({
             loading: false,
             isAuthenticated: true,
-            getToken: async () => 'margle the world',
+            authToken: 'margle the world',
             type: 'custom',
           } as AuthContextInterface)
         }
@@ -52,22 +52,5 @@ describe('FetchConfigProvider', () => {
         '{"uri":"https://api.example.com/graphql","headers":{"auth-provider":"custom","authorization":"Bearer margle the world"}}'
       )
     )
-  })
-
-  test('Loading screen is rendered', async () => {
-    render(
-      <FetchConfigProvider
-        renderLoading={() => <>I am loading...</>}
-        useAuth={() =>
-          ({
-            loading: true,
-            isAuthenticated: false,
-          } as AuthContextInterface)
-        }
-      >
-        <FetchConfigToString />
-      </FetchConfigProvider>
-    )
-    await waitFor(() => screen.getByText('I am loading...'))
   })
 })


### PR DESCRIPTION
This PR does a whole bunch, and changes some fundemental behaviour, but for the better.

Previously we would block all rendering until we were able to determine if a user was logged in, once we were able to determine that a user was logged, and they were, we would further block until we had a currentUser.

This blocking behaviour is now based on the type of route:`<Private />` blocks, `<Route />` does not. You can also supply a loading component whilst you're waiting for auth-state-hydration:

```<Private whileLoading={() => 'Loading...'} />```

Thanks to @dac09 for the idea!

/cc @Tobbe you might find this interesting too :)