### PR TITLE
Use correct syntax for permisisons

### DIFF
--- a/.github/workflows/proj.yml
+++ b/.github/workflows/proj.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update milestone to 'next-release'
     permissions:
-      pull-requests: read|write
+      pull-requests: write
     steps:
       # to use a private action, you have to check out the repo
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Remove milestone
     permissions:
-      pull-requests: read|write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
`read|write` isn't a valid value for a permission; reducing it to just write, assuming it can also read (it needs to read the PR's current milestone).  