### PR TITLE
logger.ts: Fix comment spelling

### DIFF
--- a/packages/create-redwood-app/template/api/src/lib/logger.ts
+++ b/packages/create-redwood-app/template/api/src/lib/logger.ts
@@ -4,8 +4,8 @@ import { createLogger } from '@redwoodjs/api/logger'
  * Creates a logger with RedwoodLoggerOptions
  *
  * These extend and override default LoggerOptions,
- * can define a destination like a file or other supported pin log transport stream,
- * and sets where or not to show the logger configuration settings (defaults to false)
+ * can define a destination like a file or other supported pino log transport stream,
+ * and sets whether or not to show the logger configuration settings (defaults to false)
  *
  * @param RedwoodLoggerOptions
  *


### PR DESCRIPTION
This PR fixes some typos in the JSDoc comment in logger.ts