### PR TITLE
fix`rw prisma [command] --help` console output

### DIFF
--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -56,7 +56,13 @@ export const builder = (yargs) => {
     autoFlags.push('--schema', `"${paths.api.dbSchema}"`)
   }
 
-  const args = [...argv.filter((x) => !['--help'].includes(x)), ...autoFlags]
+  const args = argv.some((x) => x.includes('help'))
+    ? [
+        ...argv.filter((x) => !['--help'].includes(x) && !['help'].includes(x)),
+        '--help',
+      ]
+    : [...argv, ...autoFlags]
+
   execa(`"${path.join(paths.base, 'node_modules/.bin/prisma')}"`, args, {
     shell: true,
     stdio: 'inherit',


### PR DESCRIPTION
This fix enables `rw prisma [command] --help` to run `yarn prisma [command] --help`. Previously the `--help` flag was being removed from the args.

Will accept either `help` or `--help`, which is the same behavior as all the other RW Yargs commands.