### PR TITLE
Router: Populate `routes` for tests

### DIFF
--- a/packages/testing/src/MockRouter.tsx
+++ b/packages/testing/src/MockRouter.tsx
@@ -3,35 +3,31 @@ import React from 'react'
 
 // Bypass the `main` field in `package.json` because we alias `@redwoodjs/router`
 // for jest and Storybook. Not doing so would cause an infinite loop.
-// See: ./packages/core/config/jest.config.web.js
+// See: ./packages/core/config/src/configs/browser/jest.createConfig.ts
 // @ts-ignore
-import { Private, Route } from '@redwoodjs/router/dist/index'
+import { isRoute } from '@redwoodjs/router/dist/router'
+import { flattenAll, replaceParams } from '@redwoodjs/router/dist/util'
 // @ts-ignore
 export * from '@redwoodjs/router/dist/index'
 
 export const routes: { [routeName: string]: () => string } = {}
-
-const getPrivateRoutes = (children: React.ReactNode) =>
-  (React.Children.toArray(children) as React.ReactElement[])
-    .filter((child) => child.type === Private)
-    .map((child) => child.props.children)
-    .flat(Infinity)
 
 /**
  * We overwrite the default `Router` export.
  * It populates the `routes.<pagename>()` utility object.
  */
 export const Router: React.FunctionComponent = ({ children }) => {
-  // get all children from <Private> blocks.
-  const privateRoutes = getPrivateRoutes(children)
+  const flatChildArray = flattenAll(children)
 
-  const normalRoutes = (React.Children.toArray(
-    children
-  ) as React.ReactElement[]).filter((child) => child.type === Route)
+  flatChildArray.forEach((child) => {
+    if (isRoute(child)) {
+      const { name, path } = child.props
 
-  for (const child of [...privateRoutes, ...normalRoutes]) {
-    const { name } = child.props
-    routes[name] = () => name
-  }
+      if (name && path) {
+        routes[name] = (args = {}) => replaceParams(path, args)
+      }
+    }
+  })
+
   return <></>
 }


### PR DESCRIPTION
We have a separate `<MockRouter>` that we use instead of the real `<Router>` when running tests in RW apps (not RW framework). This MockRouter is now updated to reflect the rewrite of the real Router.

Fixes #2131