### PR TITLE
Add support to realtime/subscriptions with Apollo Subscriptions

### DIFF
--- a/packages/core/src/babelPlugins/babel-plugin-redwood-cell.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-cell.ts
@@ -12,8 +12,11 @@ import type { PluginObj, types } from '@babel/core'
 // A cell can export the declarations below.
 const EXPECTED_EXPORTS_FROM_CELL = [
   'beforeQuery',
+  'beforeSubscription',
   'QUERY',
+  'SUBSCRIPTION',
   'afterQuery',
+  'afterSubscription',
   'Loading',
   'Success',
   'Failure',
@@ -58,9 +61,13 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
       Program: {
         exit(path) {
           // Validate that this file has exports which are "cell-like":
-          // If the user is not exporting `QUERY` and has a default export then
+          // If the user is not exporting `QUERY` or `SUBSCRIPTION` and has a default export then
           // it's likely not a cell.
-          if (hasDefaultExport && !exportNames.includes('QUERY')) {
+          if (
+            hasDefaultExport &&
+            !exportNames.includes('QUERY') &&
+            !exportNames.includes('SUBSCRIPTION')
+          ) {
             return
           }
 

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -69,8 +69,8 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
 
   /**
    * https://github.com/apollographql/apollo-client/issues/3967
-   * {} cannot be returned from connectionParams in case
-   * there is no user authenticated
+   * Only include the connectionParams property if
+   * isAuthenticated (token available) is true
    */
   let wsLinkOptions
   if (isAuthenticated) {

--- a/packages/web/src/components/GraphQLHooksProvider.tsx
+++ b/packages/web/src/components/GraphQLHooksProvider.tsx
@@ -19,6 +19,11 @@ export interface GraphQLHooks {
     query: DocumentNode,
     options?: GraphQLHookOptions
   ) => OperationResult
+  useSubscription: (
+    subscription: DocumentNode,
+    options?: GraphQLHookOptions
+  ) => OperationResult
+
   useMutation: (
     mutation: DocumentNode,
     options?: GraphQLHookOptions
@@ -30,6 +35,11 @@ export const GraphQLHooksContext = React.createContext<GraphQLHooks>({
       'You must register a useQuery hook via the `GraphQLHooksProvider`'
     )
   },
+  useSubscription: () => {
+    throw new Error(
+      'You must register a useSubscription hook via the `GraphQLHooksProvider`'
+    )
+  },
   useMutation: () => {
     throw new Error(
       'You must register a useMutation hook via the `GraphQLHooksProvider`'
@@ -38,9 +48,9 @@ export const GraphQLHooksContext = React.createContext<GraphQLHooks>({
 })
 
 /**
- * GraphQLHooksProvider stores standard `useQuery` and `useMutation` hooks for Redwood
- * that can be mapped to your GraphQL library of choice's own `useQuery`
- * and `useMutation` implementation.
+ * GraphQLHooksProvider stores standard `useQuery`, `useSubscription` and `useMutation` hooks for Redwood
+ * that can be mapped to your GraphQL library of choice's own `useQuery`,
+ * `useSubscription` and `useMutation` implementation.
  *
  * @todo Let the user pass in the additional type for options.
  */
@@ -49,15 +59,20 @@ export const GraphQLHooksProvider: React.FunctionComponent<{
     query: DocumentNode,
     options?: GraphQLHookOptions
   ) => OperationResult
+  useSubscription: (
+    subscription: DocumentNode,
+    options?: GraphQLHookOptions
+  ) => OperationResult
   useMutation: (
     mutation: DocumentNode,
     options?: GraphQLHookOptions
   ) => MutationOperationResult
-}> = ({ useQuery, useMutation, children }) => {
+}> = ({ useQuery, useSubscription, useMutation, children }) => {
   return (
     <GraphQLHooksContext.Provider
       value={{
         useQuery,
+        useSubscription,
         useMutation,
       }}
     >
@@ -71,6 +86,13 @@ export function useQuery<TData = any>(
   options?: GraphQLHookOptions
 ): OperationResult<TData> {
   return React.useContext(GraphQLHooksContext).useQuery(query, options)
+}
+
+export function useSubscription<TData = any>(
+  subscription: DocumentNode,
+  options?: GraphQLHookOptions
+): OperationResult<TData> {
+  return React.useContext(GraphQLHooksContext).useSubscription(subscription, options)
 }
 
 export function useMutation<TData = any>(

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -9,6 +9,7 @@ export {
 export {
   GraphQLHooksProvider,
   useQuery,
+  useSubscription,
   useMutation,
 } from './components/GraphQLHooksProvider'
 


### PR DESCRIPTION
Hi everyone! I wanted to try out using subscriptions (natively with cells instead of using the apollo client directly) with Nhost and RedwoodJS and so here is a proposal for adding support to them. Prisma doesn't support subscriptions so one would have to use something else like Nhost and Hasura. 

This PR adds support for [apollo subscriptions](https://www.apollographql.com/docs/react/data/subscriptions/), through cells, by allowing for the export of the named constant `SUBSCRIPTION`, as well as `QUERY`. Depending on which one is exported, a subscription or a query is used.

[here](https://github.com/nhost-examples/nhost-redwoodjs-realtime) is the example app I used to test the PR. 

Missing bits:

- [ ] tests
- [ ] (to discuss) add a flag to `yarn rw g cell CellName` to export the name constant `SUBSCRIPTION` instead of the default `QUERY`.
- [ ] `subscriptions-transport-ws` has to be added manually to the redwood app (adding it to this repo's web package is not working) because of an issue with webpack 4 (solved on v5): https://github.com/webpack/webpack/issues/6191.

Looking forward to getting feedback from you.

<img width="898" alt="Screenshot 2021-02-16 at 22 41 02" src="https://user-images.githubusercontent.com/1523504/108135699-19869880-70a8-11eb-90d2-74e7a26bc71c.png">

