### PR TITLE
add learn.rwjs.com repo to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,10 @@ And there you have it.
     <td align="center"><a href="https://edjiang.com/"><img src="https://avatars1.githubusercontent.com/u/918770?v=4" width="100px;" alt=""/><br /><sub><b>Edward Jiang</b></sub></a></td>
     <td align="center"><a href="http://manukall.de/"><img src="https://avatars0.githubusercontent.com/u/117418?v=4" width="100px;" alt=""/><br /><sub><b>Manuel Kallenbach</b></sub></a></td>
     <td align="center"><a href="https://github.com/NickSchmitt"><img src="https://avatars3.githubusercontent.com/u/23244885?v=4" width="100px;" alt=""/><br /><sub><b>Nick Schmitt</b></sub></a></td>
+    <td align="center"><a href="https://monoglot.dev/"><img src="https://avatars0.githubusercontent.com/u/13792200?v=4" width="100px;" alt=""/><br /><sub><b>Jon Meyers</b></sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/mbush92"><img src="https://avatars0.githubusercontent.com/u/15862774?v=4" width="100px;" alt=""/><br /><sub><b>Matthew Bush</b></sub></a></td>
   </tr>
 </table>
 

--- a/tasks/all-contributors/.all-contributorsrc
+++ b/tasks/all-contributors/.all-contributorsrc
@@ -250,7 +250,8 @@
       "contributions": [
         "code",
         "doc",
-        "tool"
+        "tool",
+        "tutorial"
       ]
     },
     {
@@ -1395,6 +1396,24 @@
       "profile": "https://github.com/NickSchmitt",
       "contributions": [
         "doc"
+      ]
+    },
+    {
+      "login": "dijonmusters",
+      "name": "Jon Meyers",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/13792200?v=4",
+      "profile": "https://monoglot.dev/",
+      "contributions": [
+        "doc"
+      ]
+    },
+    {
+      "login": "mbush92",
+      "name": "Matthew Bush",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/15862774?v=4",
+      "profile": "https://github.com/mbush92",
+      "contributions": [
+        "tutorial"
       ]
     }
   ]

--- a/tasks/all-contributors/.crwa.all-contributorsrc
+++ b/tasks/all-contributors/.crwa.all-contributorsrc
@@ -147,5 +147,5 @@
       ]
     }
   ],
-  "contributorsPerLine": 7
+  "contributorsPerLine": 5
 }

--- a/tasks/all-contributors/.learn.all-contributorsrc
+++ b/tasks/all-contributors/.learn.all-contributorsrc
@@ -1,0 +1,34 @@
+{
+  "projectName": "learn.redwoodjs.com",
+  "projectOwner": "redwoodjs",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "contributorTemplate": "<a href=\"<%= contributor.profile %>\"><img src=\"<%= contributor.avatar_url %>\" width=\"<%= options.imageSize %>px;\" alt=\"\"/><br /><sub><b><%= contributor.name %></b></sub></a>",
+  "commit": false,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "mbush92",
+      "name": "Matthew Bush",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/15862774?v=4",
+      "profile": "https://github.com/mbush92",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "Thieffen",
+      "name": "Thieffen",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/847877?v=4",
+      "profile": "https://github.com/Thieffen",
+      "contributions": [
+        "tutorial"
+      ]
+    }
+  ],
+  "contributorsPerLine": 5
+}

--- a/tasks/all-contributors/.rwjs.com.all-contributorsrc
+++ b/tasks/all-contributors/.rwjs.com.all-contributorsrc
@@ -820,7 +820,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "dijonmusters",
+      "name": "Jon Meyers",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/13792200?v=4",
+      "profile": "https://monoglot.dev/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
-  "contributorsPerLine": 7
+  "contributorsPerLine": 5
 }

--- a/tasks/all-contributors/README.md
+++ b/tasks/all-contributors/README.md
@@ -16,7 +16,7 @@ Redwood has a vibrant community that we want to highlight as much as possible. U
 
 ## Managing All-Contributors Data
 In general, this is a three-part process:
-1. Update the three `*.all-contributorsrc` files with new contributors
+1. Update the four `*.all-contributorsrc` files with new contributors
 2. Merge changes into the main `.all-contributorsrc` file
 3. Update README.md#Contributors with changes
 
@@ -33,16 +33,38 @@ _note: this file is also used for all aggregated contributors_
 **Website** `redwoodjs/redwoodjs.com` project:
 - `.rwjs.com.all-contributorsrc`
 
+**Learn** `redwoodjs/learn.redwoodjs.com` project:
+- `.learn.all-contributorsrc`
+
 >When adding contributors, use this "type" key for specific repos:
 >- 💻 (code) == Framework
 >- 📖 (doc) == Redwoodjs.com
 >- 🔧 (tool) == Create-Redwood-App
+>- ✅ (tutorial) == Learn.Redwoodjs.com
 >
 >The "type" is required.
 
 ### Step 1: Check for new contributors and add to `*rc` files
 
-'cd tasks/all-contributors'
+`cd tasks/all-contributors`
+`yarn install`
+
+> **NOTE:**
+> Do not add [bot] accounts to the files.
+>
+> Also, members of the Core Team are manually added to the #core-team section. To avoid duplication, do not add the following profiles to the files below:
+> - peterp
+> - thedavidprice
+> - mojombo
+> - cannikin
+> - jtoar
+> - Tobbe
+> - RobertBroersma
+> - dthyresson
+> - dac09
+> - aldonline
+> - clairefro
+> - ajcwebdev
 
 #### Framework
 ```js
@@ -69,6 +91,15 @@ yarn all-contributors check --config .crwa.all-contributorsrc
 // For each contributor listed in output, repeat the following:
 
 yarn all-contributors add --config .crwa.all-contributorsrc <contributor> tool
+```
+
+#### Learn.Redwoodjs.com
+```js
+yarn all-contributors check --config .learn.all-contributorsrc
+
+// For each contributor listed in output, repeat the following:
+
+yarn all-contributors add --config .learn.all-contributorsrc <contributor> tutorial
 ```
 
 ### Step 2: Merge contributors into main file

--- a/tasks/all-contributors/mergeContributors.js
+++ b/tasks/all-contributors/mergeContributors.js
@@ -11,6 +11,7 @@ const mainContribFile = JSON.parse(fs.readFileSync(targetFile))
 const contribFiles = [
   '.crwa.all-contributorsrc',
   '.rwjs.com.all-contributorsrc',
+  '.learn.all-contributorsrc',
 ]
 
 async function main() {


### PR DESCRIPTION
This adds the new `learn.redwoodjs.com` repo to the #contributors data files and docs. Contributors are also up to date. 

Total count is 151 + 12 (core team) = 163

@clairefro I've added @mbush92 and @Thieffen to the contributor's data for `learn.redwoodjs.com`. You're already included in the #core-team section. And @Thieffen is already a contributor but there's additional information about the contribution to this repo.

When the project is announced, we'll do a proper write up giving massive props to you all (and the others that help between now and then) 🚀