### PR TITLE
Router: Fix auth

### DIFF
--- a/packages/router/src/private-context.tsx
+++ b/packages/router/src/private-context.tsx
@@ -32,12 +32,7 @@ export const PrivateContextProvider: React.FC<ProviderProps> = ({
   unauthenticated,
 }) => {
   const routerState = useRouterState()
-  const isAuthenticated = routerState.useAuth
-    ? routerState.useAuth().isAuthenticated
-    : false
-  const hasRole = routerState.useAuth
-    ? routerState.useAuth().hasRole
-    : () => false
+  const { isAuthenticated, hasRole } = routerState.useAuth()
 
   const unauthorized = useCallback(() => {
     return !(isAuthenticated && (!role || hasRole(role)))

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -1,6 +1,6 @@
 import React, { useReducer, createContext, useContext } from 'react'
 
-import type { useAuth } from '@redwoodjs/auth'
+import { useAuth } from '@redwoodjs/auth'
 
 import { ParamType } from './internal'
 
@@ -9,7 +9,7 @@ const DEFAULT_PAGE_LOADING_DELAY = 1000 // milliseconds
 export interface RouterState {
   paramTypes?: Record<string, ParamType>
   pageLoadingDelay?: number
-  useAuth?: typeof useAuth
+  useAuth: typeof useAuth
 }
 
 const RouterStateContext = createContext<RouterState | undefined>(undefined)
@@ -22,18 +22,22 @@ const RouterSetContext = createContext<
   React.Dispatch<Partial<RouterState>> | undefined
 >(undefined)
 
+interface ProviderProps extends Omit<RouterState, 'useAuth'> {
+  useAuth?: typeof useAuth
+}
+
 function stateReducer(state: RouterState, newState: Partial<RouterState>) {
   return { ...state, ...newState }
 }
 
-export const RouterContextProvider: React.FC<RouterState> = ({
-  useAuth,
+export const RouterContextProvider: React.FC<ProviderProps> = ({
+  useAuth: customUseAuth,
   paramTypes,
   pageLoadingDelay = DEFAULT_PAGE_LOADING_DELAY,
   children,
 }) => {
   const [state, setState] = useReducer(stateReducer, {
-    useAuth,
+    useAuth: customUseAuth || useAuth,
     paramTypes,
     pageLoadingDelay,
   })

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -83,6 +83,7 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
   const location = useLocation()
   const routerState = useRouterState()
   const { isPrivate, unauthorized, unauthenticated } = usePrivate()
+  const { loading } = routerState.useAuth()
 
   if (notfound) {
     // The "notfound" route is handled by <NotFoundChecker>
@@ -107,14 +108,6 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
   }
 
   if (isPrivate) {
-    if (!routerState.useAuth) {
-      throw new Error(
-        'You need to pass `useAuth` to the router when using private routes'
-      )
-    }
-
-    const { loading } = routerState.useAuth()
-
     if (loading) {
       return whileLoading()
     }


### PR DESCRIPTION
Hooks need to run in a predictable order.

If `useAuth` isn't passed to the router, it should use the default one from @redwoodjs/auth