### PR TITLE
e2e cy: Fix for step 1

### DIFF
--- a/tasks/e2e/cypress/integration/01-tutorial/tutorial.spec.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/tutorial.spec.js
@@ -59,7 +59,7 @@ describe('The Redwood Tutorial - Golden path edition', () => {
       path.join(BASE_DIR, 'web/src/pages/AboutPage/AboutPage.js'),
       Step2_2_PagesAbout
     )
-    cy.get('h1').should('contain', 'AboutPage')
+    cy.get('h1').should('contain', 'Redwood Blog')
     cy.contains('Return home').click()
   })
 


### PR DESCRIPTION
This fixes an assertion in our E2E Cypress tests. In the first step we generate the About page, and then we update the content of that page. Previously we asserted on the original content of the file even after updating it. Now it asserts on the updated content instead. 

I think the reason it still passed before was Cypress managed to do the assertion before HMR had a chance to update the page with the new content.