### PR TITLE
Correctly type `GraphQLHookOptions`

### DIFF
--- a/packages/web/src/components/GraphQLHooksProvider.tsx
+++ b/packages/web/src/components/GraphQLHooksProvider.tsx
@@ -2,6 +2,9 @@ import type { DocumentNode } from 'graphql'
 
 export interface GraphQLHookOptions {
   variables?: Record<string, any>
+  refetchQueries?: { query: DocumentNode; variables?: Record<string, any> }[]
+  onCompleted?: () => any
+  [key: string]: any
 }
 export interface OperationResult<TData = any> {
   data?: TData

--- a/packages/web/src/components/GraphQLHooksProvider.tsx
+++ b/packages/web/src/components/GraphQLHooksProvider.tsx
@@ -3,7 +3,7 @@ import type { DocumentNode } from 'graphql'
 export interface GraphQLHookOptions {
   variables?: Record<string, any>
   refetchQueries?: { query: DocumentNode; variables?: Record<string, any> }[]
-  onCompleted?: () => any
+  onCompleted?: (data: any) => void
   [key: string]: any
 }
 export interface OperationResult<TData = any> {


### PR DESCRIPTION
Currently, completing [tutorial 2](https://learn.redwoodjs.com/docs/tutorial2/creating-a-comment-form#graphql-query-caching) in TS throws a type error because the `onCompleted` and `refetchQueries` keys aren't permitted in `GraphQLHookOptions`.

I've also added a catch-all `[key: string]: any`. Since `GraphQLHooksOptions` just passes its options into the underlying implementation, it's possible that the user's implementation will accept/expect more keys, and those shouldn't throw an error if provided.

cc @peterp 