### PR TITLE
Adds resolution for react to template

### DIFF
--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -17,5 +17,9 @@
   "engines": {
     "node": ">=12",
     "yarn": ">=1.15"
+  },
+  "resolutions": {
+    "react": "17.0.1",
+    "react-dom": "17.0.1"
   }
 }


### PR DESCRIPTION
to prevent module duplication in web/node_modules

### Why?
The recent upgrade to React 17.x, and storybook's dependency on 16.x causes this duplication.

Fixes https://github.com/redwoodjs/redwood/issues/1907
Fixes https://github.com/redwoodjs/redwood/issues/1931


