### PR TITLE
Generate AvailableRouteNames

### DIFF
--- a/packages/core/src/babelPlugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -61,16 +61,11 @@ export default function (
         enter() {
           pages = processPagesDir()
 
-          // Produces:
-          // routes.home: () => "/home"
-          // routes.aboutUs: () => "/about-us"
-          const availableRoutes = project
-            .getRouter()
-            .routes.filter((r) => !r.isNotFound)
-            .map(
-              (r) =>
-                `${r.name}: (params?: RouteParams<"${r.path}"> & QueryParams) => "${r.path}"`
-            )
+          const routes = project.getRouter().routes.filter((r) => !r.isNotFound)
+          const availableRoutes = routes.map(
+            ({ name, path }) =>
+              `${name}: (params?: RouteParams<"${path}"> & QueryParams) => "${path}"`
+          )
 
           const pageImports = pages.map(
             (page) => `import type ${page.const}Type from '${page.importPath}'`
@@ -89,6 +84,12 @@ export default function (
               interface AvailableRoutes {
                 ${availableRoutes.join('\n    ')}
               }
+
+              // TODO: Split these between authenticated and unauthenticated route names,
+              // since these are mostly used in "unauthenticated".
+              type AvailableRouteNames = ${routes
+                .map(({ name }) => `"${name}"`)
+                .join(' | ')}
             }
             `
             .split('\n')

--- a/packages/router/src/private-context.tsx
+++ b/packages/router/src/private-context.tsx
@@ -2,6 +2,10 @@ import React, { createContext, useCallback, useContext } from 'react'
 
 import { useRouterState } from './router-context'
 
+// @ts-expect-error This "type" is declared in user-land. We do not declare it internally,
+// because we cannot redeclare types.
+import type { AvailableRouteNames } from './index'
+
 /**
  * @param isPrivate - Always true for any children wrapped in a `<Private>`
  *                    component
@@ -14,7 +18,7 @@ import { useRouterState } from './router-context'
 interface PrivateState {
   isPrivate: boolean
   unauthorized: (role?: string | string[]) => boolean
-  unauthenticated: string
+  unauthenticated: AvailableRouteNames
 }
 
 const PrivateContext = createContext<PrivateState | undefined>(undefined)
@@ -22,7 +26,7 @@ const PrivateContext = createContext<PrivateState | undefined>(undefined)
 interface ProviderProps {
   isPrivate: boolean
   role?: string | string[]
-  unauthenticated: string
+  unauthenticated: AvailableRouteNames
 }
 
 export const PrivateContextProvider: React.FC<ProviderProps> = ({

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -22,6 +22,9 @@ import { SplashPage } from './splash-page'
 import { flattenAll, isReactElement } from './util'
 
 import type { AvailableRoutes } from './index'
+// @ts-expect-error This "type" is declared in user-land. We do not declare it internally,
+// because we cannot redeclare types.
+import type { AvailableRouteNames } from './index'
 
 // namedRoutes is populated at run-time by iterating over the `<Route />`
 // components, and appending them to this object.
@@ -146,7 +149,7 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
 
 interface PrivateProps {
   /** The page name where a user will be redirected when not authenticated */
-  unauthenticated: string
+  unauthenticated: AvailableRouteNames
   role?: string | string[]
 }
 


### PR DESCRIPTION
This PR generates a union of available route names that can be used to inform Private's "unauthenticated" property.

![image](https://user-images.githubusercontent.com/44849/113842817-5c551a80-9793-11eb-9ccf-39f086c25c0e.png)

Typically types cannot be enhanced, because TypeScript will complain about duplicate definitions, but this works by not declaring the original type and suppressing the TypeScript errors where they are imported. The types are provided by the client side at build-time and TypeScript is none the wiser in the end.

I hope that this technique will illustrate some additional flexibility in our TypeScript generation toolbox, but perhaps there's a way to do this entirely dynamically with inference? If that's possible then I would appreciate any direction in the comments, so I can start building up my TypeScript inference skillset. (I did attempt this, but I quickly ran into the "duplicate definition" problem that this is attempting to solve.)

/cc @Tobbe @dac09

- [ ] Genearate AvailableRouteNamesPrivate
- [ ] Genearate AvailableRouteNamesPublic
- [ ] Add post-build step to include `// @ts-expect-error` to generated type definitions.