### PR TITLE
Fix page generator taking in ts | Fix rw serve crashing out cli

### DIFF
--- a/packages/api-server/src/middleware/withWebServer.ts
+++ b/packages/api-server/src/middleware/withWebServer.ts
@@ -6,12 +6,12 @@ import express from 'express'
 
 import { getPaths } from '@redwoodjs/internal'
 
-const indexContent = fs.readFileSync(
-  path.join(getPaths().web.dist, '/index.html'),
-  'utf-8'
-)
-
 const withWebServer = (app: Application) => {
+  const indexContent = fs.readFileSync(
+    path.join(getPaths().web.dist, '/index.html'),
+    'utf-8'
+  )
+
   app.use(
     express.static(getPaths().web.dist, {
       redirect: false,

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -123,6 +123,12 @@ export const builder = (yargs) => {
       type: 'boolean',
       default: true,
     })
+    .option('typescript', {
+      alias: ['ts'],
+      description: 'Generate in TypeScript',
+      type: 'boolean',
+      default: false,
+    })
     .option('stories', {
       description: 'Generate storybook files',
       type: 'boolean',
@@ -142,6 +148,7 @@ export const handler = async ({
   force,
   tests = true,
   stories = true,
+  typescript = false,
 }) => {
   if (process.platform === 'win32') {
     // running `yarn rw g page home /` on Windows using GitBash
@@ -181,6 +188,7 @@ export const handler = async ({
             path,
             tests,
             stories,
+            typescript,
             ...paramVariants(path),
           })
           return writeFilesTask(f, { overwriteExisting: force })

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -443,14 +443,9 @@ const tasks = ({ model, path, force, typescript, javascript }) => {
   )
 }
 
-export const handler = async ({
-  model: modelArg,
-  force,
-  typescript,
-  javascript,
-}) => {
+export const handler = async ({ model: modelArg, force, typescript }) => {
   const { model, path } = splitPathAndModel(modelArg)
-  const t = tasks({ model, path, force, typescript, javascript })
+  const t = tasks({ model, path, force, typescript })
 
   try {
     await t.run()

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -43,17 +43,20 @@ const style = {
   green: chalk.green,
 }
 
-const { _: args, 'yarn-install': yarnInstall, javascript } = yargs
+const { _: args, 'yarn-install': yarnInstall, typescript } = yargs
   .scriptName(name)
   .usage('Usage: $0 <project directory> [option]')
   .example('$0 newapp')
   .option('yarn-install', {
     default: true,
+    type: 'boolean',
     describe: 'Skip yarn install with --no-yarn-install',
   })
-  .option('javascript', {
-    default: true,
-    describe: 'Generate a JavaScript project',
+  .option('typescript', {
+    alias: 'ts',
+    default: false,
+    type: 'boolean',
+    describe: 'Generate a TypeScript project. JavaScript by default.',
   })
   .version(version)
   .strict().argv
@@ -151,11 +154,12 @@ new Listr(
     },
     {
       title: 'Convert TypeScript files to JavaScript',
-      skip: () => {
-        if (javascript === false) {
-          return 'skipped on request'
-        }
-      },
+      enabled: () => typescript === false,
+      // skip: () => {
+      //   if (typescript === true) {
+      //     return 'Skipped on request'
+      //   }
+      // },
       task: () => {
         return execa('yarn rw ts-to-js', {
           shell: true,

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -155,11 +155,6 @@ new Listr(
     {
       title: 'Convert TypeScript files to JavaScript',
       enabled: () => typescript === false,
-      // skip: () => {
-      //   if (typescript === true) {
-      //     return 'Skipped on request'
-      //   }
-      // },
       task: () => {
         return execa('yarn rw ts-to-js', {
           shell: true,

--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -40,7 +40,7 @@ const createRedwoodJSApp = () => {
   try {
     execa.sync(
       'yarn babel-node src/create-redwood-app.js',
-      [REDWOOD_PROJECT_DIRECTORY, '--no-yarn-install', '--no-javascript'],
+      [REDWOOD_PROJECT_DIRECTORY, '--no-yarn-install', '--typescript'],
       {
         cwd: path.join(REDWOODJS_FRAMEWORK_PATH, 'packages/create-redwood-app'),
         shell: true,


### PR DESCRIPTION
Some fixes for the release. Mostly stuff I broke 

![mild_panic](https://user-images.githubusercontent.com/1521877/115768701-908b2680-a3a2-11eb-96ef-19bbc654391c.png)


- [x] Cli now runs without crashing out (change in withWebserver middleware)
- [x] Page generators take `--ts` or `--typescript` parameter

- [x] create-redwood-app changes the param from `--no-javascript` to `--typescript`
@thedavidprice this is a breaking change for CRWA (which is why e2e tests failing). Need to discuss this!

