### PR TITLE
feat(webhooks): Handle base64 encoded webhook payloads

### DIFF
--- a/packages/api/src/webhooks/index.ts
+++ b/packages/api/src/webhooks/index.ts
@@ -17,6 +17,19 @@ export {
 export const DEFAULT_WEBHOOK_SIGNATURE_HEADER = 'RW-WEBHOOK-SIGNATURE'
 
 /**
+ * Extracts body payload from event with base64 encoding check
+ *
+ */
+const eventBody = (event: APIGatewayProxyEvent) => {
+  console.debug(event.isBase64Encoded)
+  if (event.isBase64Encoded) {
+    return Buffer.from(event.body || '', 'base64').toString('utf-8')
+  } else {
+    return event.body || ''
+  }
+}
+
+/**
  * Extracts signature from Lambda Event.
  *
  * @param {APIGatewayProxyEvent} event - The event that incudes the request details, like headers
@@ -70,8 +83,10 @@ export const verifyEvent = (
   if (payload) {
     body = payload
   } else {
-    body = event.body || ''
+    body = eventBody(event)
   }
+
+  console.debug(body)
 
   const signature = signatureFromEvent({
     event,

--- a/packages/api/src/webhooks/index.ts
+++ b/packages/api/src/webhooks/index.ts
@@ -21,7 +21,6 @@ export const DEFAULT_WEBHOOK_SIGNATURE_HEADER = 'RW-WEBHOOK-SIGNATURE'
  *
  */
 const eventBody = (event: APIGatewayProxyEvent) => {
-  console.debug(event.isBase64Encoded)
   if (event.isBase64Encoded) {
     return Buffer.from(event.body || '', 'base64').toString('utf-8')
   } else {
@@ -85,8 +84,6 @@ export const verifyEvent = (
   } else {
     body = eventBody(event)
   }
-
-  console.debug(body)
 
   const signature = signatureFromEvent({
     event,

--- a/packages/api/src/webhooks/webhooks.test.ts
+++ b/packages/api/src/webhooks/webhooks.test.ts
@@ -23,7 +23,7 @@ const buildEvent = ({
   const body = isBase64Encoded
     ? Buffer.from(payload || '').toString('base64')
     : payload
-  console.debug(body)
+
   return {
     body,
     headers,


### PR DESCRIPTION
There can be situations where the event is base64 encoded (which apparently can happen often on Vercel).

See with discussion between @Burnsy and @alecortega:

> I had this exact same issue with all my functions hosted on Vercel. I found that when working with Redwood locally the body of a function is decoded, however, once deployed to Vercel, the body may be base64 encoded. 

https://github.com/redwoodjs/redwood/issues/1410#issuecomment-825156426

Therefore, this PR checks the event to see if it isBase64Encoded and decodes before sending to the verifier.
