### PR TITLE
Remove `index` from paths

### DIFF
--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -23,7 +23,6 @@ export interface BrowserTargetPaths {
   base: string
   src: string
   app: string
-  index: string | null
   routes: string
   pages: string
   components: string
@@ -70,7 +69,6 @@ const PATH_WEB_DIR_PAGES = 'web/src/pages/'
 const PATH_WEB_DIR_COMPONENTS = 'web/src/components'
 const PATH_WEB_DIR_SRC = 'web/src'
 const PATH_WEB_DIR_SRC_APP = 'web/src/App'
-const PATH_WEB_DIR_SRC_INDEX = 'web/src/index' // .js|.tsx
 const PATH_WEB_DIR_CONFIG = 'web/config'
 const PATH_WEB_DIR_CONFIG_WEBPACK = 'web/config/webpack.config.js'
 const PATH_WEB_DIR_CONFIG_POSTCSS = 'web/config/postcss.config.js'
@@ -161,7 +159,6 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       layouts: path.join(BASE_DIR, PATH_WEB_DIR_LAYOUTS),
       src: path.join(BASE_DIR, PATH_WEB_DIR_SRC),
       app: resolveFile(path.join(BASE_DIR, PATH_WEB_DIR_SRC_APP)) as string,
-      index: resolveFile(path.join(BASE_DIR, PATH_WEB_DIR_SRC_INDEX)),
       config: path.join(BASE_DIR, PATH_WEB_DIR_CONFIG),
       webpack: path.join(BASE_DIR, PATH_WEB_DIR_CONFIG_WEBPACK),
       postcss: path.join(BASE_DIR, PATH_WEB_DIR_CONFIG_POSTCSS),


### PR DESCRIPTION
Now that we have pre-rendering the entry that was used as `index` is now
called `App`, therefore the `index` is no longer used.