### PR TITLE
Lint the create-redwood-app template

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,6 @@ dist
 fixtures
 packages/core/**/__fixtures__/**/*
 packages/core/config/storybook/**/*
-packages/create-redwood-app/template/**/*
+# We ignore these because the eslint plugin won't be able to find redwood.toml.
+packages/create-redwood-app/template/web/src/Routes.js
+packages/create-redwood-app/template/web/src/Routes.tsx

--- a/packages/create-redwood-app/template/web/src/entry.js
+++ b/packages/create-redwood-app/template/web/src/entry.js
@@ -7,7 +7,7 @@ import App from './index'
  * prerendering. So React attaches event listeners to the existing markup
  * rather than replacing it.
  * https://reactjs.org/docs/react-dom.html#hydrate
-*/
+ */
 const rootElement = document.getElementById('redwood-app')
 
 if (rootElement.hasChildNodes()) {

--- a/packages/create-redwood-app/template/web/src/index.js
+++ b/packages/create-redwood-app/template/web/src/index.js
@@ -1,8 +1,8 @@
-import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 import { FatalErrorBoundary } from '@redwoodjs/web'
+import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 
-import Routes from 'src/Routes'
 import FatalErrorPage from 'src/pages/FatalErrorPage'
+import Routes from 'src/Routes'
 
 import './index.css'
 


### PR DESCRIPTION
Thi would've prevented the bug in #1819, which was that a variable was undefined.