### PR TITLE
Private: Make it accept wrap (from Set)

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -7,13 +7,13 @@ import { isRoute } from './router'
 import { useRouterState } from './router-context'
 import { flattenAll, matchPath } from './util'
 
-type WrapperType<WTProps> = (
+export type WrapperType<WTProps> = (
   props: WTProps & { children: ReactNode }
 ) => ReactElement | null
 
 type ReduceType = ReactElement | undefined
 
-type SetProps<P> = P & {
+export type SetProps<P> = P & {
   wrap: WrapperType<P> | WrapperType<P>[]
   children: ReactNode
 }

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -556,3 +556,28 @@ test('Set is not rendered for unauthenticated user.', async () => {
 
   await waitFor(() => screen.getByText(/auth thyself/))
 })
+
+test('Private can be used as a Set', async () => {
+  const PrivateLayout = ({ children }) => (
+    <div>
+      <h1>Private Layout</h1>
+      {children}
+    </div>
+  )
+
+  const TestRouter = () => (
+    <Router useAuth={mockUseAuth(true)}>
+      <Route path="/" page={HomePage} name="home" />
+      <Private wrap={PrivateLayout} unauthenticated="home">
+        <Route path="/private" page={PrivatePage} name="private" />
+      </Private>
+    </Router>
+  )
+  const screen = render(<TestRouter />)
+
+  await waitFor(() => screen.getByText(/Home Page/i))
+
+  act(() => navigate('/private'))
+  await waitFor(() => screen.getByText(/Private Layout/))
+  await waitFor(() => screen.getByText(/Private Page/))
+})

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -18,6 +18,8 @@ import {
   RouterContextProviderProps,
   useRouterState,
 } from './router-context'
+import { Set } from './Set'
+import type { SetProps, WrapperType } from './Set'
 import { SplashPage } from './splash-page'
 import { flattenAll, isReactElement } from './util'
 
@@ -144,10 +146,11 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
   )
 }
 
-interface PrivateProps {
+type PrivateProps<P> = Omit<SetProps<P>, 'wrap'> & {
   /** The page name where a user will be redirected when not authenticated */
   unauthenticated: string
   role?: string | string[]
+  wrap?: WrapperType<P> | WrapperType<P>[]
 }
 
 /**
@@ -155,18 +158,23 @@ interface PrivateProps {
  * When a user is not authenticated and attempts to visit this route they will be
  * redirected to `unauthenticated` route.
  */
-const Private: React.FC<PrivateProps> = ({
-  children,
-  unauthenticated,
-  role,
-}) => {
+function Private<WrapperProps>(props: PrivateProps<WrapperProps>) {
+  const { role, unauthenticated, children, wrap, ...rest } = props
+
   return (
     <PrivateContextProvider
       isPrivate={true}
       role={role}
       unauthenticated={unauthenticated}
     >
-      {children}
+      {wrap ? (
+        // @ts-expect-error - Set
+        <Set wrap={wrap} {...rest}>
+          {children}
+        </Set>
+      ) : (
+        children
+      )}
     </PrivateContextProvider>
   )
 }


### PR DESCRIPTION
This is an alternative to https://github.com/redwoodjs/redwood/pull/2209 where we instead make `<Private>` accept a `wrap` prop to wrap components around its children

With #2209
```tsx
const TestRouter = () => (
  <Router useAuth={mockUseAuth(true)}>
    <Route path="/" page={HomePage} name="home" />
    <Set private wrap={PrivateLayout} unauthenticated="home">
      <Route path="/private" page={PrivatePage} name="private" />
    </Private>
  </Router>
)
```

With this PR
```tsx
const TestRouter = () => (
  <Router useAuth={mockUseAuth(true)}>
    <Route path="/" page={HomePage} name="home" />
    <Private wrap={PrivateLayout} unauthenticated="home">
      <Route path="/private" page={PrivatePage} name="private" />
    </Private>
  </Router>
)
```