### PR TITLE
Fix rwt link performance issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build:types": "ttsc --build --verbose",
     "build:clean": "rimraf ./packages/**/dist",
     "build:watch": "lerna run build:watch --parallel; ttsc --build",
-    "build:link": "lerna run 'build:link' --parallel",
+    "build:link": "./tasks/build-link",
     "test": "lerna run test --stream -- --colors --maxWorkers=4",
     "lint": "cross-env __REDWOOD__CONFIG_PATH=packages/create-redwood-app/template eslint -c .eslintrc.js packages",
     "lint:fix": "cross-env __REDWOOD__CONFIG_PATH=packages/create-redwood-app/template eslint -c .eslintrc.js --fix packages"

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -37,7 +37,6 @@
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
-
     "fix:permissions": "chmod +x dist/index.js; chmod +x dist/watch.js"
   },
   "gitHead": "c235e7d7186e5e258764699c0e0e1d5cc0fdd0b5"

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
-    "build:link": "../../tasks/build-link",
+
     "fix:permissions": "chmod +x dist/index.js; chmod +x dist/watch.js"
   },
   "gitHead": "c235e7d7186e5e258764699c0e0e1d5cc0fdd0b5"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,7 +43,7 @@
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
-    "build:link": "../../tasks/build-link",
+
     "test": "jest",
     "test:watch": "yarn test --watch"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,7 +43,6 @@
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
-
     "test": "jest",
     "test:watch": "yarn test --watch"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,7 +25,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "prepublishOnly": "yarn build",
     "build:clean-dist": "yarn rimraf 'dist/**/*/__tests__'",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\" --copy-files --no-copy-ignored && yarn build:clean-dist",
-    "build:link": "../../tasks/build-link",
+
     "fix:permissions": "chmod +x dist/index.js dist/redwood-tools.js",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
     "test": "jest",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,6 @@
     "prepublishOnly": "yarn build",
     "build:clean-dist": "yarn rimraf 'dist/**/*/__tests__'",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\" --copy-files --no-copy-ignored && yarn build:clean-dist",
-
     "fix:permissions": "chmod +x dist/index.js dist/redwood-tools.js",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
     "test": "jest",

--- a/packages/cli/src/redwood-tools.js
+++ b/packages/cli/src/redwood-tools.js
@@ -195,7 +195,7 @@ const rwtLink = async (yargs) => {
   // Delete existing redwood folders in node_modules
   rimraf.sync(path.join(getPaths().base, 'node_modules/@redwoodjs/'))
 
-  await execa('yarn build:link', ['-- --', '--dest', projectPackagesPath], {
+  await execa('yarn build:link', ['--dest', projectPackagesPath], {
     shell: true,
     stdio: 'inherit',
     cleanup: true,
@@ -227,16 +227,12 @@ const rwtLink = async (yargs) => {
 
   if (watch) {
     // Restart build:link scripts in watchmode
-    execa(
-      'yarn build:link',
-      ['-- --', '--dest', projectPackagesPath, '--watch'],
-      {
-        shell: true,
-        stdio: 'inherit',
-        cleanup: true,
-        cwd: frameworkPath,
-      }
-    )
+    execa('yarn build:link', ['--dest', projectPackagesPath, '--watch'], {
+      shell: true,
+      stdio: 'inherit',
+      cleanup: true,
+      cwd: frameworkPath,
+    })
   }
 }
 

--- a/packages/cli/src/redwood-tools.js
+++ b/packages/cli/src/redwood-tools.js
@@ -209,7 +209,7 @@ const rwtLink = async (yargs) => {
   )
 
   // Let workspaces do the link
-  await execa('yarn install', ['--pure-lockfile'], {
+  await execa('yarn install', ['--pure-lockfile', '--check-files'], {
     shell: true,
     stdio: 'inherit',
     cleanup: true,

--- a/packages/cli/src/redwood-tools.js
+++ b/packages/cli/src/redwood-tools.js
@@ -141,7 +141,7 @@ const rwtCopyWatch = ({ RW_PATH = process.env.RW_PATH }) => {
 
 const rwtLink = async (yargs) => {
   const RW_PATH = yargs.RW_PATH || process.env.RW_PATH
-  const { clean, watch } = yargs
+  const { clean, watch, only } = yargs
 
   if (!RW_PATH) {
     console.error(c.error('You must specify a path to your local redwood repo'))
@@ -195,12 +195,18 @@ const rwtLink = async (yargs) => {
   // Delete existing redwood folders in node_modules
   rimraf.sync(path.join(getPaths().base, 'node_modules/@redwoodjs/'))
 
-  await execa('yarn build:link', ['--dest', projectPackagesPath], {
-    shell: true,
-    stdio: 'inherit',
-    cleanup: true,
-    cwd: frameworkPath,
-  })
+  const onlyParams = only ? ['--only', only] : []
+
+  await execa(
+    'yarn build:link',
+    ['--dest', projectPackagesPath, ...onlyParams],
+    {
+      shell: true,
+      stdio: 'inherit',
+      cleanup: true,
+      cwd: frameworkPath,
+    }
+  )
 
   // Let workspaces do the link
   await execa('yarn install', ['--pure-lockfile'], {
@@ -227,12 +233,16 @@ const rwtLink = async (yargs) => {
 
   if (watch) {
     // Restart build:link scripts in watchmode
-    execa('yarn build:link', ['--dest', projectPackagesPath, '--watch'], {
-      shell: true,
-      stdio: 'inherit',
-      cleanup: true,
-      cwd: frameworkPath,
-    })
+    execa(
+      'yarn build:link',
+      ['--dest', projectPackagesPath, '--watch', ...onlyParams],
+      {
+        shell: true,
+        stdio: 'inherit',
+        cleanup: true,
+        cwd: frameworkPath,
+      }
+    )
   }
 }
 
@@ -395,6 +405,11 @@ yargs
           type: 'boolean',
           description: 'Build and watch the supplied redwood repo',
           default: true,
+        })
+        .option('only', {
+          alias: 'only',
+          type: 'string',
+          description: 'Specify folder to link from RW_PATH/packages',
         })
     },
     desc: 'Run your local version of redwood in this project',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -34,7 +34,6 @@
     "build": "yarn build:js",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
     "fix:permissions": "chmod +x dist/main.js"
   },

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -34,7 +34,7 @@
     "build": "yarn build:js",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
     "fix:permissions": "chmod +x dist/main.js"
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,7 +21,6 @@
     "prettier": "^2.1.1"
   },
   "scripts": {
-
     "build": "echo 'Nothing to build..'"
   },
   "gitHead": "c235e7d7186e5e258764699c0e0e1d5cc0fdd0b5"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -21,7 +21,7 @@
     "prettier": "^2.1.1"
   },
   "scripts": {
-    "build:link": "../../tasks/build-link",
+
     "build": "echo 'Nothing to build..'"
   },
   "gitHead": "c235e7d7186e5e258764699c0e0e1d5cc0fdd0b5"

--- a/packages/eslint-plugin-redwood/package.json
+++ b/packages/eslint-plugin-redwood/package.json
@@ -14,7 +14,6 @@
     "build": "yarn build:js",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist",
-
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build\""
   }
 }

--- a/packages/eslint-plugin-redwood/package.json
+++ b/packages/eslint-plugin-redwood/package.json
@@ -14,7 +14,7 @@
     "build": "yarn build:js",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist",
-    "build:link": "../../tasks/build-link",
+
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build\""
   }
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -18,7 +18,6 @@
     "build": "yarn build:js",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",
     "test:watch": "yarn test --watch"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -18,7 +18,7 @@
     "build": "yarn build:js",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",
     "test:watch": "yarn test --watch"

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -27,7 +27,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -27,7 +27,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -26,7 +26,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx,.jsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -26,7 +26,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx,.jsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -23,7 +23,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -23,7 +23,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -48,7 +48,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -48,7 +48,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -21,7 +21,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'",
     "test": "jest",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -21,7 +21,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext 'js,ts,tsx' --ignore dist --exec 'yarn build'",
     "test": "jest",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,6 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "yarn cross-env NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
-    "build:link": "../../tasks/build-link",
+
     "build:types": "ttsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "test": "jest",

--- a/tasks/build-link
+++ b/tasks/build-link
@@ -123,11 +123,14 @@ process.on('SIGINT', () => {
 
 const runAsync = async () => {
   // STEP 1: Run build:types from root of framework
-  await buildAllTypes()
+
+  if (!only) {
+    await buildAllTypes()
+  }
   // STEP 2: Run yarn lerna run build --parallel, ignore types as they've just been built
   await build({
     packageFolderName: only,
-    types: false,
+    types: only ? true : false,
   })
 
   await copyDistFiles({

--- a/tasks/build-link
+++ b/tasks/build-link
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node, es6*/
-
+//@ts-check
 const fs = require('fs')
 const path = require('path')
 
@@ -14,91 +14,157 @@ const yargs = require('yargs')
 const args = yargs
   .option('watch', { default: false, type: 'boolean', alias: 'w' })
   .option('dest', { required: true, type: 'string', alias: 'd' })
-  .command('build-link')
-  .example('build-link --dest /tmp/redwood-app/packages')
+  .option('only', { required: false, type: 'string', alias: 'o' })
+  // .command('build-link')
+  // .example('build-link --dest /tmp/redwood-app/packages')
   .help()
   .strict().argv
 
-const { dest, watch } = args
+const { dest, watch, only } = args
 
-const CURRENT_DIR = process.cwd()
-const pkgJson = require(path.join(CURRENT_DIR, 'package.json'))
-const OUT_DIR = path.join(dest, `/${pkgJson.name.replace('@redwoodjs/', '')}`)
+const RW_BASEPATH = path.join(__dirname, '../')
 
-const srcFiles = glob
-  .sync('src/**/*.{ts,js,tsx,jsx,json}', {
-    cwd: CURRENT_DIR,
-    ignore: [
-      '**/*.test.ts',
-      '**/*.test.js',
-      '**/__fixtures__/**',
-      '**/__tests__/**',
-    ],
+const packagePaths = glob
+  .sync('packages/*', {
+    cwd: RW_BASEPATH,
   })
-  .map((filePath) => `./${filePath}`)
+  .filter((packagePath) => (only ? packagePath.includes(only) : true))
+  .filter((packageName) => !packageName.includes('create-redwood-app'))
 
-const buildAndCopy = () =>
-  execa('yarn build', {
+const buildAllTypes = () =>
+  execa('yarn build:types', {
     shell: true,
     stdio: 'inherit',
     cleanup: true,
-    cwd: CURRENT_DIR,
-  }).then(() => {
-    if ('bin' in pkgJson) {
-      // Chmod if package has bins
-      execa('yarn fix:permissions', {
-        cwd: CURRENT_DIR,
-      })
-    }
-    return packlist({ path: CURRENT_DIR }).then((files) => {
-      files.forEach((file) => {
-        copyToDest(file, OUT_DIR)
-      })
-      return files
-    })
+    cwd: RW_BASEPATH,
   })
 
+const build = async ({ packageFolderName, types }) => {
+  const execaOptionsForBase = {
+    shell: true,
+    stdio: 'inherit',
+    cleanup: true,
+    cwd: RW_BASEPATH,
+  }
+
+  await execa(
+    'yarn lerna run',
+    [
+      types ? 'build' : 'build:js',
+      '--parallel',
+      packageFolderName && `--scope @redwoodjs/${packageFolderName}`,
+    ],
+    execaOptionsForBase
+  )
+
+  return execa(
+    'yarn lerna run',
+    [
+      'fix:permissions',
+      '--parallel',
+      packageFolderName && `--scope @redwoodjs/${packageFolderName}`,
+    ],
+    execaOptionsForBase
+  )
+}
+
+const copyDistFiles = ({ packageFolderName }) => {
+  return Promise.all(
+    packagePaths
+      // Only copy things in the package specified by --only
+      // If not, run it for all packages
+      .filter((packagePath) =>
+        packageFolderName ? packagePath.includes(packageFolderName) : true
+      )
+      .map((packagePath) => {
+        const pkgJson = require(path.join(
+          RW_BASEPATH,
+          packagePath,
+          'package.json'
+        ))
+
+        return packlist({ path: packagePath }).then((files) => {
+          const destinationDir = path.join(
+            dest,
+            `/${pkgJson.name.replace('@redwoodjs/', '')}`
+          )
+
+          files.forEach((file) => {
+            copyPackageFileToDest(packagePath, file, destinationDir)
+          })
+          return files
+        })
+      })
+  )
+}
+
 // Creates folders where required, before copying
-const copyToDest = (src, dest) => {
-  const dirName = path.dirname(path.join(dest, `/${src}`))
-  const fileName = path.basename(src)
+const copyPackageFileToDest = (packagePath, relativeSrc, dest) => {
+  const dirName = path.dirname(path.join(dest, `/${relativeSrc}`))
+  const fileName = path.basename(relativeSrc)
 
   const exist = fs.existsSync(dirName)
   if (!exist) {
     fs.mkdirSync(dirName, { recursive: true })
   }
 
-  fs.copyFileSync(src, path.join(dirName, fileName))
+  fs.copyFileSync(
+    path.join(RW_BASEPATH, packagePath, relativeSrc),
+    path.join(dirName, fileName)
+  )
 }
 
 // Assigned if watch is true
 let watchHandle
 
 process.on('SIGINT', () => {
-  watchHandle?.cancel()
+  watchHandle?.close()
 })
+
+const runAsync = async () => {
+  // STEP 1: Run build:types from root of framework
+  await buildAllTypes()
+  // STEP 2: Run yarn lerna run build --parallel, ignore types as they've just been built
+  await build({
+    packageFolderName: only,
+    types: false,
+  })
+
+  await copyDistFiles({
+    packageFolderName: only,
+  })
+}
+
+const onChange = _.debounce((packageFolderName) => {
+  console.log('Building 📦', packageFolderName)
+  build({ packageFolderName, types: true })
+  copyDistFiles({ packageFolderName })
+}, 200)
 
 // @Note:
 // --watch flag starts the watcher, but won't build until change detected
-if (watch) {
-  // Start watcher
-  packlist({ path: CURRENT_DIR }).then((files) => {
-    const filesToWatch = [
-      ...srcFiles,
-      ...files.filter((fileName) => !fileName.match('dist/')),
-    ]
+const packageNameRegex = /^^packages\/(\w+-?\w*)\/?/
 
-    watchHandle = chokidar
-      .watch(filesToWatch, {
-        persistent: true,
-      })
-      .on(
-        'change',
-        _.debounce(() => {
-          buildAndCopy()
-        }, 500)
-      )
-  })
+if (watch) {
+  // Start watcher for packages/*, ignore dist
+  // if file changed in package/{packageName}, run build and copy for packageName
+
+  watchHandle = chokidar
+    .watch(packagePaths, {
+      persistent: true,
+      ignored: [
+        '**/*.test.ts',
+        '**/*.test.js',
+        '**/__fixtures__/**',
+        '**/__tests__/**',
+        '**/dist/**',
+      ],
+    })
+    .on('change', (fileName) => {
+      const dirName = path.dirname(fileName)
+      const packageFolderName = packageNameRegex.exec(dirName)[1]
+      onChange(packageFolderName)
+    })
 } else {
-  buildAndCopy()
+  runAsync()
 }


### PR DESCRIPTION
Try number 1500.

Tries to make `yarn rwt link` faster by only spinning up one watcher (rather than like 16).

Bonus:
- Now supports --only flag to selectively link a certain package e.g.
```
yarn rwt link ~/Code/redwood --only router
```
Note that only is the folder name, not the package name. i.e. the part here -> `@redwoodjs/<PACKAGE_FOLDER_NAME>`

- Much easier to link to any project directly from the framework (but only use this if you know what you're doing)
```
yarn build:link --dest ~/MyRedwoodProject/packages
```
This just does the build, you still need to install on the repo to actually link. This can be really useful in certain situations. Note that the path has packages because this is included by default in your workspaces

