### PR TITLE
Upgrade to Prisma 2.19.0 (Prisma Migrate GA)

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.10",
-    "@prisma/client": "2.18.0",
+    "@prisma/client": "2.19.0",
     "apollo-server-lambda": "2.21.1",
     "@redwoodjs/internal": "^0.27.1",
     "core-js": "3.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.18.0",
+    "@prisma/sdk": "2.19.0",
     "@redwoodjs/internal": "^0.27.1",
     "@redwoodjs/prerender": "^0.27.1",
     "@redwoodjs/structure": "^0.27.1",

--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -52,7 +52,7 @@ export const builder = async (yargs) => {
 
   // Only pass auto flags, when not running help
   if (!hasHelpFlag) {
-    if (['migrate', 'db'].includes(argv[0])) {
+    if (['db'].includes(argv[0])) {
       // this is safe as is if a user also adds --preview-feature
       autoFlags.push('--preview-feature')
     }

--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -52,12 +52,13 @@ export const builder = async (yargs) => {
 
   // Only pass auto flags, when not running help
   if (!hasHelpFlag) {
-    if (['db'].includes(argv[0])) {
+    if (['push', 'seed'].includes(argv[1])) {
       // this is safe as is if a user also adds --preview-feature
       autoFlags.push('--preview-feature')
     }
 
     if (
+      // `introspect` to be replaced by `db pull`; still valid as of prisma@2.19
       ['generate', 'introspect', 'db', 'migrate', 'studio'].includes(argv[0])
     ) {
       if (!fs.existsSync(paths.api.dbSchema)) {
@@ -93,7 +94,7 @@ export const builder = async (yargs) => {
     prismaCommand.stderr?.pipe(process.stderr)
 
     // So we can check for yarn prisma in the output
-    // e.g. yarn prisma introspect
+    // e.g. yarn prisma db pull
     const { stdout } = await prismaCommand
 
     if (hasHelpFlag || stdout?.match('yarn prisma')) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^1.3.5",
     "null-loader": "^4.0.1",
-    "prisma": "2.18.0",
+    "prisma": "2.19.0",
     "react-refresh": "^0.9.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.18.0",
+    "@prisma/sdk": "2.19.0",
     "@redwoodjs/internal": "^0.27.1",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,30 +2974,30 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@prisma/client@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.18.0.tgz#bff0a206f3caf7525583c703146f835dee0b5ad6"
-  integrity sha512-tRu0bdYNKIdWnFIbtgUmZyPgtDLV3AgwO8NYXirlbSn5poygbSaV87UfOBh1NmrvjS9EBP5dQv+bs62sVB84hA==
+"@prisma/client@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.19.0.tgz#a45f17a59fd109e95b61bf4b56d4a7642169ec0e"
+  integrity sha512-QK4M8TjJh1QesyO9aLM7DeAQUi5+UnNHpEAm5kwqBO1cq/4Ag5yU9ladctJFJleEE5BLewXHwV2t9A+VfCZslg==
   dependencies:
-    "@prisma/engines-version" "2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1"
+    "@prisma/engines-version" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
 
-"@prisma/debug@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.18.0.tgz#850abd31c0a9ea43638805bdba6446ea483e9a1b"
-  integrity sha512-t9JBGWKMbcBvXuxf9irI0qC1DfEP9k1G4/1P5LMlhBDMn43Jlu2UEmqYEqWtZUbyB0IHslXobn1hcb/9ibi/LA==
+"@prisma/debug@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.19.0.tgz#5d9c6b9deb0d5214360ee23644c4e40bee0f251d"
+  integrity sha512-rCFF69WVC2G8x89UaIf786m+Ik1CcEq8XiJ10kIHezOECJQRZAHVjuCXrCnHa9Z1D5r8xaSw6/SuCAmr0Fuedg==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.18.0.tgz#260fb1e78a25042484d70b7280334c96b72fa02e"
-  integrity sha512-GsYLoCrnPtTBvlp7557ZUqboFx92UaJYbWVXxudrSGkyUSpJlnkAcqvBbsUflgC/dhANH+H1+8AdUNl9SAVUxQ==
+"@prisma/engine-core@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.19.0.tgz#89172fc048b4a02aa1062f81c2292697d95fdbe5"
+  integrity sha512-utcC150Rf1yWgLptVArTLis2beQBs4ce3lq5IApKdM6+U/5CDaF4pVCriHbyMcYqeeKMgf5SdFh1t1RJIbCsNQ==
   dependencies:
-    "@prisma/debug" "2.18.0"
-    "@prisma/engines" "2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1"
-    "@prisma/generator-helper" "2.18.0"
-    "@prisma/get-platform" "2.18.0"
+    "@prisma/debug" "2.19.0"
+    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+    "@prisma/generator-helper" "2.19.0"
+    "@prisma/get-platform" "2.19.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -3007,23 +3007,23 @@
     terminal-link "^2.1.1"
     undici "3.3.3"
 
-"@prisma/engines-version@2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1":
-  version "2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1.tgz#c595c9d85ab2c67b67d0eb7bfbb0a3b05b41fdbe"
-  integrity sha512-+Eljsb1XItfq9B6vRTA1Oe4CQOGAxbsjtPAIORZwaU4Gt9RybnXapFlrQ8Mac89PXeSgcO4RnPSLEYhcd3kSVg==
+"@prisma/engines-version@2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d":
+  version "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz#a7f80d481ec6cb8e2975ab530664d4ca5fc9eba6"
+  integrity sha512-NzhbwC4iMbRQwJxdhNQX6eaVcOuNGtHRk6aesWE4KMf/YmlW5kfi3HDy7WZ/C4P0Iyn9oURDuk+xZV6QDUVjTw==
 
-"@prisma/engines@2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1":
-  version "2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1.tgz#647a7e2735b08fe28425be135120bb54ea408256"
-  integrity sha512-Q5q5mQePRFSSGbd/14Ogq1RNkebbbwskiTbWsvrSq14t9Us0rC9Xsecd4mr4rEAy8Yd6sXEJW4czZ/88DGzz2w==
+"@prisma/engines@2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d":
+  version "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz#db2809a6f7f18584e3ca89b1f5bad884155629ec"
+  integrity sha512-rEWpaG7wZvPuWJC5SwkBB/Iwue//oC5yv58Mse7r+ibtgkA7vGdWc1bFDQ32DT9tDL5WSC6bBwqEASGV/1Gm1Q==
 
-"@prisma/fetch-engine@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.18.0.tgz#95e855df2c836ab0995f530277f476db6a15a73e"
-  integrity sha512-jaMXZLZAED5H+9mbo/Gt72B7RAj00tJOQNh8UDVD5008RBqu/XuX29gw9ZHJjGCuedZ2qX2Bi+ZSfVtSKnQOnQ==
+"@prisma/fetch-engine@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.19.0.tgz#a01ebfc184ab09cc0ed9d6d4ef966c3846fb5332"
+  integrity sha512-Hc0OhvzWoGFQnsApGH//LSHdQggXIys/U1VQQpjOPowe5l1PQZBV/drHLrDo8jxkmQfTTFvSxcOeflkky2Bj0g==
   dependencies:
-    "@prisma/debug" "2.18.0"
-    "@prisma/get-platform" "2.18.0"
+    "@prisma/debug" "2.19.0"
+    "@prisma/get-platform" "2.19.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3040,34 +3040,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.18.0.tgz#c0222cba59940dafd284b3b089713884fce265e8"
-  integrity sha512-k+spncRdTE+k+1EFIxiBGSYr8e++uXvkHDA7UmQViLkOHTg7dxL3bQoDUM49r54Lzqt81wRaEGbaRlw5JGLGNQ==
+"@prisma/generator-helper@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.19.0.tgz#452ef6f47bf47d4df8cca79c0aff52160b0a7dc0"
+  integrity sha512-ZMTLyzPiqx7CETwZuo7DBlwLeckT3no3DbWN0r6iEGEyeOgOpoXhlL/ka3Payprc3j4MJ08M8MoI80biw/vdJw==
   dependencies:
-    "@prisma/debug" "2.18.0"
+    "@prisma/debug" "2.19.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.18.0.tgz#b94a1cfb68140901b4ec87924474c4c1c45dbe4a"
-  integrity sha512-OIoC65Fz1KaPYhH+K0iq+Du/qUSiwk59gGvLRVIJ/9KhVmA/gIjUTLnhJsIGpKD5cyVlP6Xva3VeKM6V7PsG6w==
+"@prisma/get-platform@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.19.0.tgz#1cf1fc975c28351cd50602c74f5f6532ca72bac5"
+  integrity sha512-tAv4BzJDxDDEdsU1mADdP0PKLVf8zbU9WI6nTDNSIhZsnVyBjMSWsHYnuoCgP94JtbnJ2gUSY35qJBvjLsl3kA==
   dependencies:
-    "@prisma/debug" "2.18.0"
+    "@prisma/debug" "2.19.0"
 
-"@prisma/sdk@2.18.0":
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.18.0.tgz#7fb6025d807041735fde32a583a7f5e407ff1f37"
-  integrity sha512-lUyeDmNcaE0UmH75clO8WqbwJ5adSWZjmrRDJCDwqZhs7w+d0XASVHFXfLVdbryYI56bzuRYIodDTS4MH0yk0A==
+"@prisma/sdk@2.19.0":
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.19.0.tgz#e871a4d34df64931fbdeb71613e6c10c6dc3bcc5"
+  integrity sha512-OeyinhRTWdcekIxpcfaGlXNADXukb80CWM9ok84rV8lh0q+++N3P8aiEvW85JAE5eMr5eTwlkzYlVDmfs17dRQ==
   dependencies:
-    "@prisma/debug" "2.18.0"
-    "@prisma/engine-core" "2.18.0"
-    "@prisma/engines" "2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1"
-    "@prisma/fetch-engine" "2.18.0"
-    "@prisma/generator-helper" "2.18.0"
-    "@prisma/get-platform" "2.18.0"
+    "@prisma/debug" "2.19.0"
+    "@prisma/engine-core" "2.19.0"
+    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+    "@prisma/fetch-engine" "2.19.0"
+    "@prisma/generator-helper" "2.19.0"
+    "@prisma/get-platform" "2.19.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
@@ -15166,12 +15166,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.18.0.tgz#b19a2d4a487b8b62759777be55506567af41f6ae"
-  integrity sha512-03po/kFW3/oGHtnANgZiKYz22KEx6NpdaIP2r4eievmVam9f2+0PdP4x/KSFdMCT6B6VHh+3ILTi2z3bYosCgA==
+prisma@2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.19.0.tgz#2c14f9cbbfb0ab69c8a9473e16736759713d29ad"
+  integrity sha512-iartCNVrtR4XT20ABN3zrSi3R/pCBe75Y0ZH8681QIGm8qjRQzf3DnbscPZgZ9iY4KFuVxL8ZrBQVDmRhpN0EQ==
   dependencies:
-    "@prisma/engines" "2.18.0-34.da6fafb57b24e0b61ca20960c64e2d41f9e8cff1"
+    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
 
 prismjs@^1.8.4:
   version "1.23.0"


### PR DESCRIPTION
- [x] Upgrade to Prisma v2.19.0: [Release Notes](https://github.com/prisma/prisma/releases/tag/2.19.0)
  - Prisma Migrate now GA
- [x] remove --preview-feature flag for migrate
- [x] add support for `prisma db pull`, which was added in 2.18 and will replace `introspect` in the future. Currently both are supported

updated docs here: https://github.com/redwoodjs/redwoodjs.com/pull/636

closed #2013 