### PR TITLE
Fixed path on windows to allow for pages under subdirectories

### DIFF
--- a/packages/internal/src/__tests__/paths.test.ts
+++ b/packages/internal/src/__tests__/paths.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('paths', () => {
   describe('processPagesDir', () => {
-    it('it accurately finds the pages', () => {
+    it('it accurately finds and names the pages', () => {
       const pagesDir = path.resolve(
         __dirname,
         '../../../../__fixtures__/example-todo-main/web/src/pages'

--- a/packages/internal/src/__tests__/paths.test.ts
+++ b/packages/internal/src/__tests__/paths.test.ts
@@ -16,22 +16,27 @@ describe('paths', () => {
       )
 
       const pages = processPagesDir(pagesDir)
+      expect(pages[0].importName).toEqual('adminEditUserPage')
       expect(pages[0].importPath).toEqual(
         importStatementPath(
           path.join(pagesDir, 'admin/EditUserPage/EditUserPage')
         )
       )
+      expect(pages[1].importName).toEqual('FatalErrorPage')
       expect(pages[1].importPath).toEqual(
         importStatementPath(
           path.join(pagesDir, 'FatalErrorPage/FatalErrorPage')
         )
       )
+      expect(pages[2].importName).toEqual('HomePage')
       expect(pages[2].importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'HomePage/HomePage'))
       )
+      expect(pages[3].importName).toEqual('NotFoundPage')
       expect(pages[3].importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'NotFoundPage/NotFoundPage'))
       )
+      expect(pages[4].importName).toEqual('TypeScriptPage')
       expect(pages[4].importPath).toEqual(
         importStatementPath(
           path.join(pagesDir, 'TypeScriptPage/TypeScriptPage')

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -178,6 +178,8 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
 
 /**
  * Process the pages directory and return information useful for automated imports.
+ *
+ * Note: glob.sync returns posix style paths on Windows machines
  */
 export const processPagesDir = (
   webPagesDir: string = getPaths().web.pages
@@ -188,7 +190,7 @@ export const processPagesDir = (
   return pagePaths.map((pagePath) => {
     const p = path.parse(pagePath)
 
-    const importName = p.dir.replace(path.sep, '')
+    const importName = p.dir.replace('/', '')
     const importPath = importStatementPath(
       path.join(webPagesDir, p.dir, p.name)
     )


### PR DESCRIPTION
Fixes Issue #2015 

On Windows, the path did not resolve correctly when using pages in subdirectories.  Added some new tests and made a simple change to the code.  Note that glob appears to return posix style paths on Windows, so to the reference to path.sep did not work.

This is my first or (ever) so let me know if you have any suggestions for the future.
