### PR TITLE
Router: Explicitly build types

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -22,9 +22,10 @@
     "react-dom": "^16.13.1"
   },
   "scripts": {
-    "build": "yarn build:js",
+    "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
+    "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",
     "test:watch": "yarn test --watch"


### PR DESCRIPTION
Makes type generation run when you manually build just the router package. See this comment for more context https://github.com/redwoodjs/redwood/pull/1641#discussion_r569810369