### PR TITLE
Remove backticks

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -119,7 +119,7 @@ const installNodeModulesTasks = ({ newAppDir }) => {
       },
     },
     {
-      title: 'Running `yarn install`... (This could take a while)',
+      title: "Running 'yarn install'... (This could take a while)",
       skip: () => {
         if (yarnInstall === false) {
           return 'skipped on request'


### PR DESCRIPTION
I propose this change for uniformity reason so that anyone searching for "single-quoted" strings would not miss this one. There is a chance that the author had a good reason for avoiding "double-quoted" strings - in that case, please ignore this PR.