### PR TITLE
use prisma db push for test DB

### DIFF
--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -100,7 +100,7 @@ export const handler = async ({
 
     // Create a test database
     if (sides.includes('api')) {
-      await execa.command(`yarn rw prisma migrate dev`, {
+      await execa.command(`yarn rw prisma db push --force`, {
         stdio: 'inherit',
         shell: true,
         env: { DATABASE_URL },


### PR DESCRIPTION
Required for back-to-back runs of `rw test`. Otherwise would prompt for migrations and/or being out of sync.