### PR TITLE
Explicit target environment for MSW

### DIFF
--- a/packages/auth/src/authClients/netlify.ts
+++ b/packages/auth/src/authClients/netlify.ts
@@ -25,7 +25,7 @@ export const netlify = (client: NetlifyIdentity): AuthClient => {
       })
     },
     logout: () => {
-      return new Promise((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         client.logout()
         client.on('logout', resolve)
         client.on('error', reject)

--- a/packages/core/src/configs/browser/jest.setup.js
+++ b/packages/core/src/configs/browser/jest.setup.js
@@ -19,6 +19,6 @@ beforeEach(async () => {
   for (const m of project.mocks) {
     require(m)
   }
-  await startMSW()
+  await startMSW('node')
   setupRequestHandlers() // reset the handlers in each test.
 })

--- a/packages/core/src/storybook/StorybookProvider.tsx
+++ b/packages/core/src/storybook/StorybookProvider.tsx
@@ -24,7 +24,7 @@ export const StorybookProvider: React.FunctionComponent<{
         reqs(r)
       })
 
-      await startMSW()
+      await startMSW('browsers')
       setupRequestHandlers()
       setLoading(false)
     }

--- a/packages/testing/src/mockRequests.ts
+++ b/packages/testing/src/mockRequests.ts
@@ -15,18 +15,17 @@ let REQUEST_HANDLER_QUEUE: RequestHandler[] = []
 let SERVER_INSTANCE: SetupWorkerApi | any
 
 /**
- * This will import the correct runtime (node/ browser) of MSW,
- * and start the functionality that captures requests.
+ * Plugs fetch for the correct target in order to capture requests.
  *
  * Request handlers can be registered lazily (via `mockGraphQL<Query|Mutation>`),
  * the queue will be drained and used.
  */
-export const startMSW = async () => {
+export const startMSW = async (target: 'node' | 'browsers') => {
   if (SERVER_INSTANCE) {
     return SERVER_INSTANCE
   }
 
-  if (typeof global.process === 'undefined') {
+  if (target === 'browsers') {
     SERVER_INSTANCE = setupWorker()
     await SERVER_INSTANCE.start()
   } else {


### PR DESCRIPTION
We tried to automatically determine which env MSW is using, that was flakey. Now it's explicit by passing in the required target.