### PR TITLE
Add --pr to upgrade command

### DIFF
--- a/.github/workflows/publish_pr_packages.yaml
+++ b/.github/workflows/publish_pr_packages.yaml
@@ -45,11 +45,12 @@ jobs:
         run: |
           pr_number=${{ steps.pr_number.outputs.pr_number }}
           cd pr-packages/$pr_number
+          v_sha=$(ls | grep "\.tgz$" | sed 's/\.tgz$//' | head -n1 | awk -F"-" '{ print $(NF-1)"-"$NF }')
           msg="📦 Packages for this PR can be downloaded from%0A"
           for p in *; do
             msg+="https://rw-pr-redwoodjs-com.s3.amazonaws.com/$pr_number/$p%0A"
           done
-          msg+="%0AInstall locally with yarn, e.g. \`yarn workspace web add <url>\`"
+          msg+="%0AInstall this PR by running \`yarn rw upgrade --pr $pr_number:$v_sha\`"
           echo "::set-output name=msg::$msg"
 
       - name: Find Comment


### PR DESCRIPTION
Adds the ability to install the PR packages we build using the `upgrade` cli command.

Example:
`$ yarn rw upgrade --pr 1454:0.21.0-d3b0abd`

You specify the PR id (1454 in the example above), the base RW version the PR is based on (0.21.0 above) and the SHA of the commit that was built (d3b0abd).

Yes, it would be nice if you could just do `yarn rw upgrade --pr 1454` and get the latest packages built for that PR. But I think we can add that in a future PR. Also, the exact command you need to run is provided as a comment on the PR. So just copy/paste and you're good to go. I think that's easy enough.