### PR TITLE
Pass service args through to beforeResolver verification functions

### DIFF
--- a/packages/api/src/__tests__/beforeResolverSpec.test.js
+++ b/packages/api/src/__tests__/beforeResolverSpec.test.js
@@ -224,6 +224,24 @@ describe('BeforeResolverSpec', () => {
       spec.verify('posts')
     })
 
+    it('passes an undefined second argument by default', () => {
+      const spec = new BeforeResolverSpec(services)
+      spec.add((_name, other) => {
+        expect(other).toEqual(undefined)
+      })
+      spec.verify('posts')
+    })
+
+    it('passes any additional arguments sent to the resolver', () => {
+      const spec = new BeforeResolverSpec(services)
+      spec.add((_name, { foo, baz }, quux) => {
+        expect(foo).toEqual('bar')
+        expect(baz).toEqual('qux')
+        expect(quux).toEqual('garply')
+      })
+      spec.verify('posts', [{ foo: 'bar', baz: 'qux' }, 'garply'])
+    })
+
     it('bubbles up validation errors', () => {
       const spec = new BeforeResolverSpec(services)
       spec.add(() => {

--- a/packages/api/src/__tests__/beforeResolverSpec.test.js
+++ b/packages/api/src/__tests__/beforeResolverSpec.test.js
@@ -234,6 +234,7 @@ describe('BeforeResolverSpec', () => {
 
     it('passes any additional arguments sent to the resolver', () => {
       const spec = new BeforeResolverSpec(services)
+      // @MARK RC where would quux come from?
       spec.add((_name, { foo, baz }, quux) => {
         expect(foo).toEqual('bar')
         expect(baz).toEqual('qux')

--- a/packages/api/src/__tests__/beforeResolverSpec.test.js
+++ b/packages/api/src/__tests__/beforeResolverSpec.test.js
@@ -234,7 +234,6 @@ describe('BeforeResolverSpec', () => {
 
     it('passes any additional arguments sent to the resolver', () => {
       const spec = new BeforeResolverSpec(services)
-      // @MARK RC where would quux come from?
       spec.add((_name, { foo, baz }, quux) => {
         expect(foo).toEqual('bar')
         expect(baz).toEqual('qux')

--- a/packages/api/src/beforeResolverSpec.ts
+++ b/packages/api/src/beforeResolverSpec.ts
@@ -81,13 +81,13 @@ export const BeforeResolverSpec = class implements BeforeResolverSpecType {
     })
   }
 
-  public verify(name: string) {
+  public verify(name: string, args: Array<unknown>) {
     if (this._canSkipService(name)) {
       return []
     } else if (this._isInsecureService(name)) {
       throw new InsecureServiceError(name)
     } else {
-      return this._invokeValidators(name)
+      return this._invokeValidators(name, args)
     }
   }
 
@@ -161,11 +161,11 @@ export const BeforeResolverSpec = class implements BeforeResolverSpecType {
   // Returns an array of the results of every validation function being run.
   // We don't do anything with this list currently, but maybe we can pass it
   // through to the service at some point so the user can do something with it?
-  _invokeValidators(name: string) {
+  _invokeValidators(name: string, args: Array<unknown>) {
     const validators = this.befores[name].validators
 
     return validators.map((rule: RuleValidator) => {
-      return rule.call(this, name)
+      return rule.apply(this, [name, ...[args].flat()])
     })
   }
 

--- a/packages/api/src/makeServices.ts
+++ b/packages/api/src/makeServices.ts
@@ -33,8 +33,8 @@ export const makeServices: MakeServices = ({ services }) => {
 
       if (typeof resolverFunc === 'function') {
         // wrap resolver function in spec verification
-        exportResolvers[resolverName] = (...args) => {
-          spec.verify(resolverName)
+        exportResolvers[resolverName] = (...args: Array<unknown>) => {
+          spec.verify(resolverName, args)
           return resolverFunc(...args)
         }
       } else {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -21,7 +21,7 @@ export type MakeServices = (args: MakeServicesInterface) => ServicesCollection
 
 export type GraphQLTypeWithFields = GraphQLObjectType | GraphQLInterfaceType
 
-export type RuleValidator = (name: string) => any
+export type RuleValidator = (name: string, ...inputs: Array<unknown>) => void
 export type ValidatorCollection = {
   validators: Array<RuleValidator>
   skippable: boolean
@@ -43,6 +43,10 @@ export type RuleOptions =
     }
 
 export interface BeforeResolverSpecType {
+  /**
+   * @param  {RuleValidator|Array<RuleValidator>} functions - Function or Array of Functions that validates whether service function is allowed to run. Should Throw if not.
+   * @param @optional {RuleOptions} options - Pass to selectively apply rule to specific service functions
+   */
   add: (
     functions: RuleValidator | Array<RuleValidator>,
     options?: RuleOptions

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -45,11 +45,24 @@ export type RuleOptions =
 export interface BeforeResolverSpecType {
   /**
    * @param  {RuleValidator|Array<RuleValidator>} functions - Function or Array of Functions that validates whether service function is allowed to run. Should Throw if not.
-   * @param @optional {RuleOptions} options - Pass to selectively apply rule to specific service functions
+   * @param {RuleOptions} [options]  - Optionally pass to selectively apply rule to specific service functions
    */
   add: (
     functions: RuleValidator | Array<RuleValidator>,
     options?: RuleOptions
   ) => void
+  /**
+   *
+   * @param {RuleValidator|Array<RuleValidator>} functions - Function or Array of Functions that validates whether service function is allowed to run. Should Throw if not.
+   * @param {RuleOptions} [options]  - Optionally pass to selectively skip rule for specific service functions
+   *
+   * @example <caption>Skip all rules</caption>
+   * rules.skip()
+   * @example <caption>Skip single rule</caption>
+   * rules.skip(requireAuth)
+   * @example <caption>Skip single rule, for a single service function</caption>
+   * rules.skip(requireAuth, {only: 'posts'})
+   *
+   * */
   skip: (...args: SkipArgs) => void
 }


### PR DESCRIPTION
This provides an update to Secure Services (which was merged like 2 hours ago). Now, any arguments that would have been given to the service function call (like the variables coming in from GraphQL) will also be given to the resolver function, so it can use them in determining whether a call is valid or not.

A great use case is verifying the format of data before allowing a record to be created or updated, like an email address. Rather than doing it in the service function itself, it can happen in `beforeResolvers` and the service can just focus on creating/updating the record:

```javascript
const EMAIL_REGEX = new Regexp(/[^@]+@[^\.]+\..+/)

export const beforeResolvers = (rules) => {
  const verifyEmail = (name, { input }) => {
    if (!emailRegex.test(input.email)) {
      throw Error, `Invalid email address given to the ${name} service`
    }
  }

  rules.apply(requireAuth)
  rules.apply(verifyEmail, { only: ['createUser'] })
}

export const users = () => {
  return db.user.findMany()
}

export const createUser = ({ input }) => {
  return db.user.create({ data: { input }})
}
```