### PR TITLE
[v0.28.3] Upgrade apollo-server-lambda and remove resolution

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
     "@prisma/client": "2.19.0",
     "@redwoodjs/internal": "^0.28.2",
     "@types/pino": "^6.3.6",
-    "apollo-server-lambda": "2.18.2",
+    "apollo-server-lambda": "2.22.2",
     "core-js": "3.6.5",
     "graphql": "15.5.0",
     "graphql-scalars": "1.9.0",

--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -20,8 +20,6 @@
   },
   "resolutions": {
     "react": "17.0.1",
-    "react-dom": "17.0.1",
-    "// Temporary fix for": "https://github.com/redwoodjs/redwood/issues/2127",
-    "apollo-server-core": "2.21.2"
+    "react-dom": "17.0.1"
   }
 }

--- a/packages/create-redwood-app/template/yarn.lock
+++ b/packages/create-redwood-app/template/yarn.lock
@@ -1782,10 +1782,10 @@
     tslib "^2.1.0"
     warning "^4.0.3"
 
-"@redwoodjs/api-server@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/api-server/-/api-server-0.28.0.tgz#29ee2dc206066a4636725835a8e85f40beb5d6bf"
-  integrity sha512-Tb9j2k13rRfXPYRBU4kaheUIUNTMpQyojaTaE2QVAX7Jc8muueLnQIkDcQasAJFBQUqMdt+kp6PkrMS6vE9qMA==
+"@redwoodjs/api-server@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/api-server/-/api-server-0.28.2.tgz#5c66b5fec74f2c17d086019b31ff9181f1cc8dc3"
+  integrity sha512-h3fD8xrZ55aGBc5YXfz92+wdL5iH42uAqE+dm5abdQRAyaiIIwSXoUtdezk5h6F66zj9lV2aQniAIffqUjZ0Lw==
   dependencies:
     body-parser "^1.19.0"
     chokidar "3.5.1"
@@ -1799,14 +1799,14 @@
     youch "^2.1.1"
     youch-terminal "^1.0.1"
 
-"@redwoodjs/api@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/api/-/api-0.28.0.tgz#427e2639b37d761b6d99a53524d3205917369fc0"
-  integrity sha512-re1u/FeYE/pJQ+GQSgZcLm1t/8Figgm64oa1MuSD5IuTZ7YnbS2TNjA7Q8JU71Fan3xJGugtxD4RVk+Ye+gsvw==
+"@redwoodjs/api@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/api/-/api-0.28.2.tgz#2e08e770927a1b68138c9916fa7d26172705c277"
+  integrity sha512-+i0Y75D/akB5hekDPIVWKoFw4nDyY35xSksqWy5Ev/neteIheLxo5TBa+fZYKVokoCu1pUCbfA2iBQgZNPqxwg==
   dependencies:
     "@graphql-tools/merge" "6.2.10"
     "@prisma/client" "2.19.0"
-    "@redwoodjs/internal" "^0.28.0"
+    "@redwoodjs/internal" "^0.28.2"
     "@types/pino" "^6.3.6"
     apollo-server-lambda "2.18.2"
     core-js "3.6.5"
@@ -1819,20 +1819,20 @@
     pino "^6.11.1"
     pino-pretty "^4.7.0"
 
-"@redwoodjs/auth@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/auth/-/auth-0.28.0.tgz#1360dad65df9981d98b3fe9e44c96c4388790b9a"
-  integrity sha512-TiBDrszWdWBBpdtQt5+/eeZPgS9iATRzLCY7VjnlJu4R+PMzH/iIxRzNoN/oWx6Xv4fjs6uIdFSSPm+R2d8H7A==
+"@redwoodjs/auth@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/auth/-/auth-0.28.2.tgz#8a90767cc261cc511e235060b7bc673a24da5cb4"
+  integrity sha512-AqKtEG5BdIyK8XyxgetpIasTMwRQHCOt5Cjf5sYyj0sk2csTT/jbSORTGEXwuZBef6WnWJiTgS8U1UnQhdD6hQ==
 
-"@redwoodjs/cli@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/cli/-/cli-0.28.0.tgz#5b816caae2835a067d504b48f3f5c38da15c3af5"
-  integrity sha512-2mAFt0eXtriOTbw+Sh643jXKPdlZHlfJbVLYZKH83xSe0RsLW9L0+aCUBdMtN0jjR7TWjyzX05tVoHPJA4VxMA==
+"@redwoodjs/cli@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/cli/-/cli-0.28.2.tgz#2777e74fe00177c601568abd1dad46882ad373b7"
+  integrity sha512-E9nfdYuL2QzGkWuoymHCLI8G248BluiZEVi/+t0owQ7jvT0Y8CiJTU7jcSg5OG1JWsQacZLFsN+GLSt1uLRR0Q==
   dependencies:
     "@prisma/sdk" "2.19.0"
-    "@redwoodjs/internal" "^0.28.0"
-    "@redwoodjs/prerender" "^0.28.0"
-    "@redwoodjs/structure" "^0.28.0"
+    "@redwoodjs/internal" "^0.28.2"
+    "@redwoodjs/prerender" "^0.28.2"
+    "@redwoodjs/structure" "^0.28.2"
     boxen "^4.2.0"
     camelcase "^6.0.0"
     chalk "^4.1.0"
@@ -1857,10 +1857,10 @@
     terminal-link "^2.1.1"
     yargs "^16.0.3"
 
-"@redwoodjs/core@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/core/-/core-0.28.0.tgz#77d16f562c379a16d79dffda68fbd807ed4b689a"
-  integrity sha512-pilFGA5egzsS5Xwvr/Rqd+RPQ5Ge4Q+Kg7W+8Epnqik99kjzQ+F3hDnXFBAwbsoTpfQBeqrWVVS9Bf26/43oZA==
+"@redwoodjs/core@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/core/-/core-0.28.2.tgz#951952908b53865eaa0f753ddd3a7044fead38f7"
+  integrity sha512-Y6PpjZPkDhwO3YwfjuziXG44ZAyjTfPLlhGV8yRLqhHcbzFPt337lVNLLgWotjJp3jf9lN4N0dikbx/9qTPNfg==
   dependencies:
     "@babel/cli" "^7.11.6"
     "@babel/core" "^7.11.6"
@@ -1872,11 +1872,11 @@
     "@babel/preset-typescript" "^7.10.4"
     "@babel/runtime-corejs3" "^7.11.2"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.4.3"
-    "@redwoodjs/cli" "^0.28.0"
-    "@redwoodjs/dev-server" "^0.28.0"
-    "@redwoodjs/eslint-config" "^0.28.0"
-    "@redwoodjs/internal" "^0.28.0"
-    "@redwoodjs/testing" "^0.28.0"
+    "@redwoodjs/cli" "^0.28.2"
+    "@redwoodjs/dev-server" "^0.28.2"
+    "@redwoodjs/eslint-config" "^0.28.2"
+    "@redwoodjs/internal" "^0.28.2"
+    "@redwoodjs/testing" "^0.28.2"
     "@storybook/addon-a11y" "^6.1.19"
     "@storybook/react" "^6.1.21"
     "@testing-library/jest-dom" "5.11.6"
@@ -1925,13 +1925,13 @@
     webpack-retry-chunk-load-plugin "^1.4.0"
     whatwg-fetch "^3.5.0"
 
-"@redwoodjs/dev-server@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/dev-server/-/dev-server-0.28.0.tgz#c339c0b0ae6bf6e80d492d1aeed97db76d27c4cb"
-  integrity sha512-GJu/TOkjfxjsbMCcIAXK5YKISfwrCVKGzvnJPH9YH1yuKReWjUgb+Ai1X6E5ZTulEBkCVhaOsuNgtG9zFDuRyw==
+"@redwoodjs/dev-server@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/dev-server/-/dev-server-0.28.2.tgz#c3480684e6fe3e866c2dc3617b539f65fc26f794"
+  integrity sha512-sMb3LTA4bvDBcIsl1kNRJJaH4wcngg46TQFAHVfa5xT3HOzPQoCXR0dstaG++Imf3frQiOH1U95azIE6JQXyzw==
   dependencies:
     "@babel/register" "^7.9.0"
-    "@redwoodjs/internal" "^0.28.0"
+    "@redwoodjs/internal" "^0.28.2"
     body-parser "^1.19.0"
     chokidar "^3.4.3"
     express "^4.17.1"
@@ -1942,12 +1942,12 @@
     youch "^2.1.1"
     youch-terminal "^1.0.1"
 
-"@redwoodjs/eslint-config@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/eslint-config/-/eslint-config-0.28.0.tgz#1926e83a9cfaaf4897ccbe08b4f36acdad2ae064"
-  integrity sha512-HueUYOoWzISvtdeMmtjlwYH1Cp/T4KITYHLnqgZUvg6YdLil6+ObmwRuCd8pmX6Tgi/tAoXqscr1GqKCaPSNZA==
+"@redwoodjs/eslint-config@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/eslint-config/-/eslint-config-0.28.2.tgz#7a718a1a70fd7fe73cf9d6ab7bcb47ccd10be5e1"
+  integrity sha512-4NbKWS8B0EGMoiWYGM+chhSDxdIB20acMvZUlFHz7S3wNrh8o0soPym9R0s//zLVsmhluyJijOzfHPBnrtd6fA==
   dependencies:
-    "@redwoodjs/eslint-plugin-redwood" "^0.28.0"
+    "@redwoodjs/eslint-plugin-redwood" "^0.28.2"
     "@typescript-eslint/eslint-plugin" "^4.0.1"
     "@typescript-eslint/parser" "^4.0.1"
     babel-eslint "^10.1.0"
@@ -1963,25 +1963,25 @@
     eslint-plugin-react-hooks "^4.1.0"
     prettier "^2.1.1"
 
-"@redwoodjs/eslint-plugin-redwood@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/eslint-plugin-redwood/-/eslint-plugin-redwood-0.28.0.tgz#8d543f2aa28f160c3f6bae7c9c5dc2b6c6199535"
-  integrity sha512-GhFNRsHUl2qeA4o3jkbLnjmvNjcWp20I6PvWSBZj6ZZlLKn1iZqeBkJr9gMRkmBWHav3YX/xV7hq95FWa3bFhg==
+"@redwoodjs/eslint-plugin-redwood@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/eslint-plugin-redwood/-/eslint-plugin-redwood-0.28.2.tgz#14d9edc141ccc4e3f3e24877766e9b7103a4622b"
+  integrity sha512-oJFdDAjUmvc1c4L4fBCtrfpFrAK7iNhZTD3H7iqBr5Cc1z08RbV6LnGHz4CetV4TwXHLWnRYX/a++incvNjxQw==
 
-"@redwoodjs/forms@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/forms/-/forms-0.28.0.tgz#106d782a3c1a7d2925f72a72d9ef6db3e9e34600"
-  integrity sha512-1vKJuizOfuznErfIN7B5C4p5WR+9kduWs5bytkNAkjKko3/cDY5eB0+fi2ci9zZer5s86ZagS8sJWuBQWyeC2g==
+"@redwoodjs/forms@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/forms/-/forms-0.28.2.tgz#febc056029ddc523a353ac3568231d5cf24db766"
+  integrity sha512-I+bNAMrqLdRBoIYuJAAF1mWpqV0bJbGuHMioiRxV/SQnSQCvdSemXNoIDueeDvURBpEjwCGb9Ov/dyS6HZT38A==
   dependencies:
     "@types/pascalcase" "^1.0.0"
     core-js "3.6.5"
     pascalcase "1.0.0"
     react-hook-form "^6.9.5"
 
-"@redwoodjs/internal@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/internal/-/internal-0.28.0.tgz#70d42f5a4502e9026f51895f6a59c0f474024725"
-  integrity sha512-0VrS5VqGAmKlqEhX5iHKQAISEIltnq7rEls5WrVNXZ/9P6W5tbPFZqgNSp2gzw6FCH+LgVPy3r57knkGI6AyZg==
+"@redwoodjs/internal@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/internal/-/internal-0.28.2.tgz#439eb96bcdd525d1f4724b6868b2f68427f1380b"
+  integrity sha512-gQOESZxAa9XApVFSs0fwSS1a+CdHy+4wgULHVg0qaa/Q314wG3phqoHwUWYg2+0rF+66ZxI4v8rg7WEe8SkrbQ==
   dependencies:
     "@babel/plugin-transform-typescript" "^7.11.6"
     deepmerge "^4.2.2"
@@ -1990,37 +1990,37 @@
     kill-port "^1.6.1"
     toml "^3.0.0"
 
-"@redwoodjs/prerender@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/prerender/-/prerender-0.28.0.tgz#72bc9a709f42379e24bcd18765b3965a5674e36d"
-  integrity sha512-gGBV1w92rbVNf7GHIMHuWlTYYS3Q0wKLFP8xomazzlma5sXfwGnAMY8xRx9XdlzF6AL+jTKbrn4f9tx4EU4oAQ==
+"@redwoodjs/prerender@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/prerender/-/prerender-0.28.2.tgz#489369f3cac85bf0956a41100edc8b8dfea2119e"
+  integrity sha512-W7b0ZtAL/a4rO9OMEh14F+EQa2iITpmcQMpksaPj6Rh3oeC5Xdy9VZ1qEbvEBRF1XMnNiwX0V2SaZgNcOvQbwQ==
   dependencies:
     "@babel/register" "^7.9.0"
-    "@redwoodjs/auth" "^0.28.0"
-    "@redwoodjs/internal" "^0.28.0"
-    "@redwoodjs/router" "^0.28.0"
-    "@redwoodjs/structure" "^0.28.0"
-    "@redwoodjs/web" "^0.28.0"
+    "@redwoodjs/auth" "^0.28.2"
+    "@redwoodjs/internal" "^0.28.2"
+    "@redwoodjs/router" "^0.28.2"
+    "@redwoodjs/structure" "^0.28.2"
+    "@redwoodjs/web" "^0.28.2"
     babel-plugin-ignore-html-and-css-imports "^0.1.0"
     node-fetch "^2.6.1"
 
-"@redwoodjs/router@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/router/-/router-0.28.0.tgz#9437b01401a6755b6d94e85b0daa455c6ad88a49"
-  integrity sha512-fuO+BucZvo+bb1IHAK0ZsT7JAzojqP4pNPCNwS/55/oomKdPXDmk4tBHBzKID5RoGLAcio3OmZhE4p1UCNWKLQ==
+"@redwoodjs/router@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/router/-/router-0.28.2.tgz#b4a65fb77312921d0c1153e009b0d531cf28e336"
+  integrity sha512-uahtinqcH0xW63NGylGW3NM41ZdRlhLjA6jumRIpqjd8bPlXYCoNlLfVCM4cvVn84V/t9FCdp/mvBXgMtHzn9Q==
   dependencies:
     "@reach/skip-nav" "^0.13.2"
-    "@redwoodjs/auth" "^0.28.0"
+    "@redwoodjs/auth" "^0.28.2"
     core-js "3.6.5"
     lodash.isequal "^4.5.0"
 
-"@redwoodjs/structure@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/structure/-/structure-0.28.0.tgz#c93ccc7e8720b6d550cf63b0b1205d3545466590"
-  integrity sha512-OHAzP8TmI/ghlhwIoxmW32+Dd82NWBHnhI9HVrBI8BzkcL9fokwugHlQiPfesc31TA5M32rJglaVZbriRmMJlg==
+"@redwoodjs/structure@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/structure/-/structure-0.28.2.tgz#b9d3a58304fa02d0009dc934a71c3ef74a1b2e3a"
+  integrity sha512-+E7r6VAbVOHoxLkYfmKSHpgI6bbUnN+0eGeX2RiuiyHO1RnADAFgZxEAVjEmaTuGAwEZacwqdZeIfnjSTPgpUg==
   dependencies:
     "@prisma/sdk" "2.19.0"
-    "@redwoodjs/internal" "^0.28.0"
+    "@redwoodjs/internal" "^0.28.2"
     "@types/line-column" "^1.0.0"
     camelcase "^6.0.0"
     deepmerge "^4.2.2"
@@ -2041,26 +2041,26 @@
     vscode-languageserver-types "3.15.1"
     yargs-parser "^18.1.3"
 
-"@redwoodjs/testing@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/testing/-/testing-0.28.0.tgz#f963a7445d67ccbcdd9948bb5802b876678e6644"
-  integrity sha512-cc2WoK1Y3m3RG5Y7zNU4FcLoqOM/ZTJtYqo6TKT0qzp7jLtzK1zUZdSU4+opsf3+p/mZidrwFNQVXsrTlzqOEA==
+"@redwoodjs/testing@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/testing/-/testing-0.28.2.tgz#decd0e4d825ccf1adc755554d7bf95c647d0a769"
+  integrity sha512-YRNleZQiV64OCFUHrm3tfRAAdU41x/1gfUqAkSQFPac/oSgUznsMNPbsuh/woSY0GXWAX8UOZPX0aW7yRDmYSg==
   dependencies:
-    "@redwoodjs/auth" "^0.28.0"
-    "@redwoodjs/internal" "^0.28.0"
-    "@redwoodjs/router" "^0.28.0"
-    "@redwoodjs/web" "^0.28.0"
+    "@redwoodjs/auth" "^0.28.2"
+    "@redwoodjs/internal" "^0.28.2"
+    "@redwoodjs/router" "^0.28.2"
+    "@redwoodjs/web" "^0.28.2"
     "@testing-library/react" "11.2.2"
     "@types/react" "17.0.3"
     msw "^0.21.2"
 
-"@redwoodjs/web@^0.28.0":
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/web/-/web-0.28.0.tgz#e67f46c64fd6676c7afb0ea34b0f08bdfb13324d"
-  integrity sha512-X8QEskhgOl2g+a2YgoNYS34AzdYfrgz53DYXmOW2GPttjc+ry44S7gyjnkR5X+asleeWJGeRPCe7lrJtOqdM+A==
+"@redwoodjs/web@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/web/-/web-0.28.2.tgz#7e5856a65631f0699d8f0047d59bd2df2a3b127e"
+  integrity sha512-iFc0iHN9We9PUK8/hBnxC0wahB+1OLan07g2MMPPUIaZdJqJjmR/w8lF0WRrtgP+PNdevOfHmobvEYx5bd9Uyg==
   dependencies:
     "@apollo/client" "^3.3.11"
-    "@redwoodjs/auth" "^0.28.0"
+    "@redwoodjs/auth" "^0.28.2"
     core-js "3.6.5"
     graphql "^15.3.0"
     proptypes "^1.1.0"
@@ -3610,7 +3610,7 @@ apollo-server-caching@^0.5.3:
   dependencies:
     lru-cache "^6.0.0"
 
-apollo-server-core@2.21.2, apollo-server-core@^2.18.2:
+apollo-server-core@^2.18.2:
   version "2.21.2"
   resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.21.2.tgz#9f44bdcb4d5467a426f0fecd112afc95479d4b07"
   integrity sha512-jIXMVQPOUzIOl4El/mzSixxJ5IDrqSk3L9uJ1U+ncwiQj0IjtkkyDSuYngcgyEi+KfO2lAzxeOiAy9fIjjkC2A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,13 +47,6 @@
   dependencies:
     apollo-env "^0.6.6"
 
-"@apollographql/graphql-playground-html@1.6.26":
-  version "1.6.26"
-  resolved "https://registry.yarnpkg.com/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.26.tgz#2f7b610392e2a872722912fc342b43cf8d641cb3"
-  integrity sha512-XAwXOIab51QyhBxnxySdK3nuMEUohhDsHQ5Rbco/V1vjlP75zZ0ZLHD9dTpXTN8uxKxopb2lUvJTq+M4g2Q0HQ==
-  dependencies:
-    xss "^1.0.6"
-
 "@apollographql/graphql-playground-html@1.6.27":
   version "1.6.27"
   resolved "https://registry.yarnpkg.com/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.27.tgz#bc9ab60e9445aa2a8813b4e94f152fa72b756335"
@@ -1920,6 +1913,11 @@
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
+
+"@josephg/resolvable@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.0.tgz#cd75b09cfad18cd945de9221d403203aa07e3d0a"
+  integrity sha512-OfTtjoqB2doov5aTJxkyAMK8dXoo7CjCUQSYUEtiY34jbWduOGV7+168tmCT8COMsUEd5DMSFg/0iAOPCBTNAQ==
 
 "@lerna/add@3.21.0":
   version "3.21.0"
@@ -4790,20 +4788,20 @@ anymatch@^3.0.3, anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-cache-control@^0.11.6:
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.11.6.tgz#f7bdf924272af47ac474cf3f3f35cfc038cc9485"
-  integrity sha512-YZ+uuIG+fPy+mkpBS2qKF0v1qlzZ3PW6xZVaDukeK3ed3iAs4L/2YnkTqau3OmoF/VPzX2FmSkocX/OVd59YSw==
+apollo-cache-control@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.12.0.tgz#45aea0a232d0704e33c2b1a3c428a5500b29818c"
+  integrity sha512-kClF5rfAm159Nboul1LxA+l58Tjz0M8L1GUknEMpZt0UHhILLAn3BfcG3ToX4TbNoR9M57kKMUcbPWLdy3Up7w==
   dependencies:
     apollo-server-env "^3.0.0"
-    apollo-server-plugin-base "^0.10.4"
+    apollo-server-plugin-base "^0.11.0"
 
-apollo-datasource@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.7.3.tgz#c824eb1457bdee5a3173ced0e35e594547e687a0"
-  integrity sha512-PE0ucdZYjHjUyXrFWRwT02yLcx2DACsZ0jm1Mp/0m/I9nZu/fEkvJxfsryXB6JndpmQO77gQHixf/xGCN976kA==
+apollo-datasource@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.8.0.tgz#8cf9103e83558bd30b3b522cb8ec80725c3160ce"
+  integrity sha512-gXgsGVLuejLc138z/2jUjPAzadDQxWbcLJyBgaQsg5BaXJNkv5uW/NjiSPk00cK51hyZrb0Xx8a+L+wPk2qIBA==
   dependencies:
-    apollo-server-caching "^0.5.3"
+    apollo-server-caching "^0.6.0"
     apollo-server-env "^3.0.0"
 
 apollo-env@^0.6.6:
@@ -4841,35 +4839,36 @@ apollo-reporting-protobuf@^0.6.2:
   dependencies:
     "@apollo/protobufjs" "^1.0.3"
 
-apollo-server-caching@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.5.3.tgz#cf42a77ad09a46290a246810075eaa029b5305e1"
-  integrity sha512-iMi3087iphDAI0U2iSBE9qtx9kQoMMEWr6w+LwXruBD95ek9DWyj7OeC2U/ngLjRsXM43DoBDXlu7R+uMjahrQ==
+apollo-server-caching@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.6.0.tgz#3140a023ce0be8c43ba0b2f5be9cc5d15d1a32f6"
+  integrity sha512-SfjKaccrhRzUQ8TAke9FrYppp4pZV3Rp8KCs+4Ox3kGtbco68acRPJkiYYtSVc4idR8XNAUOOVfAEZVNHdZQKQ==
   dependencies:
     lru-cache "^6.0.0"
 
-apollo-server-core@^2.18.2:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.21.2.tgz#9f44bdcb4d5467a426f0fecd112afc95479d4b07"
-  integrity sha512-jIXMVQPOUzIOl4El/mzSixxJ5IDrqSk3L9uJ1U+ncwiQj0IjtkkyDSuYngcgyEi+KfO2lAzxeOiAy9fIjjkC2A==
+apollo-server-core@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.22.2.tgz#daee67a17aa4f1bf0df3e448e237a37324906b5d"
+  integrity sha512-YPrhfN+I5vUerc4c0I6pd89fdqP5UNYCt/+MGv4bDA/a0kOCLvzylkQ3NlEepK1fewtqf4QO+S1LscC8vMmYdg==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.3"
     "@apollographql/graphql-playground-html" "1.6.27"
     "@apollographql/graphql-upload-8-fork" "^8.1.3"
+    "@josephg/resolvable" "^1.0.0"
     "@types/ws" "^7.0.0"
-    apollo-cache-control "^0.11.6"
-    apollo-datasource "^0.7.3"
+    apollo-cache-control "^0.12.0"
+    apollo-datasource "^0.8.0"
     apollo-graphql "^0.6.0"
     apollo-reporting-protobuf "^0.6.2"
-    apollo-server-caching "^0.5.3"
+    apollo-server-caching "^0.6.0"
     apollo-server-env "^3.0.0"
     apollo-server-errors "^2.4.2"
-    apollo-server-plugin-base "^0.10.4"
-    apollo-server-types "^0.6.3"
-    apollo-tracing "^0.12.2"
+    apollo-server-plugin-base "^0.11.0"
+    apollo-server-types "^0.7.0"
+    apollo-tracing "^0.13.0"
     async-retry "^1.2.1"
     fast-json-stable-stringify "^2.0.0"
-    graphql-extensions "^0.12.8"
+    graphql-extensions "^0.13.0"
     graphql-tag "^2.11.0"
     graphql-tools "^4.0.8"
     loglevel "^1.6.7"
@@ -4878,14 +4877,6 @@ apollo-server-core@^2.18.2:
     subscriptions-transport-ws "^0.9.11"
     uuid "^8.0.0"
     ws "^6.0.0"
-
-apollo-server-env@^2.4.5:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.4.5.tgz#73730b4f0439094a2272a9d0caa4079d4b661d5f"
-  integrity sha512-nfNhmGPzbq3xCEWT8eRpoHXIPNcNy3QcEoBlzVMjeglrBGryLG2LXwBSPnVmTRRrzUYugX0ULBtgE3rBFNoUgA==
-  dependencies:
-    node-fetch "^2.1.2"
-    util.promisify "^1.0.0"
 
 apollo-server-env@^3.0.0:
   version "3.0.0"
@@ -4900,41 +4891,41 @@ apollo-server-errors@^2.4.2:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz#1128738a1d14da989f58420896d70524784eabe5"
   integrity sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==
 
-apollo-server-lambda@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/apollo-server-lambda/-/apollo-server-lambda-2.18.2.tgz#3d89afd49ac617b44b141949d9acae6d77d671e6"
-  integrity sha512-w1PxAAyrNLXOTeKl+Kp4fp37CGuAwn/ubSsWv+dz9fLgs/AXnPhb9B9mWCwLW5LOBOTWH7zYDqtSNqs/J7+r1Q==
+apollo-server-lambda@2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-lambda/-/apollo-server-lambda-2.22.2.tgz#8beb0f2cfbb9048ae8dfa609afbfcb8fa42de622"
+  integrity sha512-QOVHg6u1+jqnY6c+fb4njUtfQEQr118guerDveZgG3vQP1t8/AtYDT33m03JhsKWRkzZjOgj5cs0RA1iSYw7cg==
   dependencies:
-    "@apollographql/graphql-playground-html" "1.6.26"
+    "@apollographql/graphql-playground-html" "1.6.27"
     "@types/aws-lambda" "^8.10.31"
-    apollo-server-core "^2.18.2"
-    apollo-server-env "^2.4.5"
-    apollo-server-types "^0.6.0"
-    graphql-tools "^4.0.0"
+    apollo-server-core "^2.22.2"
+    apollo-server-env "^3.0.0"
+    apollo-server-types "^0.7.0"
+    graphql-tools "^4.0.8"
 
-apollo-server-plugin-base@^0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.4.tgz#fbf73f64f95537ca9f9639dd7c535eb5eeb95dcd"
-  integrity sha512-HRhbyHgHFTLP0ImubQObYhSgpmVH4Rk1BinnceZmwudIVLKrqayIVOELdyext/QnSmmzg5W7vF3NLGBcVGMqDg==
+apollo-server-plugin-base@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.11.0.tgz#6ceeb4d5f643ed739fd00e8b26d9981186c200d0"
+  integrity sha512-Du68x0XCyQ6EWlgoL9Z+1s8fJfXgY131QbKP7ao617StQPzwB0aGCwxBDfcMt1A75VXf4TkvV1rdUH5YeJFlhQ==
   dependencies:
-    apollo-server-types "^0.6.3"
+    apollo-server-types "^0.7.0"
 
-apollo-server-types@^0.6.0, apollo-server-types@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-0.6.3.tgz#f7aa25ff7157863264d01a77d7934aa6e13399e8"
-  integrity sha512-aVR7SlSGGY41E1f11YYz5bvwA89uGmkVUtzMiklDhZ7IgRJhysT5Dflt5IuwDxp+NdQkIhVCErUXakopocFLAg==
+apollo-server-types@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-0.7.0.tgz#a9b62974ada5da5edb6157a41d8ddb993b57203a"
+  integrity sha512-pJ6ri2N4xJ+e2PUUPHeCNpMDzHUagJyn0DDZGQmXDz6aoMlSd4B2KUvK81hHyHkw3wHk9clgcpfM9hKqbfZweA==
   dependencies:
     apollo-reporting-protobuf "^0.6.2"
-    apollo-server-caching "^0.5.3"
+    apollo-server-caching "^0.6.0"
     apollo-server-env "^3.0.0"
 
-apollo-tracing@^0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.12.2.tgz#a261c3970bb421b6dadf50cd85d75b2567a7e52c"
-  integrity sha512-SYN4o0C0wR1fyS3+P0FthyvsQVHFopdmN3IU64IaspR/RZScPxZ3Ae8uu++fTvkQflAkglnFM0aX6DkZERBp6w==
+apollo-tracing@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.13.0.tgz#8621b1ae351f862bb48b6de7a85696288977d148"
+  integrity sha512-28z4T+XfLQ6t696usU0nTFDxVN8BfF3o74d2p/zsT4eu1OuoyoDOEmVJqdInmVRpyTJK0tDEOjkIuDJJHZftog==
   dependencies:
     apollo-server-env "^3.0.0"
-    apollo-server-plugin-base "^0.10.4"
+    apollo-server-plugin-base "^0.11.0"
 
 apollo-utilities@^1.0.1, apollo-utilities@^1.3.0:
   version "1.3.4"
@@ -10138,14 +10129,14 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
-graphql-extensions@^0.12.8:
-  version "0.12.8"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.12.8.tgz#9cdc2c43d8fe5e0f6c3177a004ac011da2a8aa0f"
-  integrity sha512-xjsSaB6yKt9jarFNNdivl2VOx52WySYhxPgf8Y16g6GKZyAzBoIFiwyGw5PJDlOSUa6cpmzn6o7z8fVMbSAbkg==
+graphql-extensions@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.13.0.tgz#34d7f9c1bf49d09c4f1fa8b5d33e6c961a1889fb"
+  integrity sha512-Bb7E97nvfX4gtrIdZ/i5YFlqOd6MGzrw8ED+t4wQVraYje6NQ+8P8MHMOV2WZLfbW8zsNTx8NdnnlbsdH5siag==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.3"
     apollo-server-env "^3.0.0"
-    apollo-server-types "^0.6.3"
+    apollo-server-types "^0.7.0"
 
 graphql-scalars@1.9.0:
   version "1.9.0"
@@ -10166,7 +10157,7 @@ graphql-tag@^2.12.0:
   dependencies:
     tslib "^1.14.1"
 
-graphql-tools@^4.0.0, graphql-tools@^4.0.8:
+graphql-tools@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.8.tgz#e7fb9f0d43408fb0878ba66b522ce871bafe9d30"
   integrity sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==
@@ -19063,7 +19054,7 @@ xregexp@4.0.0:
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
   integrity sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
 
-xss@^1.0.6, xss@^1.0.8:
+xss@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.8.tgz#32feb87feb74b3dcd3d404b7a68ababf10700535"
   integrity sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==


### PR DESCRIPTION
_continues https://github.com/redwoodjs/redwood/issues/2127 and https://github.com/redwoodjs/redwood/pull/2129_

If this is gtg, I'd like to include in v0.28.3 patch

- [x] upgrades to apollo-server-lambda@2.22.2
    - API console is clean — see screenshot below
- [x] removes apollo-server-core resolution in CRWA template
- [x] updates template yarn.lock 

I've added notes to v0.29 draft to remove resolution (if exists).

@peterp Let's discuss further the addition of crwa/template/yarn.lock I still don't see the benefit as it wouldn't have caught this issue had it existed previously. Feels like overhead that's not a full solution and my preference would be to remove it. TBD and doesn't need to be resolved prior to merging this PR.

<img width="513" alt="Screen Shot 2021-03-29 at 11 06 27 PM" src="https://user-images.githubusercontent.com/2951/112942163-90ba3e00-90e4-11eb-9317-e3250e48b578.png">
