### PR TITLE
fix(eslint): Adds process and require to eslint config web

### DIFF
--- a/packages/api/src/webhooks/index.ts
+++ b/packages/api/src/webhooks/index.ts
@@ -17,6 +17,18 @@ export {
 export const DEFAULT_WEBHOOK_SIGNATURE_HEADER = 'RW-WEBHOOK-SIGNATURE'
 
 /**
+ * Extracts body payload from event with base64 encoding check
+ *
+ */
+const eventBody = (event: APIGatewayProxyEvent) => {
+  if (event.isBase64Encoded) {
+    return Buffer.from(event.body || '', 'base64').toString('utf-8')
+  } else {
+    return event.body || ''
+  }
+}
+
+/**
  * Extracts signature from Lambda Event.
  *
  * @param {APIGatewayProxyEvent} event - The event that incudes the request details, like headers
@@ -70,7 +82,7 @@ export const verifyEvent = (
   if (payload) {
     body = payload
   } else {
-    body = event.body || ''
+    body = eventBody(event)
   }
 
   const signature = signatureFromEvent({

--- a/packages/api/src/webhooks/webhooks.test.ts
+++ b/packages/api/src/webhooks/webhooks.test.ts
@@ -16,15 +16,19 @@ const buildEvent = ({
   payload,
   signature,
   signatureHeader,
+  isBase64Encoded = false,
 }): APIGatewayProxyEvent => {
   const headers = {}
   headers[signatureHeader.toLocaleLowerCase()] = signature
+  const body = isBase64Encoded
+    ? Buffer.from(payload || '').toString('base64')
+    : payload
 
   return {
-    body: payload,
+    body,
     headers,
     multiValueHeaders: {},
-    isBase64Encoded: false,
+    isBase64Encoded,
     path: '',
     pathParameters: null,
     stageVariables: null,
@@ -191,6 +195,24 @@ describe('webhooks', () => {
           payload,
           signature,
           signatureHeader: DEFAULT_WEBHOOK_SIGNATURE_HEADER,
+        })
+
+        expect(
+          verifyEvent('timestampSchemeVerifier', { event, secret })
+        ).toBeTruthy()
+      })
+
+      test('it can verify an event base64encoded body payload with a signature it generates', () => {
+        const signature = signPayload('timestampSchemeVerifier', {
+          payload,
+          secret,
+        })
+
+        const event = buildEvent({
+          payload,
+          signature,
+          signatureHeader: DEFAULT_WEBHOOK_SIGNATURE_HEADER,
+          isBase64Encoded: true,
         })
 
         expect(

--- a/packages/cli/src/commands/deploy/render.js
+++ b/packages/cli/src/commands/deploy/render.js
@@ -12,11 +12,6 @@ export const builder = (yargs) => {
       description: 'select side to build',
       type: 'string',
     })
-    .option('build', {
-      description: 'Build for production',
-      type: 'boolean',
-      default: 'true',
-    })
     .option('prisma', {
       description: 'Apply database migrations',
       type: 'boolean',
@@ -28,6 +23,11 @@ export const builder = (yargs) => {
       default: 'true',
       alias: 'dm',
     })
+    .option('serve', {
+      description: 'Run server for api in production',
+      type: 'boolean',
+      default: 'true',
+    })
     .epilogue(
       `For more commands, options, and examples, see ${terminalLink(
         'Redwood CLI Reference',
@@ -36,24 +36,22 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ side, build, prisma, dm: dataMigrate }) => {
+export const handler = async ({ side, prisma, dm: dataMigrate, serve }) => {
   const paths = getPaths()
   let commandSet = []
   if (side == 'api') {
-    if (build) {
-      commandSet.push('yarn rw build api')
-    }
     if (prisma) {
       commandSet.push('yarn rw prisma migrate deploy')
     }
     if (dataMigrate) {
       commandSet.push('yarn rw dataMigrate up')
     }
-  } else if (side == 'web') {
-    if (build) {
-      commandSet.push('yarn')
-      commandSet.push('yarn rw build web')
+    if (serve) {
+      commandSet.push('yarn rw serve api')
     }
+  } else if (side == 'web') {
+    commandSet.push('yarn')
+    commandSet.push('yarn rw build web')
   }
 
   execa(commandSet.join(' && '), {

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -69,9 +69,9 @@ export const builder = (yargs) => {
 
       if (
         // serve both
-        (positionalArgs.length === 1 &&
-          !fs.existsSync(path.join(getPaths().api.dist))) ||
-        !fs.existsSync(path.join(getPaths().web.dist), 'index.html')
+        positionalArgs.length === 1 &&
+        (!fs.existsSync(path.join(getPaths().api.dist)) ||
+          !fs.existsSync(path.join(getPaths().web.dist), 'index.html'))
       ) {
         console.error(
           c.error(

--- a/packages/cli/src/commands/setup/deploy/deploy.js
+++ b/packages/cli/src/commands/setup/deploy/deploy.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
+import boxen from 'boxen'
 import execa from 'execa'
 import Listr from 'listr'
 import terminalLink from 'terminal-link'
@@ -195,9 +196,14 @@ export const handler = async ({ provider, force, database }) => {
       {
         title: 'One more thing...',
         task: (_ctx, task) => {
-          task.title = `One more thing...\n\n   ${providerData.notes.join(
-            '\n   '
-          )}\n`
+          task.title = `One more thing...\n\n ${boxen(
+            providerData.notes.join('\n   '),
+            {
+              padding: { top: 0, bottom: 0, right: 0, left: 0 },
+              margin: 1,
+              borderColour: 'gray',
+            }
+          )}  \n`
         },
       },
     ].filter(Boolean),

--- a/packages/cli/src/commands/setup/deploy/providers/render.js
+++ b/packages/cli/src/commands/setup/deploy/providers/render.js
@@ -8,7 +8,13 @@ import { getPaths } from 'src/lib'
 const PROJECT_NAME = getPaths().base.match(/[^/|\\]+$/)[0]
 
 const RENDER_YAML = (database) => {
-  return `services:
+  return `#####
+# Documentation
+# Redwood: https://render.com/docs/deploy-redwood
+# YAML (all config values): https://render.com/docs/yaml-spec
+#####
+
+services:
 - name: ${PROJECT_NAME}-web
   type: web
   env: static
@@ -20,8 +26,12 @@ const RENDER_YAML = (database) => {
   routes:
   - type: rewrite
     source: /.redwood/functions/*
-# replace destination api url after first deploy to Render
-    destination: replace_me_with_api_url/*
+#####
+# NOTE: replace destination api url after first deploy to Render
+# example:
+#   destination: https://myredwoodproject-api.onrender.com/*
+#####
+    destination: replace_with_api_url/*
   - type: rewrite
     source: /*
     destination: /index.html
@@ -29,8 +39,9 @@ const RENDER_YAML = (database) => {
 - name: ${PROJECT_NAME}-api
   type: web
   env: node
-  buildCommand: yarn && yarn rw deploy render api
-  startCommand: yarn rw serve api
+  region: oregon
+  buildCommand: yarn && yarn rw build api
+  startCommand: yarn rw deploy render api
   envVars:
   - key: NODE_VERSION
     value: 14
@@ -45,6 +56,7 @@ const POSTGRES_YAML = `  - key: DATABASE_URL
 
 databases:
   - name: ${PROJECT_NAME}-db
+    region: oregon
 `
 
 const SQLITE_YAML = `  - key: DATABASE_URL
@@ -121,7 +133,8 @@ export const apiProxyPath = '/.redwood/functions'
 
 // any notes to print out when the job is done
 export const notes = [
-  'You are ready to deploy to Render!',
-  'Check out the docs at https://render.com/docs/deploy-redwood to get started\n',
-  'Note: After first deployment to Render update rewrite rule destiation in render.yaml',
+  'You are ready to deploy to Render!\n',
+  'Go to https://dashboard.render.com/iacs to create your account and deploy to Render',
+  'Check out the deployment docs at https://render.com/docs/deploy-redwood for detailed instructions',
+  'Note: After first deployment to Render update the rewrite rule destination in `./render.yaml`',
 ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "css-minimizer-webpack-plugin": "^1.2.0",
     "dotenv-webpack": "^2.0.0",
     "error-overlay-webpack-plugin": "^0.4.1",
-    "esbuild": "0.11.6",
+    "esbuild": "0.11.13",
     "esbuild-loader": "^2.10.0",
     "file-loader": "^6.0.0",
     "findup-sync": "^4.0.0",

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -52,6 +52,8 @@ module.exports = {
       globals: {
         React: 'readonly',
         gql: 'readonly',
+        process: 'readonly',
+        require: 'readonly',
       },
     },
     // Test, stories, scenarios, and mock files

--- a/yarn.lock
+++ b/yarn.lock
@@ -8980,10 +8980,10 @@ esbuild-loader@^2.10.0:
     type-fest "^0.21.3"
     webpack-sources "^2.2.0"
 
-esbuild@0.11.6:
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.6.tgz#20961309c4cfed00b71027e18806150358d0cbb0"
-  integrity sha512-L+nKW9ftVS/N2CVJMR9YmXHbkm+vHzlNYuo09rzipQhF7dYNvRLfWoEPSDRTl10and4owFBV9rJ2CTFNtLIOiw==
+esbuild@0.11.13:
+  version "0.11.13"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.13.tgz#f61bb9b62f1ea5b749537db78fafb11c9cc0e096"
+  integrity sha512-d5coY4dd4rVWle0WzrR8+32ukKtZroVJ/wJzOwbBEmoSFB/H3QME0l+3IAN5Sf3LtuoUSivdv1/b5rD7OykXeg==
 
 esbuild@^0.9.2:
   version "0.9.6"


### PR DESCRIPTION
This PR addresses the discussions in the RedwoodJS Community post https://community.redwoodjs.com/t/eslint-process-and-require-undefined-error-in-web-side/2046 raised by @clairefro 

> We are noticing eslint errors in /src/web js files when using process.env.FOO and require are undefined (‘process’/‘require’ is not defined. eslint no-undef rule) in the auth playground app.

Seen here:

![image](https://user-images.githubusercontent.com/1051633/116109285-a474a800-a682-11eb-9b9c-310826843572.png)


@peterp Suggested that `process` and `require` could be added as globals to the web-side eslint config.

This PR does just that:

```js
    // `web` side
    {
      files: 'web/src/**',
      env: {
        browser: true,
        es6: true,
      },
      globals: {
        React: 'readonly',
        gql: 'readonly',
        process: 'readonly',
        require: 'readonly',
      },
    },
```

And after the globals:

![image](https://user-images.githubusercontent.com/1051633/116109410-bc4c2c00-a682-11eb-8d36-f267b8ab0f44.png)


Can see that several `process` have been recognized, but a few have not -- but that is the IDE warning about them not being in the `.env` even though they are in `env.defaults`.

![image](https://user-images.githubusercontent.com/1051633/116109592-f0bfe800-a682-11eb-9d08-e1d9146bf72f.png)
