### PR TITLE
Router: More helpful typings for Route

### DIFF
--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -53,9 +53,10 @@ type InternalRouteProps = Partial<
   RouteProps & RedirectRouteProps & NotFoundRouteProps
 >
 
-const Route: React.VFC<RouteProps | RedirectRouteProps | NotFoundRouteProps> = (
-  props
-) => {
+function Route(props: RouteProps): JSX.Element
+function Route(props: RedirectRouteProps): JSX.Element
+function Route(props: NotFoundRouteProps): JSX.Element
+function Route(props: RouteProps | RedirectRouteProps | NotFoundRouteProps) {
   return <InternalRoute {...props} />
 }
 


### PR DESCRIPTION
By utilizing function overloads I was able to make the types for `<Route>` much more helpful.
VS Code now complains if you miss a prop, or if you combine props that shouldn't be combined, when declaring your routes.

A few examples:

Missing `page`
![image](https://user-images.githubusercontent.com/30793/119139275-1c947a80-ba43-11eb-8f7b-9b25622733f9.png)

`name` shouldn't be specified for redirect routes
![image](https://user-images.githubusercontent.com/30793/119139420-4a79bf00-ba43-11eb-869b-c405cc1f2921.png)

No `path` should be specified for the "not found" route
![image](https://user-images.githubusercontent.com/30793/119139565-75641300-ba43-11eb-913f-275e48ff4be6.png)

This is (parts of) the error message VS Code gives you for the last one

![image](https://user-images.githubusercontent.com/30793/119139722-a2b0c100-ba43-11eb-824e-6f92656d59fd.png)

# Breaking change

If someone has a TypeScript `Routes.tsx` file with misconfigured routes it will now not compile for them anymore.