### PR TITLE
Router.tsx: Test Route matching in Sets

### DIFF
--- a/packages/router/src/__tests__/route-announcer.test.tsx
+++ b/packages/router/src/__tests__/route-announcer.test.tsx
@@ -3,12 +3,7 @@ import '@testing-library/jest-dom/extend-expect'
 
 import { navigate } from '@redwoodjs/history'
 
-import {
-  Router,
-  Route,
-  routes,
-  getAnnouncement,
-} from '../internal'
+import { Router, Route, routes, getAnnouncement } from '../internal'
 import RouteAnnouncement from '../route-announcement'
 
 // SETUP

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -497,6 +497,30 @@ test('renders first matching route only, even if multiple routes have the same n
   expect(screen.queryByText('About Two Page')).not.toBeInTheDocument()
 })
 
+test('renders first matching route only, also with Private', async () => {
+  const ParamPage = ({ param }: { param: string }) => <div>param {param}</div>
+
+  const TestRouter = () => (
+    <Router useAuth={mockUseAuth()}>
+      <Route path="/" page={HomePage} name="home" />
+      <Route path="/login" page={LoginPage} name="login" />
+      <Route path="/about" page={AboutPage} name="about" />
+      <Private unauthenticated="login">
+        <Route path="/{param}" page={ParamPage} name="param" />
+      </Private>
+    </Router>
+  )
+
+  const screen = render(<TestRouter />)
+
+  await waitFor(() => screen.getByText(/Home Page/))
+
+  // go to about page, and make sure that's the only page rendered
+  act(() => navigate(routes.about()))
+  await waitFor(() => screen.getByText('About Page'))
+  expect(screen.queryByText(/param/)).not.toBeInTheDocument()
+})
+
 test('params should never be an empty object', async (done) => {
   const ParamPage = () => {
     const params = useParams()


### PR DESCRIPTION
```jsx
<Router>
  <Route path="/" page={HomePage} name="home" />
  <Route path="/about" page={AboutPage} name="about" />
  <Set private unauthenticated="home">
    <Route path="/{param}" page={ParamPage} name="param" />
  </Set>
</Router>
```

If you tried to navigate to `/about` the private Set would see that `/about` matches `/{param}` (`param` would be set to "about"), and if you weren't authenticated, you'd be redirected to the home page

This PR fixes this by looking at the route name. It knows you're trying to go to the "about" page, so in the Set, it looks at name="param" and sees that "param" !== "about", and so it skips it.