### PR TITLE
Add a workflow file to create-redwood-app

### DIFF
--- a/packages/create-redwood-app/template/.github/workflows/ci.yml
+++ b/packages/create-redwood-app/template/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  lint:
+  runCI:
     name: Run CI
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +30,6 @@ jobs:
       # install dependencies
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      # lint, check, run tests, and build
+      # lint, check, run tests, and build using RedwoodJS's GitHub Action
       - name: Run CI
-        uses: redwoodjs/redwoodjs-ci@v1
+        uses: redwoodjs/project-action-ci@v1

--- a/packages/create-redwood-app/template/.github/workflows/ci.yml
+++ b/packages/create-redwood-app/template/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  lint:
+    name: Lint, run tests, and build
+    runs-on: ubuntu-latest
+    steps:
+      # check out this repo (so that this workflow can use it)
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v2
+      # set up a node environment
+      # https://github.com/actions/setup-node
+      - name: Setup Node.js v14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      # cache dependencies and build outputs to improve workflow execution time
+      # https://github.com/actions/cache
+      - name: Cache "node_modules"
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: node_modules_${{ hashFiles('**/yarn.lock') }}
+      # install dependencies
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      # lint, run tests, and build
+      - name: Lint
+        run: yarn rw lint
+      - name: Run tests
+        run: yarn rw test
+      - name: Build
+        run: yarn rw build

--- a/packages/create-redwood-app/template/.github/workflows/ci.yml
+++ b/packages/create-redwood-app/template/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    name: Lint, run tests, and build
+    name: Run CI
     runs-on: ubuntu-latest
     steps:
       # check out this repo (so that this workflow can use it)
@@ -30,10 +30,6 @@ jobs:
       # install dependencies
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      # lint, run tests, and build
-      - name: Lint
-        run: yarn rw lint
-      - name: Run tests
-        run: yarn rw test --no-watch
-      - name: Build
-        run: yarn rw build
+      # lint, check, run tests, and build
+      - name: Run CI
+        uses: redwoodjs/redwoodjs-ci@v1

--- a/packages/create-redwood-app/template/.github/workflows/ci.yml
+++ b/packages/create-redwood-app/template/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Lint
         run: yarn rw lint
       - name: Run tests
-        run: yarn rw test
+        run: yarn rw test --no-watch
       - name: Build
         run: yarn rw build


### PR DESCRIPTION
Closes #2559; but the purpose of this PR is more to just get the conversation started. I pretty much just copied the "Lint, build and run tests" workflow in our repo (located here https://github.com/redwoodjs/redwood/blob/main/.github/workflows/build-eslint-jest.yaml). Those three things seem like table stakes.

@thedavidprice you had mentioned publishing a Redwood action. This PR adds a workflow instead. Even if we do publish an action, it'll have to be used in a workflow, so it makes sense to add `.github/workflows/ci.yml` or `main.yml`, etc. to create-redwood-app at some point. But would the action just encapsulate all these jobs/steps? Would it take inputs? What did you imagine it being?

Other considerations:
- Should we have one file with many jobs with many steps, or many files with few jobs and few steps?
- I think we need to add more comments. Way more comments. Workflows and actions have their own learning curve
- Is ubuntu-latest enough as far as runners go?