### PR TITLE
Allows users to create a custom storybook preview config

### DIFF
--- a/packages/core/config/storybook/main.js
+++ b/packages/core/config/storybook/main.js
@@ -29,6 +29,10 @@ const baseConfig = {
       }
     }
 
+    if (fs.existsSync(getPaths().web.storybookPreviewConfig)) {
+      sbConfig.resolve.alias['~__REDWOOD__USER_STORYBOOK_PREVIEW_CONFIG'] = getPaths().web.storybookPreviewConfig
+    }
+
     sbConfig.resolve.extensions = rwConfig.resolve.extensions
     sbConfig.resolve.plugins = rwConfig.resolve.plugins // Directory Named Plugin
 

--- a/packages/core/config/storybook/preview.js
+++ b/packages/core/config/storybook/preview.js
@@ -14,3 +14,11 @@ require('~__REDWOOD__USER_WEB_DEFAULT_CSS')
 addDecorator((storyFn, { id }) => {
   return React.createElement(StorybookProvider, { storyFn, id })
 })
+
+try {
+  require('~__REDWOOD__USER_STORYBOOK_PREVIEW_CONFIG')
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') {
+    throw e
+  }
+}

--- a/packages/internal/src/paths.ts
+++ b/packages/internal/src/paths.ts
@@ -33,6 +33,7 @@ export interface BrowserTargetPaths {
   webpack: string
   postcss: string
   storybookConfig: string
+  storybookPreviewConfig: string
   dist: string
 }
 
@@ -77,6 +78,7 @@ const PATH_WEB_DIR_CONFIG = 'web/config'
 const PATH_WEB_DIR_CONFIG_WEBPACK = 'web/config/webpack.config.js'
 const PATH_WEB_DIR_CONFIG_POSTCSS = 'web/config/postcss.config.js'
 const PATH_WEB_DIR_CONFIG_STORYBOOK_CONFIG = 'web/config/storybook.config.js'
+const PATH_WEB_DIR_CONFIG_STORYBOOK_PREVIEW = 'web/config/storybook.preview.js'
 
 const PATH_WEB_DIR_DIST = 'web/dist'
 
@@ -172,6 +174,10 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       storybookConfig: path.join(
         BASE_DIR,
         PATH_WEB_DIR_CONFIG_STORYBOOK_CONFIG
+      ),
+      storybookPreviewConfig: path.join(
+        BASE_DIR,
+        PATH_WEB_DIR_CONFIG_STORYBOOK_PREVIEW
       ),
       dist: path.join(BASE_DIR, PATH_WEB_DIR_DIST),
     },


### PR DESCRIPTION
This allows a user to create a custom Storybook preview file in `web/config/storybook.preview.js` and have it imported into the framework's version.

I haven't added any documentation yet for two reasons. First, I want some confirmation that this approach is reasonable. But also, this actually took me a lot longer than it should have because I didn't realize that we're still on Storybook 5.3 and had to use the old `addDecorator` syntax. I suspect this will trip up other users as well, so perhaps it would be worthwhile to update to the latest Storybook before publicizing this feature? Anyone who tries to reference the Storybook docs for the syntax of this file will likely also be confused.

Sample `web/config/storybook.preview.js`:

```javascript
import React from 'react'
import { addDecorator } from '@storybook/react'

addDecorator((Story) => {
  return (
    <div style={{ backgroundColor: 'red' }}>
      <Story />
    </div>
  )
})
```

And displayed component:
<img width="729" alt="Screen Shot 2021-03-20 at 8 06 03 AM" src="https://user-images.githubusercontent.com/176426/111875197-d133f200-8955-11eb-9d8d-c4031ac84db5.png">

cc @peterp who opened https://github.com/redwoodjs/redwood/issues/1595 and @Tobbe who pointed me to it from the Discord!