### PR TITLE
Add learn.rwjs.com translator contributors from crowdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,9 @@ And there you have it.
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/mlabate"><img src="https://avatars.githubusercontent.com/u/17139676?v=4" width="100px;" alt=""/><br /><sub><b>mlabate</b></sub></a></td>
+    <td align="center"><a href="https://github.com/pdjota"><img src="https://avatars.githubusercontent.com/u/93544?v=4" width="100px;" alt=""/><br /><sub><b>Pablo Dejuan</b></sub></a></td>
+    <td align="center"><a href="https://github.com/bugsfunny"><img src="https://avatars.githubusercontent.com/u/12965842?v=4" width="100px;" alt=""/><br /><sub><b>bugsfunny</b></sub></a></td>
+    <td align="center"><a href="https://github.com/luispinto23"><img src="https://avatars.githubusercontent.com/u/4148663?v=4" width="100px;" alt=""/><br /><sub><b>Luís Pinto</b></sub></a></td>
   </tr>
 </table>
 

--- a/tasks/all-contributors/.all-contributorsrc
+++ b/tasks/all-contributors/.all-contributorsrc
@@ -1550,7 +1550,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/18013532?v=4",
       "profile": "https://simoncrypta.dev/",
       "contributions": [
-        "code"
+        "code",
+        "tutorial"
       ]
     },
     {
@@ -1627,7 +1628,8 @@
       "profile": "https://github.com/renansoares",
       "contributions": [
         "code",
-        "doc"
+        "doc",
+        "tutorial"
       ]
     },
     {
@@ -1826,6 +1828,33 @@
       "name": "mlabate",
       "avatar_url": "https://avatars.githubusercontent.com/u/17139676?v=4",
       "profile": "https://github.com/mlabate",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "pdjota",
+      "name": "Pablo Dejuan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/93544?v=4",
+      "profile": "https://github.com/pdjota",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "bugsfunny",
+      "name": "bugsfunny",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12965842?v=4",
+      "profile": "https://github.com/bugsfunny",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "luispinto23",
+      "name": "Luís Pinto",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4148663?v=4",
+      "profile": "https://github.com/luispinto23",
       "contributions": [
         "tutorial"
       ]

--- a/tasks/all-contributors/.learn.all-contributorsrc
+++ b/tasks/all-contributors/.learn.all-contributorsrc
@@ -136,6 +136,51 @@
       "contributions": [
         "tutorial"
       ]
+    },
+    {
+      "login": "pdjota",
+      "name": "Pablo Dejuan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/93544?v=4",
+      "profile": "https://github.com/pdjota",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "renansoares",
+      "name": "Renan Andrade",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1657840?v=4",
+      "profile": "https://github.com/renansoares",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "bugsfunny",
+      "name": "bugsfunny",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12965842?v=4",
+      "profile": "https://github.com/bugsfunny",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "luispinto23",
+      "name": "Luís Pinto",
+      "avatar_url": "https://avatars.githubusercontent.com/u/4148663?v=4",
+      "profile": "https://github.com/luispinto23",
+      "contributions": [
+        "tutorial"
+      ]
+    },
+    {
+      "login": "simoncrypta",
+      "name": "Simon Gagnon",
+      "avatar_url": "https://avatars.githubusercontent.com/u/18013532?v=4",
+      "profile": "https://simoncrypta.dev/",
+      "contributions": [
+        "tutorial"
+      ]
     }
   ],
   "contributorsPerLine": 5


### PR DESCRIPTION
_continued from #2545_

Crowdin does not include the translator in the PRs to the repo; added manually to `.learn.all-contributorsrc`

Adds these users as translator contributors to learn repo:
- https://github.com/pdjota
- https://github.com/renansoares
- https://github.com/bugsfunny
- https://github.com/luispinto23
- https://github.com/simoncrypta

---

@clairefro I re-ran the process 1) added directly to `.learn.all-contributorsrc` 2) ran the merge script and 3) ran the update README command

Could you confirm these are the correct folks?
