### PR TITLE
upgrade Prisma v2.23.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.14",
-    "@prisma/client": "2.22.1",
+    "@prisma/client": "2.23.0",
     "@types/pino": "^6.3.8",
     "apollo-server-lambda": "2.22.2",
     "core-js": "3.12.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.22.1",
+    "@prisma/sdk": "2.23.0",
     "@redwoodjs/api-server": "^0.32.2",
     "@redwoodjs/internal": "^0.32.2",
     "@redwoodjs/prerender": "^0.32.2",

--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -19,7 +19,7 @@ const runScript = async (scriptPath, scriptArgs) => {
         'babel-plugin-module-resolver',
         {
           alias: {
-            '$api': getPaths().api.base,
+            $api: getPaths().api.base,
           },
         },
       ],
@@ -52,7 +52,7 @@ export const builder = (yargs) => {
 
 export const handler = async (args) => {
   const { name, ...scriptArgs } = args
-  const scriptPath = path.join(getPaths().scripts,  name)
+  const scriptPath = path.join(getPaths().scripts, name)
   try {
     require.resolve(scriptPath)
   } catch {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "mini-css-extract-plugin": "^1.4.1",
     "null-loader": "^4.0.1",
-    "prisma": "2.22.1",
+    "prisma": "2.23.0",
     "react-refresh": "^0.10.0",
     "style-loader": "^1.1.3",
     "svg-react-loader": "^0.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3294,17 +3294,25 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.22.1.tgz#10fdcd1532a6baf46dd1c464cad9a54af0532bc8"
-  integrity sha512-JQjbsY6QSfFiovXHEp5WeJHa5p2CuR1ZFPAeYXmUsOAQOaMCrhgQmKAL6w2Q3SRA7ALqPjrKywN9/QfBc4Kp1A==
+"@prisma/client@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.23.0.tgz#4bf16ab19b140873ba79bd159da86842b1746e0a"
+  integrity sha512-xsHdo3+wIH0hJVGfKHYTEKtifStjKH0b5t8t7hV32Fypq6+3uxhAi3F25yxuI4XSHXg21nb7Ha82lNwU/0TERA==
   dependencies:
-    "@prisma/engines-version" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
+    "@prisma/engines-version" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
 
 "@prisma/debug@2.22.1":
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.22.1.tgz#b0c3e3b6cf567f7d3e9173c0108122bba4e30881"
   integrity sha512-y5pAe1bEEERlEbnAOYaCnWIdHK8b4s7zHV3TE0ptyo0yhEIOZYmH72QdWRHuK1HdzLQj2KK8tIqHtb62T7RjAw==
+  dependencies:
+    debug "4.3.2"
+    ms "^2.1.3"
+
+"@prisma/debug@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.23.0.tgz#abc1309b802a6794bdcbded4cf5263ca5e46c283"
+  integrity sha512-ZMUWQ8XB+qcYRC4vY9K5fjtjKLdPIPofDeT6GjkFfi0NHEOpLP0iR+6o4D9g3bMXG5aCADd7WYZ3HcJ/J8YglA==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
@@ -3327,15 +3335,38 @@
     terminal-link "^2.1.1"
     undici "3.3.6"
 
-"@prisma/engines-version@2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c":
-  version "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c.tgz#e98ee17217a0ebb54f2f9314fbbfd610b05e6e31"
-  integrity sha512-OkkVwk6iTzTbwwl8JIKAENyxmh4TFORal55QMKQzrHEY8UzbD0M90mQnmziz3PAopQUZgTFFMlaPAq1WNrLMtA==
+"@prisma/engine-core@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.23.0.tgz#914a0588456be45858ac4d944ad32791bfe557b1"
+  integrity sha512-vnVD8JBc1vWZ1kpz9/S+gfc2n6F2p1OTfV0+wuaUSus9XZmu9yHPKXYjI0lbls8lS4fn99bENU/0wyDtlkqLwQ==
+  dependencies:
+    "@prisma/debug" "2.23.0"
+    "@prisma/engines" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
+    "@prisma/generator-helper" "2.23.0"
+    "@prisma/get-platform" "2.23.0"
+    chalk "^4.0.0"
+    execa "^5.0.0"
+    get-stream "^6.0.0"
+    indent-string "^4.0.0"
+    new-github-issue-url "^0.2.1"
+    p-retry "^4.2.0"
+    terminal-link "^2.1.1"
+    undici "3.3.6"
+
+"@prisma/engines-version@2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b":
+  version "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b.tgz#c813279bbea48dedad039b0bc3b044117d2dbaa1"
+  integrity sha512-VNgnOe+oPQKmy3HOtWi/Q1fvcKZUQkf1OfTD1pzrLBx9tJPejyxt1Mq54L+OOAuYvfrua6bmfojFVLh7uXuWVw==
 
 "@prisma/engines@2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c":
   version "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
   resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c.tgz#4ccd255e0823605db3d8387a5195b6fdabe3b0c0"
   integrity sha512-KmWdogrsfsSLYvfqY3cS3QcDGzaEFklE+T6dNJf+k/KPQum4A29IwDalafMwh5cMN8ivZobUbowNSwWJrMT08Q==
+
+"@prisma/engines@2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b":
+  version "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b.tgz#440abe0ebef44b6e1bdaf2b4d14fcde9fe74f18c"
+  integrity sha512-Tgk3kggO5B9IT6mimJAw6HSxbFoDAuDKL3sHHSS41EnQm76j/nf4uhGZFPzOQwZWOLeT5ZLO2khr4/FCA9Nkhw==
 
 "@prisma/fetch-engine@2.22.1":
   version "2.22.1"
@@ -3344,6 +3375,29 @@
   dependencies:
     "@prisma/debug" "2.22.1"
     "@prisma/get-platform" "2.22.1"
+    chalk "^4.0.0"
+    execa "^5.0.0"
+    find-cache-dir "^3.3.1"
+    hasha "^5.2.0"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.0.2"
+    node-fetch "^2.6.0"
+    p-filter "^2.1.0"
+    p-map "^4.0.0"
+    p-retry "^4.2.0"
+    progress "^2.0.3"
+    rimraf "^3.0.2"
+    temp-dir "^2.0.0"
+    tempy "^1.0.0"
+
+"@prisma/fetch-engine@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.23.0.tgz#20caf4be7b3690d766184f517c3b2fecba5e84f0"
+  integrity sha512-M6bQ/47qtIAjRsSIirByJ1NIolEeYis1j1xKlkcJmm0v9S1sudzu53HT0TxBTLT9/SwYb5OrIhP2fPzwBjpz+w==
+  dependencies:
+    "@prisma/debug" "2.23.0"
+    "@prisma/get-platform" "2.23.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3370,12 +3424,29 @@
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
+"@prisma/generator-helper@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.23.0.tgz#464eb51148bb951c43f9e2b9f6b0b113188c129c"
+  integrity sha512-tTRgYK9FreLhHGfteLt0IHpT3YtLl22QgCQ8vSFs5tj2XvvfpLZjVmbSZcRkbej/x97icwkQ4xe4A71ITs0jcA==
+  dependencies:
+    "@prisma/debug" "2.23.0"
+    "@types/cross-spawn" "^6.0.1"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+
 "@prisma/get-platform@2.22.1":
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.22.1.tgz#81818939f2bf0c31a35352281b0367dfc43c4c7d"
   integrity sha512-yQS6KnGS2FtLYre1iW1oGg8xGC39yh+rMoP5l4y6w+dCY0GQ1X5SbOkvioyqtQ0dNXUqAuszUuHl5CaxNQh+Rw==
   dependencies:
     "@prisma/debug" "2.22.1"
+
+"@prisma/get-platform@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.23.0.tgz#f7d14e1f964050ce706148679e1726597e9c43e3"
+  integrity sha512-QLtVZ6Q7fQVwyrcwMg8LEjtbWnXy85MgF7A5STcmzb4t66ShQiMxhaBCRcXP6mlxMVJclbwYQFvq1Uuo03PTsQ==
+  dependencies:
+    "@prisma/debug" "2.23.0"
 
 "@prisma/sdk@2.22.1":
   version "2.22.1"
@@ -3395,6 +3466,47 @@
     checkpoint-client "1.1.20"
     cli-truncate "^2.1.0"
     dotenv "^8.2.0"
+    execa "^5.0.0"
+    find-up "5.0.0"
+    global-dirs "^3.0.0"
+    globby "^11.0.0"
+    has-yarn "^2.1.0"
+    is-ci "^3.0.0"
+    make-dir "^3.0.2"
+    node-fetch "2.6.1"
+    p-map "^4.0.0"
+    read-pkg-up "^7.0.1"
+    resolve-pkg "^2.0.0"
+    rimraf "^3.0.2"
+    shell-quote "^1.7.2"
+    string-width "^4.2.0"
+    strip-ansi "6.0.0"
+    strip-indent "3.0.0"
+    tar "^6.0.1"
+    temp-dir "^2.0.0"
+    temp-write "^4.0.0"
+    tempy "^1.0.0"
+    terminal-link "^2.1.1"
+    tmp "0.2.1"
+
+"@prisma/sdk@2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.23.0.tgz#ea107eb6e8de7b15384217d7cb1c661e893d0eb7"
+  integrity sha512-87wDQUfYYl0RMA/3peWnPe3x0ojgZvpZPp/gQJkG2j6aI/STmzLqlXVwLo8wQlVhzX4y7R9RSW97AgQTH3pJgw==
+  dependencies:
+    "@prisma/debug" "2.23.0"
+    "@prisma/engine-core" "2.23.0"
+    "@prisma/engines" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
+    "@prisma/fetch-engine" "2.23.0"
+    "@prisma/generator-helper" "2.23.0"
+    "@prisma/get-platform" "2.23.0"
+    "@timsuchanek/copy" "^1.4.5"
+    archiver "^4.0.0"
+    arg "^5.0.0"
+    chalk "4.1.1"
+    checkpoint-client "1.1.20"
+    cli-truncate "^2.1.0"
+    dotenv "^9.0.0"
     execa "^5.0.0"
     find-up "5.0.0"
     global-dirs "^3.0.0"
@@ -8941,6 +9053,11 @@ dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
+dotenv@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
+  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
 
 downshift@^6.0.6:
   version "6.1.0"
@@ -15907,12 +16024,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.22.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.22.1.tgz#884687a90c7b797b34c6110ea413049078c8da6e"
-  integrity sha512-hwvCM3zyxgSda/+/p+GW7nz93jRebtMU01wAG7YVVnl0OKU+dpw1wPvPFmQRldkZHk8fTCleYmjc24WaSdVPZQ==
+prisma@2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.23.0.tgz#6464cca0e085ed23b1815013a67c868eff07a7d2"
+  integrity sha512-3c/lmDy8nsPcEsfCufvCTJUEuwmAcTPbeGg9fL1qjlvS314duLUA/k2nm3n1rq4ImKqzeC5uaKfvI2IoAfwrJA==
   dependencies:
-    "@prisma/engines" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
+    "@prisma/engines" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"


### PR DESCRIPTION
Prisma {v2.23.0 Release Notes](https://github.com/prisma/prisma/releases/tag/2.23.0)
- JSON Filtering is now in Preview
- BREAKING: Options in groupBy queries are now prefixed with an underscore
- DEPRECATING: Options in aggregate queries
