### PR TITLE
upgrade prisma v2.21.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.10",
-    "@prisma/client": "2.20.1",
+    "@prisma/client": "2.21.0",
     "@redwoodjs/internal": "^0.29.0",
     "@redwoodjs/api-server": "^0.29.0",
     "@types/pino": "^6.3.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.20.1",
+    "@prisma/sdk": "2.21.0",
     "@redwoodjs/internal": "^0.29.0",
     "@redwoodjs/prerender": "^0.29.0",
     "@redwoodjs/structure": "^0.29.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^1.4.1",
     "null-loader": "^4.0.1",
-    "prisma": "2.20.1",
+    "prisma": "2.21.0",
     "react-refresh": "^0.10.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.20.1",
+    "@prisma/sdk": "2.21.0",
     "@redwoodjs/internal": "^0.29.0",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,30 +2813,30 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
   integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
-"@prisma/client@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.20.1.tgz#45e7bade3a1b58972fc35e511578e313ead18770"
-  integrity sha512-/IYPubBi55rNMHfE0wwglA6eTWEZD77oz+x+3Mm9ji2lDKdS1lnYKZ0wZX0E3AB8gTNL/zsGtfzmfjgn3ePyIw==
+"@prisma/client@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.21.0.tgz#97cb64d7ac76c1cce7f65f7a207320733efbac3a"
+  integrity sha512-RMtX0sdDl5MDJ49WOvGMzqgPF5yN6DQMSpzr+jpCkL7kuHASGiVcBYpvkBlNNA5a186zKCHuaMdNb8h7hDS4/A==
   dependencies:
-    "@prisma/engines-version" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+    "@prisma/engines-version" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
 
-"@prisma/debug@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.20.1.tgz#cc7635188ad9be964738f0e2896cd24fb400bcef"
-  integrity sha512-/21PtPjusr+gFFTFe/HjQ7hxFfZEqZU8axFvP4xVX6CrXIjNEcUf6UKm1JbpbCKRwEEd6M040ovjS8jLAp253w==
+"@prisma/debug@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.21.0.tgz#70f4a4295558a7ada69ce6525b0d2d0782489c80"
+  integrity sha512-fCAQKn62KDgPWnx+h2g9M8kXcnToEWG74wQ0xALO9HC0HM49ZJldB89/uiB5cU8tWG6ccgQacmXxj7c7a/WFCw==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.20.1.tgz#bcf1978eee080e7a4de6b43a9c917657fcbc176b"
-  integrity sha512-OQc8dVRZXJ9nrMs3s1DTHuq389CqcXFytm2CbqH/7L+LRWSdLm2pZOzuofhZ+Soh55/nGs82xUtarSAo5NKKuQ==
+"@prisma/engine-core@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.21.0.tgz#ba446a0a8596a58e93bc2171efdb48bab3909cef"
+  integrity sha512-BNG6oChhIXOHuoNisxYHQLKtNv9riIO3yITYtGeUv153J5t7XZQLC7kp8LFUaYEgAr8ZwR8aYhqfzje1NTlzSA==
   dependencies:
-    "@prisma/debug" "2.20.1"
-    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-    "@prisma/generator-helper" "2.20.1"
-    "@prisma/get-platform" "2.20.1"
+    "@prisma/debug" "2.21.0"
+    "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+    "@prisma/generator-helper" "2.21.0"
+    "@prisma/get-platform" "2.21.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -2844,25 +2844,25 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "3.3.3"
+    undici "3.3.4"
 
-"@prisma/engines-version@2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e":
-  version "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#1189f0a7e682f500015446cfe2b34d2753452190"
-  integrity sha512-fJhbGZXm2SPs/RsI79Ew4SFe+6QmChNdgU2I/SIjmU18bUgK8f1TBEWnVtFdBqEDHYPGxbpaianF7lp04KN7EA==
+"@prisma/engines-version@2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d":
+  version "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz#b749bae4173eb766dafc298aaa7d883c2dbe555b"
+  integrity sha512-9/fE1gdPWmjbMjXUJjrTMt848TsgEnSjZCcJ1wu9OAcRlAKKJBLehftqC3gSEShDijvMYgeTdGU5snMpwmv4vg==
 
-"@prisma/engines@2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e":
-  version "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e.tgz#18f23c4a8a335a93fd338f88c310f5cf120f5591"
-  integrity sha512-zOWETm7DTRvlwf/CekPNSeJe6EC5bn2IFexd74wM9zgBXCZo+1sMDuNGtCqIt4Rzv8CcimEgyzrEFVq0LPV8qg==
+"@prisma/engines@2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d":
+  version "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz#aafed60c9506bc766e49ea60b9f8ce7da2385bc6"
+  integrity sha512-L57tvSoom2GDWDqik4wrAUBvLTAv5MTm2OOzNMBKsv0w5cX7ONoZ8KnGQN+csmdJpQVBs93dIvIBm72OO+l/9Q==
 
-"@prisma/fetch-engine@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.20.1.tgz#caee8aeb4ae661e31cbb2880dde4a306b360cd73"
-  integrity sha512-DWwozghLIkqQJ+jE6AF9lx+qwc9+0+bg0t3LOTDVpZsr00C23hsZXJyaNjz8x62/SbmxAqvPeatS3U+xXPE5Gg==
+"@prisma/fetch-engine@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.21.0.tgz#7236843e8d53eb7d7664929824d542f0e5980e2a"
+  integrity sha512-smXXSx9zns3HKOA60hKI5qRgAjrjfWzX4RpQT6E7ieQW4x3YfEmzqCl6BTDftOB++esK8BpOLaes5J9NLbdAIw==
   dependencies:
-    "@prisma/debug" "2.20.1"
-    "@prisma/get-platform" "2.20.1"
+    "@prisma/debug" "2.21.0"
+    "@prisma/get-platform" "2.21.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -2879,39 +2879,39 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.20.1.tgz#a94725876e1521becc4ef080904cff54dc641091"
-  integrity sha512-FY6D1Xu3uhaM0/qIg1P+P8U82HDKer418bCLJJU3IRd3XS/arybRGpZ4V3LGRgA8EmgCgOmvHDmnlFPDEhoODw==
+"@prisma/generator-helper@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.21.0.tgz#378b8edbefee3d619d099efbb0a1eed77a3b0813"
+  integrity sha512-Aldje91NQ3d45eWjXcSqchD3JAhLlkCI2mp1sdASGnNmGfU28baDHH+igEonOIVe5obsRtnbQRKnAFw1LJHkQw==
   dependencies:
-    "@prisma/debug" "2.20.1"
+    "@prisma/debug" "2.21.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.20.1.tgz#19cde8941c7c0cf387317bd43b7c99ba06aebc14"
-  integrity sha512-kb/qTAPLnIdaeYiW385Qs35xuPHpgN/qzqxtkh//z1GuiQ8Izdq4UmoqqAdC63R1ipRYw6TJPcLSMpKTM1JF2A==
+"@prisma/get-platform@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.21.0.tgz#24677cfb79eef4b3c1eb8da92c99d68bce99a9e4"
+  integrity sha512-goHgU43l2kDF8n+wKNk6MfDAtM55ekC61Ud7qhjiF6DZM0z61oyf0ZsGqW0FqXMqFS1ckKJRw64/qeFgEhZc6g==
   dependencies:
-    "@prisma/debug" "2.20.1"
+    "@prisma/debug" "2.21.0"
 
-"@prisma/sdk@2.20.1":
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.20.1.tgz#960b29c3fa7c12bf45dc6223ae0eb7d2755051f6"
-  integrity sha512-lu6WifrNBJAHwFsyu7brtrQWC3q4tSWNy6Dt+Z6+FBnXXMChASYK6Tkp9BzojlgfMS5XYHDXbIiBM1Bmxi/5Qg==
+"@prisma/sdk@2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.21.0.tgz#25a18b8d7010c077980d03bdc73f7485abc93beb"
+  integrity sha512-nwI+OuEAhsmmy29/MwI5TzSkowavB6KNz+mQpKfdcgEjgawzTnefgSk/HX3gLLekIfOOgs4Y4Wcfwq7YRERlVg==
   dependencies:
-    "@prisma/debug" "2.20.1"
-    "@prisma/engine-core" "2.20.1"
-    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
-    "@prisma/fetch-engine" "2.20.1"
-    "@prisma/generator-helper" "2.20.1"
-    "@prisma/get-platform" "2.20.1"
+    "@prisma/debug" "2.21.0"
+    "@prisma/engine-core" "2.21.0"
+    "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+    "@prisma/fetch-engine" "2.21.0"
+    "@prisma/generator-helper" "2.21.0"
+    "@prisma/get-platform" "2.21.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
     chalk "4.1.0"
-    checkpoint-client "1.1.19"
+    checkpoint-client "1.1.20"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
     execa "^5.0.0"
@@ -6445,13 +6445,13 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-checkpoint-client@1.1.19:
-  version "1.1.19"
-  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.19.tgz#8a32bddbbc6acf6e20542f18780b71e5e0b981ed"
-  integrity sha512-aChSq/qsvyu3TXAJdtKgA03JxzUD/w3fwKpUhILPGFnHEO8OHx+cg6dgjuchQsIs2r3lSPPcwzgi21xohqTrmQ==
+checkpoint-client@1.1.20:
+  version "1.1.20"
+  resolved "https://registry.yarnpkg.com/checkpoint-client/-/checkpoint-client-1.1.20.tgz#c869eeba84130ea3e5660b1fd71440981b5df8f5"
+  integrity sha512-AHDELBFMXBV9Rzp4JaN0JR03YQomZpaaVFDjgH7Ue4CcPuzNV2dZ94ZORJ9OoQsASYca/uR7UNGXmeNuWHc+IQ==
   dependencies:
     ci-info "3.1.1"
-    env-paths "2.2.0"
+    env-paths "2.2.1"
     fast-write-atomic "0.2.1"
     make-dir "3.1.0"
     ms "2.1.3"
@@ -8383,12 +8383,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-env-paths@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
-  integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
-
-env-paths@^2.2.0:
+env-paths@2.2.1, env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
@@ -15147,12 +15142,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.20.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.20.1.tgz#28c52135523e0853258cd4ca7e883e9e4b5a9d40"
-  integrity sha512-zyPvJSUfJrmciP2D/4aUrsyIefiH8AIJUeuq1a0X1df1AFw9QQ+ata/7VQdoP+RIQHnCb6Kln9kqfUw/fieljw==
+prisma@2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.21.0.tgz#ffab3901fbd2335b77d9d939c5cf3031fe11a8f3"
+  integrity sha512-lmlfcWEyl24AO788DmZOerFl8npH0xW2aY1BmXLeTgHvovvk3/AJIYZNfaDEx9wuvjNLhZTExICMDAtJIFi3kQ==
   dependencies:
-    "@prisma/engines" "2.20.0-26.60ba6551f29b17d7d6ce479e5733c70d9c00860e"
+    "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"
@@ -18140,10 +18135,10 @@ undefsafe@^2.0.3:
   dependencies:
     debug "^2.2.0"
 
-undici@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-3.3.3.tgz#a90a783a5605fd3d0e093624e261aae234646452"
-  integrity sha512-JcC6p86DLPDne5vhm9nZ9N6hW/WPCtO8/NV+7YHS+x/mQ+NpWvtGxIt28ObBsySPec8FsabyiLPhmn7Htl9w3A==
+undici@3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-3.3.4.tgz#a52dab910cf4f46ce1a39377dd9049bb08656d2a"
+  integrity sha512-9BAepS9jBqD9lLKO2UJ8vPZlIHNmVibkMt23c+qBQhpXpG11F6SH12ttYeKGfEiFaHyZ1wZlOIHED7TTZOCTGQ==
 
 unfetch@^4.1.0, unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Release Notes: 
https://github.com/prisma/prisma/releases/tag/2.21.0

## Breaking: 
- Previously, aggregations on nullable fields always returned 0. All aggregated fields are now nullable. Aggregated fields can return null when there's either no record in the database or if all the aggregated records are null.
- `disconnect` no longer throws an error on unconnected records
- `@default(dbgenerated(""))` is no longer permitted