### PR TITLE
Rename prisma introspect to prisma db pull

### DIFF
--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -59,7 +59,7 @@ export const builder = async (yargs: Argv) => {
     }
 
     if (
-      ['generate', 'introspect', 'db', 'migrate', 'studio'].includes(argv[0])
+      ['generate', 'pull', 'push', 'db', 'migrate', 'studio'].includes(argv[0])
     ) {
       if (!fs.existsSync(paths.api.dbSchema)) {
         console.error(
@@ -94,7 +94,7 @@ export const builder = async (yargs: Argv) => {
     prismaCommand.stderr?.pipe(process.stderr)
 
     // So we can check for yarn prisma in the output
-    // e.g. yarn prisma introspect
+    // e.g. yarn prisma db pull
     const { stdout } = await prismaCommand
 
     if (hasHelpFlag || stdout?.match('yarn prisma')) {

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -54,8 +54,10 @@ export const builder = async (yargs: Argv) => {
   // Only pass auto flags, when not running help
   if (!hasHelpFlag) {
     if (['migrate', 'db'].includes(argv[0])) {
-      // this is safe as is if a user also adds --preview-feature
-      autoFlags.push('--preview-feature')
+      if (['pull'].includes(argv[0])) {
+        // this is safe as is if a user also adds --preview-feature
+        autoFlags.push('--preview-feature')
+      }
     }
 
     if (

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -54,7 +54,7 @@ export const builder = async (yargs: Argv) => {
   // Only pass auto flags, when not running help
   if (!hasHelpFlag) {
     if (['migrate', 'db'].includes(argv[0])) {
-      if (!['pull'].includes(argv[0])) {
+      if (!['pull'].includes(argv[1])) {
         // this is safe as is if a user also adds --preview-feature
         autoFlags.push('--preview-feature')
       }

--- a/packages/cli/src/commands/prisma.ts
+++ b/packages/cli/src/commands/prisma.ts
@@ -54,7 +54,7 @@ export const builder = async (yargs: Argv) => {
   // Only pass auto flags, when not running help
   if (!hasHelpFlag) {
     if (['migrate', 'db'].includes(argv[0])) {
-      if (['pull'].includes(argv[0])) {
+      if (!['pull'].includes(argv[0])) {
         // this is safe as is if a user also adds --preview-feature
         autoFlags.push('--preview-feature')
       }


### PR DESCRIPTION
Prisma 2.10.0 introduced prisma db push command that enables developers to update their database schema from a Prisma schema file without using migrations.

In 2.18 they renamed `introspect` to `db pull` for symmetry in commands:

> For the "opposite" motion (i.e., updating the Prisma schema from an existing database schema), use `prisma db pull`.