### PR TITLE
Firebase Auth: Signup, login with email, password

### DIFF
--- a/packages/auth/src/authClients/firebase.ts
+++ b/packages/auth/src/authClients/firebase.ts
@@ -14,12 +14,13 @@ export type oAuthProvider =
   | 'microsoft.com'
   | 'apple.com'
 
-export type PasswordProvider = { email: string; password: string }
+export type PasswordCreds = { email: string; password: string }
 
-const isPasswordProvider = (
-  usingProvider: oAuthProvider | PasswordProvider
-): usingProvider is PasswordProvider => {
-  return (usingProvider as PasswordProvider).email !== undefined
+const isPasswordCreds = (
+  withCreds: oAuthProvider | PasswordCreds
+): withCreds is PasswordCreds => {
+  const creds = withCreds as PasswordCreds
+  return creds.email !== undefined && creds.password !== undefined
 }
 
 export const firebase = (client: Firebase): AuthClient => {
@@ -33,34 +34,34 @@ export const firebase = (client: Firebase): AuthClient => {
     client,
     restoreAuthState: () => client.auth().getRedirectResult(),
     login: async (
-      usingProvider: oAuthProvider | PasswordProvider = 'google.com'
+      withAuth: oAuthProvider | PasswordCreds = 'google.com'
     ) => {
-      if (isPasswordProvider(usingProvider)) {
+      if (isPasswordCreds(withAuth)) {
         return client
           .auth()
           .signInWithEmailAndPassword(
-            usingProvider.email,
-            usingProvider.password
+            withAuth.email,
+            withAuth.password
           )
       }
 
-      const provider = getProvider(usingProvider)
+      const provider = getProvider(withAuth)
       return client.auth().signInWithPopup(provider)
     },
     logout: () => client.auth().signOut(),
     signup: async (
-      usingProvider: oAuthProvider | PasswordProvider = 'google.com'
+      withAuth: oAuthProvider | PasswordCreds = 'google.com'
     ) => {
-      if (isPasswordProvider(usingProvider)) {
+      if (isPasswordCreds(withAuth)) {
         return client
           .auth()
           .createUserWithEmailAndPassword(
-            usingProvider.email,
-            usingProvider.password
+            withAuth.email,
+            withAuth.password
           )
       }
 
-      const provider = getProvider(usingProvider)
+      const provider = getProvider(withAuth)
       return client.auth().signInWithPopup(provider)
     },
     getToken: async () => client.auth().currentUser?.getIdToken() ?? null,

--- a/packages/auth/src/authClients/firebase.ts
+++ b/packages/auth/src/authClients/firebase.ts
@@ -14,6 +14,14 @@ export type oAuthProvider =
   | 'microsoft.com'
   | 'apple.com'
 
+export type PasswordProvider = { email: string; password: string }
+
+const isPasswordProvider = (
+  usingProvider: oAuthProvider | PasswordProvider
+): usingProvider is PasswordProvider => {
+  return (usingProvider as PasswordProvider).email !== undefined
+}
+
 export const firebase = (client: Firebase): AuthClient => {
   // Use a function to allow us to extend for non-oauth providers in the future
   const getProvider = (providerId: oAuthProvider) => {
@@ -24,12 +32,34 @@ export const firebase = (client: Firebase): AuthClient => {
     type: 'firebase',
     client,
     restoreAuthState: () => client.auth().getRedirectResult(),
-    login: async (usingProvider: oAuthProvider = 'google.com') => {
+    login: async (
+      usingProvider: oAuthProvider | PasswordProvider = 'google.com'
+    ) => {
+      if (isPasswordProvider(usingProvider)) {
+        return client
+          .auth()
+          .signInWithEmailAndPassword(
+            usingProvider.email,
+            usingProvider.password
+          )
+      }
+
       const provider = getProvider(usingProvider)
       return client.auth().signInWithPopup(provider)
     },
     logout: () => client.auth().signOut(),
-    signup: async (usingProvider: oAuthProvider = 'google.com') => {
+    signup: async (
+      usingProvider: oAuthProvider | PasswordProvider = 'google.com'
+    ) => {
+      if (isPasswordProvider(usingProvider)) {
+        return client
+          .auth()
+          .createUserWithEmailAndPassword(
+            usingProvider.email,
+            usingProvider.password
+          )
+      }
+
       const provider = getProvider(usingProvider)
       return client.auth().signInWithPopup(provider)
     },


### PR DESCRIPTION
Adds `password` as a login/signup method for [Firebase Auth](https://firebase.google.com/docs/auth/web/password-auth).

Example:
```javascript
const { logIn, signUp } = useAuth()

await signUp({ email: 'test@test.com', password: 'testPassword' })

await login({ email: 'test@test.com', password: 'testPassword' })
```