### PR TITLE
Use consistent GQL operation name case in cell scaffolds generators

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -362,7 +362,7 @@ exports[`in javascript (default) mode creates a show cell 1`] = `
 "import Post from 'src/components/Post'
 
 export const QUERY = gql\`
-  query FIND_POST_BY_ID($id: Int!) {
+  query FindPostById($id: Int!) {
     post: post(id: $id) {
       id
       title
@@ -855,7 +855,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import PostForm from 'src/components/PostForm'
 
 export const QUERY = gql\`
-  query FIND_POST_BY_ID($id: Int!) {
+  query FindPostById(($id: Int!) {
     post: post(id: $id) {
       id
       title
@@ -924,7 +924,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import UserProfileForm from 'src/components/UserProfileForm'
 
 export const QUERY = gql\`
-  query FIND_USER_PROFILE_BY_ID($id: Int!) {
+  query FindUserProfileById(($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
       username
@@ -1518,7 +1518,7 @@ exports[`in typescript mode creates a show cell 1`] = `
 "import Post from 'src/components/Post'
 
 export const QUERY = gql\`
-  query FIND_POST_BY_ID($id: Int!) {
+  query FindPostById($id: Int!) {
     post: post(id: $id) {
       id
       title
@@ -2011,7 +2011,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import PostForm from 'src/components/PostForm'
 
 export const QUERY = gql\`
-  query FIND_POST_BY_ID($id: Int!) {
+  query FindPostById(($id: Int!) {
     post: post(id: $id) {
       id
       title
@@ -2080,7 +2080,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import UserProfileForm from 'src/components/UserProfileForm'
 
 export const QUERY = gql\`
-  query FIND_USER_PROFILE_BY_ID($id: Int!) {
+  query FindUserProfileById(($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
       username

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -855,7 +855,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import PostForm from 'src/components/PostForm'
 
 export const QUERY = gql\`
-  query FindPostById(($id: Int!) {
+  query FindPostById($id: Int!) {
     post: post(id: $id) {
       id
       title
@@ -924,7 +924,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import UserProfileForm from 'src/components/UserProfileForm'
 
 export const QUERY = gql\`
-  query FindUserProfileById(($id: Int!) {
+  query FindUserProfileById($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
       username
@@ -2011,7 +2011,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import PostForm from 'src/components/PostForm'
 
 export const QUERY = gql\`
-  query FindPostById(($id: Int!) {
+  query FindPostById($id: Int!) {
     post: post(id: $id) {
       id
       title
@@ -2080,7 +2080,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import UserProfileForm from 'src/components/UserProfileForm'
 
 export const QUERY = gql\`
-  query FindUserProfileById(($id: Int!) {
+  query FindUserProfileById($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
       username

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
@@ -4,7 +4,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import ${singularPascalName}Form from 'src/components/${pascalScaffoldPath}${singularPascalName}Form'
 
 export const QUERY = gql`
-  query Find${singularPascalName}ById(($id: ${idType}!) {
+  query Find${singularPascalName}ById($id: ${idType}!) {
     ${singularCamelName}: ${singularCamelName}(id: $id) {<% columns.forEach(column => { %>
       <%= column.name %><% }) %>
     }

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.js.template
@@ -4,7 +4,7 @@ import { navigate, routes } from '@redwoodjs/router'
 import ${singularPascalName}Form from 'src/components/${pascalScaffoldPath}${singularPascalName}Form'
 
 export const QUERY = gql`
-  query FIND_${singularConstantName}_BY_ID($id: ${idType}!) {
+  query Find${singularPascalName}ById(($id: ${idType}!) {
     ${singularCamelName}: ${singularCamelName}(id: $id) {<% columns.forEach(column => { %>
       <%= column.name %><% }) %>
     }

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameCell.js.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameCell.js.template
@@ -1,7 +1,7 @@
 import ${singularPascalName} from 'src/components/${pascalScaffoldPath}${singularPascalName}'
 
 export const QUERY = gql`
-  query FIND_${singularConstantName}_BY_ID($id: ${idType}!) {
+  query Find${singularPascalName}ById($id: ${idType}!) {
     ${singularCamelName}: ${singularCamelName}(id: $id) {<% columns.forEach(column => { %>
       <%= column.name %><% }) %>
     }


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/2764

Andrew Lam from the Discord Community asked:

> Hi, I'm curious what is the reason for using different casing for the name of query and mutation?

![image](https://user-images.githubusercontent.com/1051633/121186875-81b6e100-c835-11eb-95f0-46f45ca10792.png)

There is inconsistency in the operation name casing and redwood could standardize: 

* Pascal Case (OperationName)
* Capitalized Snake Name (OPERATION_NAME)

This PR fixes the edit and view cells such that their templates will have a pascal cased operation name consistency with other queries and mutations.

Change is to use `singularPascalName` instead of `singularConstantName` and change the template surrounding operation name casing:

```
    -   query FIND_USER_PROFILE_BY_ID($id: Int!) {
    +   query FindUserProfileById(($id: Int!) {

    -   query FIND_POST_BY_ID($id: Int!) {
    +   query FindPostById($id: Int!) {
```

Test snapshots also updated. 