### PR TITLE
Small improvements to rwt link

### DIFF
--- a/packages/cli/src/redwood-tools.js
+++ b/packages/cli/src/redwood-tools.js
@@ -177,7 +177,7 @@ const rwtLink = async (yargs) => {
     })
   }
 
-  // Unlink framework repo, when process cancelled
+  // Inform user to unlink framework repo, when process cancelled
   process.on('SIGINT', () => {
     const message = `
     🙏  Thanks for contributing..\n
@@ -192,9 +192,6 @@ const rwtLink = async (yargs) => {
     )
   })
 
-  // Delete existing redwood folders in node_modules
-  rimraf.sync(path.join(getPaths().base, 'node_modules/@redwoodjs/'))
-
   const onlyParams = only ? ['--only', only] : []
 
   await execa(
@@ -207,6 +204,10 @@ const rwtLink = async (yargs) => {
       cwd: frameworkPath,
     }
   )
+
+  // Delete existing redwood folders in node_modules
+  // Do this right before install, incase build:link fails
+  rimraf.sync(path.join(getPaths().base, 'node_modules/@redwoodjs/'))
 
   // Let workspaces do the link
   await execa('yarn install', ['--pure-lockfile', '--check-files'], {

--- a/tasks/build-link
+++ b/tasks/build-link
@@ -4,6 +4,9 @@
 const fs = require('fs')
 const path = require('path')
 
+// @NOTE: not all of these modules are defined as dependencies in core
+// This is because some of them are transitive dependencies through redwood/cli for example
+const chalk = require('chalk')
 const chokidar = require('chokidar')
 const execa = require('execa')
 const { glob } = require('glob')
@@ -123,26 +126,47 @@ process.on('SIGINT', () => {
 
 const runAsync = async () => {
   // STEP 1: Run build:types from root of framework
+  try {
+    if (!only) {
+      await buildAllTypes()
+    }
+    // STEP 2: Run yarn lerna run build --parallel, ignore types as they've just been built
+    await build({
+      packageFolderName: only,
+      types: only ? true : false,
+    })
 
-  if (!only) {
-    await buildAllTypes()
+    await copyDistFiles({
+      packageFolderName: only,
+    })
+  } catch (e) {
+    console.error(
+      `\n [rwt link] ${chalk.red.bold(
+        'error'
+      )} - Could not build your redwood framework.`
+    )
+    process.exit(1)
   }
-  // STEP 2: Run yarn lerna run build --parallel, ignore types as they've just been built
-  await build({
-    packageFolderName: only,
-    types: only ? true : false,
-  })
-
-  await copyDistFiles({
-    packageFolderName: only,
-  })
 }
 
 const onChange = _.debounce(async (packageFolderName) => {
-  console.log('Building 📦...', packageFolderName)
-  await build({ packageFolderName, types: true })
-  await copyDistFiles({ packageFolderName })
-  console.log(`${packageFolderName} ready to use ✔`)
+  console.log('[rwt link] Building 📦...', packageFolderName)
+  try {
+    await build({ packageFolderName, types: true })
+    await copyDistFiles({ packageFolderName })
+    console.log(
+      `\n [rwt link] ${chalk.greenBright.bold(
+        'success'
+      )} - @redwoodjs/${packageFolderName} ready to use`
+    )
+  } catch (e) {
+    console.error(
+      `\n [rwt link] ${chalk.red.bold(
+        'error'
+      )} - Could not link @redwoodjs/${packageFolderName}. Build failed.`
+    )
+  }
+  console.log()
 }, 200)
 
 // @Note:


### PR DESCRIPTION
### What? 

- Adds better messages for rwt link 
e.g. tells you if it can't compile a specific package after you make a change (common with types)

- Watcher does not exist on build failure

- Only remove node_modules after a succesful framework build
Just moves where rimraf is called