### PR TITLE
Fix Logger Readme destination param in transport examples

### DIFF
--- a/packages/api/src/logger/README.md
+++ b/packages/api/src/logger/README.md
@@ -296,8 +296,8 @@ To stream your logs to [Datadog](https://www.datadoghq.com/), you can
 // ...
 
 export const logger = createLogger({
-   options: { ...defaultLoggerOptions,
-   destination: stream},
+   options: { ...defaultLoggerOptions },
+   destination: stream },
 })
 ```
 
@@ -326,8 +326,8 @@ export const stream = createWriteStream({
 })
 
 export const logger = createLogger({
-  options: { ...defaultLoggerOptions,
-  destination: stream},
+  options: { ...defaultLoggerOptions },
+  destination: stream },
 })
 ```
 


### PR DESCRIPTION
The params in the Datadog and Logflare example code for the Logger README had incorrect params.

This PR fixes that so there are both `options` and `destination` params (not the destination is a part of options).