### PR TITLE
dataMigrate install uses prisma migrate command

### DIFF
--- a/packages/cli/src/commands/dataMigrate/install.js
+++ b/packages/cli/src/commands/dataMigrate/install.js
@@ -43,7 +43,7 @@ const appendModel = () => {
 const save = async () => {
   return await execa(
     'yarn rw',
-    ['prisma migrate dev', '--create-only', '--name=create_data_migrations'],
+    ['prisma migrate dev', '--name create_data_migrations', '--create-only'],
     {
       cwd: getPaths().base,
       shell: true,

--- a/packages/cli/src/commands/dataMigrate/install.js
+++ b/packages/cli/src/commands/dataMigrate/install.js
@@ -19,7 +19,7 @@ const POST_INSTALL_INSTRUCTIONS = `${c.warning(
   "Don't forget to apply your migration when ready:"
 )}
 
-    yarn rw dataMigrate up
+    yarn rw prisma migrate dev
 `
 
 // Creates dataMigrations directory
@@ -41,10 +41,14 @@ const appendModel = () => {
 
 // Create a new migration
 const save = async () => {
-  return await execa('yarn rw', ['db save', 'create data migrations'], {
-    cwd: getPaths().base,
-    shell: true,
-  })
+  return await execa(
+    'yarn rw',
+    ['prisma migrate dev --create-only', '--name=create_data_migrations'],
+    {
+      cwd: getPaths().base,
+      shell: true,
+    }
+  )
 }
 
 export const command = 'install'
@@ -53,7 +57,7 @@ export const builder = (yargs) => {
   yargs.epilogue(
     `Also see the ${terminalLink(
       'Redwood CLI Reference',
-      'https://redwoodjs.com/reference/command-line-interface#datMigrate-install'
+      'https://redwoodjs.com/docs/cli-commands#install'
     )}`
   )
 }

--- a/packages/cli/src/commands/dataMigrate/install.js
+++ b/packages/cli/src/commands/dataMigrate/install.js
@@ -43,10 +43,11 @@ const appendModel = () => {
 const save = async () => {
   return await execa(
     'yarn rw',
-    ['prisma migrate dev --create-only', '--name=create_data_migrations'],
+    ['prisma migrate dev', '--create-only', '--name=create_data_migrations'],
     {
       cwd: getPaths().base,
       shell: true,
+      stdio: 'inherit',
     }
   )
 }
@@ -91,5 +92,6 @@ export const handler = async () => {
     await tasks.run()
   } catch (e) {
     console.log(c.error(e.message))
+    process.exit(e?.exitCode || 1)
   }
 }

--- a/packages/cli/src/commands/dataMigrate/install.js
+++ b/packages/cli/src/commands/dataMigrate/install.js
@@ -19,7 +19,7 @@ const POST_INSTALL_INSTRUCTIONS = `${c.warning(
   "Don't forget to apply your migration when ready:"
 )}
 
-    yarn rw prisma migrate dev
+    ${c.bold('yarn rw prisma migrate dev')}
 `
 
 // Creates dataMigrations directory

--- a/packages/cli/src/commands/dataMigrate/up.js
+++ b/packages/cli/src/commands/dataMigrate/up.js
@@ -102,7 +102,7 @@ export const builder = (yargs) => {
   yargs.epilogue(
     `Also see the ${terminalLink(
       'Redwood CLI Reference',
-      'https://redwoodjs.com/reference/command-line-interface#datMigrate-up'
+      'https://redwoodjs.com/docs/cli-commands#up'
     )}`
   )
 }


### PR DESCRIPTION
The legacy dataMigrate install invoked `yarn rw db save` which is deprecated and not longer works.

This PR changes the command to use:

`yarn rw prisma migrate dev --create-only` and passes the migration name as `--name=create_data_migrations`.

Note that I have tested that `yarn prisma migrate dev --create-only --name=create_data_migrations --preview-feature --schema "...api/db/schema.prisma"` works as expected, so I know can pass the migration name this way.

Unfortunately due to other prisma output issues (? https://github.com/redwoodjs/redwood/issues/1786 ?) when running the command in the current `0.25.1-canary.2` release with this PR applied:

`yarn rw dataMigrate install`

I get the error:

```
✔ Creating dataMigrations directory...
  ✔ Adding RW_DataMigration model to schema.prisma...
  ✖ Create db migration...
    → info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this comm
…
    One more thing...
Command failed with exit code 1: yarn rw prisma migrate dev --create-only --name=create_data_migrations
......
      else throw err
           ^

TypeError: innerYargs._parseArgs is not a function
```

This PR also updates the url to link to the install command on the docs site.

