### PR TITLE
fix(router): Include queryParams in redirectTo

### DIFF
--- a/packages/router/src/__tests__/router.test.js
+++ b/packages/router/src/__tests__/router.test.js
@@ -87,7 +87,7 @@ test('unauthenticated user is redirected away from private page', async () => {
   act(() => navigate(routes.private()))
 
   await waitFor(() => {
-    expect(screen.queryByText(/Private Page/i)).toBeNull()
+    expect(screen.queryByText(/Private Page/i)).not.toBeInTheDocument()
     expect(window.location.pathname).toBe('/login')
     expect(window.location.search).toBe('?redirectTo=/private')
     screen.getByText(/Login Page/i)

--- a/packages/router/src/__tests__/router.test.js
+++ b/packages/router/src/__tests__/router.test.js
@@ -1,6 +1,7 @@
 import { render, waitFor, act } from '@testing-library/react'
 
 import { Router, Route, Private, Redirect, navigate, routes } from '../'
+import { resetNamedRoutes } from '../named-routes'
 
 // SETUP
 const HomePage = () => <h1>Home Page</h1>
@@ -17,6 +18,7 @@ const mockAuth = (isAuthenticated = false) => {
 
 beforeEach(() => {
   window.history.pushState({}, null, '/')
+  resetNamedRoutes()
 })
 
 test('inits routes and navigates as expected', async () => {
@@ -98,7 +100,7 @@ test('unauthenticated user is redirected including search params', async () => {
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={LoginPage} name="login" />
       <Private unauthenticated="login">
-        <Route path="/private" page={PrivatePage} name="xxx" />
+        <Route path="/private" page={PrivatePage} name="private" />
       </Private>
     </Router>
   )
@@ -109,7 +111,7 @@ test('unauthenticated user is redirected including search params', async () => {
 
   // navigate to private page
   // should redirect to login
-  act(() => navigate(routes.xxx({ bazinga: 'yeah' })))
+  act(() => navigate(routes.private({ bazinga: 'yeah' })))
 
   await waitFor(() => {
     expect(screen.queryByText(/Private Page/i)).toBeNull()

--- a/packages/router/src/__tests__/router.test.js
+++ b/packages/router/src/__tests__/router.test.js
@@ -98,7 +98,7 @@ test('unauthenticated user is redirected including search params', async () => {
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={LoginPage} name="login" />
       <Private unauthenticated="login">
-        <Route path="/private" page={PrivatePage} name="private" />
+        <Route path="/private" page={PrivatePage} name="xxx" />
       </Private>
     </Router>
   )
@@ -109,7 +109,7 @@ test('unauthenticated user is redirected including search params', async () => {
 
   // navigate to private page
   // should redirect to login
-  act(() => navigate(routes.private({ bazinga: 'yeah' })))
+  act(() => navigate(routes.xxx({ bazinga: 'yeah' })))
 
   await waitFor(() => {
     expect(screen.queryByText(/Private Page/i)).toBeNull()

--- a/packages/router/src/named-routes.js
+++ b/packages/router/src/named-routes.js
@@ -6,6 +6,10 @@ import { validatePath, replaceParams } from './internal'
 let namedRoutes = {}
 let namedRoutesDone = false
 
+export const resetNamedRoutes = () => {
+  namedRoutesDone = false
+}
+
 const mapNamedRoutes = (routes) => {
   if (namedRoutesDone) {
     return namedRoutes


### PR DESCRIPTION
Fixed #1453 

e.g. Say you're going to `https://mysite.com/dashboard?param1=something&token=hunter2`

It used to redirect to `https://mysite.com/login?redirectTo=/dashboard`. Now it'll redirect to `https://mysite.com/login?redirectTo=/dashboard%3Fparam1%3Dsomething%26token%3Dhunter2`

Adds tests for:
- [x] redirectTo
- [x] redirectTo with query params
- [x] Figure out why the test fails (see below) thanks @peterp 

---
