### PR TITLE
Set dependabot to monthly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     versioning-strategy: "increase"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
+      day: "wednesday"
     open-pull-requests-limit: 20


### PR DESCRIPTION
Myself @thedavidprice, Dom and Danny had a chat about this. @thedavidprice  is the person that handles _all_ of the dependabot things, but I feel like we're getting slaughtered by them every Friday.

I would like to make them monthly whilst we are heading towards `v.1.0.0`. So other options that we can consider:

1. Modify the directory config to update some packages more frequently than others.
2. Use a different process to warn us about packages that are not updated, and upgrade a bunch of them based on the "phase" of development.
