### PR TITLE
Ignore dev.db-journal

### DIFF
--- a/packages/create-redwood-app/template/.gitignore
+++ b/packages/create-redwood-app/template/.gitignore
@@ -3,7 +3,7 @@
 .env
 .netlify
 .redwood
-dev.db
+dev.db*
 dist
 dist-babel
 node_modules


### PR DESCRIPTION
Noticing that the migrate command also creates a dev.db-journal file