### PR TITLE
Set: Forward props to wrapper components

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -7,14 +7,18 @@ import { isRoute } from './router'
 import { useRouterState } from './router-context'
 import { flattenAll, matchPath } from './util'
 
+type WrapperType<WTProps> = (
+  props: WTProps & { children: ReactNode }
+) => ReactElement | null
+
 type ReduceType = ReactElement | undefined
 
-interface SetProps {
-  wrap: unknown | unknown[]
+type SetProps<P> = P & {
+  wrap: WrapperType<P> | WrapperType<P>[]
   children: ReactNode
-  [_: string]: unknown
 }
-export function Set(props: SetProps) {
+
+export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   const { wrap, children, ...rest } = props
   const routerState = useRouterState()
   const location = useLocation()
@@ -55,7 +59,10 @@ export function Set(props: SetProps) {
       // Expand and nest the wrapped elements.
       return (
         wrappers.reduceRight<ReduceType>((acc, wrapper) => {
-          return React.createElement(wrapper, rest, acc ? acc : children)
+          return React.createElement(wrapper, {
+            ...rest,
+            children: acc ? acc : children,
+          } as SetProps<WrapperProps>)
         }, undefined) || null
       )
     }

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, FunctionComponentElement } from 'react'
+import React, { ReactElement, ReactNode } from 'react'
 
 import { Redirect } from './links'
 import { useLocation } from './location'
@@ -7,19 +7,15 @@ import { isRoute } from './router'
 import { useRouterState } from './router-context'
 import { flattenAll, matchPath } from './util'
 
-interface PropsWithChildren {
+type ReduceType = ReactElement | undefined
+
+interface SetProps {
+  wrap: unknown | unknown[]
   children: ReactNode
+  [_: string]: unknown
 }
-
-type WrapperType = (props: { children: any }) => ReactElement | null
-type ReduceType = FunctionComponentElement<PropsWithChildren> | undefined
-
-interface Props {
-  wrap: WrapperType | WrapperType[]
-  children: ReactNode
-}
-
-export const Set: React.FC<Props> = ({ children, wrap }) => {
+export function Set(props: SetProps) {
+  const { wrap, children, ...rest } = props
   const routerState = useRouterState()
   const location = useLocation()
   const { loading } = routerState.useAuth()
@@ -59,7 +55,7 @@ export const Set: React.FC<Props> = ({ children, wrap }) => {
       // Expand and nest the wrapped elements.
       return (
         wrappers.reduceRight<ReduceType>((acc, wrapper) => {
-          return React.createElement(wrapper, undefined, acc ? acc : children)
+          return React.createElement(wrapper, rest, acc ? acc : children)
         }, undefined) || null
       )
     }

--- a/packages/router/src/__tests__/set.test.tsx
+++ b/packages/router/src/__tests__/set.test.tsx
@@ -93,7 +93,6 @@ test('wraps components in other components', async () => {
 
 test('passes props to wrappers', async () => {
   interface Props {
-    children: React.ReactNode
     propOne: string
     propTwo: string
   }

--- a/packages/router/src/__tests__/set.test.tsx
+++ b/packages/router/src/__tests__/set.test.tsx
@@ -90,3 +90,67 @@ test('wraps components in other components', async () => {
     </div>
   `)
 })
+
+test('passes props to wrappers', async () => {
+  interface Props {
+    children: React.ReactNode
+    propOne: string
+    propTwo: string
+  }
+
+  const PropWrapper: React.FC<Props> = ({ children, propOne, propTwo }) => (
+    <div>
+      <h1>Prop Wrapper</h1>
+      <p>1:{propOne}</p>
+      <p>2:{propTwo}</p>
+      {children}
+    </div>
+  )
+  const TestSet = () => (
+    <Router useAuth={window.__REDWOOD__USE_AUTH}>
+      <Set wrap={[PropWrapper, GlobalLayout]} propOne="une" propTwo="deux">
+        <Route path="/" page={ChildA} name="childa" />
+      </Set>
+    </Router>
+  )
+
+  const screen = render(<TestSet />)
+
+  await waitFor(() => screen.getByText('ChildA'))
+
+  expect(screen.container).toMatchInlineSnapshot(`
+    <div>
+      <div>
+        <h1>
+          Prop Wrapper
+        </h1>
+        <p>
+          1:
+          une
+        </p>
+        <p>
+          2:
+          deux
+        </p>
+        <div>
+          <h1>
+            Global Layout
+          </h1>
+          <h1>
+            ChildA
+          </h1>
+          <div
+            aria-atomic="true"
+            aria-live="assertive"
+            id="redwood-announcer"
+            role="alert"
+            style="position: absolute; top: 0px; width: 1px; height: 1px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
+          <footer>
+            This is a footer
+          </footer>
+        </div>
+      </div>
+    </div>
+  `)
+})


### PR DESCRIPTION
Any prop you give to `<Set>` (except for `wrap`) will be passed on to the wrapper components.

This...
```
<Set wrap={[LayoutA, LayoutB]} data="atad" id="5">
  <Route path="/" page={HomePage} name="home" />
</Set>
```
becomes...
```
<LayoutA data="atad" id="5">
  <LayoutB data="atad" id="5">
    <Route path="/" page={HomePage} name="home" />
  </LayoutB>
</LayoutA>