### PR TITLE
remove CRWA/template/redwood.toml schemaPort

### DIFF
--- a/packages/create-redwood-app/template/redwood.toml
+++ b/packages/create-redwood-app/template/redwood.toml
@@ -10,7 +10,6 @@
   apiProxyPath = "/.redwood/functions"
 [api]
   port = 8911
-  schemaPath = "./api/db/schema.prisma"
 [browser]
   open = true
 [experimental]


### PR DESCRIPTION
no longer needed per changes to the default value in https://github.com/redwoodjs/redwood/pull/2677