### PR TITLE
replace instances of web/src/index.js with web/src/App.js

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -172,7 +172,7 @@ describe('in javascript (default) mode', () => {
         path.normalize('/path/to/project/web/src/components/Posts/Posts.js')
       ]
     ).toEqual(
-      loadGeneratorFixture('scaffold', path.join('components', 'App.js'))
+      loadGeneratorFixture('scaffold', path.join('components', 'index.js'))
     )
   })
 
@@ -457,7 +457,7 @@ describe('in typescript mode', () => {
         path.normalize('/path/to/project/web/src/components/Posts/Posts.js')
       ]
     ).toEqual(
-      loadGeneratorFixture('scaffold', path.join('components', 'App.js'))
+      loadGeneratorFixture('scaffold', path.join('components', 'index.js'))
     )
   })
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -172,7 +172,7 @@ describe('in javascript (default) mode', () => {
         path.normalize('/path/to/project/web/src/components/Posts/Posts.js')
       ]
     ).toEqual(
-      loadGeneratorFixture('scaffold', path.join('components', 'index.js'))
+      loadGeneratorFixture('scaffold', path.join('components', 'App.js'))
     )
   })
 
@@ -457,7 +457,7 @@ describe('in typescript mode', () => {
         path.normalize('/path/to/project/web/src/components/Posts/Posts.js')
       ]
     ).toEqual(
-      loadGeneratorFixture('scaffold', path.join('components', 'index.js'))
+      loadGeneratorFixture('scaffold', path.join('components', 'App.js'))
     )
   })
 

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -380,20 +380,20 @@ export const routes = async ({ model: name, path: scaffoldPath = '' }) => {
 }
 
 const addScaffoldImport = () => {
-  const indexJsPath = path.join(getPaths().web.src, 'index.js')
-  let indexJsContents = readFile(indexJsPath).toString()
+  const appJsPath = path.join(getPaths().web.src, 'App.js')
+  let appJsContents = readFile(appJsPath).toString()
 
-  if (indexJsContents.match(SCAFFOLD_STYLE_PATH)) {
+  if (appJsContents.match(SCAFFOLD_STYLE_PATH)) {
     return 'Skipping scaffold style include'
   }
 
-  indexJsContents = indexJsContents.replace(
+  appJsContents = appJsContents.replace(
     "import Routes from 'src/Routes'\n",
     `import Routes from 'src/Routes'\n\nimport '${SCAFFOLD_STYLE_PATH}'`
   )
-  writeFile(indexJsPath, indexJsContents, { overwriteExisting: true })
+  writeFile(appJsPath, appJsContents, { overwriteExisting: true })
 
-  return 'Added scaffold import to index.js'
+  return 'Added scaffold import to App.js'
 }
 
 export const command = 'scaffold <model>'

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -39,12 +39,12 @@ const SUPPORTED_PROVIDERS = fs
   .map((file) => path.basename(file, '.js'))
   .filter((file) => file !== 'README.md')
 
-// returns the content of index.js with import statements added
+// returns the content of App.js with import statements added
 const addWebImports = (content, imports) => {
   return `${AUTH_PROVIDER_IMPORT}\n` + imports.join('\n') + '\n' + content
 }
 
-// returns the content of index.js with init lines added
+// returns the content of App.js with init lines added
 const addWebInit = (content, init) => {
   return content.replace(
     'const App = () => (',
@@ -52,7 +52,7 @@ const addWebInit = (content, init) => {
   )
 }
 
-// returns the content of index.js with <AuthProvider> added
+// returns the content of App.js with <AuthProvider> added
 const addWebRender = (content, authProvider) => {
   const [_, indent, redwoodApolloProvider] = content.match(
     /(\s+)(<RedwoodApolloProvider>.*<\/RedwoodApolloProvider>)/s
@@ -90,18 +90,18 @@ const addWebRender = (content, authProvider) => {
   )
 }
 
-// returns the content of index.js with <AuthProvider> updated
+// returns the content of App.js with <AuthProvider> updated
 const updateWebRender = (content, authProvider) => {
   const renderContent = `<AuthProvider client={${authProvider.client}} type="${authProvider.type}">`
   return content.replace(/<AuthProvider client={.*} type=".*">/s, renderContent)
 }
 
-// returns the content of index.js without the old auth import
+// returns the content of App.js without the old auth import
 const removeOldWebImports = (content, imports) => {
   return content.replace(`${AUTH_PROVIDER_IMPORT}\n` + imports.join('\n'), '')
 }
 
-// returns the content of index.js without the old auth init
+// returns the content of App.js without the old auth init
 const removeOldWebInit = (content, init) => {
   return content.replace(init, '')
 }
@@ -145,7 +145,7 @@ export const files = (provider) => {
   }
 }
 
-// actually inserts the required config lines into index.js
+// actually inserts the required config lines into App.js
 export const addConfigToApp = async (config, force) => {
   let content = fs.readFileSync(WEB_SRC_APP_PATH).toString()
 
@@ -245,7 +245,7 @@ export const handler = async ({ provider, force }) => {
           if (webIndexDoesExist()) {
             addConfigToApp(providerData.config, force)
           } else {
-            task.skip('web/src/index.js not found, skipping')
+            task.skip('web/src/App.js not found, skipping')
           }
         },
       },

--- a/packages/cli/src/commands/setup/auth/providers/auth0.js
+++ b/packages/cli/src/commands/setup/auth/providers/auth0.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [`import { Auth0Client } from '@auth0/auth0-spa-js'`],
   init: `const auth0 = new Auth0Client({
@@ -25,7 +25,7 @@ export const apiPackages = []
 // any notes to print out when the job is done
 export const notes = [
   'You will need to create several environment variables with your Auth0 config options.',
-  'Check out web/src/index.js for the variables you need to add.',
+  'Check out web/src/App.js for the variables you need to add.',
   'See: https://auth0.com/docs/quickstart/spa/react#get-your-application-keys',
   '\n',
   "You must also create an API and set the audience parameter, or you'll",

--- a/packages/cli/src/commands/setup/auth/providers/azureActiveDirectory.js
+++ b/packages/cli/src/commands/setup/auth/providers/azureActiveDirectory.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [`import { UserAgentApplication } from 'msal'`],
   init: `const azureActiveDirectoryClient = new UserAgentApplication({
@@ -21,7 +21,7 @@ export const apiPackages = []
 
 // any notes to print out when the job is done
 export const notes = [
-  'You will need to create several environment variables with your Azure AD config options. Check out web/src/index.js for the variables you need to add.',
+  'You will need to create several environment variables with your Azure AD config options. Check out web/src/App.js for the variables you need to add.',
   '\n',
   'RedwoodJS specific Documentation:',
   'https://redwoodjs.com/docs/authentication#azure-ad',

--- a/packages/cli/src/commands/setup/auth/providers/ethereum.js
+++ b/packages/cli/src/commands/setup/auth/providers/ethereum.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [
     `import EthereumAuthClient from '@oneclickdapp/ethereum-auth'`,

--- a/packages/cli/src/commands/setup/auth/providers/firebase.js
+++ b/packages/cli/src/commands/setup/auth/providers/firebase.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [
     `import * as firebase from 'firebase/app'`,
@@ -28,6 +28,6 @@ export const apiPackages = ['firebase-admin']
 // any notes to print out when the job is done
 export const notes = [
   'You will need to create several environment variables with your Firebase config options.',
-  'Check out web/src/index.js for the variables you need to add.',
+  'Check out web/src/App.js for the variables you need to add.',
   'See: https://firebase.google.com/docs/web/setup#config-object',
 ]

--- a/packages/cli/src/commands/setup/auth/providers/goTrue.js
+++ b/packages/cli/src/commands/setup/auth/providers/goTrue.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [`import GoTrue from 'gotrue-js'`],
   init: `const goTrueClient = new GoTrue({

--- a/packages/cli/src/commands/setup/auth/providers/magicLink.js
+++ b/packages/cli/src/commands/setup/auth/providers/magicLink.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [`import { Magic } from 'magic-sdk'`],
   init: 'const m = new Magic(process.env.MAGICLINK_PUBLIC)',

--- a/packages/cli/src/commands/setup/auth/providers/netlify.js
+++ b/packages/cli/src/commands/setup/auth/providers/netlify.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [
     `import netlifyIdentity from 'netlify-identity-widget'`,

--- a/packages/cli/src/commands/setup/auth/providers/nhost.js
+++ b/packages/cli/src/commands/setup/auth/providers/nhost.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [`import { createClient } from 'nhost-js-sdk'`],
   init: `const nhostClient = createClient({

--- a/packages/cli/src/commands/setup/auth/providers/supabase.js
+++ b/packages/cli/src/commands/setup/auth/providers/supabase.js
@@ -1,4 +1,4 @@
-// the lines that need to be added to index.js
+// the lines that need to be added to App.js
 export const config = {
   imports: [`import { createClient } from '@supabase/supabase-js'`],
   init: `const supabaseClient = createClient(

--- a/packages/cli/src/commands/setup/i18n/i18n.js
+++ b/packages/cli/src/commands/setup/i18n/i18n.js
@@ -20,7 +20,7 @@ export const builder = (yargs) => {
 }
 
 export const handler = async ({ force }) => {
-  const INDEX_JS_PATH = path.join(getPaths().web.src, 'index.js')
+  const INDEX_JS_PATH = path.join(getPaths().web.src, 'App.js')
   const tasks = new Listr([
     {
       title: 'Installing packages...',
@@ -61,10 +61,10 @@ export const handler = async ({ force }) => {
       },
     },
     {
-      title: 'Adding import to index.js...',
+      title: 'Adding import to App.js...',
       task: () => {
         /**
-         * Add i18n import to the top of index.js
+         * Add i18n import to the top of App.js
          */
         let indexJS = fs.readFileSync(INDEX_JS_PATH)
         indexJS = [`import './i18n'`, indexJS].join(`\n`)


### PR DESCRIPTION
Prerender added the file `web/src/App.js` and placed `web/src/index.js` in the Redwood Web package.

This PR updates all other commands and references to index.js that should now be App.js, e.g. the Scaffold generator css is now added as an import to App.js.