### PR TITLE
Fix setup tsconfig: github version tag for canary builds

### DIFF
--- a/packages/cli/src/commands/setup/tsconfig/tsconfig.js
+++ b/packages/cli/src/commands/setup/tsconfig/tsconfig.js
@@ -24,7 +24,12 @@ export const builder = (yargs) => {
 }
 
 export const handler = async ({ force }) => {
-  const CRWA_TEMPLATE_URL = `https://raw.githubusercontent.com/redwoodjs/redwood/v${getInstalledRedwoodVersion()}/packages/create-redwood-app/template`
+  const installedRwVersion = getInstalledRedwoodVersion()
+  const GITHUB_VERSION_TAG = installedRwVersion.match('canary')
+    ? 'main'
+    : `v${installedRwVersion}`
+
+  const CRWA_TEMPLATE_URL = `https://raw.githubusercontent.com/redwoodjs/redwood/${GITHUB_VERSION_TAG}/packages/create-redwood-app/template`
 
   const tasks = new Listr([
     {

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -236,11 +236,10 @@ export const saveRemoteFileToDisk = (
     throw new Error(`${localPath} already exists.`)
   }
 
-  const file = fs.createWriteStream(localPath)
   const downloadPromise = new Promise((resolve, reject) =>
     https.get(url, (response) => {
       if (response.statusCode === 200) {
-        response.pipe(file)
+        response.pipe(fs.createWriteStream(localPath))
         resolve()
       } else {
         reject(


### PR DESCRIPTION
### What?
Fixes `yarn rw setup tsconfig` for running on canary projects. 

In pseudocode
```
if canary, use main
else use v{REDWOOD_VERSION}
```