### PR TITLE
node < 16, otherwise prisma crashes

### DIFF
--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -15,7 +15,7 @@
     "root": true
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=14 <16",
     "yarn": ">=1.15"
   },
   "resolutions": {


### PR DESCRIPTION
There's a bug with Prisma that causes it to crash on node 16. And that makes RW's api side crash. 

This PR sets the node version to be <16, which keeps us safe.

See more here: https://community.redwoodjs.com/t/node-v16-issues/2057