### PR TITLE
Update Setup TailwindCSS to v2 using PostCSS v7 compatible install

### DIFF
--- a/packages/cli/src/commands/setup/tailwind/tailwind.js
+++ b/packages/cli/src/commands/setup/tailwind/tailwind.js
@@ -74,7 +74,7 @@ export const handler = async ({ force }) => {
                 'add',
                 '-D',
                 'postcss-loader@4.0.2',
-                'tailwindcss',
+                'tailwindcss@npm:@tailwindcss/postcss7-compat',
                 'autoprefixer@9.8.6',
               ])
             },


### PR DESCRIPTION
This PR changes the version of Tailwind CSS installed by the setup command to be compatible with v7 of PostCSS. (I got the version from here: https://tailwindcss.com/docs/installation#post-css-7-compatibility-build.)