### PR TITLE
misc Dependabot patch release PRs grouped

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "yargs": "^16.0.3"
   },
   "devDependencies": {
-    "@types/listr": "^0.14.2",
+    "@types/listr": "^0.14.3",
     "@types/node-fetch": "^2.5.10"
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@storybook/react": "^6.1.21",
     "@testing-library/jest-dom": "5.11.6",
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.0.1",
+    "@types/node": "^15.0.2",
     "@types/react": "17.0.3",
     "@types/react-dom": "^17.0.1",
     "@types/webpack": "^4.41.11",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "css-minimizer-webpack-plugin": "^1.2.0",
     "dotenv-webpack": "^2.0.0",
     "error-overlay-webpack-plugin": "^0.4.1",
-    "esbuild": "0.11.16",
+    "esbuild": "0.11.20",
     "esbuild-loader": "^2.10.0",
     "file-loader": "^6.0.0",
     "findup-sync": "^4.0.0",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -35,7 +35,7 @@
     "@types/fs-extra": "^9.0.11",
     "@types/lodash": "^4.14.157",
     "@types/lru-cache": "^5.1.0",
-    "@types/node": "^15.0.1",
+    "@types/node": "^15.0.2",
     "@types/vscode": "^1.46.0"
   },
   "jest": {

--- a/tasks/e2e/yarn.lock
+++ b/tasks/e2e/yarn.lock
@@ -880,9 +880,9 @@ lodash.once@^4.1.1:
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash@^4.17.19:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10904,9 +10904,9 @@ hoopy@^0.1.4:
   integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hosted-git-info@^4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4301,10 +4301,10 @@
   resolved "https://registry.yarnpkg.com/@types/line-column/-/line-column-1.0.0.tgz#fa5a59c21e885fef3739a273b43dacf55b63437f"
   integrity sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==
 
-"@types/listr@^0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@types/listr/-/listr-0.14.2.tgz#2e5f80fbc3ca8dceb9940ce9bf8e3113ab452545"
-  integrity sha512-wCipMbQr3t2UHTm90LldVp+oTBj1TX6zvpkCJcWS4o8nn6kS8SN93oUvKJAgueIRZ5M36yOlFmScqBxYH8Ajig==
+"@types/listr@^0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@types/listr/-/listr-0.14.3.tgz#f6cfd1f0841ce6c0d2571fb114279ba07be43796"
+  integrity sha512-+TxIH5cf6w/44VH+cc1oTccaR7aBQdUJU0nas+seJ/iOYPi7q0kHf153eFayT0KitxCZMVoyFmruCrWt/bxq2g==
   dependencies:
     "@types/node" "*"
     rxjs "^6.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4409,10 +4409,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@^15.0.1":
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.1.tgz#ef34dea0881028d11398be5bf4e856743e3dc35a"
-  integrity sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==
+"@types/node@*", "@types/node@>= 8", "@types/node@>=12.12.47", "@types/node@^15.0.2":
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
+  integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
 
 "@types/node@^10.1.0", "@types/node@^10.10.0":
   version "10.17.55"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9033,10 +9033,10 @@ esbuild-loader@^2.10.0:
     type-fest "^0.21.3"
     webpack-sources "^2.2.0"
 
-esbuild@0.11.16:
-  version "0.11.16"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.16.tgz#435f00474fb21e70f59a545b85e4cfc7ba106485"
-  integrity sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==
+esbuild@0.11.20:
+  version "0.11.20"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.20.tgz#7cefa1aee8b372c184e42457885f7ce5d3e62a1e"
+  integrity sha512-QOZrVpN/Yz74xfat0H6euSgn3RnwLevY1mJTEXneukz1ln9qB+ieaerRMzSeETpz/UJWsBMzRVR/andBht5WKw==
 
 esbuild@^0.9.2:
   version "0.9.6"


### PR DESCRIPTION
- [SECURITY] bump hosted-git-info from 2.8.8 to 2.8.9 #2484
- bump esbuild from 0.11.16 to 0.11.20 #2477
- bump @types/node from 15.0.1 to 15.0.2 #2458
- bump @types/listr from 0.14.2 to 0.14.3 #2448