### PR TITLE
Hotfix: Use inherit to allow interactivity in yarn rw prisma

### DIFF
--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -75,7 +75,7 @@ export const builder = async (yargs: Argv) => {
   const args = Array.from(new Set([...argv, ...autoFlags]))
 
   console.log(
-    c.green(`Running prisma cli: \n`) +
+    c.green(`Running Prisma CLI: \n`) +
       c.info(`yarn prisma ${args.join(' ')} \n`)
   )
 
@@ -95,6 +95,7 @@ export const builder = async (yargs: Argv) => {
     prismaCommand.stderr?.pipe(process.stderr)
 
     // So we can check for yarn prisma in the output
+    // e.g. yarn prisma introspect
     const { stdout } = await prismaCommand
 
     if (hasHelpFlag || stdout?.match('yarn prisma')) {

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -75,8 +75,7 @@ export const builder = async (yargs: Argv) => {
   const args = Array.from(new Set([...argv, ...autoFlags]))
 
   console.log(
-    c.green(`Running Prisma CLI: \n`) +
-      c.info(`yarn prisma ${args.join(' ')} \n`)
+    c.green(`\nRunning Prisma CLI:\n`) + `yarn prisma ${args.join(' ')} \n`
   )
 
   try {

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -88,10 +88,7 @@ export const builder = async (yargs: Argv) => {
         cwd: paths.api.base,
         extendEnv: true,
         cleanup: true,
-        // Maintain colour formatting
-        env: {
-          FORCE_COLOR: '1',
-        },
+        stdio: 'inherit',
       }
     )
     prismaCommand.stdout?.pipe(process.stdout)
@@ -100,16 +97,11 @@ export const builder = async (yargs: Argv) => {
     // So we can check for yarn prisma in the output
     const { stdout } = await prismaCommand
 
-    // Show prisma cli output
-    // console.log(stdout)
-
-    if (hasHelpFlag || stdout.match('yarn prisma')) {
+    if (hasHelpFlag || stdout?.match('yarn prisma')) {
       printRwWrapperInfo()
     }
   } catch (e) {
-    // Prisma cli shows help on error
-    printRwWrapperInfo()
-    process.exit(1)
+    process.exit(e?.exitCode || 1)
   }
 }
 
@@ -136,7 +128,7 @@ const printRwWrapperInfo = () => {
     boxen(message, {
       padding: { top: 0, bottom: 0, right: 1, left: 1 },
       margin: 1,
-      borderStyle: 'single',
+      borderColor: 'gray',
     })
   )
 }


### PR DESCRIPTION
Fixes #1786
**1. Allows interactivity when using commands like `yarn rw prisma migrate reset`**
![Tape Preview](https://tapes.tape.sh/ckc39nw2y00040ul093cmxprp/ThermosettingGelatinRedbirdCoiffeuse.gif)

**2. Only show tip in help, or if prisma has yarn prisma in its output**
The downside:  if you run the wrong command, redwood tip won't show.
The upside: fail fast, and removes confusion where the tip isn't relevant, if you're running `yarn rw prisma migrate dev` and it fails, it won't show the tip (where its not relevant anyway)