### PR TITLE
Upgrade Prisma v2.22.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.13",
-    "@prisma/client": "2.21.2",
+    "@prisma/client": "2.22.1",
     "@redwoodjs/internal": "^0.31.2",
     "@types/pino": "^6.3.8",
     "apollo-server-lambda": "2.22.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.21.2",
+    "@prisma/sdk": "2.22.1",
     "@redwoodjs/api-server": "^0.31.2",
     "@redwoodjs/internal": "^0.31.2",
     "@redwoodjs/prerender": "^0.31.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^1.4.1",
     "null-loader": "^4.0.1",
-    "prisma": "2.21.2",
+    "prisma": "2.22.1",
     "react-refresh": "^0.10.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.21.2",
+    "@prisma/sdk": "2.22.1",
     "@redwoodjs/internal": "^0.31.2",
     "@types/line-column": "^1.0.0",
     "camelcase": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,30 +3002,30 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.21.2.tgz#ca8489832da1d61add429390210be4d7896e5e29"
-  integrity sha512-UjkOXYpxLuHyoMDsP2m0LTcxhrjQa1dEOLFe3aDrO/BLrs/2yUxyPdtwSKxizRXFzuXSGkKIK225vcjZRuMpAg==
+"@prisma/client@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.22.1.tgz#10fdcd1532a6baf46dd1c464cad9a54af0532bc8"
+  integrity sha512-JQjbsY6QSfFiovXHEp5WeJHa5p2CuR1ZFPAeYXmUsOAQOaMCrhgQmKAL6w2Q3SRA7ALqPjrKywN9/QfBc4Kp1A==
   dependencies:
-    "@prisma/engines-version" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+    "@prisma/engines-version" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
 
-"@prisma/debug@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.21.2.tgz#10ab3e5dd26217920c0a1d1c5c752a1df08ac988"
-  integrity sha512-oB5JmzR9/I0hYU7GOuzSBF2F0QCDHp1UUi1acIGb5Vu6EQtP6VOwBmgCOyNW6VrwxvnjcEsNtLXnRQ1rl4DKqw==
+"@prisma/debug@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.22.1.tgz#b0c3e3b6cf567f7d3e9173c0108122bba4e30881"
+  integrity sha512-y5pAe1bEEERlEbnAOYaCnWIdHK8b4s7zHV3TE0ptyo0yhEIOZYmH72QdWRHuK1HdzLQj2KK8tIqHtb62T7RjAw==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.21.2.tgz#cf40d7647e5ff945454fbb04655f41657be17ddf"
-  integrity sha512-t+XYncNZrVzl1HaKF6zYT1pEzBxgcJM7tHbtTuhHG6aGPVObb7oJqAmrOWI98Ac38YuKrenKJa0Ce24Qf00XWQ==
+"@prisma/engine-core@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.22.1.tgz#128edf39e0fd32f7ac862a0ea33d2aee8c068406"
+  integrity sha512-xcRzY6c0fh96ri+wGv+LooAEPfgS0MR9OgOHWUpu81dYf6TjV1Oc0IthHnPGtoUdjAQCDHogNY5rOHJfzcQjtQ==
   dependencies:
-    "@prisma/debug" "2.21.2"
-    "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
-    "@prisma/generator-helper" "2.21.2"
-    "@prisma/get-platform" "2.21.2"
+    "@prisma/debug" "2.22.1"
+    "@prisma/engines" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
+    "@prisma/generator-helper" "2.22.1"
+    "@prisma/get-platform" "2.22.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -3033,25 +3033,25 @@
     new-github-issue-url "^0.2.1"
     p-retry "^4.2.0"
     terminal-link "^2.1.1"
-    undici "3.3.4"
+    undici "3.3.6"
 
-"@prisma/engines-version@2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d":
-  version "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz#b749bae4173eb766dafc298aaa7d883c2dbe555b"
-  integrity sha512-9/fE1gdPWmjbMjXUJjrTMt848TsgEnSjZCcJ1wu9OAcRlAKKJBLehftqC3gSEShDijvMYgeTdGU5snMpwmv4vg==
+"@prisma/engines-version@2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c":
+  version "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c.tgz#e98ee17217a0ebb54f2f9314fbbfd610b05e6e31"
+  integrity sha512-OkkVwk6iTzTbwwl8JIKAENyxmh4TFORal55QMKQzrHEY8UzbD0M90mQnmziz3PAopQUZgTFFMlaPAq1WNrLMtA==
 
-"@prisma/engines@2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d":
-  version "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d.tgz#aafed60c9506bc766e49ea60b9f8ce7da2385bc6"
-  integrity sha512-L57tvSoom2GDWDqik4wrAUBvLTAv5MTm2OOzNMBKsv0w5cX7ONoZ8KnGQN+csmdJpQVBs93dIvIBm72OO+l/9Q==
+"@prisma/engines@2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c":
+  version "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c.tgz#4ccd255e0823605db3d8387a5195b6fdabe3b0c0"
+  integrity sha512-KmWdogrsfsSLYvfqY3cS3QcDGzaEFklE+T6dNJf+k/KPQum4A29IwDalafMwh5cMN8ivZobUbowNSwWJrMT08Q==
 
-"@prisma/fetch-engine@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.21.2.tgz#1dc232872e31b7479ab3e42cfba19ac27bd4d1b0"
-  integrity sha512-SKg75GdyVfmlAM8ydH/vTnxU29FpwVhvKdOP5fjJvhqv1/YGCStsiYR36x7GggBlNuh7KKtI7KtRpjc0jE+SbQ==
+"@prisma/fetch-engine@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.22.1.tgz#d97e6e187611acd8ce98435700d8b4542c53eed0"
+  integrity sha512-D4iVaKdm4ncs2pGp7yR73tl63hdiwfYwASIMrJqm2qjAVTWtGA6M7zonKT1hsKlNhpa69EgCWNwpABn2sXSfZQ==
   dependencies:
-    "@prisma/debug" "2.21.2"
-    "@prisma/get-platform" "2.21.2"
+    "@prisma/debug" "2.22.1"
+    "@prisma/get-platform" "2.22.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3068,38 +3068,38 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.21.2.tgz#5620e032bd906cc42d65c15a7de8876d239aa170"
-  integrity sha512-zo3rqKTWo3GExb2rLgwo0EMHfpeJyj6Lo8b5g1CFWCmtpe3O4gic7mqiTWRz2jk5r6FiSIyOl4+iVRBjDmHFhg==
+"@prisma/generator-helper@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.22.1.tgz#33f4c21ebc2f2daba52c065669d6fba018f36e3d"
+  integrity sha512-m4j/yzdY2z+TI9/pZKsJB/8A+AmJt1JcmIKlFkR8QnuIJZkyl4r9M3CnQNO9VABlzenFs9KP1zo2m4byAndkTA==
   dependencies:
-    "@prisma/debug" "2.21.2"
+    "@prisma/debug" "2.22.1"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.21.2.tgz#e480d9676989495b28d734f01a64caa00ea2fa15"
-  integrity sha512-z9Nme7AaD4f34S1oRPjXaJJPlF4WTEx/yPxBAxvNb4QR6w84zU4zahu5n6Vkc6ErRPihlSiRG2ptDdQie/Cdww==
+"@prisma/get-platform@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.22.1.tgz#81818939f2bf0c31a35352281b0367dfc43c4c7d"
+  integrity sha512-yQS6KnGS2FtLYre1iW1oGg8xGC39yh+rMoP5l4y6w+dCY0GQ1X5SbOkvioyqtQ0dNXUqAuszUuHl5CaxNQh+Rw==
   dependencies:
-    "@prisma/debug" "2.21.2"
+    "@prisma/debug" "2.22.1"
 
-"@prisma/sdk@2.21.2":
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.21.2.tgz#f983998febc529ba7733ac6760c3f7d89538920d"
-  integrity sha512-m35JPEGYOnldBrIGpKdwxP/xER0S4vpk7L/qiLZGW6kVMcJRaeUGEONzmgaXtAXn6dP2BopsQ0UheCs3aF8uiQ==
+"@prisma/sdk@2.22.1":
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.22.1.tgz#e797b2b6f8cf2fc4afeb153dbf1277fbbfa08ae6"
+  integrity sha512-JPEVaXDWb6PD96Eys/LWXqRR4UapflaHvR4gubTLTEhxWWtE0Iq2DE9kreGcP+3WIifVwfcybXRzdQS093Iqmg==
   dependencies:
-    "@prisma/debug" "2.21.2"
-    "@prisma/engine-core" "2.21.2"
-    "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
-    "@prisma/fetch-engine" "2.21.2"
-    "@prisma/generator-helper" "2.21.2"
-    "@prisma/get-platform" "2.21.2"
+    "@prisma/debug" "2.22.1"
+    "@prisma/engine-core" "2.22.1"
+    "@prisma/engines" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
+    "@prisma/fetch-engine" "2.22.1"
+    "@prisma/generator-helper" "2.22.1"
+    "@prisma/get-platform" "2.22.1"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
-    chalk "4.1.0"
+    chalk "4.1.1"
     checkpoint-client "1.1.20"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
@@ -3125,7 +3125,6 @@
     tempy "^1.0.0"
     terminal-link "^2.1.1"
     tmp "0.2.1"
-    url-parse "^1.4.7"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -6827,10 +6826,10 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+chalk@4.1.1, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -6850,14 +6849,6 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -15607,12 +15598,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.21.2:
-  version "2.21.2"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.21.2.tgz#a73b4cbe92a884aa98b317684d6741871b5e94a5"
-  integrity sha512-Ux9ovDIUHsMNLGLtuo6BBKCuuBVLpZmhM2LXF+VBUQvsbmsVfp3u5CRyHGEqaZqMibYQJISy7YZYF/RgozHKkQ==
+prisma@2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.22.1.tgz#884687a90c7b797b34c6110ea413049078c8da6e"
+  integrity sha512-hwvCM3zyxgSda/+/p+GW7nz93jRebtMU01wAG7YVVnl0OKU+dpw1wPvPFmQRldkZHk8fTCleYmjc24WaSdVPZQ==
   dependencies:
-    "@prisma/engines" "2.21.0-36.e421996c87d5f3c8f7eeadd502d4ad402c89464d"
+    "@prisma/engines" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"
@@ -18661,10 +18652,10 @@ undefsafe@^2.0.3:
   dependencies:
     debug "^2.2.0"
 
-undici@3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-3.3.4.tgz#a52dab910cf4f46ce1a39377dd9049bb08656d2a"
-  integrity sha512-9BAepS9jBqD9lLKO2UJ8vPZlIHNmVibkMt23c+qBQhpXpG11F6SH12ttYeKGfEiFaHyZ1wZlOIHED7TTZOCTGQ==
+undici@3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-3.3.6.tgz#06d3b97b7eeff46bce6f8a71079c09f64dd59dc1"
+  integrity sha512-/j3YTZ5AobMB4ZrTY72mzM54uFUX32v0R/JRW9G2vOyF1uSKYAx+WT8dMsAcRS13TOFISv094TxIyWYk+WEPsA==
 
 unfetch@^4.1.0, unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
- [v2.22.0 Release Notes](https://github.com/prisma/prisma/releases/tag/2.22.0)
- [v2.22.1 Release Notes](https://github.com/prisma/prisma/releases/tag/2.22.1)

## Release Notes
- `prisma db push` is now Generally Available. Prisma official [docs](https://www.prisma.io/docs/concepts/components/prisma-migrate/db-push).