### PR TITLE
Resolve promises in the console

### DIFF
--- a/packages/cli/src/commands/console.js
+++ b/packages/cli/src/commands/console.js
@@ -28,6 +28,24 @@ export const handler = () => {
 
   const r = repl.start()
 
+  // always await promises.
+  const defaultEval = r.eval;
+  r.eval = (cmd, context, filename, callback) => {
+    defaultEval(cmd, context, filename, async (err, result) => {
+      if (err) {
+        // propagate errors.
+        callback(err);
+      } else {
+        // await the promise and either return the result or error.
+        try {
+          callback(null, await Promise.resolve(result));
+        } catch (err) {
+          callback(err);
+        }
+      }
+    });
+  };
+
   // Make the project's db (i.e. Prisma Client) available
   mapDBToContext(r.context)
 }

--- a/packages/cli/src/commands/console.js
+++ b/packages/cli/src/commands/console.js
@@ -29,6 +29,7 @@ export const handler = () => {
   const r = repl.start()
 
   // always await promises.
+  // source: https://github.com/nodejs/node/issues/13209#issuecomment-619526317
   const defaultEval = r.eval;
   r.eval = (cmd, context, filename, callback) => {
     defaultEval(cmd, context, filename, async (err, result) => {


### PR DESCRIPTION
Another way of abstracting away the need for top-level await in the redwood console, by automatically resolving promises (cc @mojombo from today's contributor's meetup).

A really nice copy-paste fix I took from the resources referenced in https://github.com/redwoodjs/redwood/issues/1613#issue-781559618 ("hack the eval").

Also tagging @peterp just in case you want to take a look at this one too. Guled brought up the good point that even if we enable top-level await, it might be annoying to have to type "await ..." all the time.