### PR TITLE
Format generated *.d.ts files

### DIFF
--- a/packages/core/src/babelPlugins/babel-plugin-redwood-import-dir.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-import-dir.ts
@@ -105,7 +105,11 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         const typeDefContent = `
           // @ts-expect-error
           declare module '${importGlob.replace('../', 'src/')}';
-        `
+          `
+          .split('\n')
+          .slice(1)
+          .map((line) => line.replace('          ', ''))
+          .join('\n')
         generateTypeDef(`import-dir-${importName}.d.ts`, typeDefContent)
         generateTypeDefIndex()
       },

--- a/packages/core/src/babelPlugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -52,15 +52,20 @@ export default function (
           const typeDefContent = `
             declare module '@redwoodjs/router' {
               interface AvailableRoutes {
-                ${availableRoutes.join('\n')}
+                ${availableRoutes.join('\n    ')}
               }
             }
 
             ${pageImports.join('\n')}
+
             declare global {
-              ${pageGlobals.join('\n')}
+              ${pageGlobals.join('\n  ')}
             }
-          `
+            `
+            .split('\n')
+            .slice(1)
+            .map((line) => line.replace('            ', ''))
+            .join('\n')
 
           generateTypeDef('routes.d.ts', typeDefContent)
           generateTypeDefIndex()


### PR DESCRIPTION
This PR addresses the concern raised in https://github.com/redwoodjs/redwoodjs.com/issues/539

This is what it looks like now, with this fix (and a fix for the Windows paths, but that's another PR another time)

![image](https://user-images.githubusercontent.com/30793/106826054-60c36100-6686-11eb-878f-bec70d802ee3.png)

**EDIT:** Also added formatting of the other two .d.ts files we're generating