### PR TITLE
Prerender all routes nested in Set with prerender prop

### DIFF
--- a/__fixtures__/example-todo-main/web/src/Routes.js
+++ b/__fixtures__/example-todo-main/web/src/Routes.js
@@ -8,6 +8,7 @@
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
 import { Router, Route } from '@redwoodjs/router'
+import SetLayout from 'src/layouts/SetLayout'
 
 const Routes = () => {
   return (
@@ -15,6 +16,10 @@ const Routes = () => {
       <Route path="/" page={HomePage} name="home" prerender/>
       <Route path="/typescript" page={TypeScriptPage} name="typescriptPage" prerender />
       <Route path="/somewhereElse" page={EditUserPage} name="someOtherPage" prerender />
+      <Set wrap={SetLayout} prerender>
+        <Route path="/foo" page={FooPage} name="fooPage" />
+        <Route path="/bar" page={BarPage} name="barPage" />
+      </Set>
       <Route notfound page={NotFoundPage} />
     </Router>
   )

--- a/__fixtures__/example-todo-main/web/src/layouts/SetLayout/SetLayout.js
+++ b/__fixtures__/example-todo-main/web/src/layouts/SetLayout/SetLayout.js
@@ -1,0 +1,6 @@
+export default ({ children }) => (
+  <>
+    <h1>Set Layout</h1>
+    <div>{children}</div>
+  </>
+)

--- a/__fixtures__/example-todo-main/web/src/pages/BarPage/BarPage.tsx
+++ b/__fixtures__/example-todo-main/web/src/pages/BarPage/BarPage.tsx
@@ -1,0 +1,1 @@
+export default () => "I'm the Bar page"

--- a/__fixtures__/example-todo-main/web/src/pages/FooPage/FooPage.tsx
+++ b/__fixtures__/example-todo-main/web/src/pages/FooPage/FooPage.tsx
@@ -1,0 +1,1 @@
+export default () => "I'm the Foo page"

--- a/packages/internal/src/__tests__/paths.test.ts
+++ b/packages/internal/src/__tests__/paths.test.ts
@@ -16,39 +16,51 @@ describe('paths', () => {
       )
 
       const pages = processPagesDir(pagesDir)
-      expect(pages[0].importName).toEqual('adminEditUserPage')
-      expect(pages[0].importPath).toEqual(
+
+      expect(pages.length).toEqual(7)
+
+      const adminEditUserPage = pages.find(page => page.importName === 'adminEditUserPage')
+      expect(adminEditUserPage).not.toBeUndefined()
+      expect(adminEditUserPage.importPath).toEqual(
         importStatementPath(
           path.join(pagesDir, 'admin/EditUserPage/EditUserPage')
         )
       )
-      expect(pages[1].importName).toEqual('BarPage')
-      expect(pages[1].importPath).toEqual(
+
+      const barPage = pages.find(page => page.importName === 'BarPage')
+      expect(barPage).not.toBeUndefined()
+      expect(barPage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'BarPage/BarPage'))
       )
-      expect(pages[2].importName).toEqual('FatalErrorPage')
-      expect(pages[2].importPath).toEqual(
-        importStatementPath(
-          path.join(pagesDir, 'FatalErrorPage/FatalErrorPage')
-        )
+
+      const fatalErrorPage = pages.find(page => page.importName === 'FatalErrorPage')
+      expect(fatalErrorPage).not.toBeUndefined()
+      expect(fatalErrorPage.importPath).toEqual(
+        importStatementPath(path.join(pagesDir, 'FatalErrorPage/FatalErrorPage'))
       )
-      expect(pages[3].importName).toEqual('FooPage')
-      expect(pages[3].importPath).toEqual(
+
+      const fooPage = pages.find(page => page.importName === 'FooPage')
+      expect(fooPage).not.toBeUndefined()
+      expect(fooPage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'FooPage/FooPage'))
       )
-      expect(pages[4].importName).toEqual('HomePage')
-      expect(pages[4].importPath).toEqual(
+
+      const homePage = pages.find(page => page.importName === 'HomePage')
+      expect(homePage).not.toBeUndefined()
+      expect(homePage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'HomePage/HomePage'))
       )
-      expect(pages[5].importName).toEqual('NotFoundPage')
-      expect(pages[5].importPath).toEqual(
+
+      const notFoundPage = pages.find(page => page.importName === 'NotFoundPage')
+      expect(notFoundPage).not.toBeUndefined()
+      expect(notFoundPage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'NotFoundPage/NotFoundPage'))
       )
-      expect(pages[6].importName).toEqual('TypeScriptPage')
-      expect(pages[6].importPath).toEqual(
-        importStatementPath(
-          path.join(pagesDir, 'TypeScriptPage/TypeScriptPage')
-        )
+
+      const typeScriptPage = pages.find(page => page.importName === 'TypeScriptPage')
+      expect(typeScriptPage).not.toBeUndefined()
+      expect(typeScriptPage.importPath).toEqual(
+        importStatementPath(path.join(pagesDir, 'TypeScriptPage/TypeScriptPage'))
       )
     })
   })

--- a/packages/internal/src/__tests__/paths.test.ts
+++ b/packages/internal/src/__tests__/paths.test.ts
@@ -19,7 +19,9 @@ describe('paths', () => {
 
       expect(pages.length).toEqual(7)
 
-      const adminEditUserPage = pages.find(page => page.importName === 'adminEditUserPage')
+      const adminEditUserPage = pages.find(
+        (page) => page.importName === 'adminEditUserPage'
+      )
       expect(adminEditUserPage).not.toBeUndefined()
       expect(adminEditUserPage.importPath).toEqual(
         importStatementPath(
@@ -27,40 +29,50 @@ describe('paths', () => {
         )
       )
 
-      const barPage = pages.find(page => page.importName === 'BarPage')
+      const barPage = pages.find((page) => page.importName === 'BarPage')
       expect(barPage).not.toBeUndefined()
       expect(barPage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'BarPage/BarPage'))
       )
 
-      const fatalErrorPage = pages.find(page => page.importName === 'FatalErrorPage')
+      const fatalErrorPage = pages.find(
+        (page) => page.importName === 'FatalErrorPage'
+      )
       expect(fatalErrorPage).not.toBeUndefined()
       expect(fatalErrorPage.importPath).toEqual(
-        importStatementPath(path.join(pagesDir, 'FatalErrorPage/FatalErrorPage'))
+        importStatementPath(
+          path.join(pagesDir, 'FatalErrorPage/FatalErrorPage')
+        )
       )
 
-      const fooPage = pages.find(page => page.importName === 'FooPage')
+      const fooPage = pages.find((page) => page.importName === 'FooPage')
       expect(fooPage).not.toBeUndefined()
       expect(fooPage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'FooPage/FooPage'))
       )
 
-      const homePage = pages.find(page => page.importName === 'HomePage')
+      const homePage = pages.find((page) => page.importName === 'HomePage')
       expect(homePage).not.toBeUndefined()
       expect(homePage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'HomePage/HomePage'))
       )
 
-      const notFoundPage = pages.find(page => page.importName === 'NotFoundPage')
+      const notFoundPage = pages.find(
+        (page) => page.importName === 'NotFoundPage'
+      )
       expect(notFoundPage).not.toBeUndefined()
       expect(notFoundPage.importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'NotFoundPage/NotFoundPage'))
       )
 
-      const typeScriptPage = pages.find(page => page.importName === 'TypeScriptPage')
+      const typeScriptPage = pages.find(
+        (page) => page.importName === 'TypeScriptPage'
+      )
       expect(typeScriptPage).not.toBeUndefined()
       expect(typeScriptPage.importPath).toEqual(
-        importStatementPath(path.join(pagesDir, 'TypeScriptPage/TypeScriptPage'))
+        importStatementPath(
+          path.join(pagesDir, 'TypeScriptPage/TypeScriptPage')
+        )
       )
     })
   })

--- a/packages/internal/src/__tests__/paths.test.ts
+++ b/packages/internal/src/__tests__/paths.test.ts
@@ -22,22 +22,30 @@ describe('paths', () => {
           path.join(pagesDir, 'admin/EditUserPage/EditUserPage')
         )
       )
-      expect(pages[1].importName).toEqual('FatalErrorPage')
+      expect(pages[1].importName).toEqual('BarPage')
       expect(pages[1].importPath).toEqual(
+        importStatementPath(path.join(pagesDir, 'BarPage/BarPage'))
+      )
+      expect(pages[2].importName).toEqual('FatalErrorPage')
+      expect(pages[2].importPath).toEqual(
         importStatementPath(
           path.join(pagesDir, 'FatalErrorPage/FatalErrorPage')
         )
       )
-      expect(pages[2].importName).toEqual('HomePage')
-      expect(pages[2].importPath).toEqual(
+      expect(pages[3].importName).toEqual('FooPage')
+      expect(pages[3].importPath).toEqual(
+        importStatementPath(path.join(pagesDir, 'FooPage/FooPage'))
+      )
+      expect(pages[4].importName).toEqual('HomePage')
+      expect(pages[4].importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'HomePage/HomePage'))
       )
-      expect(pages[3].importName).toEqual('NotFoundPage')
-      expect(pages[3].importPath).toEqual(
+      expect(pages[5].importName).toEqual('NotFoundPage')
+      expect(pages[5].importPath).toEqual(
         importStatementPath(path.join(pagesDir, 'NotFoundPage/NotFoundPage'))
       )
-      expect(pages[4].importName).toEqual('TypeScriptPage')
-      expect(pages[4].importPath).toEqual(
+      expect(pages[6].importName).toEqual('TypeScriptPage')
+      expect(pages[6].importPath).toEqual(
         importStatementPath(
           path.join(pagesDir, 'TypeScriptPage/TypeScriptPage')
         )

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -24,11 +24,11 @@ type SetProps<P> = P & {
    * the wrapped route they will be redirected to `unauthenticated` route.
    */
   private?: boolean
-  /**
-   * The page name where a user will be redirected when not authenticated
-   */
+  /** The page name where a user will be redirected when not authenticated */
   unauthenticated?: string
   role?: string | string[]
+  /** Prerender all pages in the set */
+  prerender?: boolean
   children: ReactNode
 }
 

--- a/packages/structure/src/model/__tests__/model.test.ts
+++ b/packages/structure/src/model/__tests__/model.test.ts
@@ -17,6 +17,8 @@ describe('Redwood Project Model', () => {
         'NotFoundPage',
         'TypeScriptPage',
         'EditUserPage',
+        'FooPage',
+        'BarPage',
       ])
     )
     for (const page of project.pages) {
@@ -112,12 +114,11 @@ describe('Redwood Route detection', () => {
 
     const prerenderRoutes = routes
       .filter((r) => r.prerender)
-      // Make it a little easier to read
-      .map(({ name, path }) => {
-        return { name, path }
-      })
+      // Make it a little easier to read by only keeping the attributes we're
+      // interested in
+      .map(({ name, path }) => ({ name, path }))
 
-    expect(prerenderRoutes.length).toBe(3)
+    expect(prerenderRoutes.length).toBe(5)
     expect(prerenderRoutes).toContainEqual({ name: 'home', path: '/' })
     expect(prerenderRoutes).toContainEqual({
       name: 'typescriptPage',
@@ -127,6 +128,8 @@ describe('Redwood Route detection', () => {
       name: 'someOtherPage',
       path: '/somewhereElse',
     })
+    expect(prerenderRoutes).toContainEqual({ name: 'fooPage', path: '/foo' })
+    expect(prerenderRoutes).toContainEqual({ name: 'barPage', path: '/bar' })
   })
 })
 


### PR DESCRIPTION
This PR adds support for specifying `prerender` on `<Set>`s. All routes in a Set like that will be prerendered.

```
<Set prerender>
  <Route path="/foo" page={FooPage} name="fooPage" />
  <Route path="/bar" page={BarPage} name="barPage" />
</Set>
```

is equivalent to

```
<Route path="/foo" page={FooPage} name="fooPage" prerender />
<Route path="/bar" page={BarPage} name="barPage" prerender />
```