### PR TITLE
Upgrade Prisma v2.12.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.11.0",
+    "@prisma/client": "2.12.1",
     "@redwoodjs/internal": "^0.21.0",
     "apollo-server-lambda": "2.18.2",
     "core-js": "3.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.11.0",
+    "@prisma/sdk": "2.12.1",
     "@redwoodjs/internal": "^0.21.0",
     "@redwoodjs/structure": "^0.21.0",
     "boxen": "^4.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime-corejs3": "^7.11.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
-    "@prisma/cli": "2.11.0",
+    "@prisma/cli": "2.12.1",
     "@redwoodjs/cli": "^0.21.0",
     "@redwoodjs/dev-server": "^0.21.0",
     "@redwoodjs/eslint-config": "^0.21.0",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.11.0",
+    "@prisma/sdk": "2.12.1",
     "@redwoodjs/internal": "^0.21.0",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,42 +3105,42 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@prisma/bar@0.0.1":
+"@prisma/bar@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
   integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
 
-"@prisma/cli@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.11.0.tgz#34bdc5573ac40edae336b65fa73a164cae437622"
-  integrity sha512-RphW+1SPrEKgpuE5RFM0mv3BeVTF8MCRIyBt35Z9Z/E4YI30qgEWfZu6VfsNDarHRsFiJRKC73wx/aMQ2rLp4g==
+"@prisma/cli@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.12.1.tgz#1f52ab2a363ae4cc88d4d18933bd304ed7f80612"
+  integrity sha512-obkwK95dEeifCdVehG0rS0BlPQGLsOtc9U1MgbrjNX3MnhXQdwROnvymfPB3DBlNyoLoHGklPgi9UlwBokNXcQ==
   dependencies:
-    "@prisma/bar" "0.0.1"
-    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+    "@prisma/bar" "^0.0.1"
+    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
 
-"@prisma/client@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.11.0.tgz#574c1aa3b571ea01c0fa8dca348c6ba5db41dcc9"
-  integrity sha512-BF7K/yi5fAnrt7MelQqUueJyl06IGmIxf+7f5RxFSvyO6xZMbOYxhW21kV2wt10mOIS0khQbo0xY6w/8jViJuQ==
+"@prisma/client@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.12.1.tgz#ff655c9cc1188035303f374d2f9f794b66fc18c7"
+  integrity sha512-HP4/E9sRdxw/FB7XP4EeRa5ri8Lp1U/L7G4VAA95aM8C+8ARioQHMNDpEjC83NrOrOr4EcaZV5pXDDQL1H+F0g==
   dependencies:
-    "@prisma/engines-version" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+    "@prisma/engines-version" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
 
-"@prisma/debug@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.11.0.tgz#cfb9b2c331efacbf3018afc4b83e895c12cacd75"
-  integrity sha512-qOk2HrbvFCZ8VDwBvHOIdj2uw665CNAFql5qh+AS/SZjO5B6dDyvznK3EzUp5DxOLfkhx+HJ+j+Te76nAS+I0Q==
+"@prisma/debug@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.12.1.tgz#a45bafc142c0952c9c5f288f73e15e83d06138c9"
+  integrity sha512-ke4ZOvWZffATjG7Z2Ksxhig6RU7El1YXZOquds3847Rq1/kTq0mp3NFPZuxnv1xq8XDpuKe5Op4tYnzsKibWyw==
   dependencies:
     debug "^4.1.1"
 
-"@prisma/engine-core@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.11.0.tgz#b1ddda8f0827671e0da6dff04e0ebd1267e05b67"
-  integrity sha512-duxmMScKNtXugKmNN7pqm5WRvX8Vp2rD3v8knTpZyYHdIa0/ww7dbfJagA2RlB8bKXnlKL08lXDC7eEvb/r8LQ==
+"@prisma/engine-core@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.12.1.tgz#01653634af785d82469d4e6260e7784cc92f7416"
+  integrity sha512-7zl9X7rn5HQ7s3oR5T2kAP4nuIrIEFA1l8TkEas2XAnItlP9yTjy5q/CsHhP3Z4MW8XQseZSL6pHHD5g2YZ5CQ==
   dependencies:
-    "@prisma/debug" "2.11.0"
-    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
-    "@prisma/generator-helper" "2.11.0"
-    "@prisma/get-platform" "2.11.0"
+    "@prisma/debug" "2.12.1"
+    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+    "@prisma/generator-helper" "2.12.1"
+    "@prisma/get-platform" "2.12.1"
     chalk "^4.0.0"
     cross-fetch "^3.0.4"
     execa "^4.0.2"
@@ -3149,25 +3149,25 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "2.1.1"
+    undici "2.2.0"
 
-"@prisma/engines-version@2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918":
-  version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#840bb5ca8707ed3b852d250c1bac9c75098682ee"
-  integrity sha512-qlkW4dKoW1dUnperWPuhFriZ/NTHlsKLhBbebxRa8qMuD3o37SvWIDGLjFOQx1N0Eb4H04rI3XxgjkWLFVlZCw==
+"@prisma/engines-version@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
+  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#428f8996f88c92a4142e35f196584a5e17c95871"
+  integrity sha512-IHb/Jag1Wmoq5tLZhOHP5zqLHEXqQEfrHb6l0drIBSvh2AF7yWQ3yyuD0ZEb1Nq37SvbBgop5wrWMOU8YWFTGQ==
 
-"@prisma/engines@2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918":
-  version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#5f02f311ce48297ef3fa9861dcab5ec3e52f1371"
-  integrity sha512-0WaUybWM7J5zQuG/zYLbV+ZKx9/nzS7Ruu7Y0K2lXJKy3Z9koeVttq+Xt7tVmUX9TLgI1Rwhb9R2e1JMNDWbsw==
+"@prisma/engines@2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58":
+  version "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58.tgz#0e23c811cfa2f58650bb3c04394b1ac0d9dac78a"
+  integrity sha512-F6RmUZ5JpPWxmGvVDji8c4gepHIGkvYbtuFi0IoDDJVaCVo8yS656stciKFyswI6/BLWXa0X47/MIMbz6nzw7g==
 
-"@prisma/fetch-engine@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.11.0.tgz#f038475f3de4d6951edc77b965eb7f7c0b588cbe"
-  integrity sha512-shkriv/kdR5ihjAOoxJb5/ZBIRjySOYcA+dFhhzbopsFf1cTivB7cKntog9Uc1oE87aftgNXRelITPqvbbYQ6w==
+"@prisma/fetch-engine@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.12.1.tgz#884c646c22bd0757a867b0de509509ae7a3d6d99"
+  integrity sha512-huJS0uvkSUsnEU6CUrUfpgU9Z7PR3UlzJ9wbypk4hWtiMhfuoq2yU0ca2NxEpAhgHpSlERiLsZjBA8SlWw9WpQ==
   dependencies:
-    "@prisma/debug" "2.11.0"
-    "@prisma/get-platform" "2.11.0"
+    "@prisma/debug" "2.12.1"
+    "@prisma/get-platform" "2.12.1"
     chalk "^4.0.0"
     execa "^4.0.0"
     find-cache-dir "^3.3.1"
@@ -3185,37 +3185,37 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.11.0.tgz#4f8aa14e6c0f7dd7ebc76016ce0aff29c3912249"
-  integrity sha512-R+l8ZQlbcv+0xgzDQwUU7M2+mSs8jBIAeyVKbNJQWoump8+vhGKlyDn+cdTCkJM83e9QlM1K5/i8weYqB/6y7Q==
+"@prisma/generator-helper@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.12.1.tgz#b9c96d041b62c6d0c9474a889e8d93b130218c83"
+  integrity sha512-sqZcT6Lnb1xaogy1LVu/gnqrth71V/5hbw5wCXZ/3qeoSNdSmpcBJvfwXzmQ9R50K+tHVA1lZKfGyRlgYnhGUQ==
   dependencies:
-    "@prisma/debug" "2.11.0"
+    "@prisma/debug" "2.12.1"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.11.0.tgz#e90593c4b904d0613969a2ea94c9357b477282ed"
-  integrity sha512-VNx7/hYqKJm+r8cEsX7Tff/NDoiB+MwTCqOu+T5En4F9rxhxxGEuzCyTTdP+tFqmqvd7WGKtmO2qrMgw3bIylw==
+"@prisma/get-platform@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.12.1.tgz#c47115feffb130c2f654f6a5bd9cc4e1cc8a3c9d"
+  integrity sha512-bYTKvTgdbYXtNEZnaAUOdr0twiYNrtadDCGAc1YBwSCQ+P0cNmkrtn+EUwt0ZijCtKYZ1uLC6UAM0y7uxf1s6w==
   dependencies:
-    "@prisma/debug" "2.11.0"
+    "@prisma/debug" "2.12.1"
 
-"@prisma/sdk@2.11.0":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.11.0.tgz#8eb3972a4e93ce1fc026bff8c770c95e169adc48"
-  integrity sha512-a9sU9lSVNQhoMwlRV26KHbu7m1CrEv+Mz0ZwD05S6zm3Ax+KBozGM5irnMnlNlfBaM9pS6bagv3hieS5ija4/w==
+"@prisma/sdk@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.12.1.tgz#20b603b668318b4f4defe21a114df20d5a6a3f77"
+  integrity sha512-1/BokOdZU11lyOSaLhnmXnfY4c6JVLGFXWVfohIiPgemqbjUPvhbk7DpZYDOeNBozlLHIlzXYbU7Kdmwy7nsJQ==
   dependencies:
-    "@prisma/debug" "2.11.0"
-    "@prisma/engine-core" "2.11.0"
-    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
-    "@prisma/fetch-engine" "2.11.0"
-    "@prisma/generator-helper" "2.11.0"
-    "@prisma/get-platform" "2.11.0"
+    "@prisma/debug" "2.12.1"
+    "@prisma/engine-core" "2.12.1"
+    "@prisma/engines" "2.12.0-18.cf0680a1bfe8d5e743dc659cc7f08009f9587d58"
+    "@prisma/fetch-engine" "2.12.1"
+    "@prisma/generator-helper" "2.12.1"
+    "@prisma/get-platform" "2.12.1"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
-    arg "^4.1.3"
+    arg "^5.0.0"
     chalk "4.1.0"
     checkpoint-client "1.1.14"
     cli-truncate "^2.1.0"
@@ -5248,10 +5248,10 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-arg@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+arg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.0.tgz#a20e2bb5710e82950a516b3f933fee5ed478be90"
+  integrity sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -18141,10 +18141,10 @@ undefsafe@^2.0.3:
   dependencies:
     debug "^2.2.0"
 
-undici@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-2.1.1.tgz#4b7a938bd49fe5f45c5f5398aa4a3c5f2e0cd2d4"
-  integrity sha512-4HVo2WQ0Mg98UwFKauN7UCqWtQcYZiApv9LeqUPzKQEZhZDnnz/PkM0B+1KU2ytFUSrUqlQZ7X0BqyQJskvNnA==
+undici@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-2.2.0.tgz#ffef206ffb44f0db1f4013d9c1fc5a89dddf8c9c"
+  integrity sha512-pNts1nTVW1e9rOFGXdueH28FGYZz2TdeuQtJSzcto95bx7HQCegmJr+A+51fW+XU2ZNE4vZlzI7VnfKHuALitQ==
 
 unfetch@^4.1.0, unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
> note: as of Prisma 2.13 the dynamic provider is deprecated. We need to resolve the SQLite deploy issue with the Tutorial before upgrading further

This version of Prisma includes a **BREAKING** change for 1-1 relations:
https://github.com/prisma/prisma/releases/tag/2.12.0
https://github.com/prisma/prisma/releases/tag/2.12.1

- Standalone Prisma Studio app for macOS
- Prisma codemods help upgrading your codebase
- Microsoft SQL Server now supports native database types (Preview)
- BREAKING: Remove non-$ methods
- BREAKING: 1-1-relations must now have an optional side
- BREAKING: Fix how data for Json[] fields is stored
- DEPRECATION: Rename findOne to findUnique
- DEPRECATION: Move most types under the Prisma namespace