### PR TITLE
Fix serve tests

### DIFF
--- a/packages/cli/src/commands/__tests__/serve.test.js
+++ b/packages/cli/src/commands/__tests__/serve.test.js
@@ -56,12 +56,25 @@ describe('yarn rw serve', () => {
   it('Should proxy serve api with params to api-server handler', async () => {
     const parser = yargs.command('serve [side]', false, builder)
 
-    parser.parse('serve api --port 5555 --rootPath funkyFunctions')
+    parser.parse('serve api --port 5555 --apiRootPath funkyFunctions')
 
     expect(apiServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 5555,
-        apiRootPath: '/funkyFunctions/',
+        apiRootPath: 'funkyFunctions',
+      })
+    )
+  })
+
+  it('Should proxy serve api with params to api-server handler (alias and slashes in path)', async () => {
+    const parser = yargs.command('serve [side]', false, builder)
+
+    parser.parse('serve api --port 5555 --rootPath funkyFunctions/nested/')
+
+    expect(apiServerHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 5555,
+        rootPath: 'funkyFunctions/nested/',
       })
     )
   })
@@ -82,7 +95,7 @@ describe('yarn rw serve', () => {
     )
   })
 
-  it('Should proxy rw serve with params to approripate handler', async () => {
+  it('Should proxy rw serve with params to appropriate handler', async () => {
     const parser = yargs.command('serve [side]', false, builder)
 
     parser.parse('serve --port 9898 --socket abc')

--- a/packages/cli/src/commands/__tests__/serve.test.js
+++ b/packages/cli/src/commands/__tests__/serve.test.js
@@ -61,7 +61,7 @@ describe('yarn rw serve', () => {
     expect(apiServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 5555,
-        apiRootPath: 'funkyFunctions',
+        apiRootPath: expect.stringMatching(/^\/?funkyFunctions\/?$/),
       })
     )
   })
@@ -74,7 +74,7 @@ describe('yarn rw serve', () => {
     expect(apiServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 5555,
-        rootPath: 'funkyFunctions/nested/',
+        rootPath: expect.stringMatching(/^\/?funkyFunctions\/nested\/$/),
       })
     )
   })


### PR DESCRIPTION
Running the RW test suite locally I had some trouble with the `serve` tests. This fixes them.

This was the error I saw

```
Summary of all failing tests
 FAIL  src/commands/__tests__/serve.test.js
  ● yarn rw serve › Should proxy serve api with params to api-server handler

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: ObjectContaining {"apiRootPath": "/funkyFunctions/", "port": 5555}
    Received: {"$0": "..\\..\\node_modules\\jest-worker\\build\\workers\\processChild.js", "_": ["serve", "api"], "port": 5555, "rootPath": "funkyFunctions"}

    Number of calls: 1

      59 |     parser.parse('serve api --port 5555 --rootPath funkyFunctions')
      60 |
    > 61 |     expect(apiServerHandler).toHaveBeenCalledWith(
         |                              ^
      62 |       expect.objectContaining({
      63 |         port: 5555,
      64 |         apiRootPath: '/funkyFunctions/',

      at Object.<anonymous> (src/commands/__tests__/serve.test.js:61:30)

 FAIL  src/commands/__tests__/test.test.js
  ● Test suite failed to run

    Call retries were exceeded

      at ChildProcessWorker.initialize (../../node_modules/jest-worker/build/workers/ChildProcessWorker.js:193:21)


Test Suites: 2 failed, 28 passed, 30 total
Tests:       1 failed, 488 passed, 489 total
Snapshots:   135 passed, 135 total
Time:        71.768 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The actual command line arg is called `apiRootPath`, but it's also aliased as `rootPath`, so I added a test so that we test both. And then we have the value of the arg. It's passed as `funkyFunctions`, but matched as `'/funkyFunctions/'`. Looks like a regex in a string. I don't know how `objectContaining` is implemented, but passing it as a regex string is either wrong, or at least unnecessary. So I just pass it as a plain string now. Also tested with nested paths, so with slashes (/) in the pathname, to make sure that works as well. 