### PR TITLE
Add `apiURL` and `apiGraphQLServerPath` to redwood.toml.

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -110,24 +110,25 @@ export class AuthProvider extends React.Component<
     return this.reauthenticate()
   }
 
+  getApiGraphQLUrl = () => {
+    return global.REDWOOD_API_URL + global.REDWOOD_API_GRAPHQL_SERVER_PATH
+  }
+
   getCurrentUser = async (): Promise<Record<string, unknown>> => {
     // Always get a fresh token, rather than use the one in state
     const token = await this.getToken()
-    const response = await global.fetch(
-      `${global.__REDWOOD__API_PROXY_PATH}/graphql`,
-      {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'auth-provider': this.rwClient.type,
-          authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
-          query:
-            'query __REDWOOD__AUTH_GET_CURRENT_USER { redwood { currentUser } }',
-        }),
-      }
-    )
+    const response = await global.fetch(this.getApiGraphQLUrl(), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'auth-provider': this.rwClient.type,
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        query:
+          'query __REDWOOD__AUTH_GET_CURRENT_USER { redwood { currentUser } }',
+      }),
+    })
 
     if (response.ok) {
       const { data } = await response.json()

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -16,7 +16,8 @@ let CURRENT_USER_DATA: { name: string; email: string; roles?: string[] } = {
   email: 'nospam@example.net',
 }
 
-window.__REDWOOD__API_PROXY_PATH = '/.netlify/functions'
+global.REDWOOD_API_URL = '/.netlify/functions'
+global.REDWOOD_API_GRAPHQL_SERVER_PATH = '/graphql'
 const server = setupServer(
   graphql.query('__REDWOOD__AUTH_GET_CURRENT_USER', (_req, res, ctx) => {
     return res(

--- a/packages/auth/src/useAuth.ts
+++ b/packages/auth/src/useAuth.ts
@@ -12,7 +12,8 @@ declare global {
   namespace NodeJS {
     interface Global {
       __REDWOOD__USE_AUTH: () => AuthContextInterface
-      __REDWOOD__API_PROXY_PATH: string
+      REDWOOD_API_URL: string
+      REDWOOD_API_GRAPHQL_SERVER_PATH: string
     }
   }
 }

--- a/packages/cli/src/commands/setup/deploy/deploy.js
+++ b/packages/cli/src/commands/setup/deploy/deploy.js
@@ -15,22 +15,19 @@ const SUPPORTED_PROVIDERS = fs
   .map((file) => path.basename(file, '.js'))
   .filter((file) => file !== 'README.md')
 
-const updateProxyPath = (newProxyPath) => {
+const updateApiURL = (apiURL) => {
   const redwoodToml = fs.readFileSync(REDWOOD_TOML_PATH).toString()
   let newRedwoodToml = redwoodToml
 
-  if (redwoodToml.match(/apiProxyPath/)) {
-    newRedwoodToml = newRedwoodToml.replace(
-      /apiProxyPath.*/g,
-      `apiProxyPath = "${newProxyPath}"`
-    )
+  if (redwoodToml.match(/apiURL/)) {
+    newRedwoodToml = newRedwoodToml.replace(/apiURL.*/g, `apiURL = "${apiURL}"`)
   } else if (redwoodToml.match(/\[web\]/)) {
     newRedwoodToml = newRedwoodToml.replace(
       /\[web\]/,
-      `[web]\n  apiProxyPath = "${newProxyPath}"`
+      `[web]\n  apiURL = "${apiURL}"`
     )
   } else {
-    newRedwoodToml += `[web]\n  apiProxyPath = "${newProxyPath}"`
+    newRedwoodToml += `[web]\n  apiURL = "${apiURL}"`
   }
 
   fs.writeFileSync(REDWOOD_TOML_PATH, newRedwoodToml)
@@ -150,10 +147,10 @@ export const handler = async ({ provider, force, database }) => {
           await execa('yarn', ['install'])
         },
       },
-      providerData?.apiProxyPath && {
-        title: 'Updating apiProxyPath...',
+      providerData?.apiURL && {
+        title: 'Updating API URL...',
         task: async () => {
-          updateProxyPath(providerData.apiProxyPath)
+          updateApiURL(providerData.apiURL)
         },
       },
       providerData?.files?.length && {

--- a/packages/cli/src/commands/setup/deploy/providers/aws-serverless.js
+++ b/packages/cli/src/commands/setup/deploy/providers/aws-serverless.js
@@ -52,17 +52,17 @@ ${
     memorySize: 1024 # mb
     timeout: 25 # seconds (max: 29)
     tags: # Tags for this specific lambda function
-      endpoint: ${config.web.apiProxyPath}/${basename}
+      endpoint: ${config.web.apiURL}/${basename}
     # Uncomment this section to add environment variables either from the Serverless dotenv plugin or using Serverless params
     # environment:
     #   YOUR_FIRST_ENV_VARIABLE: \${env:YOUR_FIRST_ENV_VARIABLE}
     handler: ${basename}.handler
     events:
       - httpApi:
-          path: ${config.web.apiProxyPath}/${basename}
+          path: ${config.web.apiURL}/${basename}
           method: GET
       - httpApi:
-          path: ${config.web.apiProxyPath}/${basename}
+          path: ${config.web.apiURL}/${basename}
           method: POST
 `
     })

--- a/packages/cli/src/commands/setup/deploy/providers/netlify.js
+++ b/packages/cli/src/commands/setup/deploy/providers/netlify.js
@@ -32,7 +32,7 @@ export const files = [
   { path: path.join(getPaths().base, 'netlify.toml'), content: NETLIFY_TOML },
 ]
 
-export const apiProxyPath = '/.netlify/functions'
+export const apiURL = '/.netlify/functions'
 
 // any notes to print out when the job is done
 export const notes = [

--- a/packages/cli/src/commands/setup/deploy/providers/render.js
+++ b/packages/cli/src/commands/setup/deploy/providers/render.js
@@ -129,7 +129,7 @@ export const files = [
   },
 ]
 
-export const apiProxyPath = '/.redwood/functions'
+export const apiURL = '/.redwood/functions'
 
 // any notes to print out when the job is done
 export const notes = [

--- a/packages/cli/src/commands/setup/deploy/providers/vercel.js
+++ b/packages/cli/src/commands/setup/deploy/providers/vercel.js
@@ -1,4 +1,4 @@
-export const apiProxyPath = '/api'
+export const apiURL = '/api'
 
 // any notes to print out when the job is done
 export const notes = [

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -145,7 +145,10 @@ const getSharedPlugins = (isEnvProduction) => {
     // The define plugin will replace these keys with their values during build
     // time.
     new webpack.DefinePlugin({
-      __REDWOOD__API_PROXY_PATH: JSON.stringify(redwoodConfig.web.apiProxyPath),
+      ['process.env.REDWOOD_API_URL']: JSON.stringify(redwoodConfig.web.apiURL),
+      ['process.env.REDWOOD_API_GRAPHQL_SERVER_PATH']: JSON.stringify(
+        redwoodConfig.web.apiGraphQLServerPath
+      ),
       ...getEnvVars(),
     }),
     new Dotenv({

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -9,6 +9,43 @@ const webpackConfig = require('./webpack.common')
 const { mergeUserWebpackConfig } = webpackConfig
 const redwoodConfig = getConfig()
 
+const getProxyConfig = () => {
+  const { apiURL } = redwoodConfig.web
+  const { port } = redwoodConfig.api
+
+  if (apiURL.startsWith('/')) {
+    // Redwood only proxies absolute paths.
+    return {
+      [apiURL]: {
+        target: `http://[::1]:${port}`,
+        pathRewrite: {
+          // Eg: Rewrite `/.netlify/functions/graphql` to `/graphql`, which the api-server expects
+          [`^${escapeRegExp(apiURL)}`]: '',
+        },
+        headers: {
+          Connection: 'keep-alive',
+        },
+      },
+    }
+  }
+
+  if (apiURL.includes('://')) {
+    // A developer may want to point their development environment to a staging or production GraphQL server.
+    // They have specified an absolute URI,
+    // which would contain `://`, `http://`, or `https://`
+    //
+    // So don't proxy anything.
+    return undefined
+  }
+
+  console.error('Error: `apiURL` is configured incorrectly.')
+  console.error(
+    'It should be an absolute path (thats starts with `/`) or an absolute URI that starts with `http[s]://`'
+  )
+  process.exit(1)
+}
+
+/** @type {import('webpack').Configuration} */
 const baseConfig = merge(webpackConfig('development'), {
   devServer: {
     // https://webpack.js.org/configuration/dev-server/
@@ -19,17 +56,7 @@ const baseConfig = merge(webpackConfig('development'), {
     historyApiFallback: true,
     host: redwoodConfig.web.host || 'localhost',
     port: redwoodConfig.web.port,
-    proxy: {
-      [redwoodConfig.web.apiProxyPath]: {
-        target: `http://[::1]:${redwoodConfig.api.port}`,
-        pathRewrite: {
-          [`^${escapeRegExp(redwoodConfig.web.apiProxyPath)}`]: '',
-        },
-        headers: {
-          Connection: 'keep-alive',
-        },
-      },
-    },
+    proxy: getProxyConfig(),
     inline: true,
     overlay: true,
     open: redwoodConfig.browser.open,
@@ -42,5 +69,4 @@ const baseConfig = merge(webpackConfig('development'), {
   plugins: [new ErrorOverlayPlugin()].filter(Boolean),
 })
 
-/** @type {import('webpack').Configuration} */
 module.exports = mergeUserWebpackConfig('development', baseConfig)

--- a/packages/create-redwood-app/template/redwood.toml
+++ b/packages/create-redwood-app/template/redwood.toml
@@ -7,7 +7,8 @@
 
 [web]
   port = 8910
-  apiProxyPath = "/.redwood/functions"
+  apiURL = '/.netlify/functions'
+  apiGraphQLServerPath = '/graphql'
 [api]
   port = 8911
 [browser]

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -29,8 +29,8 @@ describe('getConfig', () => {
         },
         "web": Object {
           "a11y": true,
-          "apiProxyPath": "/.netlify/functions",
-          "apiProxyPort": 8911,
+          "apiGraphQLServerPath": "/graphql",
+          "apiURL": "/.netlify/functions",
           "fastRefresh": true,
           "host": "localhost",
           "path": "./web",

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -27,9 +27,25 @@ interface BrowserTargetConfig {
   port: number
   path: string
   target: TargetEnum.BROWSER
-  // TODO: apiProxyHost: string
-  apiProxyPort: number
-  apiProxyPath: string
+  /**
+   * Specify the URL to your api-server.
+   * This can be an absolute path proxied on the current domain (`/.netlify/functions`),
+   * or a fully qualified URL (`https://api.example.org:8911/functions`).
+   *
+   * Note: This shoulld not include the path to the GraphQL Server,
+   * `apiURL` and `apiGraphQLServerPath` are combined to determine the exact
+   * URL.
+   **/
+  apiURL: string
+  /**
+   * The URL relative to the `apiURL` that specifies the location to Redwood
+   * GraphQL Server.
+   **/
+  apiGraphQLServerPath: string
+  /**  @deprecated - use `apiHost` and `apiGraphQLServerPath` instead. */
+  apiProxyPort?: number
+  /**  @deprecated - use `apiHost` and `apiGraphQLServerPath` instead. */
+  apiProxyPath?: string
   fastRefresh: boolean
   a11y: boolean
 }
@@ -58,8 +74,8 @@ const DEFAULT_CONFIG: Config = {
     port: 8910,
     path: './web',
     target: TargetEnum.BROWSER,
-    apiProxyPath: '/.netlify/functions',
-    apiProxyPort: 8911,
+    apiURL: '/.netlify/functions',
+    apiGraphQLServerPath: '/graphql',
     fastRefresh: true,
     a11y: true,
   },

--- a/packages/prerender/src/internal.ts
+++ b/packages/prerender/src/internal.ts
@@ -18,7 +18,9 @@ export const getRootHtmlPath = () => {
 }
 
 export const registerShims = () => {
-  global.__REDWOOD__API_PROXY_PATH = getConfig().web.apiProxyPath
+  const rwjsConfig = getConfig()
+  global.REDWOOD_API_URL = rwjsConfig.web.apiURL
+  global.REDWOOD_API_GRAPHQL_SERVER_PATH = rwjsConfig.web.apiGraphQLServerPath
 
   global.__REDWOOD__USE_AUTH = () =>
     ({

--- a/packages/testing/config/jest/web/index.js
+++ b/packages/testing/config/jest/web/index.js
@@ -11,7 +11,8 @@ module.exports = {
     name: 'web',
   },
   globals: {
-    __REDWOOD__API_PROXY_PATH: '/',
+    REDWOOD_API_URL: '',
+    REDWOOD_API_GRAPHQL_SERVER_PATH: '/',
   },
   setupFilesAfterEnv: [path.resolve(__dirname, './jest.setup.js')],
   moduleNameMapper: {

--- a/packages/web/src/components/FetchConfigProvider.test.tsx
+++ b/packages/web/src/components/FetchConfigProvider.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react'
 import type { AuthContextInterface } from '@redwoodjs/auth'
 import '@testing-library/jest-dom/extend-expect'
 
-// @ts-expect-error Mocking api proxy path for test
-global.__REDWOOD__API_PROXY_PATH = 'https://api.example.com'
+global.REDWOOD_API_URL = 'https://api.example.com'
+global.REDWOOD_API_GRAPHQL_SERVER_PATH = '/graphql'
 
 import { FetchConfigProvider, useFetchConfig } from './FetchConfigProvider'
 

--- a/packages/web/src/components/FetchConfigProvider.tsx
+++ b/packages/web/src/components/FetchConfigProvider.tsx
@@ -1,11 +1,16 @@
 import type { AuthContextInterface, SupportedAuthTypes } from '@redwoodjs/auth'
 
+export const getApiGraphQLUrl = () => {
+  return global.REDWOOD_API_URL + global.REDWOOD_API_GRAPHQL_SERVER_PATH
+}
+
 export interface FetchConfig {
   uri: string
   headers?: { 'auth-provider': SupportedAuthTypes; authorization?: string }
 }
+
 export const FetchConfigContext = React.createContext<FetchConfig>({
-  uri: `${global.__REDWOOD__API_PROXY_PATH}/graphql`,
+  uri: getApiGraphQLUrl(),
 })
 
 const defaultAuthState = { loading: false, isAuthenticated: false }
@@ -28,7 +33,7 @@ export const FetchConfigProvider: React.FunctionComponent<{
   if (!isAuthenticated) {
     return (
       <FetchConfigContext.Provider
-        value={{ uri: `${global.__REDWOOD__API_PROXY_PATH}/graphql` }}
+        value={{ uri: getApiGraphQLUrl() }}
         {...rest}
       />
     )
@@ -37,7 +42,7 @@ export const FetchConfigProvider: React.FunctionComponent<{
   return (
     <FetchConfigContext.Provider
       value={{
-        uri: `${global.__REDWOOD__API_PROXY_PATH}/graphql`,
+        uri: getApiGraphQLUrl(),
         headers: {
           'auth-provider': type,
         },

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -1,7 +1,4 @@
-/* eslint-disable no-undef */
-// The value is read from `redwood.toml`
-// @ts-expect-error This is replaced at build time by Webpack Define Plugin.
-if (typeof __REDWOOD__API_PROXY_PATH !== 'undefined') {
-  // @ts-expect-error-next-line
-  global.__REDWOOD__API_PROXY_PATH = __REDWOOD__API_PROXY_PATH
-}
+// The `process.env.*` values are replaced by webpack at build time.
+global.REDWOOD_API_URL = process.env.REDWOOD_API_URL as string
+global.REDWOOD_API_GRAPHQL_SERVER_PATH = process.env
+  .REDWOOD_API_GRAPHQL_SERVER_PATH as string

--- a/packages/web/src/global.web-auto-imports.ts
+++ b/packages/web/src/global.web-auto-imports.ts
@@ -9,7 +9,8 @@ declare global {
   const gql: typeof _gql
 
   interface Window {
-    __REDWOOD__API_PROXY_PATH: string
+    REDWOOD_API_URL: string
+    REDWOOD_API_GRAPHQL_SERVER_PATH: string
   }
 
   // Overridable graphQL hook return types

--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -129,7 +129,7 @@ const convertProjectToJavaScript = () => {
 
 const runDevServerInBackground = () => {
   console.log('Starting RedwoodJS dev server...')
-  execa.sync('yarn rw dev --fwd="--open=false" &', {
+  execa.sync('yarn rw dev --no-generate --fwd="--open=false" &', {
     cwd: REDWOOD_PROJECT_DIRECTORY,
     shell: true,
     stdio: 'inherit',


### PR DESCRIPTION
Closes #478 

This deprecates `apiProxyPath` and adds two new configuration options:

- `apiURL` which can be an absolute path or an absolute URL to the api-server. Webpack-dev-server will proxy absolute paths, but do nothing for absolute URLs. So a developer could point their development machine to a GraphQL server running on a different machine.
- `apiGraphQLServerPath` is used in combination with `apiURL` to reference the URI of the GraphQL Server.


- [ ] Determine if `apiURL` name is correct
- [ ] Figure out how to deal with `rw serve web`