### PR TITLE
add api-server to upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -57,13 +57,14 @@ const rwPackages = [
   '@redwoodjs/router',
   '@redwoodjs/auth',
   '@redwoodjs/forms',
+  '@redwoodjs/api-server',
 ].join(' ')
 
 // yarn upgrade-interactive does not allow --tags, so we resort to this mess
 // @redwoodjs/auth may not be installed so we add check
 const installTags = (tag, isAuth) => {
   const mainString = `yarn upgrade @redwoodjs/core@${tag} \
-  && yarn workspace api upgrade @redwoodjs/api@${tag} \
+  && yarn workspace api upgrade @redwoodjs/api@${tag} @redwoodjs/api-server@${tag} \
   && yarn workspace web upgrade @redwoodjs/web@${tag} @redwoodjs/router@${tag} @redwoodjs/forms@${tag}`
 
   const authString = ` @redwoodjs/auth@${tag}`
@@ -87,6 +88,7 @@ const installPr = (pr, isAuth) => {
   const mainString =
     `yarn add -DW ${packageUrl('core')} ${packageUrl('cli')} ` +
     `&& yarn workspace api add ${packageUrl('api')} ` +
+    `${packageUrl('api-server')} ` +
     `&& yarn workspace web add ${packageUrl('web')} ` +
     `${packageUrl('router')} ${packageUrl('forms')}`
 


### PR DESCRIPTION
The package `@redwoodjs/api-server` was added to the CRWA template in v0.28.1 via https://github.com/redwoodjs/redwood/pull/2129

This adds the api-server package to the `rw upgrade` tags, PR, and dry-run options.

For release notes:
- add step to install api-server in api/package.json
- add step to confirm api/package.json is at v0.29.0 _after_ upgrade is complete

Also 🤦‍♂️