### PR TITLE
Add new setup command for a11y

### DIFF
--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -1,5 +1,5 @@
-import Listr from 'listr'
 import execa from 'execa'
+import Listr from 'listr'
 
 export const command = 'a11y'
 export const description = 'Build accessible websites with this a11y setup'

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 
 import execa from 'execa'
 import Listr from 'listr'
@@ -21,8 +22,7 @@ export const handler = async () => {
   const tasks = new Listr([
     installPackages,
     configureAxeCoreReact,
-    // maybe...
-    // configureJestAxe
+    configureJestAxe,
   ])
 
   try {
@@ -45,8 +45,7 @@ const installPackages = {
       'add',
       '-D',
       '@axe-core/react',
-      // maybe...
-      // 'jest-axe',
+      'jest-axe',
     ])
   },
 }
@@ -101,24 +100,34 @@ const configureAxeCoreReact = {
 // jest-axe
 //------------------------
 
-// not sure what we need to do for this one yet.
-//
-// const configureJestAxe = {
-//   title 'Configuring Jest Axe',
-//   tasks: () => {}
-// }
-//
-// it'd probably be setting up this test:
-//
-//   const React = require('react')
-//   const { render } =  require('react-dom')
-//   const App = require('./app')
-//
-//   const { axe, toHaveNoViolations } = require('jest-axe')
-//   expect.extend(toHaveNoViolations)
-//
-//   it('should demonstrate this matcher`s usage with react', async () => {
-//     render(<App/>, document.body)
-//     const results = await axe(document.body)
-//     expect(results).toHaveNoViolations()
-//   })
+// store as template file...
+const jestAxeConfig = [
+  "import { render } from '@redwoodjs/testing'",
+  '',
+  "import App from './App'",
+  '',
+  "import { axe, toHaveNoViolations } from 'jest-axe'",
+  '',
+  'expect.extend(toHaveNoViolations)',
+  "describe('App', () => {",
+  "  it('should not have any a11y violations', async () => {",
+  '    const { container } = render(<App />)',
+  '    const results = await axe(container)',
+  '    expect(results).toHaveNoViolations()',
+  '  })',
+  '})',
+  '\n',
+]
+
+const WEB_PATH = getPaths().web.src
+
+const configureJestAxe = {
+  title: 'Configuring jest-axe',
+  task: () => {
+    // make file App.test.ts
+    fs.writeFileSync(
+      path.join(WEB_PATH, 'App.test.js'),
+      jestAxeConfig.join('\n')
+    )
+  },
+}

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -75,8 +75,7 @@ const axeCoreReactConfig = [
   '// for more information, see: https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react',
   '//',
   "if (process.env.NODE_ENV === 'development') {",
-  "  const axe = require('@axe-core/react')",
-  '  axe(React, ReactDOM, 1000)',
+  "  import('@axe-core/react').then((axe) => axe.default(React, ReactDOM, 1000))",
   '}',
   '// END --- yarn rw setup a11y\n',
 ]

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -1,6 +1,8 @@
 import execa from 'execa'
 import Listr from 'listr'
 
+import c from 'src/lib/colors'
+
 export const command = 'a11y'
 export const description = 'Build accessible websites with this a11y setup'
 export const builder = (yargs) => {
@@ -12,7 +14,7 @@ export const builder = (yargs) => {
   })
 }
 
-export const handler = async ({ force }) => {
+export const handler = async () => {
   const tasks = new Listr([
     {
       title: 'Installing packages...',

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -16,17 +16,11 @@ export const builder = (yargs) => {
 
 export const handler = async () => {
   const tasks = new Listr([
-    {
-      title: 'Installing packages...',
-      task: async () => {
-        await execa('yarn', [
-          'workspace',
-          'web',
-          'add',
-          'eslint-plugin-jsx-a11y',
-        ])
-      },
-    },
+    installPackages,
+    configureESLintPluginJSXA11yTask,
+    configureAxeCoreReact,
+    configureStorybookAddonA11y,
+    // configureJestAxe
   ])
 
   try {
@@ -35,3 +29,63 @@ export const handler = async () => {
     console.log(c.error(e.message))
   }
 }
+
+//------------------------
+// tasks
+//------------------------
+
+const installPackages = {
+  title: 'Installing packages...',
+  task: async () => {
+    await execa('yarn', [
+      'workspace',
+      'web',
+      'add',
+      'eslint-plugin-jsx-a11y',
+      '@axe-core/react',
+      '@storybook/addon-a11y',
+      'jest-axe',
+    ])
+  },
+}
+
+const configureESLintPluginJSXA11yTask = {
+  title: 'Configuring eslint-plugin-jsx-a11y...',
+  task: () => {
+    // in web/package.json
+    // or web/.eslintrc.js
+    // or...
+  },
+}
+
+const configureAxeCoreReact = {
+  title: 'Configuring @axe-core/react...',
+  task: () => {
+    // somewhere in in web/index.js...
+    // const React = require('react');
+    // const ReactDOM = require('react-dom');
+    //
+    // if (process.env.NODE_ENV === 'development') {
+    //   const axe = require('@axe-core/react');
+    //   axe(React, ReactDOM, 1000);
+    // }
+  },
+}
+
+const configureStorybookAddonA11y = {
+  title: 'Configuring @storybook/addon-a11y...',
+  task: () => {
+    // add to main.js, in storybook config directory
+    //
+    // module.exports = {
+    //   addons: ['@storybook/addon-a11y'],
+    // };
+  },
+}
+
+// Not sure what we need to do yet.
+//
+// const configureJestAxe = {
+//   title 'Configuring Jest Axe',
+//   tasks: () => {}
+// }

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -8,7 +8,7 @@ import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 
 export const command = 'a11y'
-export const description = 'Build accessible websites with this a11y setup'
+export const description = 'Setup tooling for building accessible websites'
 export const builder = (yargs) => {
   yargs.option('force', {
     alias: 'f',

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -99,8 +99,9 @@ const configureAxeCoreReact = {
 //------------------------
 // jest-axe
 //------------------------
+//
+// TODO(dom): use writeFileTask instead; take overwrite, js/ts options
 
-// store as template file...
 const jestAxeConfig = [
   "import { render } from '@redwoodjs/testing'",
   '',
@@ -119,14 +120,13 @@ const jestAxeConfig = [
   '\n',
 ]
 
-const WEB_PATH = getPaths().web.src
+const WEB_SRC_PATH = getPaths().web.src
 
 const configureJestAxe = {
   title: 'Configuring jest-axe',
   task: () => {
-    // make file App.test.ts
     fs.writeFileSync(
-      path.join(WEB_PATH, 'App.test.js'),
+      path.join(WEB_SRC_PATH, 'App.test.js'),
       jestAxeConfig.join('\n')
     )
   },

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -61,7 +61,8 @@ const configureESLintPluginJSXA11yTask = {
 const configureAxeCoreReact = {
   title: 'Configuring @axe-core/react...',
   task: () => {
-    // somewhere in in web/index.js...
+    // somewhere, in web/index.js...
+    //
     // const React = require('react');
     // const ReactDOM = require('react-dom');
     //
@@ -75,7 +76,7 @@ const configureAxeCoreReact = {
 const configureStorybookAddonA11y = {
   title: 'Configuring @storybook/addon-a11y...',
   task: () => {
-    // add to main.js, in storybook config directory
+    // add this to main.js (in the storybook config directory):
     //
     // module.exports = {
     //   addons: ['@storybook/addon-a11y'],
@@ -83,9 +84,24 @@ const configureStorybookAddonA11y = {
   },
 }
 
-// Not sure what we need to do yet.
+// not sure what we need to do for this one yet.
 //
 // const configureJestAxe = {
 //   title 'Configuring Jest Axe',
 //   tasks: () => {}
 // }
+//
+// It'd probably be setting up this test:
+//
+// const React = require('react')
+// const { render } =  require('react-dom')
+// const App = require('./app')
+
+// const { axe, toHaveNoViolations } = require('jest-axe')
+// expect.extend(toHaveNoViolations)
+
+// it('should demonstrate this matcher`s usage with react', async () => {
+//   render(<App/>, document.body)
+//   const results = await axe(document.body)
+//   expect(results).toHaveNoViolations()
+// })

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -21,9 +21,8 @@ export const builder = (yargs) => {
 export const handler = async () => {
   const tasks = new Listr([
     installPackages,
-    // configureESLintPluginJSXA11yTask,
-    // configureAxeCoreReact,
-    // configureStorybookAddonA11y,
+    configureAxeCoreReact,
+    // maybe...
     // configureJestAxe
   ])
 
@@ -34,9 +33,9 @@ export const handler = async () => {
   }
 }
 
-//------------------------
+//------------------------------------------------
 // tasks
-//------------------------
+//------------------------------------------------
 
 const installPackages = {
   title: 'Installing packages...',
@@ -45,29 +44,11 @@ const installPackages = {
       'workspace',
       'web',
       'add',
-      'eslint-plugin-jsx-a11y',
       '@axe-core/react',
-      '@storybook/addon-a11y',
-      'jest-axe',
+      // maybe...
+      // 'jest-axe',
     ])
   },
-}
-
-//------------------------
-// eslint-plugin-jsx-a11y
-//------------------------
-//
-// in `web/package.json`, or in `web/.eslintrc.js`, (or in...)
-// we need to add, at least:
-//
-// "plugins": "jsx-a11y"
-// "extends": "plugins:jsx-a11y/recommended"
-//
-// and that's just for the MVP (i.e. this doesn't set all the rules to warn).
-
-const configureESLintPluginJSXA11yTask = {
-  title: 'Configuring eslint-plugin-jsx-a11y...',
-  task: () => {},
 }
 
 //------------------------
@@ -76,15 +57,28 @@ const configureESLintPluginJSXA11yTask = {
 //
 // we need to add this to `web/src/index.js`:
 //
-// const React = require('react');
-// const ReactDOM = require('react-dom');
+//   const React = require('react');
+//   const ReactDOM = require('react-dom');
 //
-// if (process.env.NODE_ENV === 'development') {
-//   const axe = require('@axe-core/react');
-//   axe(React, ReactDOM, 1000);
-// }
+//   if (process.env.NODE_ENV === 'development') {
+//     const axe = require('@axe-core/react');
+//     axe(React, ReactDOM, 1000);
+//   }
 //
 // this is what a vanilla `web/src/index.js` looks like: https://github.com/redwoodjs/redwood/blob/main/packages/create-redwood-app/template/web/src/index.js
+
+const WEB_INDEX_PATH = path.join(getPaths().web.src, 'index.js')
+
+const axeCoreReactConfig = [
+  // add comments, before and after (like the tailwind setup command)?
+  //
+  '\n',
+  "if (process.env.NODE_ENV === 'development') {",
+  "  const axe = require('@axe-core/react')",
+  '  axe(React, ReactDOM, 1000)',
+  '}',
+  '\n',
+]
 
 const configureAxeCoreReact = {
   title: 'Configuring @axe-core/react...',
@@ -93,35 +87,6 @@ const configureAxeCoreReact = {
     const webIndexWithAxeCoreReact = webIndex + axeCoreReactConfig.join('\n')
     fs.writeFileSync(WEB_INDEX_PATH, webIndexWithAxeCoreReact)
   },
-}
-
-const WEB_INDEX_PATH = path.join(getPaths().web.src, 'index.js')
-
-const axeCoreReactConfig = [
-  // add comments, before and after. like the tailwind setup command.
-  //
-  '\n',
-  // React might just be available?
-  "const React = require('react')",
-  "if (process.env.NODE_ENV === 'development') {",
-  "  const axe = require('@axe-core/react')",
-  '  axe(React, ReactDOM, 1000)',
-  '}',
-  '\n',
-]
-
-//------------------------
-// @storybook/addon-a11y
-//------------------------
-// add this to `main.js` (in the storybook config directory):
-//
-// module.exports = {
-//   addons: ['@storybook/addon-a11y'],
-// };
-
-const configureStorybookAddonA11y = {
-  title: 'Configuring @storybook/addon-a11y...',
-  task: () => {},
 }
 
 //------------------------
@@ -137,15 +102,15 @@ const configureStorybookAddonA11y = {
 //
 // it'd probably be setting up this test:
 //
-// const React = require('react')
-// const { render } =  require('react-dom')
-// const App = require('./app')
-
-// const { axe, toHaveNoViolations } = require('jest-axe')
-// expect.extend(toHaveNoViolations)
-
-// it('should demonstrate this matcher`s usage with react', async () => {
-//   render(<App/>, document.body)
-//   const results = await axe(document.body)
-//   expect(results).toHaveNoViolations()
-// })
+//   const React = require('react')
+//   const { render } =  require('react-dom')
+//   const App = require('./app')
+//
+//   const { axe, toHaveNoViolations } = require('jest-axe')
+//   expect.extend(toHaveNoViolations)
+//
+//   it('should demonstrate this matcher`s usage with react', async () => {
+//     render(<App/>, document.body)
+//     const results = await axe(document.body)
+//     expect(results).toHaveNoViolations()
+//   })

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -1,5 +1,4 @@
 import fs from 'fs'
-import path from 'path'
 
 import execa from 'execa'
 import Listr from 'listr'
@@ -67,22 +66,31 @@ const installPackages = {
 //
 // this is what a vanilla `web/src/index.js` looks like: https://github.com/redwoodjs/redwood/blob/main/packages/create-redwood-app/template/web/src/index.js
 
-const WEB_INDEX_PATH = path.join(getPaths().web.src, 'index.js')
-
 const axeCoreReactConfig = [
   // add comments, before and after (like the tailwind setup command)?
   //
-  '\n',
+  '\n// START --- yarn rw setup a11y',
+  '//',
+  '// `yarn rw setup a11y` placed this code here',
+  '// for more information, see: https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react',
+  '//',
   "if (process.env.NODE_ENV === 'development') {",
   "  const axe = require('@axe-core/react')",
   '  axe(React, ReactDOM, 1000)',
   '}',
-  '\n',
+  '// END --- yarn rw setup a11y\n',
 ]
 
 const configureAxeCoreReact = {
   title: 'Configuring @axe-core/react...',
-  task: () => {
+  task: async () => {
+    let WEB_INDEX_PATH = getPaths().web.index
+
+    if (!fs.existsSync(WEB_INDEX_PATH)) {
+      await execa('yarn', ['rw', 'setup', 'custom-web-index'])
+      WEB_INDEX_PATH = getPaths().web.index
+    }
+
     const webIndex = fs.readFileSync(WEB_INDEX_PATH)
     const webIndexWithAxeCoreReact = webIndex + axeCoreReactConfig.join('\n')
     fs.writeFileSync(WEB_INDEX_PATH, webIndexWithAxeCoreReact)

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -43,6 +43,7 @@ const installPackages = {
       'workspace',
       'web',
       'add',
+      '-D',
       '@axe-core/react',
       // maybe...
       // 'jest-axe',

--- a/packages/cli/src/commands/setup/a11y/a11y.js
+++ b/packages/cli/src/commands/setup/a11y/a11y.js
@@ -1,0 +1,35 @@
+import Listr from 'listr'
+import execa from 'execa'
+
+export const command = 'a11y'
+export const description = 'Build accessible websites with this a11y setup'
+export const builder = (yargs) => {
+  yargs.option('force', {
+    alias: 'f',
+    default: false,
+    description: 'Overwrite existing configuration',
+    type: 'boolean',
+  })
+}
+
+export const handler = async ({ force }) => {
+  const tasks = new Listr([
+    {
+      title: 'Installing packages...',
+      task: async () => {
+        await execa('yarn', [
+          'workspace',
+          'web',
+          'add',
+          'eslint-plugin-jsx-a11y',
+        ])
+      },
+    },
+  ])
+
+  try {
+    await tasks.run()
+  } catch (e) {
+    console.log(c.error(e.message))
+  }
+}

--- a/packages/cli/src/commands/setup/a11y/templates/App.test.tsx.template
+++ b/packages/cli/src/commands/setup/a11y/templates/App.test.tsx.template
@@ -1,0 +1,15 @@
+import { render } from '@redwoodjs/testing'
+
+import App from './App'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
+expect.extend(toHaveNoViolations)
+
+describe('App', () => {
+  it('should not have any a11y violations', async () => {
+    const { container } = render(<App />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
Since a lot of this is moving into core, what this'll actually setup is [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react) and maybe [jest-axe](https://github.com/nickcolley/jest-axe). It could still do a lot more, it just wont' do most of what's below anymore; that's what #1849 is for.

- [ ] docs?

---

This PR adds a new setup command, `a11y`, that equips a Redwood project with accessibility tooling like [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y). To start, the only thing it'll setup is eslint-plugin-jsx-a11y, a "static AST checker for a11y rules on JSX elements", but there's plenty room for more.

We want to make it easy to make accessible websites with Redwood. While the majority of that work will be done in the router, just because we manage focus/announcements/scroll doesn't mean your website's accessible&mdash;the modals, listboxes, switches, and pretty much anything interactive need to be as well, especially if they're built from scratch with React.

Since we don't want to constrain anyone to a particular UI library we know to be accessible (though we'll certainly recommend one), we need to make sure we provide the tooling you need to make making accessible websites more tractable. This setups up that tooling.

The prior art here is Gatsby https://www.gatsbyjs.com/docs/conceptual/making-your-site-accessible/#linting-with-eslint-plugin-jsx-a11y.

### Questions:

- [x] set rules to warn, or to error?
  - I think the answer to this one isn't too controversial: default to warn, but make it possible to opt into error, failing CI and such if they want to be rigorous
  - [gatsby sets them to warn](https://github.com/gatsbyjs/gatsby/blob/bfd8c8c41db5fea654a9b84c54bbf63db0ce3a54/packages/gatsby/src/utils/eslint-config.ts#L69-L158)
  - there could be a flag, `--set-to-error` or something, to setup the rules as errors from the get-go
- [x] should this just be in core? i.e., in the [@redwoodjs/eslint-config](https://github.com/redwoodjs/redwood/tree/main/packages/eslint-config) package?
  - if we set all the rules to warn (which will probably will), and we're sure it's configured correctly, I feel like the most we risk is it "being annoying"&mdash;i.e. a retort I can imagine is "I'm not ready to focus on making my website accessible yet and these warnings are just getting in the way" / "I wish I could turn them off". 
    - so is there a way to include them in core, but make something like a toml var to toggle them? 
  - if they're in core, they're harder to configure, but I can't imagine most people wanting to configure them
  - [ ] try it with a few of the most popular CSS libs, and see if anything unexpected happens. it'd be a big risk if it make a popular CSS lib unusable. the issues I'm thinking of here are:  
    - https://github.com/styled-components/styled-components/issues/2718 
    - https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/174
- [x] do all the eslint config in `web/.eslintrc.js`, `web/package.json`, or somewhere less visible?
  - the `@redwoodjs/eslint-config` preset's configured in the root `package.json`. but since this might not be a one-liner the way that one is, it might be better off in it's own file
- [x] include [@axe-core/react](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/react), [jest-axe](https://github.com/nickcolley/jest-axe), [@storybook/addon-a11y](https://github.com/storybookjs/storybook/tree/next/addons/a11y)?
  - might need this one if I'm not going to touch core https://github.com/redwoodjs/redwood/issues/989