### PR TITLE
Auth: Netlify decoder: specifically check for dev and test

### DIFF
--- a/packages/api/src/auth/decoders/netlify.ts
+++ b/packages/api/src/auth/decoders/netlify.ts
@@ -6,14 +6,18 @@ type NetlifyContext = ClientContext & {
 }
 
 export const netlify = (token: string, req: { context: LambdaContext }) => {
-  // Netlify verifies and decodes the JWT before the request is passed to our Serverless
-  // function, so the decoded JWT is already available in production.
-  if (process.env.NODE_ENV !== 'development') {
+  // Netlify verifies and decodes the JWT before the request is passed to our
+  // Serverless function, so the decoded JWT is already available in production.
+  // For development and test we can't verify the token because we don't have
+  // the signing key. Just decoding the token is the best we can do to emulate
+  // the native Netlify experience
+  if (
+    process.env.NODE_ENV === 'development' ||
+    process.env.NODE_ENV === 'test'
+  ) {
+    return jwt.decode(token)
+  } else {
     const clientContext = req.context.clientContext as NetlifyContext
     return clientContext?.user || null
-  } else {
-    // We emulate the native Netlify experience in development mode.
-    // We just decode it since we don't have the signing key.
-    return jwt.decode(token)
   }
 }


### PR DESCRIPTION
Explicitly check for `NODE_ENV === 'development'` and `NODE_ENV === 'test'` to make the code easier to understand