### PR TITLE
[Internal] Configure babel-plugin-private-methods loose explicitly

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -45,6 +45,7 @@ module.exports = {
      **/
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
+    ['@babel/plugin-proposal-private-methods', { loose: true }],
     [
       '@babel/plugin-transform-runtime',
       {


### PR DESCRIPTION
## What?
As title

## Why?
When running `yarn build`, we got warnings from babel. To reproduce, in main, run build in the cli package. 

```shell
cd packages/cli
yarn build
```

you should see warnings like this:

```
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
```