### PR TITLE
wip(auth): Get fresh token before making request

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -107,6 +107,15 @@ export class AuthProvider extends React.Component<
   constructor(props: AuthProviderProps) {
     super(props)
     this.rwClient = createAuthClient(props.client, props.type)
+
+    // Add observer if the auth client supports it
+    // @TODO: Do we need to worry about cancelling the event handler?
+    // I don't think AuthProvider ever unmounts
+    if (this.rwClient.onTokenChange) {
+      this.rwClient.onTokenChange(() => {
+        this.getToken()
+      })
+    }
   }
 
   async componentDidMount() {

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -115,6 +115,7 @@ export class AuthProvider extends React.Component<
   }
 
   getCurrentUser = async (): Promise<Record<string, unknown>> => {
+    const authToken = await this.getToken()
     const response = await window.fetch(
       `${window.__REDWOOD__API_PROXY_PATH}/graphql`,
       {
@@ -122,7 +123,7 @@ export class AuthProvider extends React.Component<
         headers: {
           'content-type': 'application/json',
           'auth-provider': this.rwClient.type,
-          authorization: `Bearer ${this.state.authToken}`,
+          authorization: `Bearer ${authToken}`,
         },
         body: JSON.stringify({
           query:

--- a/packages/auth/src/authClients/firebase.ts
+++ b/packages/auth/src/authClients/firebase.ts
@@ -35,5 +35,6 @@ export const firebase = (client: Firebase): AuthClient => {
     },
     getToken: async () => client.auth().currentUser?.getIdToken() ?? null,
     getUserMetadata: async () => client.auth().currentUser,
+    onTokenChange: client.auth().onIdTokenChanged,
   }
 }

--- a/packages/auth/src/authClients/index.ts
+++ b/packages/auth/src/authClients/index.ts
@@ -56,6 +56,7 @@ export interface AuthClient {
   getUserMetadata(): Promise<null | SupportedUserMetadata>
   client: SupportedAuthClients
   type: SupportedAuthTypes
+  onTokenChange?(callback: () => void): void
 }
 
 export const createAuthClient = (


### PR DESCRIPTION
Starts fix for #1576



- [x] Use fresh token for getCurrentUser
- [x] Use fresh token for other graphql requests
- [x] Add a way to watch for token changes from client
- [ ] Verify and test this