### PR TITLE
Ignore linting template folder in create-redwood-app

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ dist
 fixtures
 packages/core/**/__fixtures__/**/*
 packages/core/config/storybook/**/*
+packages/create-redwood-app/template/**/*

--- a/packages/api/src/auth/decoders/supabase.ts
+++ b/packages/api/src/auth/decoders/supabase.ts
@@ -8,9 +8,7 @@ export const supabase = (token: string) => {
 
   try {
     const secret = process.env.SUPABASE_JWT_SECRET as string
-    return Promise.resolve(
-      jwt.verify(token, secret) as Record<string, unknown>
-    )
+    return Promise.resolve(jwt.verify(token, secret) as Record<string, unknown>)
   } catch (error) {
     return Promise.reject(error)
   }

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -56,14 +56,13 @@ const AuthConsumer = () => {
 
   const [authToken, setAuthToken] = useState(null)
 
-  const retrieveToken = async () => {
-    const token = await getToken()
-    setAuthToken(token)
-  }
-
   useEffect(() => {
+    const retrieveToken = async () => {
+      const token = await getToken()
+      setAuthToken(token)
+    }
     retrieveToken()
-  }, [])
+  }, [getToken])
 
   if (loading) {
     return <>Loading...</>

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -76,7 +76,10 @@ export const handler = async ({ side = ['api', 'web'], forward = '' }) => {
   const jobs = {
     api: {
       name: 'api',
-      command: `cd "${path.join(BASE_DIR, 'api')}" && cross-env NODE_ENV=development yarn dev-server`,
+      command: `cd "${path.join(
+        BASE_DIR,
+        'api'
+      )}" && cross-env NODE_ENV=development yarn dev-server`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(API_DIR_SRC),
     },

--- a/packages/structure/src/model/RWPage.ts
+++ b/packages/structure/src/model/RWPage.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'fs'
 import { dirname } from 'path'
 
 import * as tsm from 'ts-morph'

--- a/packages/web/src/components/RedwoodApolloProvider.tsx
+++ b/packages/web/src/components/RedwoodApolloProvider.tsx
@@ -43,7 +43,7 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
     const authHeaders = token
       ? {
           'auth-provider': authProviderType,
-          authorization: `Bearer ${token}`
+          authorization: `Bearer ${token}`,
         }
       : {}
 


### PR DESCRIPTION
Ignores the template folder in CRWA, to avoid loading lots of eslint rules that are only meant to apply to the redwood project (on the users side), not on the redwood repo