### PR TITLE
Supabase getToken uses session to get access_token so that graphql calls are authenticated

### DIFF
--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -1,4 +1,8 @@
-import { Session, User, Provider } from '@supabase/gotrue-js/dist/main/lib/types'
+import {
+  Session,
+  User,
+  Provider,
+} from '@supabase/gotrue-js/dist/main/lib/types'
 import type SupabaseClient from '@supabase/supabase-js/dist/main/SupabaseClient'
 
 import type { AuthClient } from './index'
@@ -10,17 +14,20 @@ export interface AuthClientSupabase extends AuthClient {
     email: string
     password: string
   }): Promise<{
-    data: Session | null;
-    user: User | null;
-    provider?: Provider;
-    url?: string | null;
-    error: Error | null;
+    data: Session | null
+    user: User | null
+    provider?: Provider
+    url?: string | null
+    error: Error | null
   }>
   logout(): Promise<{ error: Error | null }>
-  signup(options: { email: string; password: string }): Promise<{
-    data: Session | null;
-    user: User | null;
-    error: Error | null;
+  signup(options: {
+    email: string
+    password: string
+  }): Promise<{
+    data: Session | null
+    user: User | null
+    error: Error | null
   }>
   client: Supabase
 }
@@ -33,9 +40,8 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
     logout: () => client.auth.signOut(),
     signup: ({ email, password }) => client.auth.signUp({ email, password }),
     getToken: async () => {
-      const supabaseJson = localStorage.getItem('supabase.auth.token')
-      const supabaseData = supabaseJson ? JSON.parse(supabaseJson) : null
-      return supabaseData?.accessToken || null
+      const currentSession = client.auth.session()
+      return currentSession?.access_token || null
     },
     getUserMetadata: async () => client.auth.user(),
   }


### PR DESCRIPTION
With the upgrade to Supabase v1.0, graphql calls are not getting authenticated because the token is not being set.

Supabase v1.0 changes the way the user and access token information is set in localStorage.

Previously, this code in the supabase auth provider client would fetch the accessToken by parsing the `supabase.auth.token' contents and then would retrieve the accessToken:

```
getToken: async () => {
      const supabaseJson = localStorage.getItem('supabase.auth.token')
      const supabaseData = supabaseJson ? JSON.parse(supabaseJson) : null
      return supabaseData?.accessToken || null
    },
```

In the new supabase-js SDK, this info is kept in a "currentSession" in localStorage and the there is a method to fetch the session which can then retrieve the access token:

```
    getToken: async () => {
      const currentSession = client.auth.session()
      return currentSession?.access_token || null
    },
```

This PR uses the latter and now requireAuth() can fetch currentUser on the api side, decode the token, and authenticate.
