### PR TITLE
Revert "Configure ApolloProvider to always use fresh tokens "

### DIFF
--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -1,7 +1,5 @@
 require('whatwg-fetch')
 
-import { useEffect, useState } from 'react'
-
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { graphql } from 'msw'
@@ -43,9 +41,9 @@ const AuthConsumer = () => {
   const {
     loading,
     isAuthenticated,
+    authToken,
     logOut,
     logIn,
-    getToken,
     userMetadata,
     currentUser,
     reauthenticate,
@@ -53,17 +51,6 @@ const AuthConsumer = () => {
     hasRole,
     error,
   } = useAuth()
-
-  const [authToken, setAuthToken] = useState(null)
-
-  const retrieveToken = async () => {
-    const token = await getToken()
-    setAuthToken(token)
-  }
-
-  useEffect(() => {
-    retrieveToken()
-  })
 
   if (loading) {
     return <>Loading...</>

--- a/packages/web/src/components/RedwoodApolloProvider.tsx
+++ b/packages/web/src/components/RedwoodApolloProvider.tsx
@@ -2,15 +2,12 @@ import {
   ApolloProvider,
   ApolloClientOptions,
   ApolloClient,
-  ApolloLink,
   InMemoryCache,
   useQuery,
   useMutation,
-  createHttpLink,
 } from '@apollo/client'
-import { setContext } from '@apollo/client/link/context'
 
-import { AuthContextInterface, useAuth } from '@redwoodjs/auth'
+import type { AuthContextInterface } from '@redwoodjs/auth'
 
 import {
   FetchConfigProvider,
@@ -23,33 +20,12 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
   config?: Omit<ApolloClientOptions<InMemoryCache>, 'cache'>
 }> = ({ config = {}, children }) => {
   const { uri, headers } = useFetchConfig()
-  const { getToken, type: authProviderType } = useAuth()
-
-  const withToken = setContext(async () => {
-    const token = await getToken()
-    return { token }
-  })
-
-  const authMiddleware = new ApolloLink((operation, forward) => {
-    const { token } = operation.getContext()
-
-    operation.setContext(() => ({
-      headers: {
-        ...headers,
-        // Duped auth headers, because we may remove FetchContext at a later date
-        'auth-provider': authProviderType,
-        authorization: token ? `Bearer ${token}` : null,
-      },
-    }))
-    return forward(operation)
-  })
-
-  const httpLink = createHttpLink({ uri })
 
   const client = new ApolloClient({
     cache: new InMemoryCache(),
+    uri,
+    headers,
     ...config,
-    link: ApolloLink.from([withToken, authMiddleware.concat(httpLink)]),
   })
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>


### PR DESCRIPTION
Reverts redwoodjs/redwood#1609

Breaking on integration tests with a very unhelpful GraphQL error `Error: getToken is not a function` and no other error output.