### PR TITLE
Structure: Fix cell comment

### DIFF
--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -9,8 +9,8 @@ import { RWComponent } from './RWComponent'
 
 export class RWCell extends RWComponent {
   /**
-   * A "Cell" is a component that ends in `Cell.{js, jsx, tsx}`, but does not
-   * have a default export AND does not export `QUERY`
+   * A "Cell" is a component that ends in `Cell.{js, jsx, tsx}`, has no
+   * default export AND exports `QUERY`
    **/
   @lazy() get isCell() {
     return !this.hasDefaultExport && this.exportedSymbols.has('QUERY')


### PR DESCRIPTION
Someone asked on Discord where we define what's a Cell and not, besides babel. 
I thought about the structure package and noticed the comment in there had a negation wrong, which is confusing. This fixes that (cells *do* have a QUERY export)