### PR TITLE
Configure ApolloProvider to always use fresh tokens 

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -16,10 +16,10 @@ export interface AuthContextInterface {
   /* Determining your current authentication state */
   loading: boolean
   isAuthenticated: boolean
- /**
-  * @deprecated auth tokens are now refreshed when they expire, and this value will be removed from the context in the next few releases: https://github.com/redwoodjs/redwood/pull/1609
-  */
-  authToken: string | null // @WARN! to be depracated
+  /**
+   * @deprecated auth tokens are now refreshed when they expire, use getToken() instead. authToken will be removed from this context in future releases
+   */
+  authToken: string | null // @WARN! deprecated, will always be null
   /* The current user's data from the `getCurrentUser` function on the api side */
   currentUser: null | CurrentUser
   /* The user's metadata from the auth provider */
@@ -28,8 +28,6 @@ export interface AuthContextInterface {
   logOut(options?: unknown): Promise<void>
   signUp(options?: unknown): Promise<void>
   getToken(): Promise<null | string>
-  // To be removed once authToken is removed
-  getFreshToken(): Promise<null | string>
   /**
    * Fetches the "currentUser" from the api side,
    * but does not update the current user state.
@@ -60,7 +58,7 @@ export interface AuthContextInterface {
 export const AuthContext = React.createContext<AuthContextInterface>({
   loading: true,
   isAuthenticated: false,
-  authToken: null, // @WARN! to be depracated
+  authToken: null, // @WARN! deprecated, will always be null
   userMetadata: null,
   currentUser: null,
 })
@@ -74,7 +72,7 @@ type AuthProviderProps = {
 type AuthProviderState = {
   loading: boolean
   isAuthenticated: boolean
-  authToken: string | null // @WARN! to be depracated
+  authToken: string | null // @WARN! deprecated, will always be null
   userMetadata: null | Record<string, any>
   currentUser: null | CurrentUser
   hasError: boolean
@@ -101,7 +99,7 @@ export class AuthProvider extends React.Component<
   state: AuthProviderState = {
     loading: true,
     isAuthenticated: false,
-    authToken: null, // @WARN! to be depracated
+    authToken: null, // @WARN! deprecated, will always be null
     userMetadata: null,
     currentUser: null,
     hasError: false,
@@ -180,22 +178,13 @@ export class AuthProvider extends React.Component<
   }
 
   getToken = async () => {
-    const authToken = await this.rwClient.getToken()
-    this.setState({ ...this.state, authToken })
-    return authToken
-  }
-
-  // Note: Used by apollo middleware to get a fresh token
-  // State isn't changed, to prevent infinite loops
-  // Remove this, and call getToken when AuthProviderState.authToken is removed
-  getFreshToken = async () => {
     return this.rwClient.getToken()
   }
 
   reauthenticate = async () => {
     const notAuthenticatedState: AuthProviderState = {
       isAuthenticated: false,
-      authToken: null, // @WARN! to be depracated
+      authToken: null, // @WARN! deprecated, will always be null
       currentUser: null,
       userMetadata: null,
       loading: false,
@@ -267,7 +256,6 @@ export class AuthProvider extends React.Component<
           getCurrentUser: this.getCurrentUser,
           hasRole: this.hasRole,
           reauthenticate: this.reauthenticate,
-          getFreshToken: this.getFreshToken,
           client,
           type,
         }}

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -16,6 +16,9 @@ export interface AuthContextInterface {
   /* Determining your current authentication state */
   loading: boolean
   isAuthenticated: boolean
+ /**
+  * @deprecated auth tokens are now refreshed when they expire, and this value will be removed from the context in the next few releases: https://github.com/redwoodjs/redwood/pull/1609
+  */
   authToken: string | null // @WARN! to be depracated
   /* The current user's data from the `getCurrentUser` function on the api side */
   currentUser: null | CurrentUser

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -9,6 +9,8 @@ import type { AuthClient } from '../authClients'
 import { AuthProvider } from '../AuthProvider'
 import { useAuth } from '../useAuth'
 
+import { useEffect, useState } from 'react'
+
 let CURRENT_USER_DATA: { name: string; email: string; roles?: string[] } = {
   name: 'Peter Pistorius',
   email: 'nospam@example.net',
@@ -41,9 +43,9 @@ const AuthConsumer = () => {
   const {
     loading,
     isAuthenticated,
-    authToken,
     logOut,
     logIn,
+    getToken,
     userMetadata,
     currentUser,
     reauthenticate,
@@ -51,6 +53,17 @@ const AuthConsumer = () => {
     hasRole,
     error,
   } = useAuth()
+
+  const [authToken, setAuthToken] = useState(null)
+
+  const retrieveToken = async () => {
+    const token = await getToken()
+    setAuthToken(token)
+  }
+
+  useEffect(() => {
+    retrieveToken()
+  })
 
   if (loading) {
     return <>Loading...</>

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -1,5 +1,7 @@
 require('whatwg-fetch')
 
+import { useEffect, useState } from 'react'
+
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { graphql } from 'msw'
@@ -8,8 +10,6 @@ import { setupServer } from 'msw/node'
 import type { AuthClient } from '../authClients'
 import { AuthProvider } from '../AuthProvider'
 import { useAuth } from '../useAuth'
-
-import { useEffect, useState } from 'react'
 
 let CURRENT_USER_DATA: { name: string; email: string; roles?: string[] } = {
   name: 'Peter Pistorius',

--- a/packages/testing/src/MockProviders.tsx
+++ b/packages/testing/src/MockProviders.tsx
@@ -24,6 +24,7 @@ const fakeUseAuth = (): AuthContextInterface => ({
   logOut: async () => undefined,
   signUp: async () => undefined,
   getToken: async () => null,
+  getFreshToken: async () => null,
   getCurrentUser: async () => null,
   hasRole: () => false,
   reauthenticate: async () => undefined,

--- a/packages/testing/src/MockProviders.tsx
+++ b/packages/testing/src/MockProviders.tsx
@@ -24,7 +24,6 @@ const fakeUseAuth = (): AuthContextInterface => ({
   logOut: async () => undefined,
   signUp: async () => undefined,
   getToken: async () => null,
-  getFreshToken: async () => null,
   getCurrentUser: async () => null,
   hasRole: () => false,
   reauthenticate: async () => undefined,

--- a/packages/web/src/components/RedwoodApolloProvider.tsx
+++ b/packages/web/src/components/RedwoodApolloProvider.tsx
@@ -23,10 +23,10 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
   config?: Omit<ApolloClientOptions<InMemoryCache>, 'cache'>
 }> = ({ config = {}, children }) => {
   const { uri, headers } = useFetchConfig()
-  const { getFreshToken, type: authProviderType } = useAuth()
+  const { getToken, type: authProviderType } = useAuth()
 
   const withToken = setContext(async () => {
-    const token = await getFreshToken()
+    const token = await getToken()
     return { token }
   })
 
@@ -36,7 +36,7 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
     operation.setContext(() => ({
       headers: {
         ...headers,
-        // Duped, because we may remove FetchContext at a later date
+        // Duped auth headers, because we may remove FetchContext at a later date
         'auth-provider': authProviderType,
         authorization: token ? `Bearer ${token}` : null,
       },

--- a/packages/web/src/components/RedwoodApolloProvider.tsx
+++ b/packages/web/src/components/RedwoodApolloProvider.tsx
@@ -2,12 +2,15 @@ import {
   ApolloProvider,
   ApolloClientOptions,
   ApolloClient,
+  ApolloLink,
   InMemoryCache,
   useQuery,
   useMutation,
+  createHttpLink,
 } from '@apollo/client'
+import { setContext } from '@apollo/client/link/context'
 
-import type { AuthContextInterface } from '@redwoodjs/auth'
+import { AuthContextInterface, useAuth } from '@redwoodjs/auth'
 
 import {
   FetchConfigProvider,
@@ -20,12 +23,33 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
   config?: Omit<ApolloClientOptions<InMemoryCache>, 'cache'>
 }> = ({ config = {}, children }) => {
   const { uri, headers } = useFetchConfig()
+  const { getFreshToken, type: authProviderType } = useAuth()
+
+  const withToken = setContext(async () => {
+    const token = await getFreshToken()
+    return { token }
+  })
+
+  const authMiddleware = new ApolloLink((operation, forward) => {
+    const { token } = operation.getContext()
+
+    operation.setContext(() => ({
+      headers: {
+        ...headers,
+        // Duped, because we may remove FetchContext at a later date
+        'auth-provider': authProviderType,
+        authorization: token ? `Bearer ${token}` : null,
+      },
+    }))
+    return forward(operation)
+  })
+
+  const httpLink = createHttpLink({ uri })
 
   const client = new ApolloClient({
     cache: new InMemoryCache(),
-    uri,
-    headers,
     ...config,
+    link: ApolloLink.from([withToken, authMiddleware.concat(httpLink)]),
   })
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>


### PR DESCRIPTION
+ AuthContext.authToken to be deparacated

Starts fix for #1576. Implements proposal and discussion in #1608

- [x] Use fresh token for getCurrentUser
- [x] Use fresh token for other graphql requests
- [x] Verify and test this

Verified only with firebase, but individual provider changes will be added later.