### PR TITLE
Improvements to `rw prisma` alias

### DIFF
--- a/packages/cli/jsconfig.json
+++ b/packages/cli/jsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -6,9 +6,9 @@ import Listr from 'listr'
 import VerboseRenderer from 'listr-verbose-renderer'
 import terminalLink from 'terminal-link'
 
-import { generatePrismaClient } from 'src/commands/prisma/generate'
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
+import { generatePrismaClient } from 'src/lib/generatePrismaClient'
 
 export const command = 'build [side..]'
 export const description = 'Build for production'

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -6,9 +6,9 @@ import terminalLink from 'terminal-link'
 
 import { getConfig, shutdownPort } from '@redwoodjs/internal'
 
-import { generatePrismaClient } from 'src/commands/prisma/generate'
 import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
+import { generatePrismaClient } from 'src/lib/generatePrismaClient'
 
 export const command = 'dev [side..]'
 export const description = 'Start development servers for api, db, and web'
@@ -44,7 +44,6 @@ export const handler = async ({ side = ['api', 'web'], forward = '' }) => {
 
   if (side.includes('api')) {
     try {
-      // This command will check if the api side has a `prisma.schema` file.
       await generatePrismaClient({
         verbose: false,
         force: false,

--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
+import path from 'path'
 
 import execa from 'execa'
-import terminalLink from 'terminal-link'
 
 import { getPaths } from '@redwoodjs/internal'
 
@@ -10,84 +10,57 @@ import c from 'src/lib/colors'
 export const command = 'prisma [...commands]'
 export const description = 'Run Prisma CLI with experimental features'
 
+/**
+ * This is a lightweight wrapper around Prisma's CLI.
+ *
+ * In order to test this command you can do the following:
+ * 0. cd __fixtures__/example-todo-main && yarn install
+ * 1. cd..; yarn build:watch
+ * 2. cd packages/cli
+ * 3. __REDWOOD__CONFIG_PATH=../../__fixtures__/example-todo-main yarn node dist/index.js prisma <test commands>
+ */
 export const builder = (yargs) => {
   const argv = process.argv.slice(3)
+
+  // We dynamically create the `--options` that are passed to this command.
+  // TODO: Figure out if there's a way to turn off yargs parsing.
+  const options = argv
+    .filter((x) => x.startsWith('--'))
+    .map((x) => x.substr(2))
+    .reduce((pv, cv) => {
+      return {
+        ...pv,
+        [cv]: {},
+      }
+    }, {})
+  yargs.help(false).option(options)
+
   const paths = getPaths()
 
-  // descriptions below generate list when `rw prisma --help` is run
-  yargs
-    .example("'yarn rw prisma migrate dev'", 'No additional options required')
-    .positional('db push', {
-      alias: 'push',
-      description:
-        'Push the state from your Prisma schema to your database without creating a migration',
-    })
-    .positional('db seed', {
-      description: "Seed your database. Requires a 'seed.js' file",
-    })
-    .positional('migrate dev', {
-      description:
-        'Create a migration from schema.prisma; apply it to the dev database',
-    })
-    .positional('migrate reset', {
-      description:
-        'Reset your database and apply all migrations, all data will be lost',
-    })
-    .positional('migrate resolve', {
-      description:
-        'Resolve issues with database migrations in deployment databases',
-    })
-    .positional('migrate status', {
-      description: 'Check the status of your database migrations',
-    })
-    .positional('studio', {
-      description: 'Browse your data with Prisma Studio',
-    })
-    .epilogue(
-      `For more commands, options, and examples, see ${terminalLink(
-        'Redwood CLI Reference',
-        'https://redwoodjs.com/docs/cli-commands#prisma'
-      )}`
-    )
-
-  // TO DO: let's find a better way, shall we?
   let autoFlags = []
   if (['migrate', 'db'].includes(argv[0])) {
     // this is safe as is if a user also adds --preview-feature
     // TO DO might be nice to message user in case of ^^
     autoFlags.push('--preview-feature')
   }
-  if (argv.includes('dev')) {
-    autoFlags.push('--name', 'migration')
-  }
-  if (argv.includes('--create-only')) {
-    autoFlags.push('--create-only')
-  }
+
   if (['generate', 'introspect', 'db', 'migrate', 'studio'].includes(argv[0])) {
-    if (argv.some((x) => x.includes('--schema'))) {
-      console.log(
-        c.error("The 'redwood prisma' command does not accept '--schema'.")
-      )
-      console.log("Manage the Schema path in 'redwood.toml' instead. \n")
-      console.log(
-        "If you know what you're doing and need '--schema', use the native 'yarn prisma' command.\n"
-      )
-      process.exit(1)
-    } else {
-      autoFlags.push('--schema', paths.api.dbSchema)
-    }
-
     if (!fs.existsSync(paths.api.dbSchema)) {
-      console.log(c.error('\n Cannot run command. No Prisma Schema found.\n'))
+      console.error(c.error('\n Cannot run command. No Prisma Schema found.\n'))
       process.exit(1)
     }
+    autoFlags.push('--schema', paths.api.dbSchema)
   }
 
-  execa('yarn prisma', [...argv, ...autoFlags], {
-    shell: true,
-    stdio: 'inherit',
-    cwd: paths.api.base,
-    extendEnv: true,
-    cleanup: true,
-  })
+  execa(
+    path.join(paths.base, 'node_modules/.bin/prisma'),
+    [...argv.filter((x) => ['--help'].includes(x)), ...autoFlags],
+    {
+      shell: true,
+      stdio: 'inherit',
+      cwd: paths.api.base,
+      extendEnv: true,
+      cleanup: true,
+    }
+  )
 }

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -5,6 +5,9 @@ import path from 'path'
 
 import { runCommandTask, getPaths } from 'src/lib'
 
+/**
+ * Conditionally generate the prisma client, skip if it already exists.
+ */
 export const generatePrismaClient = async ({
   verbose = true,
   force = true,


### PR DESCRIPTION
- [x] Make the `help`, blank and `--help` command work. Typing `yarn rw prisma`/ `yarn rw prisma unknown` / `yarn rw prisma --help` will now display the following (Note: This is the older CLI.)

```bash
◭  Prisma is a modern DB toolkit to query, migrate and model your database (https://prisma.io)

Usage

  $ prisma [command]

Commands

            init   Setup Prisma for your app
      introspect   Get the datamodel of your database
        generate   Generate artifacts (e.g. Prisma Client)
          format   Formats your schema

Flags

  --experimental   Show and run experimental Prisma commands

Examples

  Setup a new Prisma project
  $ prisma init

  Introspect an existing database
  $ prisma introspect

  Generate artifacts (e.g. Prisma Client)
  $ prisma generate
```
- [x] Skip yargs validation of flags and instead forward them to prisma's CLI. This means that users can use `--name`, `--schema`, and `--preview-feature` without breaking our alias.

Closes #1749