### PR TITLE
Run rw without 'yarn run'

### DIFF
--- a/packages/create-redwood-app/template/.shadowenv.d/rw.lisp
+++ b/packages/create-redwood-app/template/.shadowenv.d/rw.lisp
@@ -1,0 +1,1 @@
+(env/prepend-to-pathlist "PATH" (expand-path "./node_modules/.bin/"))


### PR DESCRIPTION
It's a subtle thing, and perhaps subjective, but I would love to be able to run `rw` without having to prefix it with `yarn run`. To do so, I'm proposing to use, [shadowenv](https://github.com/Shopify/shadowenv), a tool that allows defining environment changes that are tied to projects. That allows exposing the `node_module/.bin` directory at the root of the project where the `rw` executable lives, and thus being able to run all the commands without `yarn run`.

This improvement also brings some safety because it prevents people from running a global Redwood version that might be different from the one the project is pinned to. 
