### PR TITLE
CLI Storybook command: add output directory option

### DIFF
--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -26,9 +26,14 @@ export const builder = (yargs) => {
       type: 'integer',
       default: 7910,
     })
+    .option('build-directory', {
+      describe: 'Directory in web/ to store static files',
+      type: 'string',
+      default: 'storybook-static',
+    })
 }
 
-export const handler = ({ open, port, build }) => {
+export const handler = ({ open, port, build, buildDirectory }) => {
   const cwd = getPaths().web.base
 
   const staticAssetsFolder = path.join(getPaths().web.base, 'public')
@@ -46,7 +51,9 @@ export const handler = ({ open, port, build }) => {
       '--config-dir ../node_modules/@redwoodjs/core/config/storybook',
       !build && `--port ${port}`,
       !build && '--no-version-updates',
-      `--static-dir "${staticAssetsFolder}"`,
+      !build && `--static-dir "${staticAssetsFolder}"`,
+      build &&
+        `--output-dir "${path.join(getPaths().web.base, buildDirectory)}"`,
       !open && '--ci',
     ].filter(Boolean),
     {


### PR DESCRIPTION
dependency of https://github.com/redwoodjs/redwood/pull/2073

### `yarn redwood storybook --build`
This adds the `--output-directory` option to `yarn build-storybook`, providing an override to the default directory to store the built static files.
```
--build-directory  Directory in web/ to store static files
                                          [string] [default: "storybook-static"]
```

TBD whether or not the default directory should be `web/public/storybook`. Files in public will be statically served during both local dev or deployment.