### PR TITLE
Fixes `prisma` command when path has spaces

### DIFF
--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -53,7 +53,7 @@ export const builder = (yargs) => {
   }
 
   const args = [...argv.filter((x) => !['--help'].includes(x)), ...autoFlags]
-  execa(path.join(paths.base, 'node_modules/.bin/prisma'), args, {
+  execa(`"${path.join(paths.base, 'node_modules/.bin/prisma')}"`, args, {
     shell: true,
     stdio: 'inherit',
     cwd: paths.api.base,


### PR DESCRIPTION
While a prior PR fixed the case when the Prisma schema path has spaces or parentheses, this PR fixes the case where prisma itself exists in a path with spaces.
