### PR TITLE
Upgrade Prisma v2.24.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.14",
-    "@prisma/client": "2.23.0",
+    "@prisma/client": "2.24.1",
     "@types/pino": "6.3.8",
     "apollo-server-lambda": "2.24.1",
     "core-js": "3.13.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.23.0",
+    "@prisma/sdk": "2.24.1",
     "@redwoodjs/api-server": "0.32.2",
     "@redwoodjs/internal": "0.32.2",
     "@redwoodjs/prerender": "0.32.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "lodash.escaperegexp": "4.1.2",
     "mini-css-extract-plugin": "1.4.1",
     "null-loader": "4.0.1",
-    "prisma": "2.23.0",
+    "prisma": "2.24.1",
     "react-refresh": "0.10.0",
     "style-loader": "1.1.3",
     "svg-react-loader": "0.4.6",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.22.1",
+    "@prisma/sdk": "2.24.1",
     "@redwoodjs/internal": "0.32.2",
     "@types/line-column": "1.0.0",
     "camelcase": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,38 +3290,30 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.23.0.tgz#4bf16ab19b140873ba79bd159da86842b1746e0a"
-  integrity sha512-xsHdo3+wIH0hJVGfKHYTEKtifStjKH0b5t8t7hV32Fypq6+3uxhAi3F25yxuI4XSHXg21nb7Ha82lNwU/0TERA==
+"@prisma/client@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.24.1.tgz#c4f26fb4d768dd52dd20a17e626f10e69cc0b85c"
+  integrity sha512-vllhf36g3oI98GF1Q5IPmnR5MYzBPeCcl/Xiz6EAi4DMOxE069o9ka5BAqYbUG2USx8JuKw09QdMnDrp3Kyn8g==
   dependencies:
-    "@prisma/engines-version" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
+    "@prisma/engines-version" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
 
-"@prisma/debug@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.22.1.tgz#b0c3e3b6cf567f7d3e9173c0108122bba4e30881"
-  integrity sha512-y5pAe1bEEERlEbnAOYaCnWIdHK8b4s7zHV3TE0ptyo0yhEIOZYmH72QdWRHuK1HdzLQj2KK8tIqHtb62T7RjAw==
+"@prisma/debug@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.24.1.tgz#180f9ccaedc0ab1c2a4ecbd5c4be745529fd8498"
+  integrity sha512-rpcU9+wTCKzv/cFZlRsSUvGlfCM5pe9H39TuZjSlXAaxl2rOzXcXMBmZlybpFKpjA83ihvYgNXQpxsZfAX+xFg==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/debug@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.23.0.tgz#abc1309b802a6794bdcbded4cf5263ca5e46c283"
-  integrity sha512-ZMUWQ8XB+qcYRC4vY9K5fjtjKLdPIPofDeT6GjkFfi0NHEOpLP0iR+6o4D9g3bMXG5aCADd7WYZ3HcJ/J8YglA==
+"@prisma/engine-core@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.24.1.tgz#176f4674be3d3b64c2e51b8dc1cc00f74f8f41e5"
+  integrity sha512-BwqvtLqSU3qIGC+oaowAr4O9gwMI7SU63Vu8gocwIrl5H61z00KYfk/oAeo6W/biLXtkgDoHGIu8QKvCPusJ6Q==
   dependencies:
-    debug "4.3.2"
-    ms "^2.1.3"
-
-"@prisma/engine-core@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.22.1.tgz#128edf39e0fd32f7ac862a0ea33d2aee8c068406"
-  integrity sha512-xcRzY6c0fh96ri+wGv+LooAEPfgS0MR9OgOHWUpu81dYf6TjV1Oc0IthHnPGtoUdjAQCDHogNY5rOHJfzcQjtQ==
-  dependencies:
-    "@prisma/debug" "2.22.1"
-    "@prisma/engines" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
-    "@prisma/generator-helper" "2.22.1"
-    "@prisma/get-platform" "2.22.1"
+    "@prisma/debug" "2.24.1"
+    "@prisma/engines" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
+    "@prisma/generator-helper" "2.24.1"
+    "@prisma/get-platform" "2.24.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -3331,46 +3323,23 @@
     terminal-link "^2.1.1"
     undici "3.3.6"
 
-"@prisma/engine-core@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.23.0.tgz#914a0588456be45858ac4d944ad32791bfe557b1"
-  integrity sha512-vnVD8JBc1vWZ1kpz9/S+gfc2n6F2p1OTfV0+wuaUSus9XZmu9yHPKXYjI0lbls8lS4fn99bENU/0wyDtlkqLwQ==
+"@prisma/engines-version@2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4":
+  version "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4.tgz#2c5813ef98bcbe659b18b521f002f5c8aabbaae2"
+  integrity sha512-60Do+ByVfHnhJ2id5h/lXOZnDQNIf5pz3enkKWOmyr744Z2IxkBu65jRckFfMN5cPtmXDre/Ay/GKm0aoeLwrw==
+
+"@prisma/engines@2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4":
+  version "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4.tgz#7e542d510f0c03f41b73edbb17254f5a0b272a4d"
+  integrity sha512-29/xO9kqeQka+wN5Ev10l5L4XQXNVXdPToJs1M29VZ2imQsNsL4rtz26m3qGM54IoGWwwfTVdvuVRxKnDl2rig==
+
+"@prisma/fetch-engine@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.24.1.tgz#491bf0af286f0cffde863c69262777ce612fbf33"
+  integrity sha512-yz9APYZ/0QCTXsBruySD5BRAKdFhtVwSLfNMdc1j1ZQdgPjGX50oNnet2vDwCdHOwEwZWRS9RM9h7SEicRwP6A==
   dependencies:
-    "@prisma/debug" "2.23.0"
-    "@prisma/engines" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
-    "@prisma/generator-helper" "2.23.0"
-    "@prisma/get-platform" "2.23.0"
-    chalk "^4.0.0"
-    execa "^5.0.0"
-    get-stream "^6.0.0"
-    indent-string "^4.0.0"
-    new-github-issue-url "^0.2.1"
-    p-retry "^4.2.0"
-    terminal-link "^2.1.1"
-    undici "3.3.6"
-
-"@prisma/engines-version@2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b":
-  version "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b.tgz#c813279bbea48dedad039b0bc3b044117d2dbaa1"
-  integrity sha512-VNgnOe+oPQKmy3HOtWi/Q1fvcKZUQkf1OfTD1pzrLBx9tJPejyxt1Mq54L+OOAuYvfrua6bmfojFVLh7uXuWVw==
-
-"@prisma/engines@2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c":
-  version "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c.tgz#4ccd255e0823605db3d8387a5195b6fdabe3b0c0"
-  integrity sha512-KmWdogrsfsSLYvfqY3cS3QcDGzaEFklE+T6dNJf+k/KPQum4A29IwDalafMwh5cMN8ivZobUbowNSwWJrMT08Q==
-
-"@prisma/engines@2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b":
-  version "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b.tgz#440abe0ebef44b6e1bdaf2b4d14fcde9fe74f18c"
-  integrity sha512-Tgk3kggO5B9IT6mimJAw6HSxbFoDAuDKL3sHHSS41EnQm76j/nf4uhGZFPzOQwZWOLeT5ZLO2khr4/FCA9Nkhw==
-
-"@prisma/fetch-engine@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.22.1.tgz#d97e6e187611acd8ce98435700d8b4542c53eed0"
-  integrity sha512-D4iVaKdm4ncs2pGp7yR73tl63hdiwfYwASIMrJqm2qjAVTWtGA6M7zonKT1hsKlNhpa69EgCWNwpABn2sXSfZQ==
-  dependencies:
-    "@prisma/debug" "2.22.1"
-    "@prisma/get-platform" "2.22.1"
+    "@prisma/debug" "2.24.1"
+    "@prisma/get-platform" "2.24.1"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3387,115 +3356,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/fetch-engine@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.23.0.tgz#20caf4be7b3690d766184f517c3b2fecba5e84f0"
-  integrity sha512-M6bQ/47qtIAjRsSIirByJ1NIolEeYis1j1xKlkcJmm0v9S1sudzu53HT0TxBTLT9/SwYb5OrIhP2fPzwBjpz+w==
+"@prisma/generator-helper@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.24.1.tgz#ba20215be00bba058d5a2916481e08f71a724c3f"
+  integrity sha512-GyjmBq6K2+rQlT6hnxa2VzEnvpaSWvjT3o4ve6futGZnLemJJmn394AiAJJh7LrIBVJQnMp68Ze4UAtqj4Ykqg==
   dependencies:
-    "@prisma/debug" "2.23.0"
-    "@prisma/get-platform" "2.23.0"
-    chalk "^4.0.0"
-    execa "^5.0.0"
-    find-cache-dir "^3.3.1"
-    hasha "^5.2.0"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.0.2"
-    node-fetch "^2.6.0"
-    p-filter "^2.1.0"
-    p-map "^4.0.0"
-    p-retry "^4.2.0"
-    progress "^2.0.3"
-    rimraf "^3.0.2"
-    temp-dir "^2.0.0"
-    tempy "^1.0.0"
-
-"@prisma/generator-helper@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.22.1.tgz#33f4c21ebc2f2daba52c065669d6fba018f36e3d"
-  integrity sha512-m4j/yzdY2z+TI9/pZKsJB/8A+AmJt1JcmIKlFkR8QnuIJZkyl4r9M3CnQNO9VABlzenFs9KP1zo2m4byAndkTA==
-  dependencies:
-    "@prisma/debug" "2.22.1"
+    "@prisma/debug" "2.24.1"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/generator-helper@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.23.0.tgz#464eb51148bb951c43f9e2b9f6b0b113188c129c"
-  integrity sha512-tTRgYK9FreLhHGfteLt0IHpT3YtLl22QgCQ8vSFs5tj2XvvfpLZjVmbSZcRkbej/x97icwkQ4xe4A71ITs0jcA==
+"@prisma/get-platform@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.24.1.tgz#298b53fd9eecb2ff8f4ebd3f0e5f364b097f0753"
+  integrity sha512-x4e9gOdXuJ8nPYFOd2tI3s/WA+8TKpz2QXQcV9HMzVCtG9AQ50JSeNWZ1HesYCJDtQbuEHwo2PuPBtK5k6ohPw==
   dependencies:
-    "@prisma/debug" "2.23.0"
-    "@types/cross-spawn" "^6.0.1"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
+    "@prisma/debug" "2.24.1"
 
-"@prisma/get-platform@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.22.1.tgz#81818939f2bf0c31a35352281b0367dfc43c4c7d"
-  integrity sha512-yQS6KnGS2FtLYre1iW1oGg8xGC39yh+rMoP5l4y6w+dCY0GQ1X5SbOkvioyqtQ0dNXUqAuszUuHl5CaxNQh+Rw==
+"@prisma/sdk@2.24.1":
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.24.1.tgz#be9d94c3d0dddf5670e8b86e7e2575e76bcf7754"
+  integrity sha512-pdJFw/XMzOI1ttz2V6+QG9tyYY+kC8vEtNbabxkgGAfFZgZ0U1j8XB7/ZEOFWD01BJgTQN//DP+uIfmLOkvX1A==
   dependencies:
-    "@prisma/debug" "2.22.1"
-
-"@prisma/get-platform@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.23.0.tgz#f7d14e1f964050ce706148679e1726597e9c43e3"
-  integrity sha512-QLtVZ6Q7fQVwyrcwMg8LEjtbWnXy85MgF7A5STcmzb4t66ShQiMxhaBCRcXP6mlxMVJclbwYQFvq1Uuo03PTsQ==
-  dependencies:
-    "@prisma/debug" "2.23.0"
-
-"@prisma/sdk@2.22.1":
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.22.1.tgz#e797b2b6f8cf2fc4afeb153dbf1277fbbfa08ae6"
-  integrity sha512-JPEVaXDWb6PD96Eys/LWXqRR4UapflaHvR4gubTLTEhxWWtE0Iq2DE9kreGcP+3WIifVwfcybXRzdQS093Iqmg==
-  dependencies:
-    "@prisma/debug" "2.22.1"
-    "@prisma/engine-core" "2.22.1"
-    "@prisma/engines" "2.22.0-21.60cc71d884972ab4e897f0277c4b84383dddaf6c"
-    "@prisma/fetch-engine" "2.22.1"
-    "@prisma/generator-helper" "2.22.1"
-    "@prisma/get-platform" "2.22.1"
-    "@timsuchanek/copy" "^1.4.5"
-    archiver "^4.0.0"
-    arg "^5.0.0"
-    chalk "4.1.1"
-    checkpoint-client "1.1.20"
-    cli-truncate "^2.1.0"
-    dotenv "^8.2.0"
-    execa "^5.0.0"
-    find-up "5.0.0"
-    global-dirs "^3.0.0"
-    globby "^11.0.0"
-    has-yarn "^2.1.0"
-    is-ci "^3.0.0"
-    make-dir "^3.0.2"
-    node-fetch "2.6.1"
-    p-map "^4.0.0"
-    read-pkg-up "^7.0.1"
-    resolve-pkg "^2.0.0"
-    rimraf "^3.0.2"
-    shell-quote "^1.7.2"
-    string-width "^4.2.0"
-    strip-ansi "6.0.0"
-    strip-indent "3.0.0"
-    tar "^6.0.1"
-    temp-dir "^2.0.0"
-    temp-write "^4.0.0"
-    tempy "^1.0.0"
-    terminal-link "^2.1.1"
-    tmp "0.2.1"
-
-"@prisma/sdk@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.23.0.tgz#ea107eb6e8de7b15384217d7cb1c661e893d0eb7"
-  integrity sha512-87wDQUfYYl0RMA/3peWnPe3x0ojgZvpZPp/gQJkG2j6aI/STmzLqlXVwLo8wQlVhzX4y7R9RSW97AgQTH3pJgw==
-  dependencies:
-    "@prisma/debug" "2.23.0"
-    "@prisma/engine-core" "2.23.0"
-    "@prisma/engines" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
-    "@prisma/fetch-engine" "2.23.0"
-    "@prisma/generator-helper" "2.23.0"
-    "@prisma/get-platform" "2.23.0"
+    "@prisma/debug" "2.24.1"
+    "@prisma/engine-core" "2.24.1"
+    "@prisma/engines" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
+    "@prisma/fetch-engine" "2.24.1"
+    "@prisma/generator-helper" "2.24.1"
+    "@prisma/get-platform" "2.24.1"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
@@ -3513,6 +3401,7 @@
     node-fetch "2.6.1"
     p-map "^4.0.0"
     read-pkg-up "^7.0.1"
+    resolve-from "^5.0.0"
     resolve-pkg "^2.0.0"
     rimraf "^3.0.2"
     shell-quote "^1.7.2"
@@ -16661,12 +16550,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.23.0.tgz#6464cca0e085ed23b1815013a67c868eff07a7d2"
-  integrity sha512-3c/lmDy8nsPcEsfCufvCTJUEuwmAcTPbeGg9fL1qjlvS314duLUA/k2nm3n1rq4ImKqzeC5uaKfvI2IoAfwrJA==
+prisma@2.24.1:
+  version "2.24.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.24.1.tgz#f8f4cb8baf407a71800256160277f69603bd43a3"
+  integrity sha512-L+ykMpttbWzpTNsy+PPynnEX/mS1s5zs49euXBrMjxXh1M6/f9MYlTNAj+iP90O9ZSaURSpNa+1jzatPghqUcQ==
   dependencies:
-    "@prisma/engines" "2.23.0-36.adf5e8cba3daf12d456d911d72b6e9418681b28b"
+    "@prisma/engines" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"


### PR DESCRIPTION
Prisma release notes:
- [v2.24.0](https://github.com/prisma/prisma/releases/tag/2.24.0)
- [v2.24.1](https://github.com/prisma/prisma/releases/tag/2.24.1)

Highlights:
- MongoDB gets Json and Enum Support