### PR TITLE
Add Auth Provider - Ethereum

### DIFF
--- a/packages/api/src/auth/decoders/ethereum.ts
+++ b/packages/api/src/auth/decoders/ethereum.ts
@@ -2,12 +2,12 @@ import jwt from 'jsonwebtoken'
 
 export const ethereum = (token: string) => {
   if (process.env.NODE_ENV === 'production') {
-    if (!process.env.JWT_SECRET) {
+    if (!process.env.ETHEREUM_JWT_SECRET) {
       throw new Error('`JWT_SECRET` env var is not set.')
     }
 
     try {
-      const secret = process.env.JWT_SECRET as string
+      const secret = process.env.ETHEREUM_JWT_SECRET as string
       return Promise.resolve(
         jwt.verify(token, secret) as Record<string, unknown>
       )

--- a/packages/api/src/auth/decoders/ethereum.ts
+++ b/packages/api/src/auth/decoders/ethereum.ts
@@ -1,20 +1,15 @@
 import jwt from 'jsonwebtoken'
 
 export const ethereum = (token: string) => {
-  if (process.env.NODE_ENV === 'production') {
-    if (!process.env.ETHEREUM_JWT_SECRET) {
-      throw new Error('`JWT_SECRET` env var is not set.')
-    }
+  if (!process.env.ETHEREUM_JWT_SECRET) {
+    console.error('ETHEREUM_JWT_SECRET env var is not set.')
+    throw new Error('`ETHEREUM_JWT_SECRET` env var is not set.')
+  }
 
-    try {
-      const secret = process.env.ETHEREUM_JWT_SECRET as string
-      return Promise.resolve(
-        jwt.verify(token, secret) as Record<string, unknown>
-      )
-    } catch (error) {
-      return Promise.reject(error)
-    }
-  } else {
-    return Promise.resolve(jwt.decode(token))
+  try {
+    const secret = process.env.ETHEREUM_JWT_SECRET as string
+    return Promise.resolve(jwt.verify(token, secret) as Record<string, unknown>)
+  } catch (error) {
+    return Promise.reject(error)
   }
 }

--- a/packages/api/src/auth/decoders/ethereum.ts
+++ b/packages/api/src/auth/decoders/ethereum.ts
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken'
+
+export const ethereum = (token: string) => {
+  if (process.env.NODE_ENV === 'production') {
+    if (!process.env.JWT_SECRET) {
+      throw new Error('`JWT_SECRET` env var is not set.')
+    }
+
+    try {
+      const secret = process.env.JWT_SECRET as string
+      return Promise.resolve(
+        jwt.verify(token, secret) as Record<string, unknown>
+      )
+    } catch (error) {
+      return Promise.reject(error)
+    }
+  } else {
+    return Promise.resolve(jwt.decode(token))
+  }
+}

--- a/packages/api/src/auth/decoders/index.ts
+++ b/packages/api/src/auth/decoders/index.ts
@@ -6,6 +6,7 @@ import type { GlobalContext } from 'src/globalContext'
 
 import { auth0 } from './auth0'
 import { azureActiveDirectory } from './azureActiveDirectory'
+import { ethereum } from './ethereum'
 import { netlify } from './netlify'
 import { supabase } from './supabase'
 const noop = (token: string) => token
@@ -29,7 +30,7 @@ const typesToDecoders: Record<
   magicLink: noop,
   firebase: noop,
   supabase: supabase,
-  ethereum: noop,
+  ethereum: ethereum,
   custom: noop,
 }
 

--- a/packages/api/src/auth/decoders/index.ts
+++ b/packages/api/src/auth/decoders/index.ts
@@ -29,6 +29,7 @@ const typesToDecoders: Record<
   magicLink: noop,
   firebase: noop,
   supabase: supabase,
+  ethereum: noop,
   custom: noop,
 }
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -60,5 +60,6 @@ export type SupportedAuthClients =
   | MagicLink
   | Firebase
   | Supabase
+  | Ethereum
   | Custom
 ```

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,6 +12,7 @@
     "@supabase/supabase-js": "^1.1.1",
     "@types/netlify-identity-widget": "^1.4.1",
     "@types/react": "16.9.53",
+    "ethereumAuthClient": "^0.0.1",
     "firebase": "^7.14.5",
     "firebase-admin": "^9.1.1",
     "gotrue-js": "git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,7 +12,6 @@
     "@supabase/supabase-js": "^1.1.1",
     "@types/netlify-identity-widget": "^1.4.1",
     "@types/react": "16.9.53",
-    "ethereumAuthClient": "^0.0.1",
     "firebase": "^7.14.5",
     "firebase-admin": "^9.1.1",
     "gotrue-js": "git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb",

--- a/packages/auth/src/authClients/ethereum.ts
+++ b/packages/auth/src/authClients/ethereum.ts
@@ -1,17 +1,23 @@
 // import type { Ethereum, EthereumUser } from 'ethereumAuthClient'
-type Ethereum = any
-type EthereumUser = any
+export type Ethereum = any
+export type EthereumUser = any
 
-export type Ethereum = Ethereum
-export type EthereumUser = EthereumUser
+export interface EthereumUser {
+  address: string | null
+}
 
 import type { AuthClient } from './'
 
-export const ethereumAuth = (client: Ethereum): AuthClient => {
+export const ethereum = (client: Ethereum): AuthClient => {
   return {
     type: 'ethereum',
     client,
     login: async () => await client.login(),
+    signup: () => {
+      throw new Error(
+        `Ethereum auth does not support "signup". Please use "login" instead.`
+      )
+    },
     logout: async () => await client.logout(),
     getToken: async () => await client.getToken(),
     getUserMetadata: async () => await client.getUserMetadata(),

--- a/packages/auth/src/authClients/ethereum.ts
+++ b/packages/auth/src/authClients/ethereum.ts
@@ -1,9 +1,12 @@
-// import type { Ethereum, EthereumUser } from 'ethereumAuthClient'
-export type Ethereum = any
-export type EthereumUser = any
-
-export interface EthereumUser {
+export type EthereumUser = {
   address: string | null
+}
+
+export type Ethereum = {
+  login(): Promise<any>
+  logout(): Promise<any>
+  getToken(): Promise<null | string>
+  getUserMetadata(): Promise<null | EthereumUser>
 }
 
 import type { AuthClient } from './'

--- a/packages/auth/src/authClients/ethereum.ts
+++ b/packages/auth/src/authClients/ethereum.ts
@@ -1,0 +1,19 @@
+// import type { Ethereum, EthereumUser } from 'ethereumAuthClient'
+type Ethereum = any
+type EthereumUser = any
+
+export type Ethereum = Ethereum
+export type EthereumUser = EthereumUser
+
+import type { AuthClient } from './'
+
+export const ethereumAuth = (client: Ethereum): AuthClient => {
+  return {
+    type: 'ethereum',
+    client,
+    login: async () => await client.login(),
+    logout: async () => await client.logout(),
+    getToken: async () => await client.getToken(),
+    getUserMetadata: async () => await client.getUserMetadata(),
+  }
+}

--- a/packages/auth/src/authClients/index.ts
+++ b/packages/auth/src/authClients/index.ts
@@ -7,6 +7,8 @@ import type {
 import { azureActiveDirectory } from './azureActiveDirectory'
 import type { Custom } from './custom'
 import { custom } from './custom'
+import type { Ethereum, EthereumUser } from './ethereum'
+import { ethereum } from './ethereum'
 import type { Firebase } from './firebase'
 import { firebase } from './firebase'
 import type { GoTrue, GoTrueUser } from './goTrue'
@@ -17,8 +19,6 @@ import type { NetlifyIdentity } from './netlify'
 import { netlify } from './netlify'
 import type { Supabase, SupabaseUser } from './supabase'
 import { supabase } from './supabase'
-import type { Ethereum, EthereumUser } from './ethereum'
-import { ethereum } from './ethereum'
 
 const typesToClients = {
   netlify,

--- a/packages/auth/src/authClients/index.ts
+++ b/packages/auth/src/authClients/index.ts
@@ -17,6 +17,8 @@ import type { NetlifyIdentity } from './netlify'
 import { netlify } from './netlify'
 import type { Supabase, SupabaseUser } from './supabase'
 import { supabase } from './supabase'
+import type { Ethereum, EthereumUser } from './ethereum'
+import { ethereum } from './ethereum'
 
 const typesToClients = {
   netlify,
@@ -26,6 +28,7 @@ const typesToClients = {
   magicLink,
   firebase,
   supabase,
+  ethereum,
   /** Don't we support your auth client? No problem, define your own the `custom` type! */
   custom,
 }
@@ -38,6 +41,7 @@ export type SupportedAuthClients =
   | MagicLink
   | Firebase
   | Supabase
+  | Ethereum
   | Custom
 
 export type SupportedAuthTypes = keyof typeof typesToClients
@@ -47,12 +51,14 @@ export type { AzureActiveDirectoryUser }
 export type { GoTrueUser }
 export type { MagicUser }
 export type { SupabaseUser }
+export type { EthereumUser }
 export type SupportedUserMetadata =
   | Auth0User
   | AzureActiveDirectoryUser
   | GoTrueUser
   | MagicUser
   | SupabaseUser
+  | EthereumUser
 
 export interface AuthClient {
   restoreAuthState?(): void | Promise<any>

--- a/packages/cli/src/commands/generate/auth/auth.js
+++ b/packages/cli/src/commands/generate/auth/auth.js
@@ -55,18 +55,15 @@ const addWebRender = (content, authProvider) => {
   const redwoodProviderLines = redwoodProvider.split('\n').map((line) => {
     return '  ' + line
   })
-  const customRenderOpen = authProvider.render
-    ? authProvider.render.reduce(
-        (acc, component) => acc + indent + `<${component}>`,
-        ''
-      )
-    : ''
-  const customRenderClose = authProvider.render
-    ? authProvider.render.reduce(
-        (acc, component) => indent + `</${component}>` + acc,
-        ''
-      )
-    : ''
+  const customRenderOpen = (authProvider.render || []).reduce(
+    (acc, component) => acc + indent + `<${component}>`,
+    ''
+  )
+
+  const customRenderClose = (authProvider.render || []).reduce(
+    (acc, component) => indent + `</${component}>` + acc,
+    ''
+  )
 
   const renderContent =
     customRenderOpen +

--- a/packages/cli/src/commands/generate/auth/auth.js
+++ b/packages/cli/src/commands/generate/auth/auth.js
@@ -57,11 +57,15 @@ const addWebRender = (content, authProvider) => {
   })
   const renderContent =
     indent +
+    (authProvider.render ? `<${authProvider.render}>` : '') +
+    indent +
     `<AuthProvider client={${authProvider.client}} type="${authProvider.type}">` +
     indent +
     redwoodProviderLines.join('\n') +
     indent +
-    `</AuthProvider>`
+    `</AuthProvider>` +
+    indent +
+    (authProvider.render ? `</${authProvider.render}>` : '')
 
   return content.replace(
     /\s+<RedwoodProvider>.*<\/RedwoodProvider>/s,

--- a/packages/cli/src/commands/generate/auth/auth.js
+++ b/packages/cli/src/commands/generate/auth/auth.js
@@ -55,17 +55,28 @@ const addWebRender = (content, authProvider) => {
   const redwoodProviderLines = redwoodProvider.split('\n').map((line) => {
     return '  ' + line
   })
+  const customRenderOpen = authProvider.render
+    ? authProvider.render.reduce(
+        (acc, component) => acc + indent + `<${component}>`,
+        ''
+      )
+    : ''
+  const customRenderClose = authProvider.render
+    ? authProvider.render.reduce(
+        (acc, component) => indent + `</${component}>` + acc,
+        ''
+      )
+    : ''
+
   const renderContent =
-    indent +
-    (authProvider.render ? `<${authProvider.render}>` : '') +
+    customRenderOpen +
     indent +
     `<AuthProvider client={${authProvider.client}} type="${authProvider.type}">` +
     indent +
     redwoodProviderLines.join('\n') +
     indent +
     `</AuthProvider>` +
-    indent +
-    (authProvider.render ? `</${authProvider.render}>` : '')
+    customRenderClose
 
   return content.replace(
     /\s+<RedwoodProvider>.*<\/RedwoodProvider>/s,

--- a/packages/cli/src/commands/generate/auth/providers/ethereum.js
+++ b/packages/cli/src/commands/generate/auth/providers/ethereum.js
@@ -31,7 +31,6 @@ export const config = {
 
     ethereum = new EthereumAuthClient({
       makeRequest,
-      // Note: you must set NODE_ENV manually when using Netlify
       debug: process.NODE_ENV === 'development',
     })
   } catch (e) {

--- a/packages/cli/src/commands/generate/auth/providers/ethereum.js
+++ b/packages/cli/src/commands/generate/auth/providers/ethereum.js
@@ -3,17 +3,35 @@ export const config = {
   imports: [
     `import EthereumAuthClient from '@oneclickdapp/ethereum-auth'`,
     `import { ApolloClient, InMemoryCache } from '@apollo/client'`,
+    `import { FetchConfigProvider, useFetchConfig } from '@redwoodjs/web'`,
   ],
   init: `const ApolloInjector = ({ children }) => {
+  const { uri, headers } = useFetchConfig()
   let ethereum
   try {
     const graphQLClient = new ApolloClient({
       cache: new InMemoryCache(),
-      uri: \`\${window.__REDWOOD__API_PROXY_PATH}/graphql\`,
+      uri,
+      headers,
     })
-    const makeRequest = graphQLClient.mutate
+    // Default option using Apollo Client
+    const makeRequest = (mutation, variables) =>
+      graphQLClient.mutate({
+        mutation,
+        variables,
+      })
+
+    // Alternative option using graphql-hooks
+    // You'll also need to modify graphQLClient
+    // const makeRequest = (query, variables) =>
+    //   graphQLClient.request({
+    //     query,
+    //     variables,
+    //   })
+
     ethereum = new EthereumAuthClient({
       makeRequest,
+      // Note: you must set NODE_ENV manually when using Netlify
       debug: process.NODE_ENV !== 'production',
     })
   } catch (e) {
@@ -24,7 +42,7 @@ export const config = {
   authProvider: {
     client: 'ethereum',
     type: 'ethereum',
-    render: 'ApolloInjector',
+    render: ['FetchConfigProvider', 'ApolloInjector'],
   },
 }
 

--- a/packages/cli/src/commands/generate/auth/providers/ethereum.js
+++ b/packages/cli/src/commands/generate/auth/providers/ethereum.js
@@ -32,7 +32,7 @@ export const config = {
     ethereum = new EthereumAuthClient({
       makeRequest,
       // Note: you must set NODE_ENV manually when using Netlify
-      debug: process.NODE_ENV !== 'production',
+      debug: process.NODE_ENV === 'development',
     })
   } catch (e) {
     console.log(e)

--- a/packages/cli/src/commands/generate/auth/providers/ethereum.js
+++ b/packages/cli/src/commands/generate/auth/providers/ethereum.js
@@ -11,7 +11,11 @@ export const config = {
       cache: new InMemoryCache(),
       uri: \`\${window.__REDWOOD__API_PROXY_PATH}/graphql\`,
     })
-    ethereum = new EthereumAuthClient({ graphQLClient })
+    const makeRequest = graphQLClient.mutate
+    ethereum = new EthereumAuthClient({
+      makeRequest,
+      debug: process.NODE_ENV !== 'production',
+    })
   } catch (e) {
     console.log(e)
   }

--- a/packages/cli/src/commands/generate/auth/providers/ethereum.js
+++ b/packages/cli/src/commands/generate/auth/providers/ethereum.js
@@ -1,0 +1,38 @@
+// the lines that need to be added to index.js
+export const config = {
+  imports: [
+    `import EthereumAuthClient from '@oneclickdapp/ethereum-auth'`,
+    `import { ApolloClient, InMemoryCache } from '@apollo/client'`,
+  ],
+  init: `const ApolloInjector = ({ children }) => {
+  let ethereum
+  try {
+    const graphQLClient = new ApolloClient({
+      cache: new InMemoryCache(),
+      uri: \`\${window.__REDWOOD__API_PROXY_PATH}/graphql\`,
+    })
+    ethereum = new EthereumAuthClient({ graphQLClient })
+  } catch (e) {
+    console.log(e)
+  }
+  return React.cloneElement(children, { client: ethereum })
+}`,
+  authProvider: {
+    client: 'ethereum',
+    type: 'ethereum',
+    render: 'ApolloInjector',
+  },
+}
+
+// required packages to install
+export const webPackages = ['@oneclickdapp/ethereum-auth', '@apollo/client']
+export const apiPackages = ['ethereumjs-util', 'eth-sig-util', 'jsonwebtoken']
+
+// any notes to print out when the job is done
+export const notes = [
+  'There are a couple more things you need to do!',
+  'Please see the readme for instructions:',
+  'https://github.com/oneclickdapp/ethereum-auth',
+  'This is a FOSS community-maintained package.',
+  'Help us make it better!',
+]

--- a/packages/cli/src/commands/generate/auth/templates/ethereum.auth.js.template
+++ b/packages/cli/src/commands/generate/auth/templates/ethereum.auth.js.template
@@ -1,0 +1,19 @@
+import { AuthenticationError } from '@redwoodjs/api'
+
+import { db } from './db'
+
+// See https://redwoodjs.com/cookbook/role-based-access-control-rbac
+// for how to add Role-based Access Control (RBAC) here.
+
+export const getCurrentUser = async (decoded) => {
+  return db.user.findOne({ where: { address: decoded.address } })
+}
+
+// Use this function in your services to check that a user is logged in, and
+// optionally raise an error if they're not.
+
+export const requireAuth = () => {
+  if (!context.currentUser) {
+    throw new AuthenticationError("You don't have permission to do that.")
+  }
+}

--- a/packages/cli/src/commands/generate/auth/templates/ethereum.auth.js.template
+++ b/packages/cli/src/commands/generate/auth/templates/ethereum.auth.js.template
@@ -6,7 +6,7 @@ import { db } from './db'
 // for how to add Role-based Access Control (RBAC) here.
 
 export const getCurrentUser = async (decoded) => {
-  return db.user.findOne({ where: { address: decoded.address } })
+  return db.user.findUnique({ where: { address: decoded.address } })
 }
 
 // Use this function in your services to check that a user is logged in, and


### PR DESCRIPTION
This PR allows users to log in with an ethereum wallet. See discussion on discourse: https://community.redwoodjs.com/t/custom-auth-web3-ethereum/1618/2

In parallel with this PR I have created + published the client library `@oneclickdapp/ethereum-auth` https://github.com/oneclickdapp/ethereum-auth

### TODO

- [x] Add Generator for `web/src/index.js`
- [x] Add Generator stubs for `api/src/services/auth/auth.js`
- [x] Update graphql function with `getCurrentUser`?
- [x] Create a new Ethereum JWT decoder

Looking forward to feedback! 

![image](https://user-images.githubusercontent.com/35622595/103250513-37563d80-4942-11eb-97ba-ddc5d69b7b1d.png)
