### PR TITLE
[v0.25] - Prisma migrate dev now handles schema path with spaces

### DIFF
--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -74,7 +74,7 @@ export const builder = (yargs) => {
       )
       process.exit(1)
     } else {
-      autoFlags.push('--schema', paths.api.dbSchema)
+      autoFlags.push('--schema', `"${paths.api.dbSchema}"`)
     }
 
     if (!fs.existsSync(paths.api.dbSchema)) {


### PR DESCRIPTION
Addresses https://github.com/redwoodjs/redwood/issues/1749

Ran

`yarn rw prisma migrate dev --create-only`

Because my path has spaces and parentheses in it on OSX, I get and error seen before with storybook and other commands where the path isn't surrounded by quotes, etc.

```
$ '/Users/dthyresson/some path (with parens)/projects/redwoodjs/some_app/node_modules/.bin/rw' prisma migrate dev --create-only
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `yarn prisma migrate dev --create-only --preview-feature --name migration --create-only --schema /Users/dthyresson/some path (with parens)/projects/redwoodjs/some_app/api/db/schema.prisma'

...

Unknown arguments: create-only, createOnly, dev
error Command failed with exit code 1.

```

Modified

```
      autoFlags.push('--schema', `"${paths.api.dbSchema}"`)
```

so that uses quotes for schema path.

Now:

```
yarn rw prisma migrate dev --create-only

...

warn @prisma/cli has been renamed to prisma.
Please uninstall @prisma/cli: yarn remove @prisma/cli
And install prisma: yarn add prisma
Prisma schema loaded from db/schema.prisma
Datasource "DS": PostgreSQL database "redwood-app-dev", schema "public" at "localhost:undefined"

✔ Drift detected: Your database schema is not in sync with your migration history.

We need to reset the PostgreSQL database "redwood-app-dev" at "localhost:undefined".
Do you want to continue? All data will be lost. … no
```