### PR TITLE
Adds option to cell generation for lists of a given model

### DIFF
--- a/packages/cli/src/commands/destroy/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/destroy/cell/__tests__/cell.test.js
@@ -1,4 +1,5 @@
 global.__dirname = __dirname
+
 jest.mock('fs')
 jest.mock('src/lib', () => {
   return {
@@ -33,7 +34,11 @@ afterEach(() => {
 
 test('destroys cell files', async () => {
   const unlinkSpy = jest.spyOn(fs, 'unlinkSync')
-  const t = tasks({ componentName: 'cell', filesFn: files, name: 'User' })
+  const t = tasks({
+    componentName: 'cell',
+    filesFn: files,
+    name: 'User',
+  })
   t.setRenderer('silent')
 
   return t.run().then(() => {

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`"equipment" with list flag 1`] = `
 "export const QUERY = gql\`
-  query EquipmentsQuery {
-    equipments {
+  query ManyEquipmentQuery {
+    manyEquipment {
       id
     }
   }
@@ -17,15 +17,11 @@ export const Failure = ({ error }) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ equipments }) => {
+export const Success = ({ manyEquipment }) => {
   return (
     <ul>
-      {equipments.map((item) => {
-        return (
-          <li key={item.id}>
-            <div>{JSON.stringify(item)}</div>
-          </li>
-        )
+      {manyEquipment.map((item) => {
+        return <li key={item.id}>{JSON.stringify(item)}</li>
       })}
     </ul>
   )
@@ -552,11 +548,7 @@ export const Success = ({ members }) => {
   return (
     <ul>
       {members.map((item) => {
-        return (
-          <li key={item.id}>
-            <div>{JSON.stringify(item)}</div>
-          </li>
-        )
+        return <li key={item.id}>{JSON.stringify(item)}</li>
       })}
     </ul>
   )
@@ -585,11 +577,7 @@ export const Success = ({ members }) => {
   return (
     <ul>
       {members.map((item) => {
-        return (
-          <li key={item.id}>
-            <div>{JSON.stringify(item)}</div>
-          </li>
-        )
+        return <li key={item.id}>{JSON.stringify(item)}</li>
       })}
     </ul>
   )

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -1,9 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`"equipment" with list flag 1`] = `
+"export const QUERY = gql\`
+  query EquipmentsQuery {
+    equipments {
+      id
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => (
+  <div style={{ color: 'red' }}>Error: {error.message}</div>
+)
+
+export const Success = ({ equipments }) => {
+  return (
+    <ul>
+      {equipments.map((item) => {
+        return (
+          <li key={item.id}>
+            <div>{JSON.stringify(item)}</div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+"
+`;
+
+exports[`"equipment" withOUT list flag should find equipment by id 1`] = `
+"export const QUERY = gql\`
+  query FindEquipmentQuery($id: !) {
+    equipment: equipment(id: $id) {
+      id
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => (
+  <div style={{ color: 'red' }}>Error: {error.message}</div>
+)
+
+export const Success = ({ equipment }) => {
+  return <div>{JSON.stringify(equipment)}</div>
+}
+"
+`;
+
 exports[`creates a cell component with a camelCase word name 1`] = `
 "export const QUERY = gql\`
-  query UserProfileQuery {
-    userProfile {
+  query FindUserProfileQuery($id: Int!) {
+    userProfile: userProfile(id: $id) {
       id
     }
   }
@@ -25,8 +81,8 @@ export const Success = ({ userProfile }) => {
 
 exports[`creates a cell component with a kebabCase word name 1`] = `
 "export const QUERY = gql\`
-  query UserProfileQuery {
-    userProfile {
+  query FindUserProfileQuery($id: Int!) {
+    userProfile: userProfile(id: $id) {
       id
     }
   }
@@ -48,8 +104,8 @@ export const Success = ({ userProfile }) => {
 
 exports[`creates a cell component with a multi word name 1`] = `
 "export const QUERY = gql\`
-  query UserProfileQuery {
-    userProfile {
+  query FindUserProfileQuery($id: Int!) {
+    userProfile: userProfile(id: $id) {
       id
     }
   }
@@ -71,8 +127,8 @@ export const Success = ({ userProfile }) => {
 
 exports[`creates a cell component with a single word name 1`] = `
 "export const QUERY = gql\`
-  query UserQuery {
-    user {
+  query FindUserQuery($id: Int!) {
+    user: user(id: $id) {
       id
     }
   }
@@ -94,8 +150,8 @@ export const Success = ({ user }) => {
 
 exports[`creates a cell component with a snakeCase word name 1`] = `
 "export const QUERY = gql\`
-  query UserProfileQuery {
-    userProfile {
+  query FindUserProfileQuery($id: Int!) {
+    userProfile: userProfile(id: $id) {
       id
     }
   }
@@ -472,5 +528,71 @@ describe('UserProfileCell', () => {
     }).not.toThrow()
   })
 })
+"
+`;
+
+exports[`generates list cells if list flag passed in 1`] = `
+"export const QUERY = gql\`
+  query MembersQuery {
+    members {
+      id
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => (
+  <div style={{ color: 'red' }}>Error: {error.message}</div>
+)
+
+export const Success = ({ members }) => {
+  return (
+    <ul>
+      {members.map((item) => {
+        return (
+          <li key={item.id}>
+            <div>{JSON.stringify(item)}</div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+"
+`;
+
+exports[`generates list cells if name is plural 1`] = `
+"export const QUERY = gql\`
+  query MembersQuery {
+    members {
+      id
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({ error }) => (
+  <div style={{ color: 'red' }}>Error: {error.message}</div>
+)
+
+export const Success = ({ members }) => {
+  return (
+    <ul>
+      {members.map((item) => {
+        return (
+          <li key={item.id}>
+            <div>{JSON.stringify(item)}</div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
 "
 `;

--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
@@ -401,19 +401,19 @@ test('generates list cells if name is plural', () => {
 
 test('"equipment" with list flag', () => {
   const CELL_PATH = path.normalize(
-    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.js'
+    '/path/to/project/web/src/components/ManyEquipmentCell/ManyEquipmentCell.js'
   )
 
   const TEST_PATH = path.normalize(
-    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.test.js'
+    '/path/to/project/web/src/components/ManyEquipmentCell/ManyEquipmentCell.test.js'
   )
 
   const STORY_PATH = path.normalize(
-    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.stories.js'
+    '/path/to/project/web/src/components/ManyEquipmentCell/ManyEquipmentCell.stories.js'
   )
 
   const MOCK_PATH = path.normalize(
-    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.mock.js'
+    '/path/to/project/web/src/components/ManyEquipmentCell/ManyEquipmentCell.mock.js'
   )
 
   // Check the file names

--- a/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/generate/cell/__tests__/cell.test.js
@@ -20,48 +20,87 @@ let singleWordFiles,
   camelCaseWordFiles,
   withoutTestFiles,
   withoutStoryFiles,
-  withoutTestAndStoryFiles
+  withoutTestAndStoryFiles,
+  listFlagPassedIn,
+  listInferredFromName,
+  modelPluralMatchesSingularWithList,
+  modelPluralMatchesSingularWithoutList
 
 beforeAll(async () => {
   singleWordFiles = await cell.files({
     name: 'User',
     tests: true,
     stories: true,
+    list: false,
   })
   multiWordFiles = await cell.files({
     name: 'UserProfile',
     tests: true,
     stories: true,
+    list: false,
   })
   snakeCaseWordFiles = await cell.files({
     name: 'user_profile',
     tests: true,
     stories: true,
+    list: false,
   })
   kebabCaseWordFiles = await cell.files({
     name: 'user-profile',
     tests: true,
     stories: true,
+    list: false,
   })
   camelCaseWordFiles = await cell.files({
     name: 'userProfile',
     tests: true,
     stories: true,
+    list: false,
   })
   withoutTestFiles = await cell.files({
     name: 'User',
     tests: false,
     stories: true,
+    list: false,
   })
   withoutStoryFiles = await cell.files({
     name: 'User',
     tests: true,
     stories: false,
+    list: false,
   })
   withoutTestAndStoryFiles = await cell.files({
     name: 'User',
     tests: false,
     stories: false,
+    list: false,
+  })
+
+  listFlagPassedIn = await cell.files({
+    name: 'Member',
+    tests: true,
+    stories: true,
+    list: true,
+  })
+
+  listInferredFromName = await cell.files({
+    name: 'Members',
+    tests: true,
+    stories: true,
+  })
+
+  modelPluralMatchesSingularWithList = await cell.files({
+    name: 'equipment',
+    tests: true,
+    stories: true,
+    list: true,
+  })
+
+  modelPluralMatchesSingularWithoutList = await cell.files({
+    name: 'equipment',
+    tests: true,
+    stories: true,
+    list: false,
   })
 })
 
@@ -300,4 +339,120 @@ test("doesn't include storybook and test files when --stories and --tests is set
   expect(Object.keys(withoutTestAndStoryFiles)).toEqual([
     path.normalize('/path/to/project/web/src/components/UserCell/UserCell.js'),
   ])
+})
+
+test('generates list cells if list flag passed in', () => {
+  const CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.js'
+  )
+
+  const TEST_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.test.js'
+  )
+
+  const STORY_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.stories.js'
+  )
+
+  const MOCK_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.mock.js'
+  )
+
+  // Check the file names
+  expect(Object.keys(listFlagPassedIn)).toEqual([
+    MOCK_PATH,
+    TEST_PATH,
+    STORY_PATH,
+    CELL_PATH,
+  ])
+
+  // Check the contents
+  expect(listFlagPassedIn[CELL_PATH]).toMatchSnapshot()
+})
+
+test('generates list cells if name is plural', () => {
+  const CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.js'
+  )
+
+  const TEST_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.test.js'
+  )
+
+  const STORY_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.stories.js'
+  )
+
+  const MOCK_PATH = path.normalize(
+    '/path/to/project/web/src/components/MembersCell/MembersCell.mock.js'
+  )
+
+  // Check the file names
+  expect(Object.keys(listInferredFromName)).toEqual([
+    MOCK_PATH,
+    TEST_PATH,
+    STORY_PATH,
+    CELL_PATH,
+  ])
+
+  // Check the contents
+  expect(listInferredFromName[CELL_PATH]).toMatchSnapshot()
+})
+
+test('"equipment" with list flag', () => {
+  const CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.js'
+  )
+
+  const TEST_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.test.js'
+  )
+
+  const STORY_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.stories.js'
+  )
+
+  const MOCK_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentsCell/EquipmentsCell.mock.js'
+  )
+
+  // Check the file names
+  expect(Object.keys(modelPluralMatchesSingularWithList)).toEqual([
+    MOCK_PATH,
+    TEST_PATH,
+    STORY_PATH,
+    CELL_PATH,
+  ])
+
+  // Check the contents
+  expect(modelPluralMatchesSingularWithList[CELL_PATH]).toMatchSnapshot()
+})
+
+test('"equipment" withOUT list flag should find equipment by id', () => {
+  const CELL_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentCell/EquipmentCell.js'
+  )
+
+  const TEST_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentCell/EquipmentCell.test.js'
+  )
+
+  const STORY_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentCell/EquipmentCell.stories.js'
+  )
+
+  const MOCK_PATH = path.normalize(
+    '/path/to/project/web/src/components/EquipmentCell/EquipmentCell.mock.js'
+  )
+
+  // Check the file names
+  expect(Object.keys(modelPluralMatchesSingularWithoutList)).toEqual([
+    MOCK_PATH,
+    TEST_PATH,
+    STORY_PATH,
+    CELL_PATH,
+  ])
+
+  // Check the contents
+  expect(modelPluralMatchesSingularWithoutList[CELL_PATH]).toMatchSnapshot()
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/cell/__tests__/fixtures/schema.prisma
@@ -1,0 +1,25 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DB_HOST")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+// Define your own models here and run yarn db:save to create
+// migrations for them.
+model User {
+  id       Int           @id @default(autoincrement())
+  name     String?
+  email    String        @unique
+  isAdmin  Boolean       @default(false)
+  profiles UserProfile[]
+}
+
+model UserProfile {
+  id       Int    @id @default(autoincrement())
+  username String @unique
+  userId   Int
+  user     User   @relation(fields: [userId], references: [id])
+}

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,8 +1,14 @@
 import pascalcase from 'pascalcase'
+import pluralize from 'pluralize'
 
+import { getSchema } from 'src/lib'
+
+import { yargsDefaults } from '../../generate'
 import {
   templateForComponentFile,
   createYargsForComponentGeneration,
+  forcePluralizeWord,
+  isWordNonPluralizable,
 } from '../helpers'
 
 const COMPONENT_SUFFIX = 'Cell'
@@ -18,17 +24,27 @@ const getCellOperationNames = async () => {
     .filter(Boolean)
 }
 
-const uniqueOperationName = async (name, index = 1) => {
-  let operationName =
-    index <= 1
-      ? `${pascalcase(name)}Query`
-      : `${pascalcase(name)}Query_${index}`
+const uniqueOperationName = async (name, { index = 1, list = false }) => {
+  let operationName = pascalcase(
+    index <= 1 ? `find_${name}_query` : `find_${name}_query_${index}`
+  )
+
+  if (list) {
+    operationName =
+      index <= 1
+        ? `${pascalcase(name)}Query`
+        : `${pascalcase(name)}Query_${index}`
+  }
 
   const cellOperationNames = await getCellOperationNames()
   if (!cellOperationNames.includes(operationName)) {
     return operationName
   }
-  return uniqueOperationName(name, index + 1)
+  return uniqueOperationName(name, { index: index + 1 })
+}
+
+const getIdType = (model) => {
+  return model.fields.find((field) => field.isId)?.type
 }
 
 export const files = async ({
@@ -36,43 +52,73 @@ export const files = async ({
   typescript: generateTypescript,
   ...options
 }) => {
+  let cellName = name
+  let idType,
+    model = null
+  let templateNameSuffix = ''
+
   // Create a unique operation name.
-  const operationName = await uniqueOperationName(name)
+
+  const shouldGenerateList =
+    (isWordNonPluralizable(name) ? options.list : pluralize.isPlural(name)) ||
+    options.list
+
+  if (shouldGenerateList) {
+    cellName = forcePluralizeWord(name)
+    templateNameSuffix = 'List'
+    // override operationName so that its find_operationName
+  } else {
+    // needed for the singular cell GQL query find by id case
+    try {
+      model = await getSchema(pascalcase(pluralize.singular(name)))
+      idType = getIdType(model)
+    } catch {
+      // eat error so that the destroy cell generator doesn't raise when try to find prisma query engine in test runs
+    }
+  }
+
+  const operationName = await uniqueOperationName(cellName, {
+    list: shouldGenerateList,
+  })
 
   const cellFile = templateForComponentFile({
-    name,
+    name: cellName,
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.tsx' : '.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
-    templatePath: 'cell.js.template',
+    templatePath: `cell${templateNameSuffix}.js.template`,
     templateVars: {
       operationName,
+      idType,
     },
   })
+
   const testFile = templateForComponentFile({
-    name,
+    name: cellName,
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.test.tsx' : '.test.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
     templatePath: 'test.js.template',
   })
+
   const storiesFile = templateForComponentFile({
-    name,
+    name: cellName,
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.stories.tsx' : '.stories.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
     templatePath: 'stories.js.template',
   })
+
   const mockFile = templateForComponentFile({
-    name,
+    name: cellName,
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.mock.ts' : '.mock.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
-    templatePath: 'mock.js.template',
+    templatePath: `mock${templateNameSuffix}.js.template`,
   })
 
   const files = [cellFile]
@@ -106,4 +152,14 @@ export const { command, description, builder, handler } =
   createYargsForComponentGeneration({
     componentName: 'cell',
     filesFn: files,
+    optionsObj: {
+      ...yargsDefaults,
+      list: {
+        alias: 'l',
+        default: false,
+        description:
+          'Use when you want to generate a cell for a list of the model name.',
+        type: 'boolean',
+      },
+    },
   })

--- a/packages/cli/src/commands/generate/cell/templates/cellList.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.js.template
@@ -1,6 +1,6 @@
 export const QUERY = gql`
-  query ${operationName}($id: ${idType}!) {
-    ${camelName}: ${camelName}(id: $id) {
+  query ${operationName} {
+    ${camelName} {
       id
     }
   }
@@ -13,5 +13,15 @@ export const Empty = () => <div>Empty</div>
 export const Failure = ({ error }) => <div style={{color: 'red'}}>Error: {error.message}</div>
 
 export const Success = ({ ${camelName} }) => {
-  return <div>{JSON.stringify(${camelName})}</div>
+  return (
+    <ul>
+      {${camelName}.map((item) => {
+        return (
+          <li key={item.id}>
+            <div>{JSON.stringify(item)}</div>
+          </li>
+        )
+      })}
+    </ul>
+  )
 }

--- a/packages/cli/src/commands/generate/cell/templates/cellList.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.js.template
@@ -18,7 +18,7 @@ export const Success = ({ ${camelName} }) => {
       {${camelName}.map((item) => {
         return (
           <li key={item.id}>
-            <div>{JSON.stringify(item)}</div>
+            {JSON.stringify(item)}
           </li>
         )
       })}

--- a/packages/cli/src/commands/generate/cell/templates/mockList.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/mockList.js.template
@@ -1,0 +1,8 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  ${camelName}: [
+    { id: 42 },
+    { id: 43 },
+    { id: 44 }
+  ]
+  })

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -3,6 +3,7 @@ import path from 'path'
 import Listr from 'listr'
 import { paramCase } from 'param-case'
 import pascalcase from 'pascalcase'
+import pluralize from 'pluralize'
 import terminalLink from 'terminal-link'
 
 import { ensurePosixPath, getConfig } from '@redwoodjs/internal'
@@ -169,4 +170,23 @@ export const intForeignKeysForModel = (model) => {
   return model.fields
     .filter((f) => f.name.match(/Id$/) && f.type === 'Int')
     .map((f) => f.name)
+}
+
+export const isWordNonPluralizable = (word) => {
+  return pluralize.isPlural(word) === pluralize.isSingular(word)
+}
+
+/**
+ * Adds an s if it can't pluralize the word
+ */
+export const forcePluralizeWord = (word) => {
+  // If word is already plural, check if plural === singular, then add s
+  // else use plural
+  const shouldAddS = isWordNonPluralizable(word) // equipment === equipment
+
+  if (shouldAddS) {
+    return `${word}s`
+  }
+
+  return pluralize.plural(word)
 }

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -185,7 +185,7 @@ export const forcePluralizeWord = (word) => {
   const shouldAddS = isWordNonPluralizable(word) // equipment === equipment
 
   if (shouldAddS) {
-    return `${word}s`
+    return pascalcase(`many_${word}`)
   }
 
   return pluralize.plural(word)


### PR DESCRIPTION
This PR fixes issue https://github.com/redwoodjs/redwood/issues/2565

This PR updates:

* cell generator
* adds "list" variants of the cell component and mock templates
* the new list component success renders a `ul` with items
* the new list mock returns an array of items (just ids)
* the singular template renders a by id query
* the test template is unchanged

### ⚠️
* ***Important*** Scaffold generation is unchanged.
* ***Important*** Service generation is unchanged (required for the non-pluralisable names e.g. `manyEquipment`)

---

### Given the model `User` and normal general model

> yarn rw g cell User 

```terminal
cells-test % yarn rw g cell User --force 
yarn run v1.22.10
$ /Users/dthyresson/redwood-tests/cells-test/node_modules/.bin/rw g cell User --force
  ✔ Generating cell files...
    ✔ Successfully wrote file `./web/src/components/UserCell/UserCell.mock.js`
    ✔ Successfully wrote file `./web/src/components/UserCell/UserCell.test.js`
    ✔ Successfully wrote file `./web/src/components/UserCell/UserCell.stories.js`
    ✔ Successfully wrote file `./web/src/components/UserCell/UserCell.js`
✨  Done in 3.26s.
```

Generates:

```js
export const QUERY = gql`
  query FindUser($id: Int!) {
    user: user(id: $id) {
      id
    }
  }
`
.
.
```

And the mock:

```js
// Define your own mock data here:
export const standard = (/* vars, { ctx, req } */) => ({
  ${camelName}: {
    id: 42
    }
  })
```

### Given the model `User` and list option, or pluralising users
> yarn rw g cell User --list

or just 

> yarn rw g cell Users


```terminal
cells-test % yarn rw g cell User --force --list
yarn run v1.22.10
$ /Users/dthyresson/redwood-tests/cells-test/node_modules/.bin/rw g cell User --force --list
  ✔ Generating cell files...
    ✔ Successfully wrote file `./web/src/components/UsersCell/UsersCell.mock.js`
    ✔ Successfully wrote file `./web/src/components/UsersCell/UsersCell.test.js`
    ✔ Successfully wrote file `./web/src/components/UsersCell/UsersCell.stories.js`
    ✔ Successfully wrote file `./web/src/components/UsersCell/UsersCell.js`
✨  Done in 4.14s.
```

```js
export const QUERY = gql`
  query UsersQuery_2 {
    users {
      id
    }
  }
`
.
.
.
export const Success = ({ users }) => {
  return (
    <ul>
      {users.map((item) => {
        return (
          <li key={item.id}>
            <div>{JSON.stringify(item)}</div>
          </li>
        )
      })}
    </ul>
  )
}
```

And the mock:

```js
// Define your own mock data here:
export const standard = (/* vars, { ctx, req } */) => ({
  users: [{ id: 42 }, { id: 43 }, { id: 44 }],
})
```

Note: Seeing why the unique Operation name is `UsersQuery_2` -- it may think that query already exists.

---

### Detecting plurals
When we can detect that the word passed is in plural, we generate list cells.

e.g.
```
yarrn rw g cell members
```

Will generate a query for a list of members

---

### Handling difficult words

When we can't detect whether the passed in word is plural or not, we assume its singular.

e.g. 
```
yarn rw g cell equipment
```
Will generate a query for `FindEquipment` (by id)

but 
```
yarn rw g cell equipment --list
```

Will generate a query for a list of equipment

