### PR TITLE
Use `yarn --offline` in GH workflows

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --offline
-        shell: cmd # applies to Windows only
 
       - name: Build
         run: yarn build

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --offline
+        shell: cmd # applies to Windows only
 
       - name: Build
         run: yarn build

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -21,15 +21,15 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Cache "node_modules"
-        uses: actions/cache@v2
-        if: matrix.os == 'ubuntu-latest'
-        with:
-          path: '**/node_modules'
-          key: node_modules_${{ runner.os }}_${{ hashFiles('**/yarn.lock') }}
+      # - name: Cache "node_modules"
+      #   uses: actions/cache@v2
+      #   if: matrix.os == 'ubuntu-latest'
+      #   with:
+      #     path: '**/node_modules'
+      #     key: node_modules_${{ runner.os }}_${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --offline
 
       - name: Build
         run: yarn build

--- a/.github/workflows/create-pr-artifact.yaml
+++ b/.github/workflows/create-pr-artifact.yaml
@@ -21,7 +21,7 @@ jobs:
           node-version: 14
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --offline
 
       - name: Build
         run: yarn build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install framework modules
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --offline
 
       - name: Create a temporary directory
         id: createpath

--- a/.github/workflows/publish-npm-canary.yaml
+++ b/.github/workflows/publish-npm-canary.yaml
@@ -23,7 +23,7 @@ jobs:
           node --version
           yarn --version
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+        run: yarn install --frozen-lockfile --check-files --offline
 
       - name: Build
         run: yarn build

--- a/.github/workflows/publish-npm-rc.yaml
+++ b/.github/workflows/publish-npm-rc.yaml
@@ -21,7 +21,7 @@ jobs:
           node-version: '14'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --check-files
+        run: yarn install --frozen-lockfile --check-files --offline
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
_continues work from "set up yarn offline cache" #2669_

As an experiment, I've added the `--offline` option to each GitHub Workflow occurrence of `yarn install`. There is a chance this will speed up workflow run time, especially in the case of Windows where yarn encounters numerous network connection errors before installation can run.

Also, this should technically improve our CI by guaranteeing the pinned, cached dependencies are being used in CI.

Discussion and evaluation needed before moving forward.

**TO DO:**
- [ ] I've currently disabled caching on `.github/workflows/build-eslint-jest.yaml` Need to further test and enable/disable accordingly. Also include Windows runner in cache testing.