### PR TITLE
Support Supabase OAuth and Magic Link auth

### DIFF
--- a/packages/auth/src/authClients/netlify.ts
+++ b/packages/auth/src/authClients/netlify.ts
@@ -47,5 +47,8 @@ export const netlify = (client: NetlifyIdentity): AuthClient => {
     getUserMetadata: async () => {
       return client.currentUser()
     },
+    restoreAuthState: async () => {
+      return client.currentUser()
+    },
   }
 }

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -6,9 +6,17 @@ export type Supabase = SupabaseClient
 export type SupabaseUser = User
 
 export interface AuthClientSupabase extends AuthClient {
+  /**
+   * Log in an existing user, or login via a third-party provider.
+   * @param option The user login details.
+   * @param option.email The user's email address.
+   * @param option.password The user's password.
+   * @param option.provider One of the providers supported by GoTrue.
+   */
   login(options: {
-    email: string
-    password: string
+    email?: string | undefined
+    password?: string | undefined
+    provider?: Provider
   }): Promise<{
     data: Session | null
     user: User | null
@@ -17,6 +25,12 @@ export interface AuthClientSupabase extends AuthClient {
     error: Error | null
   }>
   logout(): Promise<{ error: Error | null }>
+  /**
+   * Creates a new user.
+   * @param options The user login details.
+   * @param options.email The user's email address.
+   * @param options.password The user's password.
+   */
   signup(options: {
     email: string
     password: string
@@ -32,13 +46,27 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
   return {
     type: 'supabase',
     client,
-    login: ({ email, password }) => client.auth.signIn({ email, password }),
-    logout: () => client.auth.signOut(),
-    signup: ({ email, password }) => client.auth.signUp({ email, password }),
+    login: async ({ email, password, provider }) => {
+      if (email && !password) {
+        // magic link
+        return await client.auth.signIn({ email })
+      }
+      // email and password
+      if (email && password)
+        return await client.auth.signIn({ email, password })
+      // oauth, such as github, gitlab, etc.
+      if (provider) return await client.auth.signIn({ provider })
+      throw new Error(
+        `You must provide either an email or a third-party provider.`
+      )
+    },
+    logout: async () => await client.auth.signOut(),
+    signup: async ({ email, password }) =>
+      await client.auth.signUp({ email, password }),
     getToken: async () => {
       const currentSession = client.auth.session()
       return currentSession?.access_token || null
     },
-    getUserMetadata: async () => client.auth.user(),
+    getUserMetadata: async () => await client.auth.user(),
   }
 }

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -8,10 +8,10 @@ export type SupabaseUser = User
 export interface AuthClientSupabase extends AuthClient {
   /**
    * Log in an existing user, or login via a third-party provider.
-   * @param option The user login details.
-   * @param option.email The user's email address.
-   * @param option.password The user's password.
-   * @param option.provider One of the providers supported by GoTrue.
+   * @param options The user login details.
+   * @param options.email The user's email address.
+   * @param options.password The user's password.
+   * @param {'bitbucket' | 'github' | 'gitlab' | 'google' | 'azure'} options.provider One of the providers supported by GoTrue.
    */
   login(options: {
     email?: string | undefined
@@ -47,27 +47,38 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
     type: 'supabase',
     client,
     login: async ({ email, password, provider }) => {
+      // magic link
       if (email && !password) {
-        // magic link
         return await client.auth.signIn({ email })
       }
       // email and password
-      if (email && password)
+      if (email && password) {
         return await client.auth.signIn({ email, password })
-      // oauth, such as github, gitlab, etc.
+      }
+      // oauth, such as github, gitlab, bitbucket, google, azure etc.
       if (provider) return await client.auth.signIn({ provider })
       throw new Error(
         `You must provide either an email or a third-party provider.`
       )
     },
-    logout: async () => await client.auth.signOut(),
-    signup: async ({ email, password }) =>
-      await client.auth.signUp({ email, password }),
+    logout: async () => {
+      return await client.auth.signOut()
+    },
+    signup: async ({ email, password }) => {
+      return await client.auth.signUp({ email, password })
+    },
+
     getToken: async () => {
       const currentSession = client.auth.session()
       return currentSession?.access_token || null
     },
-    getUserMetadata: async () => await client.auth.user(),
-    restoreAuthState: async () => await client.auth.refreshSession(),
+    getUserMetadata: async () => {
+      return await client.auth.user()
+    },
+    // restore authentication when an OAuth or magiclink callback
+    // redirects back to site with access token
+    restoreAuthState: async () => {
+      return await client.auth.refreshSession()
+    },
   }
 }

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -68,5 +68,6 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
       return currentSession?.access_token || null
     },
     getUserMetadata: async () => await client.auth.user(),
+    restoreAuthState: async () => await client.auth.refreshSession(),
   }
 }

--- a/packages/cli/src/commands/generate/auth/providers/supabase.js
+++ b/packages/cli/src/commands/generate/auth/providers/supabase.js
@@ -17,6 +17,6 @@ export const apiPackages = []
 
 // any notes to print out when the job is done
 export const notes = [
-  'You will need to add your Supabase URL and key to your .env file.',
+  'You will need to add your Supabase URL (SUPABASE_URL), public API KEY, and JWT SECRET (SUPABASE_KEY, and SUPABASE_JWT_SECRET) to your .env file.',
   'See: https://supabase.io/docs/library/getting-started#reference',
 ]


### PR DESCRIPTION
With Supabase 1.0, it supports OAuth via 'bitbucket' | 'github' | 'gitlab' | 'google' | 'azure' as well as Magic Link passwordless email auth.

resolves https://github.com/redwoodjs/redwood/issues/1538
resolves https://github.com/redwoodjs/redwood/issues/1537
resolves https://github.com/redwoodjs/redwood/issues/1246
addresses https://github.com/redwoodjs/redwood/issues/1479

See: https://supabase.io/docs/client/auth-signin

Note that Supabase will support Azure as well, they just have not undated their docs or admin interface to configure the provider.

Authentication doc updates are here: https://github.com/redwoodjs/redwoodjs.com/pull/531

And can be previewed: https://deploy-preview-531--redwoodjs.netlify.app/docs/authentication#supabase

Updates to the playground auth is: https://github.com/redwoodjs/playground-auth/pull/19

Note: this PR also added the restoreAuthState to Netlify as this helped with restoring state after a email magiclink invite signup for both Supabase and Netlify (both GoTrue based).

