### PR TITLE
fix(cli): Cli package should depend on api server explicitly

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
     "@graphql-tools/merge": "6.2.10",
     "@prisma/client": "2.20.1",
     "@redwoodjs/internal": "^0.29.0",
+    "@redwoodjs/api-server": "^0.29.0",
     "@types/pino": "^6.3.6",
     "apollo-server-lambda": "2.22.2",
     "core-js": "3.6.5",

--- a/packages/cli/jsconfig.json
+++ b/packages/cli/jsconfig.json
@@ -13,5 +13,6 @@
     { "path": "../internal" },
     { "path": "../structure" },
     { "path": "../prerender" },
+    { "path": "../api-server" },
   ]
 }


### PR DESCRIPTION
Adds `@redwoodjs/api-server` as explicit dependency to cli.

This may not be a major issue, since we ask people to install `@redwoodjs/api-server`anyway, but incase you don't have it, it errors out the whole cli.