### PR TITLE
Attempt to fix dm install duplicate console output

### DIFF
--- a/packages/cli/src/commands/dataMigrate/install.js
+++ b/packages/cli/src/commands/dataMigrate/install.js
@@ -47,7 +47,6 @@ const save = async () => {
     {
       cwd: getPaths().base,
       shell: true,
-      stdio: 'inherit',
     }
   )
 }


### PR DESCRIPTION
_continues https://github.com/redwoodjs/redwood/pull/1787_

In the v0.25 point release, we saw during `dataMigrate install` duplicated output like:

```
 ✔ Creating dataMigrations directory...
  ✔ Adding RW_DataMigration model to schema.prisma...
  ⠦ Create db migration...
    One more thing...
  ✔ Creating dataMigrations directory...
  ✔ Adding RW_DataMigration model to schema.prisma...
  ⠏ Create db migration...
  ✔ Creating dataMigrations directory...
  ✔ Adding RW_DataMigration model to schema.prisma...
  ⠸ Create db migration...
    One more thing...
Prisma schema loaded from db/schema.prisma
Datasource "DS": SQLite database "dev.db" at "file:./dev.db"
  ✔ Creating dataMigrations directory...
  ✔ Adding RW_DataMigration model to schema.prisma...
  ✔ Create db migration...
  ✔ Next steps:
    Don't forget to apply your migration when ready:
     yarn rw prisma migrate dev
```

This removes the `stdio: 'inherit',` from the `save()` which was added a few days ago to resolve some interactivity issues w/ the `prisma` command (but may have introduced this issue and is not needed).

Needs testing by @thedavidprice 