### PR TITLE
Corrects dataMigrate install instructions

### DIFF
--- a/packages/cli/src/commands/dataMigrate/install.js
+++ b/packages/cli/src/commands/dataMigrate/install.js
@@ -19,7 +19,7 @@ const POST_INSTALL_INSTRUCTIONS = `${c.warning(
   "Don't forget to apply your migration when ready:"
 )}
 
-     yarn rw db up
+    yarn rw dataMigrate up
 `
 
 // Creates dataMigrations directory


### PR DESCRIPTION
Fix: https://github.com/redwoodjs/redwood/issues/1717

Data Migrate Command: dataMigrate install refers to `yarn rw db up` when it should refer to `yarn rw dataMigrate up`

When running the command `yarn rw dataMigrate install`:

```
... dataMigrate install
  ✔ Creating dataMigrations directory...
  ✔ Adding RW_DataMigration model to schema.prisma...
  ✔ Create db migration...
  ✔ Next steps:
    Don't forget to apply your migration when ready:

      yarn rw db up

✨  Done in 6.17s.
```

However, the message should be:

`yarn rw dataMigrate up`

as that is the instruction after creating a dataMigration file:

```
 ✔ Generating data migration file...
    ✔ Successfully wrote file `./api/prisma/dataMigrations/20210203150029-some-migration.js`
  ✔ Next steps...

    After writing your migration, you can run it with:

      yarn rw dataMigrate up
```

This PR changes the POST_INSTALL_INSTRUCTIONS to refer to `yarn rw dataMigrate up` instead.