### PR TITLE
fix typo for `--javascript` option

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -51,7 +51,7 @@ const { _: args, 'yarn-install': yarnInstall, javascript } = yargs
     default: true,
     describe: 'Skip yarn install with --no-yarn-install',
   })
-  .option('--javascript', {
+  .option('javascript', {
     default: true,
     describe: 'Generate a JavaScript project',
   })


### PR DESCRIPTION
Currently we have

```
$ yarn create redwood-app --help
yarn create v1.22.10
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
...
[4/4] 🔨  Building fresh packages...

success Installed "create-redwood-app@0.28.4" with binaries:
      - create-redwood-app
Usage: create-redwood-app <project directory> [option]

Options:
  --help          Show help                                            [boolean]
  --yarn-install  Skip yarn install with --no-yarn-install       [default: true]
  ----javascript  Generate a JavaScript project                  [default: true]
  --version       Show version number                                  [boolean]

Examples:
  create-redwood-app newapp
✨  Done in 2.54s.
```

Surely option with four leading dashes does work (I've tried), it looks looks better following along with the rest :)


