### PR TITLE
E2E: when running against branch, build both js and ts

### DIFF
--- a/tasks/test-tutorial
+++ b/tasks/test-tutorial
@@ -34,7 +34,7 @@ if [ -z "$1" ]
   then
   cd "$SCRIPTPATH/../"
   # build all the packages
-  yarn build:clean && yarn lerna run build:js
+  yarn build:clean && yarn build
 fi
 
 cd $TMP_DIR


### PR DESCRIPTION
The E2E script has been using build:js, which _only_ builds js. This adds `ttsc --build --verbose` via `yarn build`.