### PR TITLE
Fix typeDefs for schema options

### DIFF
--- a/packages/api/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/api/src/makeMergedSchema/makeMergedSchema.ts
@@ -214,7 +214,15 @@ export const makeMergedSchema = ({
     resolvers: mergeResolvers(schemas),
     services,
   })
-  addResolveFunctionsToSchema({ schema, resolvers })
+
+  const { resolverValidationOptions, inheritResolversFromInterfaces } =
+    schemaOptions || {}
+  addResolveFunctionsToSchema({
+    schema,
+    resolvers,
+    resolverValidationOptions,
+    inheritResolversFromInterfaces,
+  })
 
   return schema
 }

--- a/packages/api/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/api/src/makeMergedSchema/makeMergedSchema.ts
@@ -196,7 +196,7 @@ export const makeMergedSchema = ({
   /**
    * A list of options passed to [makeExecutableSchema](https://www.graphql-tools.com/docs/generate-schema/#makeexecutableschemaoptions).
    */
-  schemaOptions?: IExecutableSchemaDefinition
+  schemaOptions?: Partial<IExecutableSchemaDefinition>
 }) => {
   const typeDefs = mergeTypes(
     [rootSchema.schema, ...Object.values(schemas).map(({ schema }) => schema)],


### PR DESCRIPTION
We supply typedefs a bit higher, so I'm making it optional a bit lower down.

The validation flags also need to be added to `addResolveFunctionsToSchema`, otherwise this isn't very helpful.