### PR TITLE
Just decode, not verify, auth0 token during development and test.

### DIFF
--- a/packages/api/src/auth/decoders/auth0.test.ts
+++ b/packages/api/src/auth/decoders/auth0.test.ts
@@ -1,0 +1,23 @@
+import jwt from 'jsonwebtoken'
+
+import { verifyAuth0Token } from './auth0'
+
+jest.mock('jsonwebtoken', () => ({
+  verify: jest.fn(),
+  decode: jest.fn(),
+}))
+
+test.only('verify, and not decode, should be called in production', () => {
+  const { NODE_ENV } = process.env
+  process.env.NODE_ENV = 'production'
+  process.env.AUTH0_DOMAIN = 'redwoodjs.com'
+  process.env.AUTH0_AUDIENCE = 'michael bolton'
+
+  // @ts-expect-error Ingore this error.
+  verifyAuth0Token({})
+
+  expect(jwt.decode).not.toBeCalled()
+  expect(jwt.verify).toBeCalled()
+
+  process.env.NODE_ENV = NODE_ENV
+})

--- a/packages/api/src/auth/decoders/auth0.ts
+++ b/packages/api/src/auth/decoders/auth0.ts
@@ -33,33 +33,44 @@ export const verifyAuth0Token = (
       )
     }
 
-    const client = jwksClient({
-      jwksUri: `https://${AUTH0_DOMAIN}/.well-known/jwks.json`,
-    })
-
-    jwt.verify(
-      bearerToken,
-      (header, callback) => {
-        client.getSigningKey(header.kid as string, (error, key) => {
-          callback(error, key.getPublicKey())
-        })
-      },
-      {
-        audience: AUTH0_AUDIENCE,
-        issuer: `https://${AUTH0_DOMAIN}/`,
-        algorithms: ['RS256'],
-      },
-      (verifyError, decoded) => {
-        if (verifyError) {
-          return reject(verifyError)
+    if (
+      process.env.NODE_ENV === 'development' ||
+      process.env.NODE_ENV === 'test'
+    ) {
+      const decoded = jwt.decode(bearerToken)
+      resolve(
+        typeof decoded === 'undefined'
+          ? null
+          : (decoded as Record<string, unknown>)
+      )
+    } else {
+      const client = jwksClient({
+        jwksUri: `https://${AUTH0_DOMAIN}/.well-known/jwks.json`,
+      })
+      jwt.verify(
+        bearerToken,
+        (header, callback) => {
+          client.getSigningKey(header.kid as string, (error, key) => {
+            callback(error, key.getPublicKey())
+          })
+        },
+        {
+          audience: AUTH0_AUDIENCE,
+          issuer: `https://${AUTH0_DOMAIN}/`,
+          algorithms: ['RS256'],
+        },
+        (verifyError, decoded) => {
+          if (verifyError) {
+            return reject(verifyError)
+          }
+          resolve(
+            typeof decoded === 'undefined'
+              ? null
+              : (decoded as Record<string, unknown>)
+          )
         }
-        resolve(
-          typeof decoded === 'undefined'
-            ? null
-            : (decoded as Record<string, unknown>)
-        )
-      }
-    )
+      )
+    }
   })
 }
 


### PR DESCRIPTION
This is small speed improvement for people using auth0 during development. Instead of verifying the token, which performs a network request to grab the key, we just decode it.

Closes #2155