### PR TITLE
fix(cli): Move api-server dep from api to cli

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@graphql-tools/merge": "6.2.10",
     "@prisma/client": "2.21.2",
-    "@redwoodjs/api-server": "^0.30.0",
     "@redwoodjs/internal": "^0.30.0",
     "@types/pino": "^6.3.6",
     "apollo-server-lambda": "2.22.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,6 +17,7 @@
     "@redwoodjs/internal": "^0.30.0",
     "@redwoodjs/prerender": "^0.30.0",
     "@redwoodjs/structure": "^0.30.0",
+    "@redwoodjs/api-server": "^0.30.0",
     "boxen": "^4.2.0",
     "camelcase": "^6.0.0",
     "chalk": "^4.1.0",


### PR DESCRIPTION
Fixes #2299 

## What does it do?
- Moves api-server dependency out of api and into cli
Why CLI? Because of the `yarn rw serve api` command. I think I added it to api by mistake

cc @jeliasson 