### PR TITLE
Router: Fix TS types

### DIFF
--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -22,8 +22,9 @@ interface RouteProps {
   page: Spec | React.ComponentType<unknown> | ((props: any) => JSX.Element)
   path?: string
   name?: string
-  notfound?: Spec | React.ComponentType
+  notfound?: boolean
   redirect?: string
+  prerender?: boolean
   whileLoading?: () => ReactChild | null
 }
 


### PR DESCRIPTION
Adds support for the `prerender` prop on routes, and fixes the type for `notfound`