### PR TITLE
Update error message in tasks/publish-local to point to tasks/run-loc…

### DIFF
--- a/tasks/publish-local
+++ b/tasks/publish-local
@@ -9,7 +9,7 @@ set -e
 # Publish all the packages: ./tasks/local-publish
 
 if ! lsof -Pi :4873 -sTCP:LISTEN -t >/dev/null; then
-  echo "Error: Verdaccio is not listening on port 4873, start it with './tasks/run-verdaccio'"
+  echo "Error: Verdaccio is not listening on port 4873, start it with './tasks/run-local-npm'"
   exit 1
 fi
 


### PR DESCRIPTION
The file `tasks/publish-local` outputs a non-existent script to run on an error condition. This PR updates the error output to reflect the correct script to run when Verdaccio isn't running.