### PR TITLE
Fix aws_serverless config when api folder missing

### DIFF
--- a/packages/cli/src/commands/generate/deploy/providers/aws_serverless.js
+++ b/packages/cli/src/commands/generate/deploy/providers/aws_serverless.js
@@ -38,7 +38,9 @@ provider:
 package:
   individually: true
 
-functions:
+  ${
+    fs.existsSync(path.resolve(getPaths().api.functions))
+      ? `functions:
   ${fs
     .readdirSync(path.resolve(getPaths().api.functions))
     .map((file) => {
@@ -64,7 +66,9 @@ functions:
           method: POST
 `
     })
-    .join('  ')}
+    .join('  ')}`
+      : ''
+  }
 `
 
 export const preRequisites = [

--- a/packages/cli/src/commands/generate/deploy/providers/aws_serverless.js
+++ b/packages/cli/src/commands/generate/deploy/providers/aws_serverless.js
@@ -38,9 +38,9 @@ provider:
 package:
   individually: true
 
-  ${
-    fs.existsSync(path.resolve(getPaths().api.functions))
-      ? `functions:
+${
+  fs.existsSync(path.resolve(getPaths().api.functions))
+    ? `functions:
   ${fs
     .readdirSync(path.resolve(getPaths().api.functions))
     .map((file) => {
@@ -67,8 +67,8 @@ package:
 `
     })
     .join('  ')}`
-      : ''
-  }
+    : ''
+}
 `
 
 export const preRequisites = [


### PR DESCRIPTION
Fixes #1550

Note: The ternary in the template string isn't necessarily the cleanest looking solution, but it seems to be the simplest.