### PR TITLE
Fixes marshalling datetimes in and out of forms

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/components/form.js
@@ -6,9 +6,14 @@ import {
   TextField,
   CheckboxField,
   NumberField,
+  DatetimeLocalField,
   TextAreaField,
   Submit,
 } from '@redwoodjs/forms'
+
+const formatDatetime = (value) => {
+  return value.replace(/:\d{2}\.\d{3}\w/, '')
+}
 
 const PostForm = (props) => {
   const onSubmit = (data) => {
@@ -160,9 +165,9 @@ const PostForm = (props) => {
         >
           Posted at
         </Label>
-        <TextField
+        <DatetimeLocalField
           name="postedAt"
-          defaultValue={props.post?.postedAt}
+          defaultValue={formatDatetime(props.post?.postedAt)}
           className="rw-input"
           errorClassName="rw-input rw-input-error"
           validation={{ required: true }}

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -205,6 +205,8 @@ const componentFiles = async (name, scaffoldPath = '') => {
       displayFunction: 'checkboxInputTag',
     },
     DateTime: {
+      componentName: 'DatetimeLocalField',
+      deserilizeFunction: 'formatDatetime',
       listDisplayFunction: 'timeTag',
       displayFunction: 'timeTag',
     },

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameForm.js.template
@@ -7,6 +7,10 @@ import {
   Submit,
 } from '@redwoodjs/forms'
 
+const formatDatetime = (value) => {
+  return value.replace(/:\d{2}\.\d{3}\w/, '')
+}
+
 const ${singularPascalName}Form = (props) => {
   const onSubmit = (data) => {
     props.onSave(data, props?.${singularCamelName}?.id)

--- a/packages/forms/src/__tests__/form.test.tsx
+++ b/packages/forms/src/__tests__/form.test.tsx
@@ -17,6 +17,8 @@ import {
   NumberField,
   CheckboxField,
   TextAreaField,
+  DatetimeLocalField,
+  DateField,
   Submit,
 } from '../index'
 
@@ -24,12 +26,16 @@ describe('Form', () => {
   const TestComponent = ({ onSubmit = () => {} }) => {
     return (
       <Form onSubmit={onSubmit}>
-        <TextField name="tf" defaultValue="text" />
-        <NumberField name="nf" defaultValue="42" />
-        <TextField name="ff" defaultValue="3.14" transformValue="Float" />
-        <CheckboxField name="cf" defaultChecked={true} />
+        <TextField name="text" defaultValue="text" />
+        <NumberField name="number" defaultValue="42" />
+        <TextField
+          name="floatText"
+          defaultValue="3.14"
+          transformValue="Float"
+        />
+        <CheckboxField name="checkbox" defaultChecked={true} />
         <TextAreaField
-          name="jf"
+          name="json"
           transformValue="Json"
           defaultValue={`
             {
@@ -39,6 +45,11 @@ describe('Form', () => {
             }
           `}
         />
+        <DatetimeLocalField
+          name="datetimeLocal"
+          defaultValue="2021-04-16T12:34"
+        />
+        <DateField name="date" defaultValue="2021-04-16" />
         <Submit>Save</Submit>
       </Form>
     )
@@ -118,15 +129,17 @@ describe('Form', () => {
     await waitFor(() => expect(mockFn).toHaveBeenCalledTimes(1))
     expect(mockFn).toBeCalledWith(
       {
-        tf: 'texttext',
-        nf: 4224, // i.e. NOT "4224"
-        ff: 3.141592,
-        cf: true,
-        jf: {
+        text: 'texttext',
+        number: 4224, // i.e. NOT "4224"
+        floatText: 3.141592,
+        checkbox: true,
+        json: {
           key_one: 'value1',
           key_two: 2,
           false: false,
         },
+        datetimeLocal: new Date('2021-04-16T12:34').toISOString(),
+        date: new Date('2021-04-16').toISOString(),
       },
       expect.anything() // event that triggered the onSubmit call
     )

--- a/packages/forms/src/coercion.tsx
+++ b/packages/forms/src/coercion.tsx
@@ -26,6 +26,7 @@ const COERCION_FUNCTIONS = {
   Float: (value: string) => parseFloat(value),
   Int: (value: string) => parseInt(value, 10),
   Json: (value: string) => JSON.parse(value),
+  DateTime: (value: string) => new Date(value).toISOString(),
 }
 
 export type TDefinedCoercionFunctions = keyof typeof COERCION_FUNCTIONS
@@ -33,6 +34,8 @@ export type TDefinedCoercionFunctions = keyof typeof COERCION_FUNCTIONS
 const inputTypeToDataTypeMapping: Record<string, TDefinedCoercionFunctions> = {
   checkbox: 'Boolean',
   number: 'Int',
+  date: 'DateTime',
+  'datetime-local': 'DateTime',
 }
 
 export const useCoercion = () => {


### PR DESCRIPTION
Two parts:

1. if you're using a `<DateField>` or `<DatetimeLocalField>` form element, the data will be coersed into the proper format (`yyyy-mm-ddThh:mm:ss.sssZ`) before sending through GraphQL 
2. when using the scaffold generator, datetimes are formatted properly before being set as the `defaultValue` prop in  `<DatetimeLocalField>` (`yyyy-mm-ddThh:mm`)

Closes #1457 