### PR TITLE
remove preview option from db push

### DIFF
--- a/packages/cli/src/commands/prisma.js
+++ b/packages/cli/src/commands/prisma.js
@@ -52,7 +52,7 @@ export const builder = async (yargs) => {
 
   // Only pass auto flags, when not running help
   if (!hasHelpFlag) {
-    if (['push', 'seed'].includes(argv[1])) {
+    if (['seed'].includes(argv[1])) {
       // this is safe as is if a user also adds --preview-feature
       autoFlags.push('--preview-feature')
     }


### PR DESCRIPTION
The prisma command `db push` is now GA and no longer requires the --preview option to run. This PR updates the rw command to no longer pass the --preview option.