### PR TITLE
Adds some minor polish to the TS to JS command

### DIFF
--- a/packages/internal/src/ts2js.ts
+++ b/packages/internal/src/ts2js.ts
@@ -14,6 +14,9 @@ import { getPaths } from './paths'
  */
 export const convertTsProjectToJs = (cwd = getPaths().base) => {
   const files = typeScriptSourceFiles(cwd)
+  if (files.length === 0) {
+    console.log('No TypeScript files found to convert to JS in this project.')
+  }
   for (const f of files) {
     const code = transformTSToJS(f)
     if (code) {
@@ -26,18 +29,17 @@ export const convertTsProjectToJs = (cwd = getPaths().base) => {
     }
   }
 
-  try {
+  if (fs.existsSync(path.join(cwd, 'api/tsconfig.json'))) {
     fs.renameSync(
       path.join(cwd, 'api/tsconfig.json'),
       path.join(cwd, 'api/jsconfig.json')
     )
+  }
+  if (fs.existsSync(path.join(cwd, 'web/tsconfig.json'))) {
     fs.renameSync(
       path.join(cwd, 'web/tsconfig.json'),
       path.join(cwd, 'web/jsconfig.json')
     )
-  } catch (e) {
-    // I want the user to be able to run this command multiple times.
-    console.error(e)
   }
 }
 


### PR DESCRIPTION
I was giving Redwood a test run and ran `yarn rw ts-to-js` on my new project (with no TS or TSConfigs) - what was really weird is that it raised an unexpected exception:

```sh
❯ yarn rw ts-to-js
yarn run v1.22.4
$ /Users/ortatherox/dev/orta/my-redwood-app/node_modules/.bin/rw ts-to-js
Error: ENOENT: no such file or directory, rename '/Users/ortatherox/dev/orta/my-redwood-app/api/tsconfig.json' -> '/Users/ortatherox/dev/orta/my-redwood-app/api/jsconfig.json'
    at Object.renameSync (fs.js:794:3)
    at convertTsProjectToJs (/Users/ortatherox/dev/orta/my-redwood-app/node_modules/@redwoodjs/internal/dist/ts2js.js:44:17)
    at Object.handler (/Users/ortatherox/dev/orta/my-redwood-app/node_modules/@redwoodjs/cli/dist/commands/ts-to-js.js:19:38)
    at Object.runCommand (/Users/ortatherox/dev/orta/my-redwood-app/node_modules/@redwoodjs/cli/node_modules/yargs/build/index.cjs:424:48)
    at Object.parseArgs [as _parseArgs] (/Users/ortatherox/dev/orta/my-redwood-app/node_modules/@redwoodjs/cli/node_modules/yargs/build/index.cjs:2574:57)
    at Object.get [as argv] (/Users/ortatherox/dev/orta/my-redwood-app/node_modules/@redwoodjs/cli/node_modules/yargs/build/index.cjs:2529:25)
    at Object.<anonymous> (/Users/ortatherox/dev/orta/my-redwood-app/node_modules/@redwoodjs/cli/dist/index.js:20:171)
    at Module._compile (internal/modules/cjs/loader.js:1068:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:933:32) {
  errno: -2,
  syscall: 'rename',
  code: 'ENOENT',
  path: '/Users/ortatherox/dev/orta/my-redwood-app/api/tsconfig.json',
  dest: '/Users/ortatherox/dev/orta/my-redwood-app/api/jsconfig.json'
}
✨  Done in 3.13s.

❯ node -v
v14.17.0
```

Looking at the runtime JS, I actually don't really know why that `try` isn't successfully catching the exception but JS works in mysterious ways. 

Anyway, I obviously realized after re-reading the command that this wasn't a 'convert my JS files to TS' command, and so I figured it was trivial to add an fs check. Then while I was there I figured why not also tell people that there were no files to convert so they know they probably did the wrong command like I did.