### PR TITLE
upgrade Prisma v2.20.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.10",
-    "@prisma/client": "2.19.0",
+    "@prisma/client": "2.20.1",
     "@redwoodjs/internal": "^0.28.4",
     "@types/pino": "^6.3.6",
     "apollo-server-lambda": "2.22.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.19.0",
+    "@prisma/sdk": "2.20.1",
     "@redwoodjs/internal": "^0.28.4",
     "@redwoodjs/prerender": "^0.28.4",
     "@redwoodjs/structure": "^0.28.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^1.3.5",
     "null-loader": "^4.0.1",
-    "prisma": "2.19.0",
+    "prisma": "2.20.1",
     "react-refresh": "^0.9.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.19.0",
+    "@prisma/sdk": "2.20.1",
     "@redwoodjs/internal": "^0.28.4",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,30 +2813,30 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
   integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
-"@prisma/client@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.19.0.tgz#a45f17a59fd109e95b61bf4b56d4a7642169ec0e"
-  integrity sha512-QK4M8TjJh1QesyO9aLM7DeAQUi5+UnNHpEAm5kwqBO1cq/4Ag5yU9ladctJFJleEE5BLewXHwV2t9A+VfCZslg==
+"@prisma/client@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.20.1.tgz#45e7bade3a1b58972fc35e511578e313ead18770"
+  integrity sha512-/IYPubBi55rNMHfE0wwglA6eTWEZD77oz+x+3Mm9ji2lDKdS1lnYKZ0wZX0E3AB8gTNL/zsGtfzmfjgn3ePyIw==
   dependencies:
-    "@prisma/engines-version" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+    "@prisma/engines-version" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
 
-"@prisma/debug@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.19.0.tgz#5d9c6b9deb0d5214360ee23644c4e40bee0f251d"
-  integrity sha512-rCFF69WVC2G8x89UaIf786m+Ik1CcEq8XiJ10kIHezOECJQRZAHVjuCXrCnHa9Z1D5r8xaSw6/SuCAmr0Fuedg==
+"@prisma/debug@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.20.1.tgz#cc7635188ad9be964738f0e2896cd24fb400bcef"
+  integrity sha512-/21PtPjusr+gFFTFe/HjQ7hxFfZEqZU8axFvP4xVX6CrXIjNEcUf6UKm1JbpbCKRwEEd6M040ovjS8jLAp253w==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.19.0.tgz#89172fc048b4a02aa1062f81c2292697d95fdbe5"
-  integrity sha512-utcC150Rf1yWgLptVArTLis2beQBs4ce3lq5IApKdM6+U/5CDaF4pVCriHbyMcYqeeKMgf5SdFh1t1RJIbCsNQ==
+"@prisma/engine-core@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.20.1.tgz#bcf1978eee080e7a4de6b43a9c917657fcbc176b"
+  integrity sha512-OQc8dVRZXJ9nrMs3s1DTHuq389CqcXFytm2CbqH/7L+LRWSdLm2pZOzuofhZ+Soh55/nGs82xUtarSAo5NKKuQ==
   dependencies:
-    "@prisma/debug" "2.19.0"
-    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
-    "@prisma/generator-helper" "2.19.0"
-    "@prisma/get-platform" "2.19.0"
+    "@prisma/debug" "2.20.1"
+    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+    "@prisma/generator-helper" "2.20.1"
+    "@prisma/get-platform" "2.20.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -2846,23 +2846,23 @@
     terminal-link "^2.1.1"
     undici "3.3.3"
 
-"@prisma/engines-version@2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d":
-  version "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz#a7f80d481ec6cb8e2975ab530664d4ca5fc9eba6"
-  integrity sha512-NzhbwC4iMbRQwJxdhNQX6eaVcOuNGtHRk6aesWE4KMf/YmlW5kfi3HDy7WZ/C4P0Iyn9oURDuk+xZV6QDUVjTw==
+"@prisma/engines-version@2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e":
+  version "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#1189f0a7e682f500015446cfe2b34d2753452190"
+  integrity sha512-fJhbGZXm2SPs/RsI79Ew4SFe+6QmChNdgU2I/SIjmU18bUgK8f1TBEWnVtFdBqEDHYPGxbpaianF7lp04KN7EA==
 
-"@prisma/engines@2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d":
-  version "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d.tgz#db2809a6f7f18584e3ca89b1f5bad884155629ec"
-  integrity sha512-rEWpaG7wZvPuWJC5SwkBB/Iwue//oC5yv58Mse7r+ibtgkA7vGdWc1bFDQ32DT9tDL5WSC6bBwqEASGV/1Gm1Q==
+"@prisma/engines@2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e":
+  version "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#18f23c4a8a335a93fd338f88c310f5cf120f5591"
+  integrity sha512-zOWETm7DTRvlwf/CekPNSeJe6EC5bn2IFexd74wM9zgBXCZo+1sMDuNGtCqIt4Rzv8CcimEgyzrEFVq0LPV8qg==
 
-"@prisma/fetch-engine@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.19.0.tgz#a01ebfc184ab09cc0ed9d6d4ef966c3846fb5332"
-  integrity sha512-Hc0OhvzWoGFQnsApGH//LSHdQggXIys/U1VQQpjOPowe5l1PQZBV/drHLrDo8jxkmQfTTFvSxcOeflkky2Bj0g==
+"@prisma/fetch-engine@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.20.1.tgz#caee8aeb4ae661e31cbb2880dde4a306b360cd73"
+  integrity sha512-DWwozghLIkqQJ+jE6AF9lx+qwc9+0+bg0t3LOTDVpZsr00C23hsZXJyaNjz8x62/SbmxAqvPeatS3U+xXPE5Gg==
   dependencies:
-    "@prisma/debug" "2.19.0"
-    "@prisma/get-platform" "2.19.0"
+    "@prisma/debug" "2.20.1"
+    "@prisma/get-platform" "2.20.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -2879,34 +2879,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.19.0.tgz#452ef6f47bf47d4df8cca79c0aff52160b0a7dc0"
-  integrity sha512-ZMTLyzPiqx7CETwZuo7DBlwLeckT3no3DbWN0r6iEGEyeOgOpoXhlL/ka3Payprc3j4MJ08M8MoI80biw/vdJw==
+"@prisma/generator-helper@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.20.1.tgz#a94725876e1521becc4ef080904cff54dc641091"
+  integrity sha512-FY6D1Xu3uhaM0/qIg1P+P8U82HDKer418bCLJJU3IRd3XS/arybRGpZ4V3LGRgA8EmgCgOmvHDmnlFPDEhoODw==
   dependencies:
-    "@prisma/debug" "2.19.0"
+    "@prisma/debug" "2.20.1"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.19.0.tgz#1cf1fc975c28351cd50602c74f5f6532ca72bac5"
-  integrity sha512-tAv4BzJDxDDEdsU1mADdP0PKLVf8zbU9WI6nTDNSIhZsnVyBjMSWsHYnuoCgP94JtbnJ2gUSY35qJBvjLsl3kA==
+"@prisma/get-platform@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.20.1.tgz#19cde8941c7c0cf387317bd43b7c99ba06aebc14"
+  integrity sha512-kb/qTAPLnIdaeYiW385Qs35xuPHpgN/qzqxtkh//z1GuiQ8Izdq4UmoqqAdC63R1ipRYw6TJPcLSMpKTM1JF2A==
   dependencies:
-    "@prisma/debug" "2.19.0"
+    "@prisma/debug" "2.20.1"
 
-"@prisma/sdk@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.19.0.tgz#e871a4d34df64931fbdeb71613e6c10c6dc3bcc5"
-  integrity sha512-OeyinhRTWdcekIxpcfaGlXNADXukb80CWM9ok84rV8lh0q+++N3P8aiEvW85JAE5eMr5eTwlkzYlVDmfs17dRQ==
+"@prisma/sdk@2.20.1":
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.20.1.tgz#960b29c3fa7c12bf45dc6223ae0eb7d2755051f6"
+  integrity sha512-lu6WifrNBJAHwFsyu7brtrQWC3q4tSWNy6Dt+Z6+FBnXXMChASYK6Tkp9BzojlgfMS5XYHDXbIiBM1Bmxi/5Qg==
   dependencies:
-    "@prisma/debug" "2.19.0"
-    "@prisma/engine-core" "2.19.0"
-    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
-    "@prisma/fetch-engine" "2.19.0"
-    "@prisma/generator-helper" "2.19.0"
-    "@prisma/get-platform" "2.19.0"
+    "@prisma/debug" "2.20.1"
+    "@prisma/engine-core" "2.20.1"
+    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+    "@prisma/fetch-engine" "2.20.1"
+    "@prisma/generator-helper" "2.20.1"
+    "@prisma/get-platform" "2.20.1"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
@@ -2926,6 +2926,7 @@
     read-pkg-up "^7.0.1"
     resolve-pkg "^2.0.0"
     rimraf "^3.0.2"
+    shell-quote "^1.7.2"
     string-width "^4.2.0"
     strip-ansi "6.0.0"
     strip-indent "3.0.0"
@@ -15151,12 +15152,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.19.0.tgz#2c14f9cbbfb0ab69c8a9473e16736759713d29ad"
-  integrity sha512-iartCNVrtR4XT20ABN3zrSi3R/pCBe75Y0ZH8681QIGm8qjRQzf3DnbscPZgZ9iY4KFuVxL8ZrBQVDmRhpN0EQ==
+prisma@2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.20.1.tgz#28c52135523e0853258cd4ca7e883e9e4b5a9d40"
+  integrity sha512-zyPvJSUfJrmciP2D/4aUrsyIefiH8AIJUeuq1a0X1df1AFw9QQ+ata/7VQdoP+RIQHnCb6Kln9kqfUw/fieljw==
   dependencies:
-    "@prisma/engines" "2.19.0-39.c1455d0b443d66b0d9db9bcb1bb9ee0d5bbc511d"
+    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"
@@ -16631,7 +16632,7 @@ shell-exec@1.0.2:
   resolved "https://registry.yarnpkg.com/shell-exec/-/shell-exec-1.0.2.tgz#2e9361b0fde1d73f476c4b6671fa17785f696756"
   integrity sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==
 
-shell-quote@1.7.2:
+shell-quote@1.7.2, shell-quote@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==


### PR DESCRIPTION
Release notes:
- [2.20.0](https://github.com/prisma/prisma/releases/tag/2.20.0)
- [2.20.1](https://github.com/prisma/prisma/releases/tag/2.20.1)
    - New `push` operation available for arrays on PostgreSQL
    - `groupBy` and `createMany` are now Generally Available