### PR TITLE
Add curly rule for blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
         },
       },
     ],
+    curly: 'error',
   },
   overrides: [
     {

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -39,14 +39,19 @@ const serverlessFunctions = requireDir(path.join(process.cwd(), functions), {
 
 try {
   const app = server({ requestHandler }).listen(socket || port, () => {
-    if (socket) console.log(socket)
-    else console.log(`http://localhost:${port}`)
+    if (socket) {
+      console.log(socket)
+    } else {
+      console.log(`http://localhost:${port}`)
+    }
     setLambdaFunctions(serverlessFunctions)
   })
 
   process.on('exit', () => {
     app.close(() => {
-      if (socket) rmSync(socket)
+      if (socket) {
+        rmSync(socket)
+      }
     })
   })
 } catch (e) {

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -56,7 +56,9 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
         return await client.auth.signIn({ email, password })
       }
       // oauth, such as github, gitlab, bitbucket, google, azure etc.
-      if (provider) return await client.auth.signIn({ provider })
+      if (provider) {
+        return await client.auth.signIn({ provider })
+      }
       throw new Error(
         `You must provide either an email or a third-party provider.`
       )

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -21,8 +21,12 @@ export const builder = (yargs) => {
 
   const optionDefault = (apiExists, webExists) => {
     let options = []
-    if (apiExists) options.push('api')
-    if (webExists) options.push('web')
+    if (apiExists) {
+      options.push('api')
+    }
+    if (webExists) {
+      options.push('web')
+    }
     return options
   }
 

--- a/packages/cli/src/commands/check.js
+++ b/packages/cli/src/commands/check.js
@@ -13,8 +13,12 @@ export const handler = async () => {
 
   printDiagnostics(getPaths().base, {
     getSeverityLabel: (severity) => {
-      if (severity === DiagnosticSeverity.Error) return c.error('error')
-      if (severity === DiagnosticSeverity.Warning) return c.warning('warning')
+      if (severity === DiagnosticSeverity.Error) {
+        return c.error('error')
+      }
+      if (severity === DiagnosticSeverity.Warning) {
+        return c.warning('warning')
+      }
       return c.info('info')
     },
   })

--- a/packages/cli/src/commands/dataMigrate/up.js
+++ b/packages/cli/src/commands/dataMigrate/up.js
@@ -17,8 +17,12 @@ const sortMigrations = (migrations) => {
     const aVersion = parseInt(Object.keys(a)[0])
     const bVersion = parseInt(Object.keys(b)[0])
 
-    if (aVersion > bVersion) return 1
-    if (aVersion < bVersion) return -1
+    if (aVersion > bVersion) {
+      return 1
+    }
+    if (aVersion < bVersion) {
+      return -1
+    }
     return 0
   })
 }

--- a/packages/core/src/babelPlugins/babel-plugin-redwood-directory-named-import.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-directory-named-import.ts
@@ -31,7 +31,9 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         const { filename } = state.file.opts // the file where this import statement resides
 
         // We only operate in "userland," skip node_modules.
-        if (filename?.includes('/node_modules/')) return
+        if (filename?.includes('/node_modules/')) {
+          return
+        }
         // We only need this plugin in the module could not be found.
         try {
           require.resolve(value)
@@ -41,7 +43,9 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         }
 
         const newPath = getNewPath(value, <string>filename)
-        if (!newPath) return
+        if (!newPath) {
+          return
+        }
         const newSource = t.stringLiteral(newPath)
         p.node.source = newSource
       },
@@ -57,7 +61,9 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         const { filename } = state.file.opts
 
         // We only operate in "userland," skip node_modules.
-        if (filename?.includes('/node_modules/')) return
+        if (filename?.includes('/node_modules/')) {
+          return
+        }
         // We only need this plugin in the module could not be found.
         try {
           require.resolve(value)
@@ -67,7 +73,9 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         }
 
         const newPath = getNewPath(value, <string>filename)
-        if (!newPath) return
+        if (!newPath) {
+          return
+        }
         const newSource = t.stringLiteral(newPath)
         // @ts-expect-error - TypeDef must be outdated.
         p.node.source = newSource

--- a/packages/structure/src/ide.ts
+++ b/packages/structure/src/ide.ts
@@ -91,7 +91,9 @@ export abstract class BaseNode {
 
   @lazy()
   get host(): Host {
-    if (this.parent) return this.parent.host
+    if (this.parent) {
+      return this.parent.host
+    }
     throw new Error(
       "Could not find host implementation on root node (you must override the 'host' gettter)"
     )
@@ -132,7 +134,9 @@ export abstract class BaseNode {
 
   @memo(JSON.stringify)
   async collectIDEInfo(uri?: string): Promise<IDEInfo[]> {
-    if (uri && this.bailOutOnCollection(uri)) return []
+    if (uri && this.bailOutOnCollection(uri)) {
+      return []
+    }
     try {
       const d1 = await this._ideInfo()
       const dd = await Promise.all(
@@ -140,7 +144,9 @@ export abstract class BaseNode {
       )
       const d2 = dd.flat()
       let all = [...d1, ...d2]
-      if (uri) all = all.filter((x) => x.location.uri === uri)
+      if (uri) {
+        all = all.filter((x) => x.location.uri === uri)
+      }
       return all
     } catch (e) {
       // TODO: this diagnostic is also interesting
@@ -157,7 +163,9 @@ export abstract class BaseNode {
   async collectDiagnostics(uri?: string): Promise<ExtendedDiagnostic[]> {
     // TODO: catch runtime errors and add them as diagnostics
     // TODO: we can parallelize this further
-    if (uri && this.bailOutOnCollection(uri)) return []
+    if (uri && this.bailOutOnCollection(uri)) {
+      return []
+    }
     try {
       const d1 = await this._diagnostics()
       const dd = await Promise.all(
@@ -165,11 +173,15 @@ export abstract class BaseNode {
       )
       const d2 = dd.flat()
       let all = [...d1, ...d2]
-      if (uri) all = all.filter((x) => x.uri === uri)
+      if (uri) {
+        all = all.filter((x) => x.uri === uri)
+      }
       return all
     } catch (e) {
       const uri = this.closestContainingUri
-      if (!uri) throw e
+      if (!uri) {
+        throw e
+      }
       const range = Range.create(0, 0, 0, 0)
       return [
         {
@@ -181,16 +193,24 @@ export abstract class BaseNode {
   }
 
   bailOutOnCollection(uri: string): boolean {
-    if (this.id === uri) return false
-    if (uri.startsWith(this.id)) return false
+    if (this.id === uri) {
+      return false
+    }
+    if (uri.startsWith(this.id)) {
+      return false
+    }
     return true
   }
 
   @lazy() get closestContainingUri(): string | undefined {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { uri } = this as any
-    if (uri) return uri
-    if (this.parent) return this.parent.closestContainingUri
+    if (uri) {
+      return uri
+    }
+    if (this.parent) {
+      return this.parent.closestContainingUri
+    }
     return undefined
   }
 
@@ -204,13 +224,18 @@ export abstract class BaseNode {
   @memo()
   async findNode(id: NodeID): Promise<BaseNode | undefined> {
     id = URL_file(id)
-    if (this.id === id) return this
-    if (id.startsWith(this.id))
+    if (this.id === id) {
+      return this
+    }
+    if (id.startsWith(this.id)) {
       for (const c of await this._children()) {
         // depth first search by default
         const cc = await c.findNode(id)
-        if (cc) return cc
+        if (cc) {
+          return cc
+        }
       }
+    }
     return undefined
   }
 }
@@ -236,8 +261,9 @@ export abstract class FileNode extends BaseNode {
    * parsed ts-morph source file
    */
   @lazy() get sf(): tsm.SourceFile {
-    if (typeof this.text === 'undefined')
+    if (typeof this.text === 'undefined') {
       throw new Error('undefined file ' + this.filePath)
+    }
     return createTSMSourceFile_cached(this.filePath, this.text!)
   }
   @lazy() get basenameNoExt() {
@@ -254,7 +280,9 @@ export class HostWithDocumentsStore implements Host {
   readFileSync(path: string) {
     const uri = URL_file(path)
     const doc = this.documents.get(uri)
-    if (doc) return doc.getText()
+    if (doc) {
+      return doc.getText()
+    }
     return this.defaultHost.readFileSync(path)
   }
   existsSync(path: string) {

--- a/packages/structure/src/interactive_cli/RedwoodCommandString.ts
+++ b/packages/structure/src/interactive_cli/RedwoodCommandString.ts
@@ -19,8 +19,9 @@ export class RedwoodCommandString {
   constructor(public original: string) {
     let v = original
 
-    if (typeof v !== 'string')
+    if (typeof v !== 'string') {
       throw new Error('redwood command must be a string')
+    }
 
     if (v.trim().endsWith('...')) {
       this.isComplete = false
@@ -33,8 +34,12 @@ export class RedwoodCommandString {
       .trim()
       .split(' ')
       .map((s) => s.trim())
-    if (parts[0] === 'yarn') parts.shift()
-    if (parts[0] === 'redwood' || parts[0] === 'rw') parts.shift()
+    if (parts[0] === 'yarn') {
+      parts.shift()
+    }
+    if (parts[0] === 'redwood' || parts[0] === 'rw') {
+      parts.shift()
+    }
     this.processed = parts.join(' ')
   }
   @lazy() get parsed() {
@@ -43,10 +48,18 @@ export class RedwoodCommandString {
 
   @lazy() get isInterceptable() {
     let [a, b] = this.parsed._
-    if (a === 'g') a = 'generate'
-    if (a !== 'generate') return false
-    if (b === 'sdl') return false // <-- why?
-    if (b === 'scaffold') return false // <-- why?
+    if (a === 'g') {
+      a = 'generate'
+    }
+    if (a !== 'generate') {
+      return false
+    }
+    if (b === 'sdl') {
+      return false
+    } // <-- why?
+    if (b === 'scaffold') {
+      return false
+    } // <-- why?
     return true
   }
 }

--- a/packages/structure/src/interactive_cli/command_builder.ts
+++ b/packages/structure/src/interactive_cli/command_builder.ts
@@ -50,7 +50,9 @@ class CommandBuilder {
           return
       }
     } catch (e) {
-      if (e.message === 'break') return
+      if (e.message === 'break') {
+        return
+      }
       throw e
     }
   }
@@ -81,7 +83,9 @@ class CommandBuilder {
       case 'sdl':
         const modelName = await this.arg_generate_sdl_modelName()
         const opts = await this.prompts.sdl_options()
-        if (!opts) return
+        if (!opts) {
+          return
+        }
         // TODO: serialize options
         // services: { type: 'boolean', default: true },
         // crud: { type: 'boolean', default: false },
@@ -133,7 +137,9 @@ class PromptHelper {
    */
   async prompt(msg: string): Promise<string> {
     let v = await this.opts.ui.prompt(msg)
-    if (v === '') v = undefined
+    if (v === '') {
+      v = undefined
+    }
     return breakIfNull(v)
   }
   async command() {
@@ -177,7 +183,9 @@ class PromptHelper {
       ],
       'Options...'
     )
-    if (!opts) return
+    if (!opts) {
+      return
+    }
     return new Set(opts) as any
   }
 
@@ -221,6 +229,8 @@ const generatorTypes = [
 const dbOperations = ['down', 'generate', 'save', 'seed', 'up']
 
 function breakIfNull<T>(x: T): NonNullable<T> {
-  if (typeof x === 'undefined' || x === null) throw new Error('break')
+  if (typeof x === 'undefined' || x === null) {
+    throw new Error('break')
+  }
   return x as any
 }

--- a/packages/structure/src/interactive_cli/dry_run.ts
+++ b/packages/structure/src/interactive_cli/dry_run.ts
@@ -32,10 +32,11 @@ export async function redwood_gen_dry_run(
   opts: Opts
 ): Promise<{ stdout: string; files: FileSet }> {
   const { cwd, cmd, fileOverrides, tmpdir } = opts
-  if (!cmd.isComplete)
+  if (!cmd.isComplete) {
     throw new Error(
       'cannot pass an interactive command straight to the redwood-cli. You must run it through the command_builder first'
     )
+  }
   // eslint-disable-next-line
   const x = [proxyquire].length // we need to make sure this module is required. it will be used in a script we will generate dynamically
   const tempDir = tmpdir ?? join(cwd, '.tmp')

--- a/packages/structure/src/language_server/RWLanguageServer.ts
+++ b/packages/structure/src/language_server/RWLanguageServer.ts
@@ -98,7 +98,9 @@ export class RWLanguageServer {
     connection.onCodeAction(async ({ context, textDocument: { uri } }) => {
       const actions: CodeAction[] = []
       const node = await this.getProject()?.findNode(uri)
-      if (!node) return []
+      if (!node) {
+        return []
+      }
       if (context.diagnostics.length > 0) {
         // find quick-fixes associated to diagnostics
         const xds = await node.collectDiagnostics()
@@ -107,7 +109,9 @@ export class RWLanguageServer {
             xd,
             context
           )
-          for (const a of as) actions.push(a)
+          for (const a of as) {
+            actions.push(a)
+          }
         }
       }
       return actions
@@ -148,7 +152,9 @@ export class RWLanguageServer {
 
   projectRoot: string | undefined
   getProject() {
-    if (!this.projectRoot) return undefined
+    if (!this.projectRoot) {
+      return undefined
+    }
     return new RWProject({ projectRoot: this.projectRoot, host: this.host })
   }
   get vscodeWindowMethods() {

--- a/packages/structure/src/language_server/commands.ts
+++ b/packages/structure/src/language_server/commands.ts
@@ -50,7 +50,9 @@ export class CommandsManager {
       documents,
     } = this.server
     cwd = cwd ?? projectRoot
-    if (!cwd) return // we need a cwd to run the CLI
+    if (!cwd) {
+      return
+    } // we need a cwd to run the CLI
     // parse the cmd. this will do some checks and throw
     let cmd = new RedwoodCommandString(cmdString ?? '...')
 
@@ -73,7 +75,9 @@ export class CommandsManager {
       // we have a convenience wrapper to access it
       const ui = new VSCodeWindowUI(vscodeWindowMethods)
       const cmd2 = await command_builder({ cmd, project, ui })
-      if (!cmd2) return // user cancelled the interactive process
+      if (!cmd2) {
+        return
+      } // user cancelled the interactive process
       cmd = cmd2
     }
     // run the command
@@ -88,7 +92,9 @@ export class CommandsManager {
         fileOverrides,
       })
       const edit = WorkspaceEdit_fromFileSet(files, (f) => {
-        if (!host.existsSync(URL_toFile(f))) return undefined
+        if (!host.existsSync(URL_toFile(f))) {
+          return undefined
+        }
         return host.readFileSync(URL_toFile(f))
       })
       vscodeWindowMethods.showInformationMessage(stdout)

--- a/packages/structure/src/language_server/diagnostics.ts
+++ b/packages/structure/src/language_server/diagnostics.ts
@@ -39,7 +39,9 @@ export class DiagnosticsManager {
 
   private async getDiagnosticsGroupedByUri() {
     const project = this.server.getProject()
-    if (!project) return {}
+    if (!project) {
+      return {}
+    }
     const ds = await project.collectDiagnostics()
     return ExtendedDiagnostic_groupByUri(ds)
   }

--- a/packages/structure/src/language_server/outline.ts
+++ b/packages/structure/src/language_server/outline.ts
@@ -13,12 +13,13 @@ export class OutlineManager {
   @memo() start() {
     const getRoot = () => {
       const p = this.server.getProject()
-      if (!p)
+      if (!p) {
         return {
           async children() {
             return [{ label: 'No Redwood.js project found...' }]
           },
         }
+      }
       return getOutline(p)
     }
     const tdp = new RemoteTreeDataProviderImpl(getRoot)

--- a/packages/structure/src/language_server/xmethods.ts
+++ b/packages/structure/src/language_server/xmethods.ts
@@ -13,7 +13,9 @@ export class XMethodsManager {
     const { connection } = server
     connection.onRequest('redwoodjs/x-getInfo', async (uri: string) => {
       const node = await server.getProject()?.findNode(uri)
-      if (!node) return undefined
+      if (!node) {
+        return undefined
+      }
       return await node.collectIDEInfo()
     })
     connection.onRequest(

--- a/packages/structure/src/model/RWComponent.ts
+++ b/packages/structure/src/model/RWComponent.ts
@@ -28,8 +28,11 @@ export class RWComponent extends FileNode {
     const ss = new Set<string>()
     for (const d of this.sf.getDescendantsOfKind(
       tsm.SyntaxKind.VariableDeclaration
-    ))
-      if (d.isExported()) ss.add(d.getName())
+    )) {
+      if (d.isExported()) {
+        ss.add(d.getName())
+      }
+    }
     return ss
   }
 }

--- a/packages/structure/src/model/RWEnvHelper.ts
+++ b/packages/structure/src/model/RWEnvHelper.ts
@@ -83,7 +83,9 @@ export class RWEnvHelper extends BaseNode {
 
   private _dotenv(f: string) {
     const file = join(this.parent.projectRoot, f)
-    if (!existsSync(file)) return undefined
+    if (!existsSync(file)) {
+      return undefined
+    }
     return dotenv.parse(readFileSync(file))
   }
 
@@ -138,7 +140,9 @@ class ProcessDotEnvExpression extends BaseNode {
   }
 
   bailOutOnCollection(uri: string) {
-    if (this.location.uri !== uri) return true
+    if (this.location.uri !== uri) {
+      return true
+    }
     return false
   }
 
@@ -157,11 +161,19 @@ class ProcessDotEnvExpression extends BaseNode {
   }
 
   *ideInfo() {
-    for (const x of this.render()) if (!ExtendedDiagnostic_is(x)) yield x
+    for (const x of this.render()) {
+      if (!ExtendedDiagnostic_is(x)) {
+        yield x
+      }
+    }
   }
 
   *diagnostics() {
-    for (const x of this.render()) if (ExtendedDiagnostic_is(x)) yield x
+    for (const x of this.render()) {
+      if (ExtendedDiagnostic_is(x)) {
+        yield x
+      }
+    }
   }
 
   @lazy() get value_definition_file_basename() {
@@ -169,14 +181,20 @@ class ProcessDotEnvExpression extends BaseNode {
       key,
       parent: { env, env_defaults },
     } = this
-    if (env?.[key]) return '.env'
-    if (env_defaults?.[key]) return '.env.defaults'
+    if (env?.[key]) {
+      return '.env'
+    }
+    if (env_defaults?.[key]) {
+      return '.env.defaults'
+    }
     return undefined
   }
 
   @lazy() get value_definition_location(): Location | undefined {
     const x = this.value_definition_file_basename
-    if (!x) return undefined
+    if (!x) {
+      return undefined
+    }
     const file = join(this.parent.parent.projectRoot, x)
     const content = readFileSync(file).toString()
     const lines = content.split('\n')
@@ -188,7 +206,9 @@ class ProcessDotEnvExpression extends BaseNode {
   }
 
   @lazy() get value_as_available() {
-    if (this.side === 'web') return this.parent.env_available_to_web[this.key]
+    if (this.side === 'web') {
+      return this.parent.env_available_to_web[this.key]
+    }
     const v = this.parent.env_available_to_api[this.key]
     return v
   }
@@ -245,7 +265,9 @@ class ProcessDotEnvExpression extends BaseNode {
         // so the uri (string) is converted to a vscode.Uri
         // https://github.com/microsoft/vscode-languageserver-node/issues/495
         // eslint-disable-next-line no-constant-condition
-        if (false) yield codelens
+        if (false) {
+          yield codelens
+        }
       }
     }
 

--- a/packages/structure/src/model/RWPage.ts
+++ b/packages/structure/src/model/RWPage.ts
@@ -25,12 +25,16 @@ export class RWPage extends FileNode {
   }
   @lazy() get layoutName(): string | undefined {
     const candidates = this.parent.layouts.map((l) => l.basenameNoExt)
-    if (candidates.length === 0) return undefined
+    if (candidates.length === 0) {
+      return undefined
+    }
     for (const tag of this.sf.getDescendantsOfKind(
       tsm.SyntaxKind.JsxOpeningElement
     )) {
       const t = tag.getTagNameNode().getText() //?
-      if (candidates.includes(t)) return t
+      if (candidates.includes(t)) {
+        return t
+      }
     }
     return undefined
   }
@@ -39,7 +43,9 @@ export class RWPage extends FileNode {
     // delete directory (MyPage/...)
     edits.set(dirname(this.filePath), undefined)
     // removing a page also removes its route
-    if (this.route) edits.set(this.route.jsxNode, undefined)
+    if (this.route) {
+      edits.set(this.route.jsxNode, undefined)
+    }
     // TODO: we need to transform this edits map to a standard edits map (with locations)
     return edits
   }

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -93,7 +93,9 @@ export class RWProject extends BaseNode {
   }
   @memo() async prismaDMMFModelNames() {
     const dmmf = await this.prismaDMMF()
-    if (!dmmf) return []
+    if (!dmmf) {
+      return []
+    }
     return dmmf.datamodel.models.map((m) => m.name)
   }
   @lazy() get redwoodTOML(): RWTOML {

--- a/packages/structure/src/model/RWRoute.ts
+++ b/packages/structure/src/model/RWRoute.ts
@@ -51,7 +51,9 @@ export class RWRoute extends BaseNode {
   }
 
   @lazy() get hasParameters(): boolean {
-    if (!this.path) return false
+    if (!this.path) {
+      return false
+    }
     // KLUDGE: we need a good path parsing library here
     return this.path.includes('{')
   }
@@ -66,13 +68,17 @@ export class RWRoute extends BaseNode {
   }
 
   @lazy() get outlineLabel(): string {
-    if (this.isNotFound) return '404'
+    if (this.isNotFound) {
+      return '404'
+    }
     return this.path ?? ''
   }
 
   @lazy() get outlineDescription(): string | undefined {
     const fp = this.page?.filePath
-    if (!fp) return undefined
+    if (!fp) {
+      return undefined
+    }
     return basename(fp)
   }
 
@@ -86,7 +92,9 @@ export class RWRoute extends BaseNode {
    */
 
   @lazy() get page() {
-    if (!this.page_identifier_str) return undefined
+    if (!this.page_identifier_str) {
+      return undefined
+    }
     return this.parent.parent.pages.find(
       (p) => p.const_ === this.page_identifier_str
     )
@@ -96,7 +104,9 @@ export class RWRoute extends BaseNode {
    */
   @lazy() private get page_identifier(): tsm.Identifier | undefined {
     const a = this.jsxNode.getAttribute('page')
-    if (!a) return undefined
+    if (!a) {
+      return undefined
+    }
     if (tsm.Node.isJsxAttribute(a)) {
       const init = a.getInitializer()
       if (tsm.Node.isJsxExpression(init!)) {
@@ -116,7 +126,9 @@ export class RWRoute extends BaseNode {
   }
   @lazy() get path_errorMessage(): string | undefined {
     // TODO: path validation is not strong enough
-    if (typeof this.path === 'undefined') return undefined
+    if (typeof this.path === 'undefined') {
+      return undefined
+    }
     try {
       validateRoutePath(this.path)
       return undefined
@@ -133,7 +145,9 @@ export class RWRoute extends BaseNode {
   }
   @lazy() get path_literal_node() {
     const a = this.jsxNode.getAttribute('path')
-    if (!a) return undefined
+    if (!a) {
+      return undefined
+    }
     if (tsm.Node.isJsxAttribute(a)) {
       const init = a.getInitializer()
       if (tsm.Node.isStringLiteral(init!)) {
@@ -148,33 +162,39 @@ export class RWRoute extends BaseNode {
   }
 
   *diagnostics() {
-    if (this.page_identifier && !this.page)
+    if (this.page_identifier && !this.page) {
       // normally this would be caught by TypeScript
       // but Redwood has some "magic" import behavior going on
       yield err(this.page_identifier, 'Page component not found')
-    if (this.path_errorMessage && this.path_literal_node)
+    }
+    if (this.path_errorMessage && this.path_literal_node) {
       yield err(
         this.path_literal_node,
         this.path_errorMessage,
         RWError.INVALID_ROUTE_PATH_SYNTAX
       )
-    if (this.hasPathCollision)
+    }
+    if (this.hasPathCollision) {
       yield err(this.path_literal_node!, 'Duplicate Path')
-    if (this.isPrivate && this.isNotFound)
+    }
+    if (this.isPrivate && this.isNotFound) {
       yield err(
         this.jsxNode!,
         "The 'Not Found' page cannot be within a <Private> tag"
       )
-    if (this.isNotFound && this.path)
+    }
+    if (this.isNotFound && this.path) {
       yield err(
         this.path_literal_node!,
         "The 'Not Found' page cannot have a path"
       )
-    if (this.hasPreRenderInfo && !this.hasParameters)
+    }
+    if (this.hasPreRenderInfo && !this.hasParameters) {
       yield err(
         this.jsxNode!,
         `Only routes with parameters can have associated prerender information`
       )
+    }
   }
   *ideInfo() {
     // definition: page identifier --> page
@@ -221,12 +241,20 @@ export class RWRoute extends BaseNode {
   }
 
   @lazy() private get hasPathCollision() {
-    if (!this.path) return false
+    if (!this.path) {
+      return false
+    }
     const pathWithNoParamNames = removeParamNames(this.path)
     for (const route2 of this.parent.routes) {
-      if (route2 === this) continue
-      if (!route2.path) continue
-      if (removeParamNames(route2.path) === pathWithNoParamNames) return true
+      if (route2 === this) {
+        continue
+      }
+      if (!route2.path) {
+        continue
+      }
+      if (removeParamNames(route2.path) === pathWithNoParamNames) {
+        return true
+      }
     }
     return false
     function removeParamNames(p: string) {
@@ -239,7 +267,9 @@ export class RWRoute extends BaseNode {
   private getBoolAttr(name: string) {
     const a = this.jsxNode.getAttribute(name)
     // No attribute
-    if (!a) return false
+    if (!a) {
+      return false
+    }
 
     // Attribute exists
     if (tsm.Node.isJsxAttribute(a)) {
@@ -258,22 +288,30 @@ export class RWRoute extends BaseNode {
 
   private getStringAttr(name: string) {
     const a = this.jsxNode.getAttribute(name)
-    if (!a) return undefined
+    if (!a) {
+      return undefined
+    }
     if (tsm.Node.isJsxAttribute(a)) {
       const init = a.getInitializer()
-      if (tsm.Node.isStringLiteral(init!)) return init.getLiteralValue()
+      if (tsm.Node.isStringLiteral(init!)) {
+        return init.getLiteralValue()
+      }
     }
     return undefined
   }
 
   @lazy() get parsedPath() {
-    if (!this.path) return undefined
+    if (!this.path) {
+      return undefined
+    }
     return advanced_path_parser(this.path)
   }
 
   private *decorations(): Generator<Decoration> {
     const pp = this.parsedPath
-    if (!pp) return
+    if (!pp) {
+      return
+    }
     const uri = this.parent.uri
     const pos = Range_fromNode(this.path_literal_node!).start
     const xxx = {
@@ -282,13 +320,15 @@ export class RWRoute extends BaseNode {
       path_parameter: pp.paramRanges,
       path_parameter_type: pp.paramTypeRanges,
     }
-    for (const style of Object.keys(xxx))
-      for (const x of xxx[style])
+    for (const style of Object.keys(xxx)) {
+      for (const x of xxx[style]) {
         yield {
           kind: 'Decoration',
           style: style as any,
           location: loc(x),
         }
+      }
+    }
     function loc(x: number | [number, number]) {
       if (typeof x === 'number') {
         return loc([x, x + 1])
@@ -303,8 +343,12 @@ export class RWRoute extends BaseNode {
   // TODO: we should get the URL of the server dynamically
   @lazy() get sampleLocalPreviewURL(): string | undefined {
     const { path } = this
-    if (!path) return undefined
-    if (path.includes('{')) return undefined
+    if (!path) {
+      return undefined
+    }
+    if (path.includes('{')) {
+      return undefined
+    }
     return `http://localhost:8910${path}`
   }
 }

--- a/packages/structure/src/model/RWRouter.ts
+++ b/packages/structure/src/model/RWRouter.ts
@@ -40,7 +40,9 @@ export class RWRouter extends FileNode {
     // TODO: params
     const path = this.parent.pages.find((p) => p.filePath === filePath)?.route
       ?.path
-    if (path?.includes('{')) return
+    if (path?.includes('{')) {
+      return
+    }
     return path
   }
 
@@ -61,14 +63,18 @@ export class RWRouter extends FileNode {
   @lazy() get routes() {
     const self = this
     return iter(function* () {
-      if (!self.jsxNode) return
+      if (!self.jsxNode) {
+        return
+      }
       // TODO: make sure that they are nested within the <Router> tag
       // we are not checking it right now
       for (const x of self.sf.getDescendantsOfKind(
         tsm.SyntaxKind.JsxSelfClosingElement
       )) {
         const tagName = x.getTagNameNode().getText()
-        if (tagName === 'Route') yield new RWRoute(x, self)
+        if (tagName === 'Route') {
+          yield new RWRoute(x, self)
+        }
       }
     })
   }
@@ -96,7 +102,9 @@ export class RWRouter extends FileNode {
   }
 
   @lazy() get quickFix_addNotFoundpage() {
-    if (!this.jsxNode) return undefined
+    if (!this.jsxNode) {
+      return undefined
+    }
     const change = new WorkspaceChange({ documentChanges: [] })
     let uri = URL_file(this.parent.defaultNotFoundPageFilePath)
     const p = this.parent.pages.find((p) => p.basenameNoExt === 'NotFoundPage')
@@ -141,7 +149,9 @@ export class RWRouter extends FileNode {
       return // stop checking for errors if the file doesn't exist
     }
 
-    if (!this.jsxNode) return
+    if (!this.jsxNode) {
+      return
+    }
 
     if (this.numNotFoundPages === 0) {
       const { uri, range } = LocationLike_toLocation(this.jsxNode)

--- a/packages/structure/src/model/RWSDL.ts
+++ b/packages/structure/src/model/RWSDL.ts
@@ -21,11 +21,15 @@ export class RWSDL extends FileNode {
    */
   @lazy() get schemaStringNode() {
     const i = this.sf.getVariableDeclaration('schema')?.getInitializer()
-    if (!i) return undefined
+    if (!i) {
+      return undefined
+    }
     // TODO: do we allow other kinds of strings? or just tagged literals?
     if (tsm.Node.isTaggedTemplateExpression(i)) {
       const t = i.getTemplate() //?
-      if (tsm.Node.isNoSubstitutionTemplateLiteral(t)) return t
+      if (tsm.Node.isNoSubstitutionTemplateLiteral(t)) {
+        return t
+      }
     }
     return undefined
   }
@@ -46,13 +50,19 @@ export class RWSDL extends FileNode {
   @lazy() get implementableFields() {
     const self = this
     return iter(function* () {
-      if (!self.schemaString) return //?
+      if (!self.schemaString) {
+        return
+      } //?
       const ast = parseGraphQL(self.schemaString)
-      for (const def of ast.definitions)
-        if (def.kind === 'ObjectTypeDefinition')
-          if (def.name.value === 'Query' || def.name.value === 'Mutation')
-            for (const field of def.fields ?? [])
+      for (const def of ast.definitions) {
+        if (def.kind === 'ObjectTypeDefinition') {
+          if (def.name.value === 'Query' || def.name.value === 'Mutation') {
+            for (const field of def.fields ?? []) {
               yield new RWSDLField(def, field, self)
+            }
+          }
+        }
+      }
     })
   }
 

--- a/packages/structure/src/model/RWService.ts
+++ b/packages/structure/src/model/RWService.ts
@@ -46,14 +46,18 @@ export class RWService extends FileNode {
       for (const vd of self.sf.getVariableDeclarations()) {
         if (vd.isExported()) {
           const init = vd.getInitializerIfKind(tsm.SyntaxKind.ArrowFunction)
-          if (init) yield new RWServiceFunction(vd.getName(), init, self)
+          if (init) {
+            yield new RWServiceFunction(vd.getName(), init, self)
+          }
         }
       }
       // export function foo(){}
       for (const fd of self.sf.getFunctions()) {
         if (fd.isExported() && !fd.isDefaultExport()) {
           const nn = fd.getNameNode()
-          if (nn) yield new RWServiceFunction(nn.getText(), fd, self)
+          if (nn) {
+            yield new RWServiceFunction(nn.getText(), fd, self)
+          }
         }
       }
     })

--- a/packages/structure/src/model/util/process_env.ts
+++ b/packages/structure/src/model/util/process_env.ts
@@ -9,13 +9,16 @@ import { createTSMSourceFile_cached } from '../../x/ts-morph'
 
 export function process_env_findAll(dir: string) {
   return iter(function* () {
-    for (const file of glob.sync(join(dir, 'src/**/*.{js,ts,jsx,tsx}')))
+    for (const file of glob.sync(join(dir, 'src/**/*.{js,ts,jsx,tsx}'))) {
       yield* process_env_findInFile(file, readFileSync(file).toString())
+    }
   })
 }
 
 export function process_env_findInFile(filePath: string, text: string) {
-  if (!text.includes('process.env')) return []
+  if (!text.includes('process.env')) {
+    return []
+  }
   try {
     return process_env_findInFile2(createTSMSourceFile_cached(filePath, text))
   } catch (e) {
@@ -30,13 +33,19 @@ export function process_env_findInFile2(sf: tsm.SourceFile) {
   return iter(function* () {
     for (const penv of penvs) {
       const node = penv.getParent()
-      if (!node) continue
+      if (!node) {
+        continue
+      }
       if (tsm.Node.isPropertyAccessExpression(node)) {
         yield { key: node.getName(), node }
       } else if (tsm.Node.isElementAccessExpression(node)) {
         const arg = node.getArgumentExpression()
-        if (!arg) continue
-        if (!tsm.Node.isStringLiteral(arg)) continue
+        if (!arg) {
+          continue
+        }
+        if (!tsm.Node.isStringLiteral(arg)) {
+          continue
+        }
         yield { key: arg.getLiteralText(), node }
       }
     }
@@ -44,6 +53,8 @@ export function process_env_findInFile2(sf: tsm.SourceFile) {
 }
 
 function is_process_env(n: tsm.Node): n is tsm.PropertyAccessExpression {
-  if (!tsm.Node.isPropertyAccessExpression(n)) return false
+  if (!tsm.Node.isPropertyAccessExpression(n)) {
+    return false
+  }
   return n.getExpression().getText() === 'process' && n.getName() === 'env'
 }

--- a/packages/structure/src/outline/outline.ts
+++ b/packages/structure/src/outline/outline.ts
@@ -205,7 +205,9 @@ function _schema(project: RWProject): TreeItem2 {
     ...resourceUriAndCommandFor(project.pathHelper.api.dbSchema),
     async children() {
       const dmmf = await project.prismaDMMF()
-      if (!dmmf) return []
+      if (!dmmf) {
+        return []
+      }
       const models = dmmf.datamodel.models.map((model) => {
         return {
           label: model.name,

--- a/packages/structure/src/outline/types.ts
+++ b/packages/structure/src/outline/types.ts
@@ -95,7 +95,9 @@ export type OutlineItemJSON = Omit<OutlineItem, 'children'> & {
 export async function outlineToJSON(
   item: OutlineItem
 ): Promise<OutlineItemJSON> {
-  if (!item.children) return { ...item, children: undefined }
+  if (!item.children) {
+    return { ...item, children: undefined }
+  }
   const cs = item.children ? await item.children() : []
   const css = await Promise.all(cs.map(outlineToJSON))
   return { ...item, children: css }

--- a/packages/structure/src/x/Array.ts
+++ b/packages/structure/src/x/Array.ts
@@ -7,9 +7,15 @@ export type ArrayLike<T> =
   | null
 
 export async function ArrayLike_normalize<T>(x: ArrayLike<T>): Promise<T[]> {
-  if (x instanceof Promise) return x
-  if (x === null) return []
-  if (typeof x === 'undefined') return []
+  if (x instanceof Promise) {
+    return x
+  }
+  if (x === null) {
+    return []
+  }
+  if (typeof x === 'undefined') {
+    return []
+  }
   return [...x]
 }
 

--- a/packages/structure/src/x/URL.ts
+++ b/packages/structure/src/x/URL.ts
@@ -8,9 +8,12 @@ import { isAbsolute, join, normalize, sep as path_sep } from 'path'
  * @param filePath
  */
 export function URL_file(filePath: string, ...parts: string[]): string {
-  if (filePath.startsWith(FILE_SCHEME))
+  if (filePath.startsWith(FILE_SCHEME)) {
     filePath = filePath.substr(FILE_SCHEME.length)
-  if (parts.length > 0) filePath = join(filePath, ...parts)
+  }
+  if (parts.length > 0) {
+    filePath = join(filePath, ...parts)
+  }
   return new URL(FILE_SCHEME + normalize(filePath)).href
 }
 
@@ -20,11 +23,16 @@ export function URL_file(filePath: string, ...parts: string[]): string {
  * @param sep separator string, defaults to `require('path').sep`
  */
 export function URL_toFile(uriOrFilePath: string, sep = path_sep): string {
-  if (typeof uriOrFilePath !== 'string') throw new Error('arg error')
-  if (uriOrFilePath.startsWith(FILE_SCHEME))
+  if (typeof uriOrFilePath !== 'string') {
+    throw new Error('arg error')
+  }
+  if (uriOrFilePath.startsWith(FILE_SCHEME)) {
     return fileUriToPath(uriOrFilePath, sep)
+  }
   const p = normalize(uriOrFilePath)
-  if (!isAbsolute(p)) throw new Error('absolute path expected: ' + p)
+  if (!isAbsolute(p)) {
+    throw new Error('absolute path expected: ' + p)
+  }
   return p!
 }
 
@@ -57,8 +65,12 @@ function fileUriToPath(uri: string, sep = path_sep): string {
   // As a special case, <host> can be the string "localhost" or the empty
   // string; this is interpreted as "the machine from which the URL is
   // being interpreted".
-  if (host === 'localhost') host = ''
-  if (host) host = sep + sep + host
+  if (host === 'localhost') {
+    host = ''
+  }
+  if (host) {
+    host = sep + sep + host
+  }
 
   // 3.2  Drives, drive letters, mount points, file system root
   // Drive letters are mapped into the top of a file URI in various ways,
@@ -74,7 +86,9 @@ function fileUriToPath(uri: string, sep = path_sep): string {
   // if the first segment is NOT a windows drive
   // we insert an extra empty segment
   // this will result in an initial slash (unix style)
-  if (!parts[0].includes(':')) parts.unshift('')
+  if (!parts[0].includes(':')) {
+    parts.unshift('')
+  }
 
   return parts.join(sep)
 }

--- a/packages/structure/src/x/path.ts
+++ b/packages/structure/src/x/path.ts
@@ -10,7 +10,9 @@ export function directoryNameResolver(dirName: string): string | undefined {
   const pathNoExt = parts.join(sep)
   for (const ext of extensions) {
     const path = pathNoExt + ext
-    if (existsSync(path)) return path
+    if (existsSync(path)) {
+      return path
+    }
   }
 }
 
@@ -23,7 +25,9 @@ export function followsDirNameConvention(filePath: string): boolean {
 export function basenameNoExt(path: string): string {
   path = normalize(path)
   const parts = basename(path).split('.')
-  if (parts.length > 1) parts.pop()
+  if (parts.length > 1) {
+    parts.pop()
+  }
   return parts.join('.')
 }
 

--- a/packages/structure/src/x/prisma.ts
+++ b/packages/structure/src/x/prisma.ts
@@ -13,7 +13,9 @@ export function* prisma_parseEnvExpressionsInFile(
 ) {
   const uri = URL_file(prismaSchemaFilePath)
   const file = URL_toFile(uri) // convert back and forth in case someone passed a uri
-  if (!existsSync(file)) return [] // fail silently
+  if (!existsSync(file)) {
+    return []
+  } // fail silently
   const src = readFileSync(file).toString()
   const exprs = prisma_parseEnvExpressions(src)
   for (const { range, key } of exprs) {

--- a/packages/structure/src/x/vscode-languageserver-types.ts
+++ b/packages/structure/src/x/vscode-languageserver-types.ts
@@ -19,8 +19,12 @@ import {
 import { URL_file } from './URL'
 
 export function Range_contains(range: Range, pos: Position): boolean {
-  if (Position_compare(range.start, pos) === 'greater') return false
-  if (Position_compare(range.end, pos) === 'smaller') return false
+  if (Position_compare(range.start, pos) === 'greater') {
+    return false
+  }
+  if (Position_compare(range.end, pos) === 'smaller') {
+    return false
+  }
   return true
 }
 
@@ -30,11 +34,17 @@ export function Range_overlaps(
   consider0000: boolean
 ): boolean {
   if (consider0000) {
-    if (Range_is0000(range1) || Range_is0000(range2)) return true
+    if (Range_is0000(range1) || Range_is0000(range2)) {
+      return true
+    }
   }
   const { start, end } = range2
-  if (Range_contains(range1, start)) return true
-  if (Range_contains(range2, end)) return true
+  if (Range_contains(range1, start)) {
+    return true
+  }
+  if (Range_contains(range2, end)) {
+    return true
+  }
   return true
 }
 
@@ -47,10 +57,18 @@ export function Position_compare(
   p1: Position,
   p2: Position
 ): 'greater' | 'smaller' | 'equal' {
-  if (p1.line > p2.line) return 'greater'
-  if (p2.line > p1.line) return 'smaller'
-  if (p1.character > p2.character) return 'greater'
-  if (p2.character > p1.character) return 'smaller'
+  if (p1.line > p2.line) {
+    return 'greater'
+  }
+  if (p2.line > p1.line) {
+    return 'smaller'
+  }
+  if (p1.character > p2.character) {
+    return 'greater'
+  }
+  if (p2.character > p1.character) {
+    return 'smaller'
+  }
   return 'equal'
 }
 
@@ -130,10 +148,15 @@ export function LocationLike_toLocation(x: LocationLike): Location {
     return { uri: URL_file(x), range: Range.create(0, 0, 0, 0) }
   }
   if (typeof x === 'object') {
-    if (x instanceof tsm.Node) return Location_fromNode(x)
-    if (Location.is(x)) return x
-    if (ExtendedDiagnostic_is(x))
+    if (x instanceof tsm.Node) {
+      return Location_fromNode(x)
+    }
+    if (Location.is(x)) {
+      return x
+    }
+    if (ExtendedDiagnostic_is(x)) {
       return { uri: x.uri, range: x.diagnostic.range }
+    }
   }
   throw new Error()
 }
@@ -143,7 +166,9 @@ export function Location_overlaps(
   loc2: Location,
   consider0000 = false
 ) {
-  if (loc1.uri !== loc2.uri) return false
+  if (loc1.uri !== loc2.uri) {
+    return false
+  }
   return Range_overlaps(loc1.range, loc2.range, consider0000)
 }
 
@@ -161,10 +186,18 @@ function Position_is00(pos: Position): boolean {
 }
 
 export function ExtendedDiagnostic_is(x: any): x is ExtendedDiagnostic {
-  if (typeof x !== 'object') return false
-  if (typeof x === 'undefined') return false
-  if (typeof x.uri !== 'string') return false
-  if (!Diagnostic.is(x.diagnostic)) return false
+  if (typeof x !== 'object') {
+    return false
+  }
+  if (typeof x === 'undefined') {
+    return false
+  }
+  if (typeof x.uri !== 'string') {
+    return false
+  }
+  if (!Diagnostic.is(x.diagnostic)) {
+    return false
+  }
   return true
 }
 
@@ -213,7 +246,9 @@ export function Position_fromOffset(
   text: string
 ): Position | undefined {
   const res = lc(text).fromIndex(offset)
-  if (!res) return undefined
+  if (!res) {
+    return undefined
+  }
   const { line, col } = res
   return { character: col - 1, line: line - 1 }
 }
@@ -223,7 +258,9 @@ export function Position_fromOffsetOrFail(
   text: string
 ): Position {
   const p = Position_fromOffset(offset, text)
-  if (!p) throw new Error('Position_fromOffsetOrFail')
+  if (!p) {
+    throw new Error('Position_fromOffsetOrFail')
+  }
   return p
 }
 
@@ -264,9 +301,15 @@ export function err(
 }
 
 export function Diagnostic_compare(d1: Diagnostic, d2: Diagnostic): boolean {
-  if (d1.code !== d2.code) return false
-  if (d1.message !== d2.message) return false
-  if (!Range_equals(d1.range, d2.range)) return false
+  if (d1.code !== d2.code) {
+    return false
+  }
+  if (d1.message !== d2.message) {
+    return false
+  }
+  if (!Range_equals(d1.range, d2.range)) {
+    return false
+  }
   return true
 }
 
@@ -312,8 +355,12 @@ export function ExtendedDiagnostic_format(
   const getSeverityLabel = opts?.getSeverityLabel ?? DiagnosticSeverity_getLabel
 
   let base = 'file://'
-  if (cwd) base = URL_file(cwd)
-  if (!base.endsWith('/')) base += '/'
+  if (cwd) {
+    base = URL_file(cwd)
+  }
+  if (!base.endsWith('/')) {
+    base += '/'
+  }
   const file = LocationLike_toTerminalLink(d).substr(base.length)
 
   const severityLabel = getSeverityLabel(severity)
@@ -333,7 +380,9 @@ export function FileSet_fromTextDocuments(
   documents: TextDocuments<TextDocument>
 ) {
   const files: FileSet = {}
-  for (const uri of documents.keys()) files[uri] = documents.get(uri)!.getText()
+  for (const uri of documents.keys()) {
+    files[uri] = documents.get(uri)!.getText()
+  }
   return files
 }
 
@@ -367,9 +416,13 @@ export function WorkspaceEdit_fromFileSet(
 }
 
 export function Range_full(text: string, cr = '\n'): Range {
-  if (text === '') return Range.create(0, 0, 0, 0)
+  if (text === '') {
+    return Range.create(0, 0, 0, 0)
+  }
   const lines = text.split(cr)
-  if (lines.length === 0) return Range.create(0, 0, 0, 0)
+  if (lines.length === 0) {
+    return Range.create(0, 0, 0, 0)
+  }
   const start = Position.create(0, 0)
   const end = Position.create(lines.length - 1, lines[lines.length - 1].length)
   return Range.create(start, end)

--- a/packages/structure/src/x/vscode-languageserver.ts
+++ b/packages/structure/src/x/vscode-languageserver.ts
@@ -11,9 +11,13 @@ import { Connection } from 'vscode-languageserver'
  */
 export function Connection_suppressErrors<T extends Connection>(conn: T) {
   for (const k of Object.keys(conn)) {
-    if (!k.startsWith('on')) continue // only onHover, onCodeLens, etc?
+    if (!k.startsWith('on')) {
+      continue
+    } // only onHover, onCodeLens, etc?
     const v = conn[k]
-    if (typeof v !== 'function') continue
+    if (typeof v !== 'function') {
+      continue
+    }
     conn[k] = (...args) => {
       const args2 = args.map((arg) =>
         typeof arg === 'function'
@@ -46,9 +50,10 @@ function with_catch2(f, clause: CatchClause) {
   function catch2(f, clause2) {
     try {
       const res = f()
-      if (typeof res?.then === 'function')
+      if (typeof res?.then === 'function') {
         // promise
         return res.catch?.(clause2)
+      }
       return res
     } catch (e) {
       return clause2(e)

--- a/packages/structure/src/x/vscode.ts
+++ b/packages/structure/src/x/vscode.ts
@@ -104,7 +104,9 @@ export class TreeItem2Wrapper {
     public indexInParent: number = 0
   ) {}
   @lazy() get keys(): string[] {
-    if (!this.parent) return []
+    if (!this.parent) {
+      return []
+    }
     return [...(this.parent?.keys ?? []), this.key]
   }
   @lazy() get key(): string {
@@ -112,7 +114,9 @@ export class TreeItem2Wrapper {
       indexInParent,
       item: { key, label },
     } = this
-    if (key) return key
+    if (key) {
+      return key
+    }
     return (label ?? '') + '-' + indexInParent
   }
   @lazy() get id() {
@@ -132,11 +136,17 @@ export class TreeItem2Wrapper {
   }
   @memo()
   async findChild(key: string): Promise<TreeItem2Wrapper | undefined> {
-    for (const c of await this.children()) if (c.key === key) return c
+    for (const c of await this.children()) {
+      if (c.key === key) {
+        return c
+      }
+    }
   }
   @memo(JSON.stringify)
   async findChildRec(keys: string[]): Promise<TreeItem2Wrapper | undefined> {
-    if (keys.length === 0) return this
+    if (keys.length === 0) {
+      return this
+    }
     const [k, ...rest] = keys
     return await (await this.findChild(k))?.findChildRec(rest)
   }
@@ -206,7 +216,9 @@ export class RemoteTreeDataProviderImpl implements RemoteTreeDataProvider {
     this.refresh()
     setInterval(() => {
       this.refresh()
-      for (const l of this.listeners) l(undefined)
+      for (const l of this.listeners) {
+        l(undefined)
+      }
     }, this.refreshInterval)
   }
 
@@ -224,7 +236,9 @@ export class RemoteTreeDataProviderImpl implements RemoteTreeDataProvider {
     //console.log('getTreeItem', id)
     const keys = JSON.parse(id)
     const item = await this.root.findChildRec(keys)
-    if (!item) throw new Error(`item not found for id ${id}`)
+    if (!item) {
+      throw new Error(`item not found for id ${id}`)
+    }
     //console.log('--->', item.treeItemOverTheWire)
     return item.serializableTreeItem
   }
@@ -235,7 +249,9 @@ export class RemoteTreeDataProviderImpl implements RemoteTreeDataProvider {
     const keys = id ? JSON.parse(id) : []
     const self = await this.root.findChildRec(keys)
     const children = await self?.children()
-    if (!children) return []
+    if (!children) {
+      return []
+    }
     const res = children?.map((c) => c.id)
     //console.log('--->', res)
     return res
@@ -280,14 +296,22 @@ export function RemoteTreeDataProvider_publishOverLSPConnection(
 export async function ProviderResult_normalize<T>(
   x: vscode.ProviderResult<T>
 ): Promise<T | undefined> {
-  if (isThenable(x)) return await ProviderResult_normalize(await x)
-  if (x === null) return undefined
+  if (isThenable(x)) {
+    return await ProviderResult_normalize(await x)
+  }
+  if (x === null) {
+    return undefined
+  }
   return x
 }
 
 function isThenable(x: unknown): x is Thenable<unknown> {
-  if (typeof x !== 'object') return false
-  if (x === null) return false
+  if (typeof x !== 'object') {
+    return false
+  }
+  if (x === null) {
+    return false
+  }
   return typeof x['then'] === 'function'
 }
 
@@ -311,8 +335,9 @@ export function Command_open(uriOrLocation: string | Location): Command {
 
 export function Command_cli(cmd: string, title = 'run...'): Command {
   cmd = cmd.trim()
-  if (!(cmd.startsWith('rw') || cmd.startsWith('redwood')))
+  if (!(cmd.startsWith('rw') || cmd.startsWith('redwood'))) {
     cmd = 'redwood ' + cmd
+  }
   return { command: 'redwoodjs.cli', arguments: [cmd], title }
 }
 


### PR DESCRIPTION
ESlint rule against one-liners, see thread below.

> As for the braces for blocks, this should probably be enforced via `eslint`, because my (and potentially others') config defaults to one-liners.

💯  I was actually surprised it wasn't already a rule

_Originally posted by @Tobbe in https://github.com/redwoodjs/redwood/issues/1824#issuecomment-783354078_