### PR TITLE
Use env-var to toggle secure-services

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@graphql-tools/merge": "6.2.13",
     "@prisma/client": "2.22.1",
-    "@redwoodjs/internal": "^0.32.0",
     "@types/pino": "^6.3.8",
     "apollo-server-lambda": "2.22.2",
     "core-js": "3.10.1",

--- a/packages/api/src/__tests__/makeServices.test.js
+++ b/packages/api/src/__tests__/makeServices.test.js
@@ -1,14 +1,3 @@
-let mockedExperimentalSetting = {}
-jest.mock('@redwoodjs/internal', () => {
-  return {
-    getConfig: jest.fn(() => {
-      return {
-        api: mockedExperimentalSetting,
-      }
-    }),
-  }
-})
-
 import { MissingBeforeResolverError } from '../beforeResolverSpec'
 import { makeServices } from '../makeServices'
 
@@ -39,17 +28,17 @@ describe('makeServices', () => {
   })
 
   afterEach(() => {
+    delete process.env['REDWOOD_SECURE_SERVICES']
     services = []
   })
 
   it('returns same services if experimentalSecureService config option is absent', () => {
     const madeServices = makeServices({ services })
-
     expect(madeServices).toEqual(services)
   })
 
   it('throws an error if service does not export a beforeResolver()', () => {
-    mockedExperimentalSetting = { experimentalSecureServices: true }
+    process.env.REDWOOD_SECURE_SERVICES = '1'
     services.posts_posts.beforeResolver = null
 
     expect(() => {
@@ -57,14 +46,8 @@ describe('makeServices', () => {
     }).toThrow(MissingBeforeResolverError)
   })
 
-  it('exports the same named object and structure as the input', () => {
-    mockedExperimentalSetting = { experimentalSecureServices: true }
-
-    expect(true).toEqual(true)
-  })
-
   it('does not include beforeResolver() in returned services', () => {
-    mockedExperimentalSetting = { experimentalSecureServices: true }
+    process.env.REDWOOD_SECURE_SERVICES = '1'
 
     const madeServices = makeServices({ services })
 

--- a/packages/api/src/makeServices.ts
+++ b/packages/api/src/makeServices.ts
@@ -1,5 +1,3 @@
-import { getConfig } from '@redwoodjs/internal'
-
 import {
   BeforeResolverSpec,
   MissingBeforeResolverError,
@@ -7,7 +5,7 @@ import {
 import { ServicesCollection, MakeServices, Services } from './types'
 
 export const makeServices: MakeServices = ({ services }) => {
-  if (!getConfig().api.experimentalSecureServices) {
+  if (process.env.REDWOOD_SECURE_SERVICES !== '1') {
     console.warn(
       'NOTICE: Redwood v1.0 will make services secure by default. To optin to this behavior now, add `experimentalSecureServices = true` to the [api] section of your redwood.toml file. For more information: https://redwoodjs.com/docs/secure-services'
     )

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -11,7 +11,6 @@
   },
   "include": ["src/**/*", "src/../package.json"],
   "references": [
-    { "path": "../internal" },
     { "path": "../auth" },
     { "path": "../dev-server" }
   ]

--- a/packages/cli/src/commands/__tests__/serve.test.js
+++ b/packages/cli/src/commands/__tests__/serve.test.js
@@ -13,6 +13,11 @@ jest.mock('@redwoodjs/internal', () => {
         },
       }
     },
+    getConfig: () => {
+      return {
+        api: {},
+      }
+    },
   }
 })
 

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -92,7 +92,9 @@ export const handler = async ({
       command: `cd "${path.join(
         BASE_DIR,
         'api'
-      )}" && yarn cross-env NODE_ENV=development yarn dev-server`,
+      )}" && yarn cross-env NODE_ENV=development REDWOOD_SECURE_SERVICES=${
+        getConfig().api.experimentalSecureServices ? '1' : '0'
+      } yarn dev-server`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(API_DIR_SRC),
     },

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -11,6 +11,7 @@ import {
   webServerHandler,
   bothServerHandler,
 } from '@redwoodjs/api-server'
+import { getConfig } from '@redwoodjs/internal'
 import { getPaths } from '@redwoodjs/internal'
 
 import c from 'src/lib/colors'
@@ -19,6 +20,10 @@ export const command = 'serve [side]'
 export const description = 'Run server for api or web in production'
 
 export const builder = (yargs) => {
+  if (getConfig().api.experimentalSecureServices) {
+    process.env.REDWOOD_SECURE_SERVICES = '1'
+  }
+
   yargs
     .usage('usage: $0 <side>')
     .command({


### PR DESCRIPTION
`@redwoodjs/internal` can't be used at runtime because `redwood.toml` isn't present in lambda environments.