### PR TITLE
useParams should always be populated.

### DIFF
--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -465,7 +465,7 @@ test('renders first matching route only', async () => {
   expect(screen.queryByText(/param/)).not.toBeInTheDocument()
 })
 
-test('params should never be undefined', async (done) => {
+test('params should never be an empty object', async (done) => {
   const ParamPage = () => {
     const params = useParams()
     expect(params).not.toEqual({})

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -484,7 +484,7 @@ test('params should never be an empty object', async (done) => {
   render(<TestRouter />)
 })
 
-test.only('params should never be an empoty object in Set', async (done) => {
+test.only('params should never be an empty object in Set', async (done) => {
   const ParamPage = () => {
     return null
   }

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -465,10 +465,16 @@ test('renders first matching route only', async () => {
   expect(screen.queryByText(/param/)).not.toBeInTheDocument()
 })
 
-test('params should never be undefined', async (done) => {
+test.only('params should never be undefined', async (done) => {
   const ParamPage = () => {
+    // 1st render params: {}
+    // 2nd render params: { documentId: '1' }
     const params = useParams()
-    expect(params).not.toEqual({})
+
+    console.log(params)
+    // Note: Adding this expectation will not fail, and not cause the 2nd
+    // render to appear.
+    // expect(params).not.toEqual({})
     done()
     return null
   }

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -480,11 +480,11 @@ test('params should never be an empty object', async (done) => {
     </Router>
   )
 
+  act(() => navigate('/test/1'))
   render(<TestRouter />)
-  act(() => navigate(routes.param({ documentId: '1' })))
 })
 
-test('params should never be an empoty object in Set', async (done) => {
+test.only('params should never be an empoty object in Set', async (done) => {
   const ParamPage = () => {
     return null
   }
@@ -506,6 +506,7 @@ test('params should never be an empoty object in Set', async (done) => {
     </Router>
   )
 
+  act(() => navigate('/test/1'))
   render(<TestRouter />)
-  act(() => navigate(routes.param({ documentId: '1' })))
+  //act(() => navigate(routes.param({ documentId: '1' })))
 })

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -465,16 +465,10 @@ test('renders first matching route only', async () => {
   expect(screen.queryByText(/param/)).not.toBeInTheDocument()
 })
 
-test.only('params should never be undefined', async (done) => {
+test('params should never be undefined', async (done) => {
   const ParamPage = () => {
-    // 1st render params: {}
-    // 2nd render params: { documentId: '1' }
     const params = useParams()
-
-    console.log(params)
-    // Note: Adding this expectation will not fail, and not cause the 2nd
-    // render to appear.
-    // expect(params).not.toEqual({})
+    expect(params).not.toEqual({})
     done()
     return null
   }

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -464,3 +464,22 @@ test('renders first matching route only', async () => {
   await waitFor(() => screen.getByText('About Page'))
   expect(screen.queryByText(/param/)).not.toBeInTheDocument()
 })
+
+test('params should never be undefined', async (done) => {
+  const ParamPage = () => {
+    const params = useParams()
+    expect(params).not.toEqual({})
+    done()
+    return null
+  }
+
+  const TestRouter = () => (
+    // @ts-expect-error - Meh.
+    <Router useAuth={window.__REDWOOD__USE_AUTH}>
+      <Route path="/test/{documentId}" page={ParamPage} name="param" />
+    </Router>
+  )
+
+  render(<TestRouter />)
+  act(() => navigate(routes.param({ documentId: '1' })))
+})

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -484,14 +484,13 @@ test('params should never be an empty object', async (done) => {
   render(<TestRouter />)
 })
 
-test.only('params should never be an empty object in Set', async (done) => {
+test('params should never be an empty object in Set', async (done) => {
   const ParamPage = () => {
     return null
   }
 
   const SetWithUseParams = ({ children }) => {
     const params = useParams()
-    params //?
     expect(params).not.toEqual({})
     done()
     return children
@@ -508,5 +507,4 @@ test.only('params should never be an empty object in Set', async (done) => {
 
   act(() => navigate('/test/1'))
   render(<TestRouter />)
-  //act(() => navigate(routes.param({ documentId: '1' })))
 })

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -483,3 +483,29 @@ test('params should never be an empty object', async (done) => {
   render(<TestRouter />)
   act(() => navigate(routes.param({ documentId: '1' })))
 })
+
+test('params should never be an empoty object in Set', async (done) => {
+  const ParamPage = () => {
+    return null
+  }
+
+  const SetWithUseParams = ({ children }) => {
+    const params = useParams()
+    params //?
+    expect(params).not.toEqual({})
+    done()
+    return children
+  }
+
+  const TestRouter = () => (
+    // @ts-expect-error - Meh.
+    <Router useAuth={window.__REDWOOD__USE_AUTH}>
+      <Set wrap={SetWithUseParams}>
+        <Route path="/test/{documentId}" page={ParamPage} name="param" />
+      </Set>
+    </Router>
+  )
+
+  render(<TestRouter />)
+  act(() => navigate(routes.param({ documentId: '1' })))
+})

--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -134,6 +134,8 @@ export class PageLoader extends React.Component<Props> {
       slowModuleImport: false,
       params: props.params,
     })
+
+    this.context.setParams(props.params)
   }
 
   render() {

--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -128,8 +128,6 @@ export class PageLoader extends React.Component<Props> {
     // Remove the timeout because the page has loaded.
     this.clearLoadingTimeout()
 
-    this.context.setParams(props.params)
-
     this.setState({
       pageName: name,
       Page: module.default,

--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -128,14 +128,14 @@ export class PageLoader extends React.Component<Props> {
     // Remove the timeout because the page has loaded.
     this.clearLoadingTimeout()
 
+    this.context.setParams(props.params)
+
     this.setState({
       pageName: name,
       Page: module.default,
       slowModuleImport: false,
       params: props.params,
     })
-
-    this.context.setParams(props.params)
   }
 
   render() {

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -3,7 +3,7 @@ import React, { useState, useContext } from 'react'
 import { useLocation } from 'src/location'
 import { useRouterState } from 'src/router-context'
 
-import { createNamedContext, matchPath } from './internal'
+import { createNamedContext, matchPath, parseSearch } from './internal'
 
 export interface ParamsContextProps {
   params: Record<string, string>
@@ -16,7 +16,8 @@ export const ParamsProvider: React.FC = ({ children }) => {
   const { routes, paramTypes } = useRouterState()
   const location = useLocation()
 
-  let initialParams = {}
+  let initialParams = parseSearch(location.search)
+
   for (const route of routes) {
     if (route.path) {
       const { match, params } = matchPath(
@@ -24,8 +25,12 @@ export const ParamsProvider: React.FC = ({ children }) => {
         location.pathname,
         paramTypes
       )
-      if (match && params) {
-        initialParams = params
+
+      if (match) {
+        initialParams = {
+          ...initialParams,
+          ...params,
+        }
       }
     }
   }

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -12,7 +12,7 @@ export interface ParamsContextProps {
 
 export const ParamsContext = createNamedContext<ParamsContextProps>('Params')
 
-export const ParamsProvider: React.FC = ({ children, ...x }) => {
+export const ParamsProvider: React.FC = ({ children }) => {
   const { routes, paramTypes } = useRouterState()
   const location = useLocation()
 

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -10,7 +10,6 @@ export interface ParamsContextProps {
 export const ParamsContext = createNamedContext<ParamsContextProps>('Params')
 
 export const ParamsProvider: React.FC = ({ children }) => {
-  // TODO: Populate the params.
   const [params, setParams] = useState<Record<string, string> | undefined>()
 
   return (

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -1,16 +1,36 @@
 import React, { useState, useContext } from 'react'
 
-import { createNamedContext } from './internal'
+import { useLocation } from 'src/location'
+import { useRouterState } from 'src/router-context'
+
+import { createNamedContext, matchPath } from './internal'
 
 export interface ParamsContextProps {
-  params: Record<string, string> | undefined
-  setParams: (newParams: Record<string, string> | undefined) => void
+  params: Record<string, string>
+  setParams: (newParams: Record<string, string>) => void
 }
 
 export const ParamsContext = createNamedContext<ParamsContextProps>('Params')
 
-export const ParamsProvider: React.FC = ({ children }) => {
-  const [params, setParams] = useState<Record<string, string> | undefined>()
+export const ParamsProvider: React.FC = ({ children, ...x }) => {
+  const { routes, paramTypes } = useRouterState()
+  const location = useLocation()
+
+  let initialParams = {}
+  for (const route of routes) {
+    if (route.path) {
+      const { match, params } = matchPath(
+        route.path,
+        location.pathname,
+        paramTypes
+      )
+      if (match && params) {
+        initialParams = params
+      }
+    }
+  }
+
+  const [params, setParams] = useState<Record<string, string>>(initialParams)
 
   return (
     <ParamsContext.Provider value={{ params, setParams }}>
@@ -26,5 +46,5 @@ export const useParams = () => {
     throw new Error('useParams must be used within a ParamsProvider')
   }
 
-  return paramsContext.params || {}
+  return paramsContext.params
 }

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -10,9 +10,8 @@ export interface ParamsContextProps {
 export const ParamsContext = createNamedContext<ParamsContextProps>('Params')
 
 export const ParamsProvider: React.FC = ({ children }) => {
-  const [params, setParams] = useState<Record<string, string> | undefined>(
-    undefined
-  )
+  // TODO: Populate the params.
+  const [params, setParams] = useState<Record<string, string> | undefined>()
 
   return (
     <ParamsContext.Provider value={{ params, setParams }}>

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -47,8 +47,6 @@ export const RouterContextProvider: React.FC<ProviderProps> = ({
       return { name, path, page }
     })
 
-  // @ts-expect-error - Not sure what TS is complaining about here.
-  // Help. me.
   const [state, setState] = useReducer(stateReducer, {
     useAuth: customUseAuth || useAuth,
     paramTypes,

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -2,7 +2,9 @@ import React, { useReducer, createContext, useContext } from 'react'
 
 import { useAuth } from '@redwoodjs/auth'
 
-import { ParamType } from './internal'
+import type { ParamType } from 'src/internal'
+import { isRoute, PageType } from 'src/router'
+import { flattenAll } from 'src/util'
 
 const DEFAULT_PAGE_LOADING_DELAY = 1000 // milliseconds
 
@@ -10,6 +12,7 @@ export interface RouterState {
   paramTypes?: Record<string, ParamType>
   pageLoadingDelay?: number
   useAuth: typeof useAuth
+  routes: Array<{ name: string; path: string; page: PageType }>
 }
 
 const RouterStateContext = createContext<RouterState | undefined>(undefined)
@@ -36,10 +39,21 @@ export const RouterContextProvider: React.FC<ProviderProps> = ({
   pageLoadingDelay = DEFAULT_PAGE_LOADING_DELAY,
   children,
 }) => {
+  // Create an internal representation of all the routes and paths.
+  const routes = flattenAll(children)
+    .filter(isRoute)
+    .map((route) => {
+      const { name, path, page } = route.props
+      return { name, path, page }
+    })
+
+  // @ts-expect-error - Not sure what TS is complaining about here.
+  // Help. me.
   const [state, setState] = useReducer(stateReducer, {
     useAuth: customUseAuth || useAuth,
     paramTypes,
     pageLoadingDelay,
+    routes,
   })
 
   return (

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -25,7 +25,7 @@ const RouterSetContext = createContext<
   React.Dispatch<Partial<RouterState>> | undefined
 >(undefined)
 
-interface ProviderProps extends Omit<RouterState, 'useAuth'> {
+interface ProviderProps extends Omit<RouterState, 'useAuth' | 'routes'> {
   useAuth?: typeof useAuth
 }
 

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -12,7 +12,7 @@ export interface RouterState {
   paramTypes?: Record<string, ParamType>
   pageLoadingDelay?: number
   useAuth: typeof useAuth
-  routes: Array<{ name: string; path: string; page: PageType }>
+  routes: Array<{ name?: string; path?: string; page?: PageType }>
 }
 
 const RouterStateContext = createContext<RouterState | undefined>(undefined)

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -326,4 +326,4 @@ const normalizePage = (specOrPage: Spec | React.ComponentType): Spec => {
   }
 }
 
-export { Router, Route, Private, namedRoutes as routes, isRoute }
+export { Router, Route, Private, namedRoutes as routes, isRoute, PageType }


### PR DESCRIPTION
`useParams` should always contain the current parameters.

- [x] Populate params before rendering the page.

Closes #2137