### PR TITLE
Disable Cypress recording in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,5 +53,5 @@ jobs:
           browser: chrome
           env: true
           wait-on: 'http://localhost:8910'
-          record: true
+          record: false
           working-directory: ./tasks/e2e


### PR DESCRIPTION
Noticed some errors in GitHib workflows when running e2e:

```
Error: ffmpeg exited with code 1: Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
Conversion failed
```

Wondered in video recording should be disabled and ...

Per @dac09 > We’re not using the cypress dashboard

So, this PR changes the workflow setting to not record the e22 run.
