### PR TITLE
Give change milestone PR read-and-write permissions

### DIFF
--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: Update milestone to 'next-release'
+    permissions:
+      pull-requests: read|write
     steps:
       # to use a private action, you have to check out the repo
       - name: Checkout
@@ -32,6 +34,8 @@ jobs:
     if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     name: Remove milestone
+    permissions:
+      pull-requests: read|write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I just merged #2635 which adds a GitHub action for updating a pull request's milestone on merge/close. It looks like that action might fail because it doesn't have the permissions it needs, which is to be able to read (what's the current milestone) and write (change the milestone) pull requests. This PR adds those two permissions to just that GitHub action.

Here's GitHub's docs about permissions:
- https://docs.github.com/en/actions/reference/authentication-in-a-workflow