### PR TITLE
build test project: run canary upgrade earlier in tasks

### DIFF
--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -3,6 +3,7 @@
 //@ts-check
 const fs = require('fs')
 const path = require('path')
+const { title } = require('process')
 
 const execa = require('execa')
 const Listr = require('listr')
@@ -18,7 +19,7 @@ const args = yargs
     describe: 'Generate a TypeScript project. JavaScript by default.',
   })
   .option('canary', {
-    default: false,
+    default: true,
     type: 'boolean',
     describe: 'Upgrade project to latest canary version',
   })
@@ -296,7 +297,7 @@ const globalTasks = () =>
   new Listr(
     [
       {
-        title: `Installing packages`,
+        title: `Installing script packages`,
         task: async () => {
           return execa(
             'yarn install',
@@ -307,7 +308,21 @@ const globalTasks = () =>
       },
       {
         title: `Creating project`,
-        task: () => createProject(),
+        task: () => {
+          return new Listr([
+            {
+              title: `Installing project template and packages`,
+              task: () => createProject(),
+            },
+            {
+              title: `Upgrading to latest canary version`,
+              task: async () => {
+                return execa('yarn rw upgrade -t canary', [], getExecaOptions())
+              },
+              enabled: () => canary,
+            },
+          ])
+        },
       },
       {
         title: `Setting up web project`,
@@ -316,13 +331,6 @@ const globalTasks = () =>
       {
         title: `Setting up api project`,
         task: () => apiTasks(),
-      },
-      {
-        title: `Upgrading to latest canary version`,
-        task: async () => {
-          return execa('yarn rw upgrade -t canary', [], getExecaOptions())
-        },
-        enabled: () => canary,
       },
     ],
     {


### PR DESCRIPTION
_related to work in https://github.com/redwoodjs/redwood/issues/2714_

@renansoares this is a quick-fix to run the upgrade canary command immediately after the project installation. I also set the canary option to be true by default.

I did a minor console display change to make it more apparent that the installation process was running as a part of the project creation.

All just incremental for now. Ideally I think the first `yarn install` wouldn't even run in the create-redwood-project.js and we'd be able to upgrade to canary versions and then install. I just don't know of a simple way to do this (yet).