### PR TITLE
fix(eslint): Adds process and require to eslint config web

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -52,6 +52,8 @@ module.exports = {
       globals: {
         React: 'readonly',
         gql: 'readonly',
+        process: 'readonly',
+        require: 'readonly',
       },
     },
     // Test, stories, scenarios, and mock files


### PR DESCRIPTION
This PR addresses the discussions in the RedwoodJS Community post https://community.redwoodjs.com/t/eslint-process-and-require-undefined-error-in-web-side/2046 raised by @clairefro 

> We are noticing eslint errors in /src/web js files when using process.env.FOO and require are undefined (‘process’/‘require’ is not defined. eslint no-undef rule) in the auth playground app.

Seen here:

![image](https://user-images.githubusercontent.com/1051633/116109285-a474a800-a682-11eb-9b9c-310826843572.png)


@peterp Suggested that `process` and `require` could be added as globals to the web-side eslint config.

This PR does just that:

```js
    // `web` side
    {
      files: 'web/src/**',
      env: {
        browser: true,
        es6: true,
      },
      globals: {
        React: 'readonly',
        gql: 'readonly',
        process: 'readonly',
        require: 'readonly',
      },
    },
```

And after the globals:

![image](https://user-images.githubusercontent.com/1051633/116109410-bc4c2c00-a682-11eb-8d36-f267b8ab0f44.png)


Can see that several `process` have been recognized, but a few have not -- but that is the IDE warning about them not being in the `.env` even though they are in `env.defaults`.

![image](https://user-images.githubusercontent.com/1051633/116109592-f0bfe800-a682-11eb-9d08-e1d9146bf72f.png)
