### PR TITLE
[v0.30.0 release] Upgrade Prisma v2.21.2

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.10",
-    "@prisma/client": "2.21.0",
+    "@prisma/client": "2.21.2",
     "@redwoodjs/internal": "^0.29.0",
     "@redwoodjs/api-server": "^0.29.0",
     "@types/pino": "^6.3.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.21.0",
+    "@prisma/sdk": "2.21.2",
     "@redwoodjs/internal": "^0.29.0",
     "@redwoodjs/prerender": "^0.29.0",
     "@redwoodjs/structure": "^0.29.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^1.3.5",
     "null-loader": "^4.0.1",
-    "prisma": "2.21.0",
+    "prisma": "2.21.2",
     "react-refresh": "^0.10.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.21.0",
+    "@prisma/sdk": "2.21.2",
     "@redwoodjs/internal": "^0.29.0",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,30 +2813,30 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
   integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
-"@prisma/client@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.21.0.tgz#97cb64d7ac76c1cce7f65f7a207320733efbac3a"
-  integrity sha512-RMtX0sdDl5MDJ49WOvGMzqgPF5yN6DQMSpzr+jpCkL7kuHASGiVcBYpvkBlNNA5a186zKCHuaMdNb8h7hDS4/A==
+"@prisma/client@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.21.2.tgz#ca8489832da1d61add429390210be4d7896e5e29"
+  integrity sha512-UjkOXYpxLuHyoMDsP2m0LTcxhrjQa1dEOLFe3aDrO/BLrs/2yUxyPdtwSKxizRXFzuXSGkKIK225vcjZRuMpAg==
   dependencies:
     "@prisma/engines-version" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
 
-"@prisma/debug@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.21.0.tgz#70f4a4295558a7ada69ce6525b0d2d0782489c80"
-  integrity sha512-fCAQKn62KDgPWnx+h2g9M8kXcnToEWG74wQ0xALO9HC0HM49ZJldB89/uiB5cU8tWG6ccgQacmXxj7c7a/WFCw==
+"@prisma/debug@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.21.2.tgz#10ab3e5dd26217920c0a1d1c5c752a1df08ac988"
+  integrity sha512-oB5JmzR9/I0hYU7GOuzSBF2F0QCDHp1UUi1acIGb5Vu6EQtP6VOwBmgCOyNW6VrwxvnjcEsNtLXnRQ1rl4DKqw==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.21.0.tgz#ba446a0a8596a58e93bc2171efdb48bab3909cef"
-  integrity sha512-BNG6oChhIXOHuoNisxYHQLKtNv9riIO3yITYtGeUv153J5t7XZQLC7kp8LFUaYEgAr8ZwR8aYhqfzje1NTlzSA==
+"@prisma/engine-core@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.21.2.tgz#cf40d7647e5ff945454fbb04655f41657be17ddf"
+  integrity sha512-t+XYncNZrVzl1HaKF6zYT1pEzBxgcJM7tHbtTuhHG6aGPVObb7oJqAmrOWI98Ac38YuKrenKJa0Ce24Qf00XWQ==
   dependencies:
-    "@prisma/debug" "2.21.0"
+    "@prisma/debug" "2.21.2"
     "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
-    "@prisma/generator-helper" "2.21.0"
-    "@prisma/get-platform" "2.21.0"
+    "@prisma/generator-helper" "2.21.2"
+    "@prisma/get-platform" "2.21.2"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -2856,13 +2856,13 @@
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz#aafed60c9506bc766e49ea60b9f8ce7da2385bc6"
   integrity sha512-L57tvSoom2GDWDqik4wrAUBvLTAv5MTm2OOzNMBKsv0w5cX7ONoZ8KnGQN+csmdJpQVBs93dIvIBm72OO+l/9Q==
 
-"@prisma/fetch-engine@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.21.0.tgz#7236843e8d53eb7d7664929824d542f0e5980e2a"
-  integrity sha512-smXXSx9zns3HKOA60hKI5qRgAjrjfWzX4RpQT6E7ieQW4x3YfEmzqCl6BTDftOB++esK8BpOLaes5J9NLbdAIw==
+"@prisma/fetch-engine@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.21.2.tgz#1dc232872e31b7479ab3e42cfba19ac27bd4d1b0"
+  integrity sha512-SKg75GdyVfmlAM8ydH/vTnxU29FpwVhvKdOP5fjJvhqv1/YGCStsiYR36x7GggBlNuh7KKtI7KtRpjc0jE+SbQ==
   dependencies:
-    "@prisma/debug" "2.21.0"
-    "@prisma/get-platform" "2.21.0"
+    "@prisma/debug" "2.21.2"
+    "@prisma/get-platform" "2.21.2"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -2879,34 +2879,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.21.0.tgz#378b8edbefee3d619d099efbb0a1eed77a3b0813"
-  integrity sha512-Aldje91NQ3d45eWjXcSqchD3JAhLlkCI2mp1sdASGnNmGfU28baDHH+igEonOIVe5obsRtnbQRKnAFw1LJHkQw==
+"@prisma/generator-helper@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.21.2.tgz#5620e032bd906cc42d65c15a7de8876d239aa170"
+  integrity sha512-zo3rqKTWo3GExb2rLgwo0EMHfpeJyj6Lo8b5g1CFWCmtpe3O4gic7mqiTWRz2jk5r6FiSIyOl4+iVRBjDmHFhg==
   dependencies:
-    "@prisma/debug" "2.21.0"
+    "@prisma/debug" "2.21.2"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.21.0.tgz#24677cfb79eef4b3c1eb8da92c99d68bce99a9e4"
-  integrity sha512-goHgU43l2kDF8n+wKNk6MfDAtM55ekC61Ud7qhjiF6DZM0z61oyf0ZsGqW0FqXMqFS1ckKJRw64/qeFgEhZc6g==
+"@prisma/get-platform@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.21.2.tgz#e480d9676989495b28d734f01a64caa00ea2fa15"
+  integrity sha512-z9Nme7AaD4f34S1oRPjXaJJPlF4WTEx/yPxBAxvNb4QR6w84zU4zahu5n6Vkc6ErRPihlSiRG2ptDdQie/Cdww==
   dependencies:
-    "@prisma/debug" "2.21.0"
+    "@prisma/debug" "2.21.2"
 
-"@prisma/sdk@2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.21.0.tgz#25a18b8d7010c077980d03bdc73f7485abc93beb"
-  integrity sha512-nwI+OuEAhsmmy29/MwI5TzSkowavB6KNz+mQpKfdcgEjgawzTnefgSk/HX3gLLekIfOOgs4Y4Wcfwq7YRERlVg==
+"@prisma/sdk@2.21.2":
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.21.2.tgz#f983998febc529ba7733ac6760c3f7d89538920d"
+  integrity sha512-m35JPEGYOnldBrIGpKdwxP/xER0S4vpk7L/qiLZGW6kVMcJRaeUGEONzmgaXtAXn6dP2BopsQ0UheCs3aF8uiQ==
   dependencies:
-    "@prisma/debug" "2.21.0"
-    "@prisma/engine-core" "2.21.0"
+    "@prisma/debug" "2.21.2"
+    "@prisma/engine-core" "2.21.2"
     "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
-    "@prisma/fetch-engine" "2.21.0"
-    "@prisma/generator-helper" "2.21.0"
-    "@prisma/get-platform" "2.21.0"
+    "@prisma/fetch-engine" "2.21.2"
+    "@prisma/generator-helper" "2.21.2"
+    "@prisma/get-platform" "2.21.2"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
@@ -15147,10 +15147,10 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.21.0:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.21.0.tgz#ffab3901fbd2335b77d9d939c5cf3031fe11a8f3"
-  integrity sha512-lmlfcWEyl24AO788DmZOerFl8npH0xW2aY1BmXLeTgHvovvk3/AJIYZNfaDEx9wuvjNLhZTExICMDAtJIFi3kQ==
+prisma@2.21.2:
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.21.2.tgz#a73b4cbe92a884aa98b317684d6741871b5e94a5"
+  integrity sha512-Ux9ovDIUHsMNLGLtuo6BBKCuuBVLpZmhM2LXF+VBUQvsbmsVfp3u5CRyHGEqaZqMibYQJISy7YZYF/RgozHKkQ==
   dependencies:
     "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
 
@@ -15689,15 +15689,15 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-refresh@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
+  integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
+
 react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
-
-react-refresh@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
-  integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
 react-sizeme@^2.5.2, react-sizeme@^2.6.7:
   version "2.6.12"


### PR DESCRIPTION
@dac09 @peterp 
Using our [Patch Release Process](https://github.com/redwoodjs/redwood/issues/2067#issuecomment-808721151), I have created branch `v0.30.0-branch` and cherry-picked the following:
- upgrade Prisma v2.21.0 (#2273) 3315f14b @thedavidprice 
   - see this PR for Prisma Release Notes (includes breaking)
- Fix: webpack optimizations for JS (#2235) 73c78878 @dac09 
- Adds better messages for rwt link | Watcher does not exist on build failure | Only remove node_modules after a succesful framework build (#2269) 472d5378 @dac09
- fix(cli): Cli package should depend on api server explicitly (#2251) d3ce5d45 @dac09 

This PR will merge a branch with Prisma v2.21.2 (including fix for Netlify deploy) against `v0.30.0-branch`.

@peterp The next step will be to release v0.30.0 using the remaining steps in our patch release process.

## Release Notes for the PR
- https://github.com/prisma/prisma/releases/tag/2.21.2