### PR TITLE
Fix rw prisma alias bugs

### DIFF
--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -7,7 +7,7 @@ import { getPaths } from '@redwoodjs/internal'
 
 import c from 'src/lib/colors'
 
-export const command = 'prisma [...commands]'
+export const command = 'prisma [commands..]'
 export const description = 'Run Prisma CLI with experimental features'
 
 /**

--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -52,15 +52,12 @@ export const builder = (yargs) => {
     autoFlags.push('--schema', `"${paths.api.dbSchema}"`)
   }
 
-  execa(
-    path.join(paths.base, 'node_modules/.bin/prisma'),
-    [...argv.filter((x) => ['--help'].includes(x)), ...autoFlags],
-    {
-      shell: true,
-      stdio: 'inherit',
-      cwd: paths.api.base,
-      extendEnv: true,
-      cleanup: true,
-    }
-  )
+  const args = [...argv.filter((x) => !['--help'].includes(x)), ...autoFlags]
+  execa(path.join(paths.base, 'node_modules/.bin/prisma'), args, {
+    shell: true,
+    stdio: 'inherit',
+    cwd: paths.api.base,
+    extendEnv: true,
+    cleanup: true,
+  })
 }


### PR DESCRIPTION
Two fixes. 

I wrote the format of the yargs command incorrectly and I was filtering out the wrong things in the args.