### PR TITLE
improve `rw upgrade` command and remove "publish PR packages" option

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "execa": "^5.0.0",
     "fs-extra": "^10.0.0",
     "humanize-string": "^2.1.0",
+    "latest-version": "^5.1.0",
     "listr": "^0.14.3",
     "listr-verbose-renderer": "^0.6.0",
     "lodash": "^4.17.19",

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -96,7 +96,7 @@ export const handler = async ({ dryRun, tag, verbose }) => {
       },
       {
         title: 'Refreshing the Prisma client',
-        task: () => refreshPrismaClient(verbose),
+        task: (_ctx, task) => refreshPrismaClient(task, { verbose }),
         skip: () => dryRun,
       },
       {
@@ -222,30 +222,19 @@ function updateRedwoodDepsForAllSides(ctx, options) {
   )
 }
 
-function refreshPrismaClient(verbose) {
+async function refreshPrismaClient(task, { verbose }) {
   /** Relates to prisma/client issue, @see: https://github.com/redwoodjs/redwood/issues/1083 */
-  console.log('definitely here!!')
-  return new Listr(
-    [
-      {
-        title: '...',
-        task: async (_ctx, task) => {
-          try {
-            await generatePrismaClient({
-              verbose,
-              force: false,
-              schema: getPaths().api.dbSchema,
-            })
-          } catch (e) {
-            task.skip('Refreshing the Prisma client caused an Error.')
-            console.log(
-              'You may need to update your prisma client manually: $ yarn rw prisma generate'
-            )
-            console.log(c.error(e.message))
-          }
-        },
-      },
-    ],
-    { collapse: false, renderer: verbose && VerboseRenderer }
-  )
+  try {
+    await generatePrismaClient({
+      verbose,
+      force: false,
+      schema: getPaths().api.dbSchema,
+    })
+  } catch (e) {
+    task.skip('Refreshing the Prisma client caused an Error.')
+    console.log(
+      'You may need to update your prisma client manually: $ yarn rw prisma generate'
+    )
+    console.log(c.error(e.message))
+  }
 }

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -34,7 +34,7 @@ export const builder = (yargs) => {
       coerce: validateTag,
     })
     .option('verbose', {
-      alias: 'vvv',
+      alias: 'v',
       description: 'Print verbose logs',
       type: 'boolean',
       default: false,

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -1,5 +1,10 @@
+import fs from 'fs'
+import path from 'path'
+
 import execa from 'execa'
+import latestVersion from 'latest-version'
 import Listr from 'listr'
+import VerboseRenderer from 'listr-verbose-renderer'
 import terminalLink from 'terminal-link'
 
 import { getPaths } from 'src/lib'
@@ -28,12 +33,12 @@ export const builder = (yargs) => {
       type: 'string',
       coerce: validateTag,
     })
-    .option('pr', {
-      description: 'Installs packages for the given PR',
-      requiresArg: true,
-      type: 'string',
+    .option('verbose', {
+      alias: 'vvv',
+      description: 'Print verbose logs',
+      type: 'boolean',
+      default: false,
     })
-    .conflicts('tag', 'pr')
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
@@ -50,169 +55,7 @@ export const builder = (yargs) => {
     )
 }
 
-const rwPackages = [
-  '@redwoodjs/core',
-  '@redwoodjs/api',
-  '@redwoodjs/web',
-  '@redwoodjs/router',
-  '@redwoodjs/auth',
-  '@redwoodjs/forms',
-  '@redwoodjs/api-server',
-].join(' ')
-
-// yarn upgrade-interactive does not allow --tags, so we resort to this mess
-// @redwoodjs/auth may not be installed so we add check
-const installTags = (tag, isAuth) => {
-  const mainString = `yarn upgrade @redwoodjs/core@${tag} \
-  && yarn workspace api upgrade @redwoodjs/api@${tag} @redwoodjs/api-server@${tag} \
-  && yarn workspace web upgrade @redwoodjs/web@${tag} @redwoodjs/router@${tag} @redwoodjs/forms@${tag}`
-
-  const authString = ` @redwoodjs/auth@${tag}`
-
-  if (isAuth) {
-    return mainString + authString
-  } else {
-    return mainString
-  }
-}
-
-/** `pr` example: 1454:0.21.0-d3b0abd */
-const installPr = (pr, isAuth) => {
-  const packageUrl = (pkg) => {
-    const baseUrl = 'https://rw-pr-redwoodjs-com.s3.amazonaws.com/'
-    const [prNbr, vSha] = pr.split(':')
-
-    return `${baseUrl}${prNbr}/redwoodjs-${pkg}-${vSha}.tgz`
-  }
-
-  const mainString =
-    `yarn add -DW ${packageUrl('core')} ${packageUrl('cli')} ` +
-    `&& yarn workspace api add ${packageUrl('api')} ` +
-    `${packageUrl('api-server')} ` +
-    `&& yarn workspace web add ${packageUrl('web')} ` +
-    `${packageUrl('router')} ${packageUrl('forms')}`
-
-  const authString = ` ${packageUrl('auth')}`
-
-  if (isAuth) {
-    return mainString + authString
-  } else {
-    return mainString
-  }
-}
-
-const refreshPrismaClient = () => {
-  /** Relates to prisma/client issue, @see: https://github.com/redwoodjs/redwood/issues/1083 */
-  return [
-    {
-      title: '...',
-      task: async (_ctx, task) => {
-        try {
-          await generatePrismaClient({
-            verbose: false,
-            force: false,
-            schema: getPaths().api.dbSchema,
-          })
-        } catch (e) {
-          task.skip('Refreshing the Prisma client caused an Error.')
-          console.log(
-            'You may need to update your prisma client manually: $ yarn rw prisma generate'
-          )
-          console.log(c.error(e.message))
-        }
-      },
-    },
-  ]
-}
-
-const checkInstalled = () => {
-  const basePath = getPaths().base
-  return [
-    {
-      // yarn upgrade will install listed packages even if not already installed
-      // this is a workaround to check for Auth install and then add to options if true
-      // TODO: this will not support cases where api/ or web/ do not exist;
-      // need to build a list of installed and use reference object to map commands
-      title: '...',
-      task: async (ctx, task) => {
-        try {
-          const { stdout } = await execa.command(
-            'yarn list --depth 0 --pattern @redwoodjs/auth',
-            {
-              cwd: basePath,
-            }
-          )
-          if (stdout.includes('redwoodjs/auth')) {
-            ctx.auth = true
-            task.title = 'Found @redwoodjs/auth'
-          } else {
-            task.title = 'Done'
-          }
-        } catch (e) {
-          task.skip('"yarn list ..." caused an Error')
-          console.log(c.error(e.message))
-        }
-      },
-    },
-  ]
-}
-
-// yargs allows passing the 'dry-run' alias 'd' here,
-// which we need to use because babel fails on 'dry-run'
-const runUpgrade = ({ d: dryRun, tag, pr }) => {
-  const basePath = getPaths().base
-  return [
-    {
-      title: '...',
-      task: (ctx, task) => {
-        if (dryRun) {
-          task.title =
-            tag || pr
-              ? 'The --dry-run option is not supported for --tag or --pr'
-              : 'Checking available upgrades for @redwoodjs packages'
-          // 'yarn outdated --scope @redwoodjs' will include netlify plugin
-          // so we have to use hardcoded list,
-          // which will NOT display info for uninstalled packages
-          if (!tag) {
-            execa.command(`yarn outdated ${rwPackages}`, {
-              stdio: 'inherit',
-              cwd: basePath,
-            })
-          } else {
-            throw new Error()
-          }
-          // using @tag with workspaces limits us to use 'upgrade' with full list
-        } else if (tag) {
-          task.title = `Force upgrading @redwoodjs packages to latest ${tag} release`
-          execa.command(installTags(tag, ctx.auth), {
-            stdio: 'inherit',
-            shell: true,
-            cwd: basePath,
-          })
-        } else if (pr) {
-          task.title = `Installs packages from PR ${pr}`
-          execa.command(installPr(pr, ctx.auth), {
-            stdio: 'inherit',
-            shell: true,
-            cwd: basePath,
-          })
-        } else {
-          task.title = 'Running @redwoodjs package interactive upgrade CLI'
-          execa(
-            'yarn upgrade-interactive',
-            ['--scope @redwoodjs', '--latest'],
-            {
-              stdio: 'inherit',
-              shell: true,
-              cwd: basePath,
-            }
-          )
-        }
-      },
-    },
-  ]
-}
-
+// Used in yargs builder to coerce tag
 const SEMVER_REGEX = /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/gi
 const validateTag = (tag) => {
   const isTagValid =
@@ -233,24 +76,49 @@ const validateTag = (tag) => {
   return tag
 }
 
-export const handler = async ({ d, tag, pr }) => {
+export const handler = async ({ dryRun, tag, verbose }) => {
   // structuring as nested tasks to avoid bug with task.title causing duplicates
   const tasks = new Listr(
     [
       {
-        title: 'Checking installed packages',
-        task: () => new Listr(checkInstalled()),
+        title: 'Checking latest version',
+        task: async (ctx) => setLatestVersionToContext(ctx, tag),
       },
       {
-        title: 'Running upgrade command',
-        task: () => new Listr(runUpgrade({ d, tag, pr })),
+        title: 'Updating your project package.json(s)',
+        task: (ctx) => updateRedwoodDepsForAllSides(ctx, { dryRun, verbose }),
+        enabled: (ctx) => !!ctx.versionToUpgradeTo,
+      },
+      {
+        title: 'Running yarn install',
+        task: (ctx) => yarnInstall(ctx, { dryRun, verbose }),
+        skip: () => dryRun,
       },
       {
         title: 'Refreshing the Prisma client',
-        task: () => new Listr(refreshPrismaClient()),
+        task: () => refreshPrismaClient(verbose),
+        skip: () => dryRun,
+      },
+      {
+        title: 'One more thing..',
+        task: (ctx, task) => {
+          const version = ctx.versionToUpgradeTo
+          task.title =
+            `One more thing...\n\n   ${c.warning(
+              `🎉 Your project has been upgraded to RedwoodJS ${version}!`
+            )} \n\n` +
+            `   Please review the release notes for any manual steps: \n   ❖ ${terminalLink(
+              `Redwood community discussion`,
+              `https://community.redwoodjs.com/search?q=${version}%23announcements`
+            )}\n   ❖ ${terminalLink(
+              `GitHub Release notes`,
+              `https://github.com/redwoodjs/redwood/releases` // intentionally not linking to specific version
+            )}
+          `
+        },
       },
     ],
-    { collapse: false }
+    { collapse: false, renderer: verbose && VerboseRenderer }
   )
 
   try {
@@ -259,4 +127,125 @@ export const handler = async ({ d, tag, pr }) => {
     console.error(c.error(e.message))
     process.exit(e?.exitCode || 1)
   }
+}
+async function yarnInstall({ verbose }) {
+  try {
+    await execa('yarn install', ['--force', '--non-interactive'], {
+      shell: true,
+      stdio: verbose ? 'inherit' : 'pipe',
+
+      cwd: getPaths().base,
+    })
+  } catch (e) {
+    throw new Error(
+      'Could not finish installation. Please run `yarn install --force`, before continuing'
+    )
+  }
+}
+
+async function setLatestVersionToContext(ctx, tag) {
+  try {
+    const foundVersion = await latestVersion(
+      '@redwoodjs/core',
+      tag ? { version: tag } : {}
+    )
+
+    ctx.versionToUpgradeTo = foundVersion
+    return foundVersion
+  } catch (e) {
+    throw new Error('Could not find the latest version')
+  }
+}
+
+/**
+ * Iterates over Redwood dependencies in package.json files and updates the version.
+ */
+function updatePackageJsonVersion(pkgPath, version, { dryRun, verbose }) {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(pkgPath, 'package.json'), 'utf-8')
+  )
+
+  if (pkg.dependencies) {
+    for (const depName of Object.keys(pkg.dependencies).filter((x) =>
+      x.startsWith('@redwoodjs/')
+    )) {
+      if (verbose || dryRun) {
+        console.log(
+          ` - ${depName}: ${pkg.dependencies[depName]} => ^${version}`
+        )
+      }
+      pkg.dependencies[depName] = `^${version}`
+    }
+  }
+  if (pkg.devDependencies) {
+    for (const depName of Object.keys(pkg.devDependencies).filter((x) =>
+      x.startsWith('@redwoodjs/')
+    )) {
+      if (verbose || dryRun) {
+        console.log(
+          ` - ${depName}: ${pkg.devDependencies[depName]} => ^${version}`
+        )
+      }
+      pkg.devDependencies[depName] = `^${version}`
+    }
+  }
+
+  if (!dryRun) {
+    fs.writeFileSync(
+      path.join(pkgPath, 'package.json'),
+      JSON.stringify(pkg, undefined, 2)
+    )
+  }
+}
+
+function updateRedwoodDepsForAllSides(ctx, options) {
+  if (!ctx.versionToUpgradeTo) {
+    throw new Error('Failed to upgrade')
+  }
+
+  const updatePaths = [
+    getPaths().base,
+    getPaths().api.base,
+    getPaths().web.base,
+  ]
+
+  return new Listr(
+    updatePaths.map((basePath) => {
+      const pkgJsonPath = path.join(basePath, 'package.json')
+      return {
+        title: `Updating ${pkgJsonPath}`,
+        task: () =>
+          updatePackageJsonVersion(basePath, ctx.versionToUpgradeTo, options),
+        skip: () => !fs.existsSync(pkgJsonPath),
+      }
+    })
+  )
+}
+
+function refreshPrismaClient(verbose) {
+  /** Relates to prisma/client issue, @see: https://github.com/redwoodjs/redwood/issues/1083 */
+  console.log('definitely here!!')
+  return new Listr(
+    [
+      {
+        title: '...',
+        task: async (_ctx, task) => {
+          try {
+            await generatePrismaClient({
+              verbose,
+              force: false,
+              schema: getPaths().api.dbSchema,
+            })
+          } catch (e) {
+            task.skip('Refreshing the Prisma client caused an Error.')
+            console.log(
+              'You may need to update your prisma client manually: $ yarn rw prisma generate'
+            )
+            console.log(c.error(e.message))
+          }
+        },
+      },
+    ],
+    { collapse: false, renderer: verbose && VerboseRenderer }
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4731,14 +4731,6 @@
     "@typescript-eslint/typescript-estree" "4.23.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
-  integrity sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==
-  dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
-
 "@typescript-eslint/scope-manager@4.23.0":
   version "4.23.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz#8792ef7eacac122e2ec8fa2d30a59b8d9a1f1ce4"
@@ -4747,28 +4739,10 @@
     "@typescript-eslint/types" "4.23.0"
     "@typescript-eslint/visitor-keys" "4.23.0"
 
-"@typescript-eslint/types@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
-  integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
-
 "@typescript-eslint/types@4.23.0":
   version "4.23.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.23.0.tgz#da1654c8a5332f4d1645b2d9a1c64193cae3aa3b"
   integrity sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==
-
-"@typescript-eslint/typescript-estree@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz#b5d95d6d366ff3b72f5168c75775a3e46250d05c"
-  integrity sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==
-  dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.23.0":
   version "4.23.0"
@@ -4782,14 +4756,6 @@
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz#169dae26d3c122935da7528c839f42a8a42f6e47"
-  integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
-  dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.23.0":
   version "4.23.0"
@@ -12805,7 +12771,7 @@ language-tags@^1.0.5:
   dependencies:
     language-subtag-registry "~0.3.2"
 
-latest-version@^5.0.0:
+latest-version@^5.0.0, latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
@@ -15759,7 +15725,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -16136,7 +16102,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@17.0.1, react-dom@^17.0.1:
+react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
@@ -16275,7 +16241,7 @@ react-textarea-autosize@^8.1.1, react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@17.0.1, react@^17.0.1:
+react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
@@ -18672,7 +18638,7 @@ typescript-transform-paths@^2.2.2:
   dependencies:
     minimatch "^3.0.4"
 
-typescript@4.2.4, typescript@^4.2.4:
+typescript@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
@@ -19079,7 +19045,7 @@ vscode-jsonrpc@^5.0.1:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
-vscode-languageserver-protocol@3.15.3, vscode-languageserver-protocol@^3.15.3:
+vscode-languageserver-protocol@^3.15.3:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==


### PR DESCRIPTION
## What does this do?
As per @peterp's suggestion, this implements the upgrade command to:
1. query npm to find the lastest/ canary package versions
2. iterate over a user's package.json (root, web, api) files, replace the versions of packages that start with @redwoodjs/*
3. run yarn install

What it looks like: https://s.tape.sh/UFLppMbI

### Note:
- I've removed the upgrade pr command/flag as its unstable