### PR TITLE
Router: routes is not a prop

### DIFF
--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -25,7 +25,8 @@ const RouterSetContext = createContext<
   React.Dispatch<Partial<RouterState>> | undefined
 >(undefined)
 
-interface ProviderProps extends Omit<RouterState, 'useAuth' | 'routes'> {
+export interface RouterContextProviderProps
+  extends Omit<RouterState, 'useAuth' | 'routes'> {
   useAuth?: typeof useAuth
 }
 
@@ -33,7 +34,7 @@ function stateReducer(state: RouterState, newState: Partial<RouterState>) {
   return { ...state, ...newState }
 }
 
-export const RouterContextProvider: React.FC<ProviderProps> = ({
+export const RouterContextProvider: React.FC<RouterContextProviderProps> = ({
   useAuth: customUseAuth,
   paramTypes,
   pageLoadingDelay = DEFAULT_PAGE_LOADING_DELAY,

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -15,7 +15,7 @@ import { PrivateContextProvider, usePrivate } from './private-context'
 import { RouteNameProvider, useRouteName } from './RouteNameContext'
 import {
   RouterContextProvider,
-  RouterState,
+  RouterContextProviderProps,
   useRouterState,
 } from './router-context'
 import { SplashPage } from './splash-page'
@@ -177,7 +177,7 @@ function isRoute(
   return isReactElement(node) && node.type === Route
 }
 
-interface RouterProps extends RouterState {}
+interface RouterProps extends RouterContextProviderProps {}
 
 const Router: React.FC<RouterProps> = ({
   useAuth,


### PR DESCRIPTION
In the rush to fix the `<Set>` bugs a regression to the Router props sneaked in. `routes` is not a required, or even valid, prop for `<Router>`. It's just an internal value used in the router context. Simply omitting it from the prop interface fixes the issue.

This was causing errors in our tests, and would also cause errors for all users who have a TS router (i.e. Routes.tsx). We didn't catch it because we already had other errors on that line in our tests that covered this one up (PR incoming for that as well, later)

This is what it would look like in a Redwood app

![image](https://user-images.githubusercontent.com/30793/113315105-3819b980-930d-11eb-96ab-446edc8fcc06.png)

And fixing that regression I noticed the typing for `useAuth` was wrong as well. It should be optional. So I fixed that also.

![image](https://user-images.githubusercontent.com/30793/113316522-b9be1700-930e-11eb-8c81-531535b77c1f.png)
