### PR TITLE
Test Project Build: fix lint errors during build

### DIFF
--- a/tasks/test-project/codemods/blogPostsCell.js
+++ b/tasks/test-project/codemods/blogPostsCell.js
@@ -9,7 +9,7 @@ const query = `
     }
 `
 const successBody = `<div className="divide-y divide-grey-700">
-{posts.map((post) => <BlogPost post={post} />)}
+{posts.map((post) => <BlogPost key={post.id} post={post} />)}
 </div>`
 
 export default (file, api) => {

--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -211,6 +211,12 @@ async function webTasks() {
           return execa('yarn rw setup tailwind', [], getExecaOptions())
         },
       },
+      {
+        title: `Running lint`,
+        task: async () => {
+          return execa('yarn rw lint --fix', [], getExecaOptions())
+        },
+      },
     ],
     {
       exitOnError: true,
@@ -277,6 +283,12 @@ async function apiTasks() {
         )
       },
     },
+    {
+      title: `Running lint`,
+      task: async () => {
+        return execa('yarn rw lint --fix', [], getExecaOptions())
+      },
+    },
   ])
 }
 
@@ -304,12 +316,6 @@ const globalTasks = () =>
       {
         title: `Setting up api project`,
         task: () => apiTasks(),
-      },
-      {
-        title: `Running lint`,
-        task: async () => {
-          return execa('yarn rw lint --fix', [], getExecaOptions())
-        },
       },
       {
         title: `Upgrading to latest canary version`,


### PR DESCRIPTION
Fixes #2758

cc @renansoares 

Also, there was a strange import error in Routes.js resulting from jscodeshift adding semicolons by default. For some reason, this breaks the formatting on our generators.

The result was this line of imports mashed up:
```js
import { Router, Route, Set } from '@redwoodjs/router';import PostsLayout from 'src/layouts/PostsLayout'
```

I moved lint to run at the end of both the Web setup and the API setup, which resolved the issue.