### PR TITLE
Remove invalid dependency from CRWA template

### DIFF
--- a/packages/create-redwood-app/template/yarn.lock
+++ b/packages/create-redwood-app/template/yarn.lock
@@ -1869,7 +1869,6 @@
     "@babel/plugin-transform-runtime" "^7.11.5"
     "@babel/preset-env" "^7.11.5"
     "@babel/preset-react" "^7.12.13"
-    "@babel/preset-runtime-corejs3" "^7.10.4"
     "@babel/runtime-corejs3" "^7.11.2"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.4.3"
     "@redwoodjs/cli" "^0.30.0"


### PR DESCRIPTION
CRWA template lock file has an invalid dependency that is causing an error.

I don't know if I can just remove it from the lock file but it looks to be a simple solution.

Resolves #2316 