### PR TITLE
Fix yarn install errors: upgrade `gotrue-js` to v0.9.29

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,7 +14,7 @@
     "@types/react": "^17.0.2",
     "firebase": "^7.14.5",
     "firebase-admin": "^9.1.1",
-    "gotrue-js": "git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb",
+    "gotrue-js": "^0.9.29",
     "magic-sdk": "^2.5.0",
     "msal": "^1.4.1",
     "netlify-identity-widget": "1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10610,9 +10610,10 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-"gotrue-js@git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb":
-  version "0.9.24"
-  resolved "git://github.com/netlify/gotrue-js.git#28df09cfcac505feadcb1719714d2a9507cf68eb"
+gotrue-js@^0.9.29:
+  version "0.9.29"
+  resolved "https://registry.yarnpkg.com/gotrue-js/-/gotrue-js-0.9.29.tgz#08e62184d4eaadcd87f95cb6e49e3c4a9742a052"
+  integrity sha512-NSFwJlFfWxHd1zHDitysbh+amFPHBAyQG1YmecZJTaSe8TlC7Wja1ewdUBikfJBblN3SqghS6aViMd+Q/pPzGQ==
   dependencies:
     micro-api-client "^3.2.1"
 


### PR DESCRIPTION
Both @dthyresson and I experienced local development issues with `yarn install` failing due to the `gotrue-js` package not being found. The version of Gotrue installed is the GitHub package registry:
https://github.com/redwoodjs/redwood/blob/15dff8915505c1b0b643b51cd21aa3481e017da5/packages/auth/package.json#L17

This was added 9 months ago. Since then there have been several patch releases with no breaking changes. I upgrade to the latest version in this branch, which resolved my installation issues. See https://github.com/netlify/gotrue-js/releases I believe the GitHub registry version corresponds with [v0.9.22](https://github.com/netlify/gotrue-js/releases/tag/v0.9.22), which is 2 years old now.

@peterp I'm assuming you used the GitHub registry version to solve a specific problem. According to [commit history](https://github.com/redwoodjs/redwood/commit/4491f12a2c8b27aa7320c41d082d07cb13693d4d), it might have had something to do with types. Could you confirm this upgrade is ok, and, if so, go ahead and merge?

