### PR TITLE
Run a diagnostic check when prerender fails

### DIFF
--- a/packages/cli/src/commands/prerender.js
+++ b/packages/cli/src/commands/prerender.js
@@ -106,13 +106,13 @@ const diagnosticCheck = () => {
       ),
     },
     {
-      message: 'Duplicate React-Dom version found in web/node_modules',
+      message: 'Duplicate react-dom version found in web/node_modules',
       failure: fs.existsSync(
         path.join(getPaths().web.base, 'node_modules/react-dom')
       ),
     },
     {
-      message: 'Duplicate CoreJs version found in web/node_modules',
+      message: 'Duplicate core-js version found in web/node_modules',
       failure: fs.existsSync(
         path.join(getPaths().web.base, 'node_modules/core-js')
       ),
@@ -129,7 +129,7 @@ const diagnosticCheck = () => {
   if (checks.some((checks) => checks.failure)) {
     console.error(c.error('node_modules are being duplicated in `./web` \n'))
     console.log('⚠️  Issues found: ')
-    console.log('-'.repeat(30))
+    console.log('-'.repeat(50))
 
     checks
       .filter((check) => check.failure)
@@ -137,7 +137,7 @@ const diagnosticCheck = () => {
         console.log(`${i + 1}. ${check.message}`)
       })
 
-    console.log('-'.repeat(30))
+    console.log('-'.repeat(50))
 
     console.log(
       'Diagnostic check has found issues. See link for tips on possible resolutions:'

--- a/packages/cli/src/commands/prerender.js
+++ b/packages/cli/src/commands/prerender.js
@@ -140,12 +140,12 @@ const diagnosticCheck = () => {
     console.log('-'.repeat(50))
 
     console.log(
-      'Diagnostic check has found issues. See link for tips on possible resolutions:'
+      'Diagnostic check found issues. See the Redwood Forum link below for help:'
     )
 
     console.log(
       c.underline(
-        'https://community.redwoodjs.com/search?q=duplicate%20packages%20found'
+        'https://community.redwoodjs.com/search?q=duplicate%20package%20found'
       )
     )
 

--- a/packages/cli/src/commands/prerender.js
+++ b/packages/cli/src/commands/prerender.js
@@ -21,6 +21,12 @@ export const builder = (yargs) => {
     type: 'string',
   })
 
+  yargs.option('check', {
+    default: true,
+    description: 'Run a diagnostic check on your project',
+    type: 'boolean',
+  })
+
   yargs.option('output', {
     alias: 'output',
     default: false,
@@ -95,10 +101,16 @@ export const getTasks = (dryrun) => {
   return listrTasks
 }
 
-export const handler = async ({ path, output, dryRun, verbose }) => {
-  if (path) {
+export const handler = async ({
+  path: routerPath,
+  output,
+  check,
+  dryRun,
+  verbose,
+}) => {
+  if (routerPath) {
     await runPrerender({
-      routerPath: path,
+      routerPath,
       outputHtmlPath: output,
       dryRun,
     })
@@ -112,6 +124,72 @@ export const handler = async ({ path, output, dryRun, verbose }) => {
     renderer: verbose ? VerboseRenderer : 'default',
     concurrent: true,
   })
+
+  const diagnosticCheck = new Listr([
+    {
+      title: 'Running diagnostic check',
+      task: () => {
+        const checks = [
+          {
+            message: 'Duplicate React version found in web/node_modules',
+            failure: fs.existsSync(
+              path.join(getPaths().web.base, 'node_modules/react')
+            ),
+          },
+          {
+            message: 'Duplicate React-Dom version found in web/node_modules',
+            failure: fs.existsSync(
+              path.join(getPaths().web.base, 'node_modules/react-dom')
+            ),
+          },
+          {
+            message: 'Duplicate CoreJs version found in web/node_modules',
+            failure: fs.existsSync(
+              path.join(getPaths().web.base, 'node_modules/core-js')
+            ),
+          },
+          {
+            message:
+              'Duplicate @redwoodjs/web version found in web/node_modules',
+            failure: fs.existsSync(
+              path.join(getPaths().web.base, 'node_modules/@redwoodjs/web')
+            ),
+          },
+        ]
+
+        if (checks.some((checks) => checks.failure)) {
+          console.error(
+            '\nDiagnostic check failed. Please check your react versions in package.json and web/package.json'
+          )
+
+          console.error(
+            'If they seem correct, consider removing all node_modules and reinstalling \n'
+          )
+
+          console.log('⚠️  Issues found: ')
+          console.log('-'.repeat(30))
+
+          checks
+            .filter((check) => check.failure)
+            .forEach((check, i) => {
+              console.log(`${i + 1}. ${check.message}`)
+            })
+
+          console.log('-'.repeat(30))
+
+          throw new Error('node_modules are being duplicated in web')
+        }
+      },
+    },
+  ])
+
+  if (check) {
+    try {
+      await diagnosticCheck.run()
+    } catch (e) {
+      process.exit(1)
+    }
+  }
 
   try {
     await tasks.run()


### PR DESCRIPTION
### What?
As suggested by @thedavidprice, runs a diagnostic check for duplicated node_modules when prerendering fails


### What does it look like?
When all goes well: https://s.tape.sh/N7s2V5ED
When diagnostics pass, but prerender fails: https://s.tape.sh/W6L6LqKK
When diagnostics also fail: https://s.tape.sh/W6L6LqKK

Much clearer logs when running `yarn rw prerender --dryrun`
https://s.tape.sh/Qpm2jVKs


FYI: 
the diagnostic might be useful for storybook too, because storybook can break because of the duplicated modules as well
