### PR TITLE
Add Updating to Cells

### DIFF
--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -24,6 +24,8 @@ export type CellLoadingProps = Omit<
   'error' | 'loading' | 'data'
 >
 // @MARK not sure about this partial, but we need to do this for tests and storybook
+// `updating` is just `loading` renamed; since Cells default to stale-while-refetch,
+// this prop lets users render something like a spinner to show that a request is in-flight
 export type CellSuccessProps<TData = any> = Partial<
   Omit<QueryOperationResult<TData>, 'error' | 'data'>
 > & { updating: boolean } & A.Compute<TData> // pre-computing makes the types more readable on hover

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -133,12 +133,14 @@ export function createCell<CellProps = any>({
             }
           } else if (data) {
             if (typeof Empty !== 'undefined' && isEmpty(data)) {
-              return <Empty {...{ loading, ...queryRest }} {...props} />
+              return (
+                <Empty {...{ updating: loading, ...queryRest }} {...props} />
+              )
             } else {
               return (
                 <Success
                   {...afterQuery(data)}
-                  {...{ loading, ...queryRest }}
+                  {...{ updating: loading, ...queryRest }}
                   {...props}
                 />
               )

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -26,8 +26,7 @@ export type CellLoadingProps = Omit<
 // @MARK not sure about this partial, but we need to do this for tests and storybook
 export type CellSuccessProps<TData = any> = Partial<
   Omit<QueryOperationResult<TData>, 'error' | 'data'>
-> &
-  A.Compute<TData> // pre-computing makes the types more readable on hover
+> & { updating: boolean } & A.Compute<TData> // pre-computing makes the types more readable on hover
 
 export interface CreateCellProps<CellProps> {
   beforeQuery?: <TProps>(props: TProps) => { variables: TProps }

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -25,7 +25,7 @@ export type CellLoadingProps = Omit<
 >
 // @MARK not sure about this partial, but we need to do this for tests and storybook
 export type CellSuccessProps<TData = any> = Partial<
-  Omit<QueryOperationResult<TData>, 'error' | 'loading' | 'data'>
+  Omit<QueryOperationResult<TData>, 'error' | 'data'>
 > &
   A.Compute<TData> // pre-computing makes the types more readable on hover
 
@@ -96,7 +96,7 @@ export function createCell<CellProps = any>({
   beforeQuery = (props) => ({
     variables: props,
     fetchPolicy: 'cache-and-network',
-    nextFetchPolicy: 'cache-first',
+    notifyOnNetworkStatusChange: true,
   }),
   QUERY,
   afterQuery = (data) => ({ ...data }),
@@ -131,14 +131,20 @@ export function createCell<CellProps = any>({
             } else {
               throw error
             }
-          } else if (loading) {
-            return <Loading {...queryRest} {...props} />
           } else if (data) {
             if (typeof Empty !== 'undefined' && isEmpty(data)) {
-              return <Empty {...queryRest} {...props} />
+              return <Empty {...{ loading, ...queryRest }} {...props} />
             } else {
-              return <Success {...afterQuery(data)} {...queryRest} {...props} />
+              return (
+                <Success
+                  {...afterQuery(data)}
+                  {...{ loading, ...queryRest }}
+                  {...props}
+                />
+              )
             }
+          } else if (loading) {
+            return <Loading {...queryRest} {...props} />
           } else {
             throw new Error(
               'Cannot render cell: GraphQL success but `data` is null'


### PR DESCRIPTION
As of Apollo Client `v3`, [the default `fetchPolicy` is `cache-first`](https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy). `cache-first` is great, but `cache-and-network` is better. Accordingly, it's what we [default to](https://github.com/redwoodjs/redwood/blob/fbccb88b31c51258d04d98f5145dcf7c88436168/packages/web/src/components/createCell.tsx#L98). It comes with a hiccup though: `cache-and-network` gives you data if it's there (the "cache" part), then makes a GraphQL request to see if there's anything new ("and-network"). This means that the "result" Cells get (and use to figure out what to render) has data (usually an object/array) and `loading = true`. And if `loading = true`, that means Loading gets rendered. Because things go in order:

https://github.com/redwoodjs/redwood/blob/fbccb88b31c51258d04d98f5145dcf7c88436168/packages/web/src/components/createCell.tsx#L128-L146

This is what it looks like: https://s.tape.sh/jf6jLX7u. I'm throttling the network so that you can really see Loading render. Near the end, you can see that the `PostsPage` (which has the `PostsCell`) displays `Loading...` even though there's data in the cache. (The other pages also display loading even though they have data too!)

Much in the same vein as https://github.com/redwoodjs/redwood/pull/1878, this PR fixes this by providing an "Updating" state to Cells: https://s.tape.sh/YHPMztQO. The Loading states are gone. But there's a lot more details to consider:

- How do you opt out of this?
- If we're adding another state, we should really refactor the logic into a reducer; it's getting hard to keep track of how we get to each state. Cells are already state machines, is it time to use Xstate? We also [don't need a library for state machines](https://dev.to/davidkpiano/you-don-t-need-a-library-for-state-machines-k7h). But it seems like it's time to write one explicitly.
  - For instance, what happens when data's empty (which would render Empty) and `loading = true`?
- We talked about having Cells export another component, Updating, but will that cause the React tree to commit when it's swapping between Success and Updating and we'll end up with a terrible flash anyway? I.e., should Updating be a child of Success, so it just pops in and out?
- The way things are going, it seems like Cells might eventually look like the [`useAuth` context](https://github.com/redwoodjs/redwood/blob/e6c941aea36433ebb790c75c62a0a0dfc9edb998/packages/auth/src/AuthProvider.tsx#L15-L55), which provides an interface (logIn, signOut, etc.) that auth providers adapt themselves to.


Any and all feedback is welcome and appreciated!