### PR TITLE
`api/types` ignored in `dev-server`

### DIFF
--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -46,6 +46,7 @@ build({ incremental: true }).then((buildResult) => {
           '.test.ts',
           '.scenarios.ts',
           '.scenarios.js',
+          '.api/types/*',
         ].some((ext) => file.endsWith(ext)),
     })
     .on('ready', async () => {

--- a/packages/dev-server/src/watchApiSide.ts
+++ b/packages/dev-server/src/watchApiSide.ts
@@ -66,6 +66,7 @@ export const watchFunctions = ({
 
   const watcher = chokidar.watch(paths.base, {
     ignored: (file: string) =>
+      file.includes('api/types/*')&&
       file.includes('node_modules') ||
       WATCHER_IGNORE_EXTENSIONS.some((ext) => file.endsWith(ext)),
   })


### PR DESCRIPTION
Fix #2750 

