### PR TITLE
Add a way to disable live reload, hot reload & fast refresh.

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -73,6 +73,8 @@ export const handler = async ({
   }
 
   if (side.includes('web')) {
+    forward += getConfig().web.liveReload ? ' ' : ' --liveReload=false'
+
     try {
       await shutdownPort(getConfig().web.port)
     } catch (e) {

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -14,7 +14,6 @@ const baseConfig = merge(webpackConfig('development'), {
   devServer: {
     // https://webpack.js.org/configuration/dev-server/
     hot: redwoodConfig.web.liveReload,
-    watch: redwoodConfig.web.liveReload,
     writeToDisk: false,
     compress: true,
     quiet: true,

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -9,10 +9,12 @@ const webpackConfig = require('./webpack.common')
 const { mergeUserWebpackConfig } = webpackConfig
 const redwoodConfig = getConfig()
 
+/** @type {import('webpack').Configuration} */
 const baseConfig = merge(webpackConfig('development'), {
   devServer: {
     // https://webpack.js.org/configuration/dev-server/
-    hot: true,
+    hot: redwoodConfig.web.liveReload,
+    watch: redwoodConfig.web.liveReload,
     writeToDisk: false,
     compress: true,
     quiet: true,
@@ -42,5 +44,4 @@ const baseConfig = merge(webpackConfig('development'), {
   plugins: [new ErrorOverlayPlugin()].filter(Boolean),
 })
 
-/** @type {import('webpack').Configuration} */
 module.exports = mergeUserWebpackConfig('development', baseConfig)

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -32,6 +32,7 @@ describe('getConfig', () => {
           "apiProxyPort": 8911,
           "fastRefresh": true,
           "host": "localhost",
+          "liveReload": true,
           "path": "./web",
           "port": 8910,
           "target": "browser",

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -30,6 +30,7 @@ interface BrowserTargetConfig {
   // TODO: apiProxyHost: string
   apiProxyPort: number
   apiProxyPath: string
+  liveReload: boolean
   fastRefresh: boolean
   a11y: boolean
 }
@@ -51,6 +52,21 @@ export interface Config {
 
 // Note that web's includeEnvironmentVariables is handled in `webpack.common.js`
 // https://github.com/redwoodjs/redwood/blob/d51ade08118c17459cebcdb496197ea52485364a/packages/core/config/webpack.common.js#L19
+// TODO: All parts of RedwoodJS's config should also be controlled by `RWJS_` env-vars. Document these!
+// RWJS_WEB_PORT='8911'
+// RWJS_ESBUILD='0'
+// RWJS_WEB_OPEN='0'
+
+const liveReload =
+  typeof process.env.RWJS_WEB_LIVE_RELOAD !== 'undefined'
+    ? process.env.RWJS_WEB_LIVE_RELOAD === '1'
+    : true
+
+const fastRefresh =
+  typeof process.env.RWJS_WEB_FAST_REFRESH !== 'undefined'
+    ? process.env.RWJS_WEB_FAST_REFRESH === '1'
+    : true
+
 const DEFAULT_CONFIG: Config = {
   web: {
     host: 'localhost',
@@ -59,7 +75,8 @@ const DEFAULT_CONFIG: Config = {
     target: TargetEnum.BROWSER,
     apiProxyPath: '/.netlify/functions',
     apiProxyPort: 8911,
-    fastRefresh: true,
+    liveReload,
+    fastRefresh: liveReload && fastRefresh,
     a11y: true,
   },
   api: {

--- a/tasks/e2e/cypress/integration/01-tutorial/tutorial.spec.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/tutorial.spec.js
@@ -41,8 +41,9 @@ describe('The Redwood Tutorial - Golden path edition', () => {
 
   it('1. Our First Page', () => {
     //redwoodjs.com/tutorial/our-first-page
-    cy.visit('http://localhost:8910')
     cy.exec(`cd ${BASE_DIR}; yarn redwood generate page home / --force`)
+    cy.visit('http://localhost:8910')
+    cy.reload(true)
     cy.get('h1').should('contain', 'HomePage')
   })
 
@@ -53,12 +54,15 @@ describe('The Redwood Tutorial - Golden path edition', () => {
       path.join(BASE_DIR, 'web/src/pages/HomePage/HomePage.js'),
       Step2_1_PagesHome
     )
+    cy.visit('http://localhost:8910')
+    cy.reload(true)
     cy.contains('About').click()
     cy.get('h1').should('contain', 'AboutPage')
     cy.writeFile(
       path.join(BASE_DIR, 'web/src/pages/AboutPage/AboutPage.js'),
       Step2_2_PagesAbout
     )
+    cy.reload(true)
     cy.get('h1').should('contain', 'Redwood Blog')
     cy.contains('Return home').click()
   })
@@ -74,6 +78,8 @@ describe('The Redwood Tutorial - Golden path edition', () => {
       path.join(BASE_DIR, 'web/src/pages/HomePage/HomePage.js'),
       Step3_3_PagesHome
     )
+    cy.visit('http://localhost:8910')
+    cy.reload(true)
     cy.contains('Redwood Blog').click()
     cy.get('main').should('contain', 'Home')
 
@@ -81,6 +87,7 @@ describe('The Redwood Tutorial - Golden path edition', () => {
       path.join(BASE_DIR, 'web/src/pages/AboutPage/AboutPage.js'),
       Step3_4_PagesAbout
     )
+    cy.reload(true)
     cy.contains('About').click()
     cy.get('p').should(
       'contain',
@@ -169,8 +176,9 @@ describe('The Redwood Tutorial - Golden path edition', () => {
       path.join(BASE_DIR, 'web/src/pages/HomePage/HomePage.js'),
       Step5_3_PagesHome
     )
-    cy.visit('http://localhost:8910/posts/2') // adding step for pause
+    //cy.visit('http://localhost:8910/posts/2') // adding step for pause
     cy.visit('http://localhost:8910/')
+    cy.reload(true)
 
     cy.get('main').should(
       'contain',
@@ -253,6 +261,8 @@ describe('The Redwood Tutorial - Golden path edition', () => {
     )
     cy.writeFile(path.join(BASE_DIR, 'web/src/index.css'), Step7_3_Css)
     cy.writeFile(path.join(BASE_DIR, 'web/src/Routes.js'), Step7_4_Routes)
+
+    cy.visit('http://localhost:8910/')
 
     cy.contains('Contact').click()
     cy.contains('Save').click()

--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -129,11 +129,14 @@ const convertProjectToJavaScript = () => {
 
 const runDevServerInBackground = () => {
   console.log('Starting RedwoodJS dev server...')
-  execa.sync('yarn rw dev --fwd="--open=false" &', {
-    cwd: REDWOOD_PROJECT_DIRECTORY,
-    shell: true,
-    stdio: 'inherit',
-  })
+  execa.sync(
+    'RWJS_WEB_LIVE_RELOAD=0 yarn rw dev --no-generate --fwd="--open=false" &',
+    {
+      cwd: REDWOOD_PROJECT_DIRECTORY,
+      shell: true,
+      stdio: 'inherit',
+    }
+  )
 }
 
 const runCypress = () => {


### PR DESCRIPTION
We are getting a lot of flakey e2e tests: We write or generate a bunch of files and the live reloading mechanisms are a bit too slow for the e2e test runners to pick up all the changes correctly.

We will disable the live reload functionality, write the files to disk, and then manually refresh cypress.

This PR adds an env-var `RWJS_WEB_LIVE_RELOAD=0` that allows you to disable it.

---

Additionally, I would like all aspects of RedwoodJS to be controllable via env-vars. I think we should prefix build and design tool env-vars with `RWJS_{SIDE}`, since we already automatically import `REDWOOD_ENV` env-vars on the web side.

All of these will be documented, but this is a separate issue/ PR.