### PR TITLE
Setup 'CurrentUser' type to be extendable.

### DIFF
--- a/packages/api/src/globalContext.ts
+++ b/packages/api/src/globalContext.ts
@@ -14,11 +14,16 @@
 
 import { AsyncLocalStorage } from 'async_hooks'
 
+import type { CurrentUser } from '@redwoodjs/auth'
+
 export interface GlobalContext {
   [key: string]: unknown
+  currentUser: CurrentUser | null
 }
 
-let GLOBAL_CONTEXT: GlobalContext = {}
+let GLOBAL_CONTEXT: GlobalContext = {
+  currentUser: null,
+}
 let PER_REQUEST_CONTEXT:
   | undefined
   | AsyncLocalStorage<Map<string, GlobalContext>> = undefined

--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -8,9 +8,7 @@ import type {
 } from './authClients'
 import { createAuthClient } from './authClients'
 
-export interface CurrentUser {
-  roles?: Array<string>
-}
+import type { CurrentUser } from './index'
 
 export interface AuthContextInterface {
   /* Determining your current authentication state */

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,8 @@
 export { SupportedAuthTypes } from './authClients'
 
+export interface CurrentUser {
+  roles?: string[]
+}
+
 export { AuthProvider, AuthContextInterface } from './AuthProvider'
 export { useAuth } from './useAuth'


### PR DESCRIPTION
This export's the `CurrentUser` type from `@redwoodjs/auth` and uses it in `@redwoodjs/api` in the global context.

I moved the type to `index.ts` because @dac09  mentioned that you can only extend interface types when they're on the index. I'm not sure if exporting them on the index is good enough.