### PR TITLE
Add vercel routes config for `setup deploy vercel`

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/vercel.js
+++ b/packages/cli/src/commands/setup/deploy/providers/vercel.js
@@ -1,4 +1,23 @@
+import path from 'path'
+
+import { getPaths } from 'src/lib'
+
 export const apiProxyPath = '/api'
+
+const VERCEL_CONFIG = {
+  // spa-redirect, if you prerender, vercel knows to use filesystem first
+  rewrites: [{ source: '/(.*)', destination: '/index.html' }],
+  cleanUrls: true,
+  trailingSlash: false,
+}
+
+// any files to create
+export const files = [
+  {
+    path: path.join(getPaths().base, 'vercel.json'),
+    content: JSON.stringify(VERCEL_CONFIG, undefined, 2), // format it neatly
+  },
+]
 
 // any notes to print out when the job is done
 export const notes = [


### PR DESCRIPTION
### What does it do?
As title

### Why?
Vercel's default config is to redirect to index. However if you prerender some pages, you want it to use the prerendered html at that path if the user visits directly. 