### PR TITLE
Fixes to crwa template for prerender

### DIFF
--- a/packages/create-redwood-app/template/web/src/entry.js
+++ b/packages/create-redwood-app/template/web/src/entry.js
@@ -7,8 +7,10 @@ import App from './index'
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://reactjs.org/docs/react-dom.html#hydrate
- */
-if (document.getElementById('redwood-app').hasChildNodes()) {
+*/
+const rootElement = document.getElementById('redwood-app')
+
+if (rootElement.hasChildNodes()) {
   ReactDOM.hydrate(<App />, rootElement)
 } else {
   ReactDOM.render(<App />, rootElement)

--- a/packages/create-redwood-app/template/web/src/index.js
+++ b/packages/create-redwood-app/template/web/src/index.js
@@ -6,10 +6,12 @@ import FatalErrorPage from 'src/pages/FatalErrorPage'
 
 import './index.css'
 
-export default () => (
+const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
     <RedwoodApolloProvider>
       <Routes />
     </RedwoodApolloProvider>
   </FatalErrorBoundary>
 )
+
+export default App


### PR DESCRIPTION
- Fix entry js, not sure when rootElement went missing!
- Make index a little more readable, as it confuses people with the export default function

