### PR TITLE
CLI Storybook command: change default output directory

### DIFF
--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -29,7 +29,7 @@ export const builder = (yargs) => {
     .option('build-directory', {
       describe: 'Directory in web/ to store static files',
       type: 'string',
-      default: 'storybook-static',
+      default: 'public/storybook',
     })
 }
 


### PR DESCRIPTION
part two of https://github.com/redwoodjs/redwood/pull/2168

This changes the default output directory for `rw storybook --build` from `web/storybook-static` to `web/public/storybook`

## Breaking
The output directory for `yarn redwood storybook --build` can now be configured with the `--build-directory` flag. Prior to this, the output directory default was `web/storybook-static`. The default has been changed to `web/public/storybook`, taking advantage of Redwood's public web directory to serve static files. Users can still output to `storybook-static` via `yarn redwood storybook --build --build-directory storybook-static`.