### PR TITLE
Azure Active Directory Auth: Adding try-catch block on callback to capture empty key

### DIFF
--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -10,7 +10,9 @@ const verifyAzureActiveDirectoryToken = (
       throw new Error('`AZURE_ACTIVE_DIRECTORY_AUTHORITY` env var is not set.')
     }
 
-    /** @docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#sample-response */
+    /**
+     * @docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#sample-response
+     */
     const client = jwksClient({
       jwksUri: `${AZURE_ACTIVE_DIRECTORY_AUTHORITY}/discovery/v2.0/keys`,
     })

--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -19,7 +19,11 @@ const verifyAzureActiveDirectoryToken = (
       bearerToken,
       (header, callback) => {
         client.getSigningKey(header.kid as string, (error, key) => {
-          callback(error, key.getPublicKey())
+          try {
+            callback(error, key.getPublicKey());
+          } catch (err) {
+            console.error(`An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a outage. See https://status.azure.com/en-us/status for current status.\n`, err)
+          }
         })
       },
       {

--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -10,9 +10,7 @@ const verifyAzureActiveDirectoryToken = (
       throw new Error('`AZURE_ACTIVE_DIRECTORY_AUTHORITY` env var is not set.')
     }
 
-    /**
-     * @docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#sample-response
-     */
+    /** @docs: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#sample-response */
     const client = jwksClient({
       jwksUri: `${AZURE_ACTIVE_DIRECTORY_AUTHORITY}/discovery/v2.0/keys`,
     })

--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -22,7 +22,7 @@ const verifyAzureActiveDirectoryToken = (
           try {
             callback(error, key.getPublicKey());
           } catch (err) {
-            console.error(`An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a outage. See https://status.azure.com/en-us/status for current status.\n`, err)
+            console.error('An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a outage. See https://status.azure.com/en-us/status for current status.', err)
           }
         })
       },

--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -22,9 +22,12 @@ const verifyAzureActiveDirectoryToken = (
       (header, callback) => {
         client.getSigningKey(header.kid as string, (error, key) => {
           try {
-            callback(error, key.getPublicKey());
+            callback(error, key.getPublicKey())
           } catch (err) {
-            console.error('An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a outage. See https://status.azure.com/en-us/status for current status.', err)
+            console.error(
+              'An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a outage. See https://status.azure.com/en-us/status for current status.',
+              err
+            )
           }
         })
       },

--- a/packages/api/src/auth/decoders/azureActiveDirectory.ts
+++ b/packages/api/src/auth/decoders/azureActiveDirectory.ts
@@ -23,7 +23,7 @@ const verifyAzureActiveDirectoryToken = (
             callback(error, key.getPublicKey())
           } catch (err) {
             console.error(
-              'An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a outage. See https://status.azure.com/en-us/status for current status.',
+              'An error occurred while trying to obtain signing key from Azure Active Directory. This might be a result of an outage. See https://status.azure.com/en-us/status for current status.',
               err
             )
           }


### PR DESCRIPTION
As per ongoing partial Azure Active Directory outage I noticed that the error message thrown by the `azureActiveDirectory` auth client might be enough for initial troubleshooting. 

**Error**
```
api | TypeError: Cannot read property 'getPublicKey' of undefined
api |     at Immediate._onImmediate (/home/johan/work/git/sjoraddningssallskapet/ssrs-se-portal/node_modules/@redwoodjs/api/dist/auth/decoders/azureActiveDirectory.js:39:33)
api |     at processImmediate (internal/timers.js:463:21)
api |     at process.callbackTrampoline (internal/async_hooks.js:131:14)
```

This PR will give the developer an early indication on what may be wrong. 
```
api | An error occured while trying to obtain signing key from Azure Active Directory. This might be a result of a Azure Active Directory outage. See https://status.azure.com/en-us/status for current status.
api |  TypeError: Cannot read property 'getPublicKey' of undefined
api |     at Immediate._onImmediate (/home/johan/work/git/sjoraddningssallskapet/ssrs-se-portal/node_modules/@redwoodjs/api/dist/auth/decoders/azureActiveDirectory.js:39:33)
api |     at processImmediate (internal/timers.js:463:21)
api |     at process.callbackTrampoline (internal/async_hooks.js:131:14)
```