### PR TITLE
"pisma" is probably "prisma"

### DIFF
--- a/packages/structure/src/model/RWEnvHelper.ts
+++ b/packages/structure/src/model/RWEnvHelper.ts
@@ -56,7 +56,7 @@ export class RWEnvHelper extends BaseNode {
     return this._dotenv('.env.defaults')
   }
 
-  @lazy() get api_pisma_env() {
+  @lazy() get api_prisma_env() {
     return this._dotenv('api/prisma/.env')
   }
 


### PR DESCRIPTION
"pisma" is probably "prisma"? :)

I don't know much about the structure package and am not aware whether the code is being used anywhere else.
At least grep'ing the RW source says no.