### PR TITLE
Move experimental secure services out of toml

### DIFF
--- a/packages/api/src/makeServices.ts
+++ b/packages/api/src/makeServices.ts
@@ -6,8 +6,10 @@ import { ServicesCollection, MakeServices, Services } from './types'
 
 export const makeServices: MakeServices = ({ services }) => {
   if (process.env.REDWOOD_SECURE_SERVICES !== '1') {
+    console.warn('NOTICE: Redwood v1.0 will make resolvers secure by default.')
+
     console.warn(
-      'NOTICE: Redwood v1.0 will make services secure by default. To opt in to this behavior now, add `REDWOOD_SECURE_SERVICES=1` to the `.env.defaults` file. For more information: https://redwoodjs.com/docs/secure-services'
+      'To opt in to this behavior now, add `REDWOOD_SECURE_SERVICES=1` to your `.env.defaults` file. For more information: https://redwoodjs.com/docs/services'
     )
     return services
   }

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -92,9 +92,7 @@ export const handler = async ({
       command: `cd "${path.join(
         BASE_DIR,
         'api'
-      )}" && yarn cross-env NODE_ENV=development REDWOOD_SECURE_SERVICES=${
-        getConfig().api.experimentalSecureServices ? '1' : '0'
-      } yarn dev-server`,
+      )}" && yarn cross-env NODE_ENV=development yarn dev-server`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(API_DIR_SRC),
     },

--- a/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
+++ b/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
@@ -4,6 +4,7 @@ exports[`in javascript mode creates a multi word service file 1`] = `
 "import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules) => {
   rules.add(requireAuth)
 }
@@ -31,6 +32,7 @@ exports[`in javascript mode creates a single word service file 1`] = `
 "import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules) => {
   rules.add(requireAuth)
 }
@@ -45,6 +47,7 @@ exports[`in javascript mode creates a single word service file with CRUD actions
 "import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules) => {
   rules.add(requireAuth)
 }
@@ -84,6 +87,7 @@ exports[`in javascript mode creates a single word service file with a belongsTo 
 "import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules) => {
   rules.add(requireAuth)
 }
@@ -103,6 +107,7 @@ exports[`in javascript mode creates a single word service file with a hasMany re
 "import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules) => {
   rules.add(requireAuth)
 }
@@ -122,6 +127,7 @@ exports[`in javascript mode creates a single word service file with multiple rel
 "import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules) => {
   rules.add(requireAuth)
 }
@@ -157,6 +163,7 @@ exports[`in typescript mode creates a multi word service file 1`] = `
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }
@@ -185,6 +192,7 @@ exports[`in typescript mode creates a single word service file 1`] = `
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }
@@ -201,6 +209,7 @@ import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }
@@ -251,6 +260,7 @@ import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }
@@ -273,6 +283,7 @@ import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }
@@ -295,6 +306,7 @@ import { db } from 'src/lib/db'
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }

--- a/packages/cli/src/commands/generate/service/templates/service.ts.template
+++ b/packages/cli/src/commands/generate/service/templates/service.ts.template
@@ -4,6 +4,7 @@
 import { requireAuth } from 'src/lib/auth'
 import { BeforeResolverSpecType } from '@redwoodjs/api'
 
+// Used when the environment variable REDWOOD_SECURE_SERVICES=1
 export const beforeResolver = (rules: BeforeResolverSpecType) => {
   rules.add(requireAuth)
 }

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -11,7 +11,6 @@ import {
   webServerHandler,
   bothServerHandler,
 } from '@redwoodjs/api-server'
-import { getConfig } from '@redwoodjs/internal'
 import { getPaths } from '@redwoodjs/internal'
 
 import c from 'src/lib/colors'
@@ -20,10 +19,6 @@ export const command = 'serve [side]'
 export const description = 'Run server for api or web in production'
 
 export const builder = (yargs) => {
-  if (getConfig().api.experimentalSecureServices) {
-    process.env.REDWOOD_SECURE_SERVICES = '1'
-  }
-
   yargs
     .usage('usage: $0 <side>')
     .command({

--- a/packages/create-redwood-app/template/.env.defaults
+++ b/packages/create-redwood-app/template/.env.defaults
@@ -23,4 +23,3 @@ PRISMA_HIDE_UPDATE_MESSAGE=true
 # then invoke your api-side webhook function you will use this secret to sign and the verify.
 # Important: Please change this default to a strong password or other secret
 WEBHOOK_SECRET=THIS_IS_NOT_SECRET_PLEASE_CHANGE
-

--- a/packages/create-redwood-app/template/.env.example
+++ b/packages/create-redwood-app/template/.env.example
@@ -2,3 +2,4 @@
 # TEST_DATABASE_URL=file:./.redwood/test.db
 # PRISMA_HIDE_UPDATE_MESSAGE=true
 # LOG_LEVEL=trace
+# REDWOOD_SECURE_SERVICES=1

--- a/packages/create-redwood-app/template/redwood.toml
+++ b/packages/create-redwood-app/template/redwood.toml
@@ -11,6 +11,5 @@
 [api]
   port = 8911
   schemaPath = "./api/db/schema.prisma"
-  experimentalSecureServices = true
 [browser]
   open = true

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -10,7 +10,6 @@ describe('getConfig', () => {
     expect(config).toMatchInlineSnapshot(`
       Object {
         "api": Object {
-          "experimentalSecureServices": false,
           "host": "localhost",
           "path": "./api",
           "port": 8911,

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -19,7 +19,6 @@ export interface NodeTargetConfig {
   path: string
   target: TargetEnum.NODE
   schemaPath: string
-  experimentalSecureServices: boolean
 }
 
 interface BrowserTargetConfig {
@@ -62,7 +61,6 @@ const DEFAULT_CONFIG: Config = {
     path: './api',
     target: TargetEnum.NODE,
     schemaPath: './api/prisma/schema.prisma',
-    experimentalSecureServices: false,
   },
   browser: {
     open: false,


### PR DESCRIPTION
This does 2 things:

1. Does **not** opt-in new projects automatically (because its easy to miss the environment variable when deploying to Netlify/Vercel/whatever)
We might achieve the opposite of what we were aiming for, by accidentally making services public by default ;)

2. Removes the flag from the TOML
Secure services now only controlled using the environment variable. We originally did this because we can't read the config at runtime (causes graphql crashes)