### PR TITLE
Draft:  Refresh access token in getToken if expired

### DIFF
--- a/packages/auth/src/authClients/netlify.ts
+++ b/packages/auth/src/authClients/netlify.ts
@@ -41,6 +41,7 @@ export const netlify = (client: NetlifyIdentity): AuthClient => {
       })
     },
     getToken: async () => {
+      client.refresh()
       const user = await client.currentUser()
       return user?.token?.access_token || null
     },

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -88,6 +88,13 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
     },
     getToken: async () => {
       const currentSession = client.auth.session()
+      const expiresAt = currentSession?.expires_at
+
+      if (expiresAt && expiresAt > Math.round(Date.now() / 1000)) {
+        const { data } = await client.auth.refreshSession()
+        return data?.access_token || null
+      }
+
       return currentSession?.access_token || null
     },
     getUserMetadata: async () => {


### PR DESCRIPTION
There can be cases when even if `getToken()` is repeatedly called, the way the token is fetched may not result in a new un-expired token.

This PR aims to address that. 

The issue concerns the behavior of `getToken()` vs `getUserMetadata()`. The latter since it deals with user on the clients can rely on the client refreshing token itself as seen in `go-true`: https://github.com/netlify/gotrue-js/blob/3468f14197ee1cf288a812af09ac13ca2f8f13bf/src/user.js#L133 

But, getToken has been just relying on the stored session to have a valid unexpired token -- and it never refreshes.

So - there is a scenario (I think) in which a user stays on a single page -- or pages where userAuth() never is checked to help get some new userMetadata -- like on a page with GraphQL polling and the token will expire out from under the calls.

And since getToken() just keeps getting the stored now old token, the GraphQL call will fail since it has expired. A hard fresh would/should be a workaround, but that's not good.

Another point to consider is in `web/src/apollo`

```js
const ApolloProviderWithFetchConfig: React.FunctionComponent<{
  config?: Omit<ApolloClientOptions<InMemoryCache>, 'cache'>
}> = ({ config = {}, children }) => {
  const { uri, headers } = useFetchConfig()
  const { getToken, type: authProviderType, isAuthenticated } = useAuth()

  const withToken = setContext(async () => {
    if (isAuthenticated && getToken) {
      const token = await getToken()

      return { token }
    }

    return { token: null }
  })
```

Because `isAuthenticated` just sees if there is userMetadata it won't re- `getToken()` it is set to true in the state:

See `AuthProvider.tsx`:

```js
 const userMetadata = await this.rwClient.getUserMetadata()
      if (!userMetadata) {
        this.setState(notAuthenticatedState)
      } else {
        await this.getToken()

        const currentUser = this.props.skipFetchCurrentUser
          ? null
          : await this.getCurrentUser()

        this.setState({
          ...this.state,
          userMetadata,
          currentUser,
          isAuthenticated: true,
          loading: false,
        })
      }
```


Actually is does get the token here but not due to `withToken` -- but that won't necessarily refresh the expiration on the user JWT.

Also even though in AuthProvider:

```js
  getCurrentUser = async (): Promise<Record<string, unknown>> => {
    // Always get a fresh token, rather than use the one in state
    const token = await this.getToken()
```

getToken is called again this won't refresh an expired JWT necessarily.

Currently changed approaches are for Netlify Identity and Supabase.

## Auth Clients

### Supabase

* before, it got the currentSession and just returned its accessToken (or null) even if has expired (see: https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L203) 
* now, it gets the current session, sees if it has expired, then refreshes and returns the new session's token
* Note: the following recent PR's in Supabase helps with refreshing (https://github.com/supabase/gotrue-js/pull/68, https://github.com/supabase/gotrue-js/pull/72)

```js
    getToken: async () => {
      const currentSession = client.auth.session()
      const expiresAt = currentSession?.expires_at

      if (expiresAt && expiresAt > Math.round(Date.now() / 1000)) {
        const { data } = await client.auth.refreshSession()
        return data?.access_token || null
      }

      return currentSession?.access_token || null
    },
```

Note: https://github.com/supabase/gotrue-js/pull/72 may have fixed this already but is not in the latest npm yet.

As

```js
  /**
   * Clear and re-create refresh token timer
   * @param value time intervals in milliseconds
   */
  private _startAutoRefreshToken(value: number) {
    if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
    if (!value || !this.autoRefreshToken) return

    this.refreshTokenTimer = setTimeout(() => this._callRefreshToken(), value)
  }
```

will now refresh it on client side every 3500 seconds I beleive.

### Netlify Identity

* Before, there was no call to `client.refresh()`
* This will *not* result in many calls to get a new token because it will check its expiration on its own
* See https://github.com/netlify/netlify-identity-widget/blob/bf72002a14876b02cd1a4d05e6de94546dd2952b/src/netlify-identity.js#L60 and https://github.com/netlify/gotrue-js/blob/3468f14197ee1cf288a812af09ac13ca2f8f13bf/src/user.js#L67

```js
    getToken: async () => {
      client.refresh()
      const user = await client.currentUser()
      return user?.token?.access_token || null
    },
```

### Magiclink

Looks ok since

```js
getToken: async () => await client.user.getIdToken(),
```

and that returns a token valid for 15 mins and will keep issuing

See: https://docs.magic.link/client-sdk/web/api-reference#getidtoken

### Go-True

Should ok ok since `user.jwt()` will check the expiration (hence why client.refresh() for Netlify Identity above will work).

See: https://github.com/netlify/gotrue-js/blob/main/src/user.js#L62

```js
    getToken: async () => {
      const user = await client.currentUser()
      return user?.jwt() || null
    },
```

### Firebase

TODO

### Azure Firebase

TODO

### NHost

TODO

### Ethereum

TODO