### PR TITLE
Create github workflow to publish release candidate

### DIFF
--- a/.github/workflows/publish-npm-rc.yaml
+++ b/.github/workflows/publish-npm-rc.yaml
@@ -1,0 +1,43 @@
+name: Publish release candidate
+
+on:
+  push:
+    branches: ['release/**']
+
+jobs:
+  build:
+    if: github.repository == 'redwoodjs/redwood'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required because lerna uses tags to determine the version.
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --check-files
+
+      - name: Build
+        run: yarn build
+
+      - name: Run ESLint
+        run: yarn lint
+        env:
+          CI: true
+
+      - name: Run tests
+        run: yarn test
+        env:
+          CI: true
+
+      - name: Publish
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
+          ./tasks/publish-rc
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/tasks/publish-rc
+++ b/tasks/publish-rc
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This publishes a "canary" version of our packages to npm.
+# It is run when a branch is merged to main.
+# https://github.com/lerna/lerna/tree/master/commands/publish#--canary
+
+yarn lerna publish --force-publish --canary --preid rc --dist-tag rc --yes


### PR DESCRIPTION
Github workflow to publish release candidate created based on the instructions in the [CONTRIBUTING.md](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#releases).

I added the need to check the pattern 0.0.0-rc0  in the branches' name. Not sure if we need it.

Closes #2342 