### PR TITLE
Fixed a few eslint warnings

### DIFF
--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -7,12 +7,10 @@ const verifyAzureActiveDirectoryToken = (
   return new Promise((resolve, reject) => {
     const { AZURE_ACTIVE_DIRECTORY_AUTHORITY } = process.env
     if (!AZURE_ACTIVE_DIRECTORY_AUTHORITY) {
-      throw new Error(
-        '`AZURE_ACTIVE_DIRECTORY_AUTHORITY` env var is not set.'
-      )
+      throw new Error('`AZURE_ACTIVE_DIRECTORY_AUTHORITY` env var is not set.')
     }
 
-    /** @docs:  https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#sample-response */
+    /** @docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#sample-response */
     const client = jwksClient({
       jwksUri: `${AZURE_ACTIVE_DIRECTORY_AUTHORITY}/discovery/v2.0/keys`,
     })

--- a/packages/api/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/api/src/makeMergedSchema/makeMergedSchema.ts
@@ -19,7 +19,14 @@ const mapFieldsToService = ({
   services,
 }: {
   fields: GraphQLFieldMap<any, any>
-  resolvers: { [key: string]: Function }
+  resolvers: {
+    [key: string]: (
+      root: unknown,
+      args: unknown,
+      context: unknown,
+      info: unknown
+    ) => any
+  }
   services: Services
 }) =>
   Object.keys(fields).reduce((resolvers, name) => {

--- a/packages/auth/src/authClients/azureActiveDirectory.ts
+++ b/packages/auth/src/authClients/azureActiveDirectory.ts
@@ -6,7 +6,9 @@ import type { AuthClient } from './'
 export type AzureActiveDirectoryClient = AzureActiveDirectory
 export interface AzureActiveDirectoryUser {}
 
-export const azureActiveDirectory = (client: AzureActiveDirectoryClient): AuthClient => {
+export const azureActiveDirectory = (
+  client: AzureActiveDirectoryClient
+): AuthClient => {
   return {
     type: 'azureActiveDirectory',
     client,

--- a/packages/auth/src/authClients/index.ts
+++ b/packages/auth/src/authClients/index.ts
@@ -1,6 +1,9 @@
 import type { Auth0, Auth0User } from './auth0'
 import { auth0 } from './auth0'
-import type { AzureActiveDirectory, AzureActiveDirectoryUser } from './azureActiveDirectory'
+import type {
+  AzureActiveDirectory,
+  AzureActiveDirectoryUser,
+} from './azureActiveDirectory'
 import { azureActiveDirectory } from './azureActiveDirectory'
 import type { Custom } from './custom'
 import { custom } from './custom'

--- a/packages/cli/src/commands/generate/auth/providers/azureActiveDirectory.js
+++ b/packages/cli/src/commands/generate/auth/providers/azureActiveDirectory.js
@@ -27,5 +27,5 @@ export const notes = [
   'https://redwoodjs.com/docs/authentication#azure-ad',
   '\n',
   'MSAL.js Documentation:',
-  'https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-initializing-client-applications'
+  'https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-initializing-client-applications',
 ]

--- a/packages/cli/src/commands/generate/component/__tests__/component.test.ts
+++ b/packages/cli/src/commands/generate/component/__tests__/component.test.ts
@@ -27,12 +27,12 @@ beforeAll(() => {
   withoutTestFiles = component.files({
     name: 'withoutTests',
     javascript: true,
-    tests: false
+    tests: false,
   })
   withoutStoryFiles = component.files({
     name: 'withoutStories',
     javascript: true,
-    stories: false
+    stories: false,
   })
 })
 

--- a/packages/cli/src/commands/generate/layout/__tests__/layout.test.ts
+++ b/packages/cli/src/commands/generate/layout/__tests__/layout.test.ts
@@ -26,12 +26,12 @@ beforeAll(() => {
   withoutTestFiles = layout.files({
     name: 'withoutTests',
     javascript: true,
-    tests: false
+    tests: false,
   })
   withoutStoryFiles = layout.files({
     name: 'withoutStories',
     javascript: true,
-    stories: false
+    stories: false,
   })
 })
 

--- a/packages/core/src/storybook/StorybookProvider.tsx
+++ b/packages/core/src/storybook/StorybookProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { ReactNode, ReactPortal, useEffect, useState } from 'react'
 
 import {
   MockProviders,
@@ -7,7 +7,7 @@ import {
 } from '@redwoodjs/testing'
 
 export const StorybookProvider: React.FunctionComponent<{
-  storyFn: Function
+  storyFn: () => ReactNode | ReactPortal
   id: string
 }> = ({ storyFn, id }) => {
   const [loading, setLoading] = useState(true)

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -95,8 +95,8 @@ const inputTagProps = <T extends InputTagProps>(
   const {
     errorClassName,
     errorStyle,
-    dataType,
-    transformValue,
+    dataType, // eslint-disable-line @typescript-eslint/no-unused-vars
+    transformValue, // eslint-disable-line @typescript-eslint/no-unused-vars
     ...tagProps
   } = props
   if (validationError) {
@@ -210,7 +210,7 @@ interface FormWithCoercionContext
   validation?: UseFormOptions
   onSubmit?: (
     values: Record<string, any>,
-    event: React.BaseSyntheticEvent<object, any, any> | undefined
+    event?: React.BaseSyntheticEvent
   ) => void
 }
 

--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -3,11 +3,7 @@ import * as tsm from 'ts-morph'
 import { DiagnosticSeverity } from 'vscode-languageserver-types'
 
 import { lazy } from '../x/decorators'
-import {
-  err,
-  ExtendedDiagnostic,
-  Range_fromNode,
-} from '../x/vscode-languageserver-types'
+import { err, Range_fromNode } from '../x/vscode-languageserver-types'
 
 import { RWComponent } from './RWComponent'
 

--- a/packages/structure/src/model/RWRouter.ts
+++ b/packages/structure/src/model/RWRouter.ts
@@ -1,4 +1,3 @@
-import { rangeRight } from 'lodash'
 import * as tsm from 'ts-morph'
 import {
   CodeAction,

--- a/packages/structure/src/x/child_process.ts
+++ b/packages/structure/src/x/child_process.ts
@@ -33,7 +33,9 @@ export function spawnCancellable(
   ;(promise as any).cancel = () => {
     try {
       cp.kill()
-    } catch (e) {}
+    } catch (e) {
+      // intentionally left empty
+    }
   }
   return promise as any
 }

--- a/packages/testing/src/__tests__/MockRouter.test.tsx
+++ b/packages/testing/src/__tests__/MockRouter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import { Route, Private } from '@redwoodjs/router'
 import '@testing-library/jest-dom/extend-expect'


### PR DESCRIPTION
I've fixed 20 eslint warnings. (106 down to 86.)
I didn't look at all the `any` warnings. 

There are a couple of other warnings that I plain didn't know how to fix. Plz help? It's "Don't use `Function` as a type." in `mockRequests.ts` and "Don't use `{}` as a type" in `vscode.ts`. Both can totally be left to be solved in another PR.

As long as no one spots any error in what I've done I think this is good to merge, and then we can keep squashing those warnings in future PRs.

