### PR TITLE
Use --accept-data-loss in `...test` command to comply with prisma 2.17.0

### DIFF
--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -104,7 +104,7 @@ export const handler = async ({
 
     // Create a test database
     if (sides.includes('api')) {
-      await execa(`yarn rw`, ['prisma db push', '--force'], {
+      await execa(`yarn rw`, ['prisma db push', '--accept-data-loss'], {
         cwd: getPaths().api.base,
         stdio: 'inherit',
         shell: true,


### PR DESCRIPTION
This PR fixes an error I'm seeing an error when I run `yarn rw test` after upgrading `0.26.2`:

```
$ yarn rw test
yarn run v1.19.1
$ /.../node_modules/.bin/rw test
$ /.../node_modules/.bin/rw prisma db push --force

Running Prisma CLI:
yarn prisma db push --force --preview-feature --schema "/.../api/db/schema.prisma" 

Error: The --force flag was renamed to --accept-data-loss in 2.17.0, use yarn prisma db push --preview-feature --accept-data-loss
```

I've confirmed that this fix allows for me to run `yarn rw test` without a problem.
