### PR TITLE
Remove a11y addon (for now)

### DIFF
--- a/packages/core/config/storybook/main.js
+++ b/packages/core/config/storybook/main.js
@@ -8,9 +8,9 @@ const config = getConfig()
 
 const baseConfig = {
   stories: ['../../../../web/src/**/*.stories.{tsx,jsx,js}'],
-  addons: [
-     config.web.a11y && '@storybook/addon-a11y'
-  ].filter(Boolean),
+  // addons: [
+  //    config.web.a11y && '@storybook/addon-a11y'
+  // ].filter(Boolean),
   webpackFinal: (sbConfig, { configType }) => {
     // configType is 'PRODUCTION' or 'DEVELOPMENT', why shout?
     const isEnvProduction = configType && configType.toLowerCase() === 'production'


### PR DESCRIPTION
The a11y add on hasn't been fixed yet (see https://github.com/storybookjs/storybook/issues/14321); this PR just comments out the block of code enabling it by default. We can comment it back in when it's fixed.

Here's the console in the terminal again for reference:

![image](https://user-images.githubusercontent.com/32992335/112346143-e6c15880-8c82-11eb-96b0-b786d95d0aab.png)
