### PR TITLE
Adding Transform Capability to SelectField

### DIFF
--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -276,7 +276,7 @@ const SelectField = forwardRef<
   React.useEffect(() => {
     setCoercion({
       name: props.name,
-      transformValue: props.transformValue, // || props.dataType,
+      transformValue: props.transformValue,
     })
   }, [setCoercion, props.name, props.transformValue])
 

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -82,7 +82,7 @@ const inputTagProps = <T extends InputTagProps>(
   const contextError = fieldErrorsContext[props.name]
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  useEffect(() => {
+  React.useEffect(() => {
     if (contextError) {
       setError(props.name, { type: 'server', message: contextError })
     }
@@ -233,7 +233,7 @@ const TextAreaField = forwardRef<
   const { register } = useFormContext()
   const { setCoercion } = useCoercion()
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (process.env.NODE_ENV !== 'production' && props.dataType !== undefined) {
       console.warn(
         'Using the "dataType" prop on form input fields is deprecated. Use "transformValue" instead.'
@@ -271,6 +271,15 @@ const SelectField = forwardRef<
   ValidatableFieldProps & React.SelectHTMLAttributes<HTMLSelectElement>
 >((props, ref) => {
   const { register } = useFormContext()
+  const { setCoercion } = useCoercion()
+
+  React.useEffect(() => {
+    setCoercion({
+      name: props.name,
+      transformValue: props.transformValue, // || props.dataType,
+    })
+  }, [setCoercion, props.name, props.transformValue])
+
   const tagProps = inputTagProps(props)
 
   return (


### PR DESCRIPTION
I noted that the `SelectField `did not have a `transformValue `capability, so I added it in a manner consistent with the other Form input components.   It makes things more seamless when selecting options that map to integer values that I need to send back in mutations, and I think this would be a fairly common use case.

Note that I did not add the capability to use dataType as that is depreciated, and no-one should be using it on a `SelectField `as it would not have worked. 

I hope that helps and please let me know if you have any suggestions.