### PR TITLE
Router: Remove RouteScanner, don't store all routes in context

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,10 +1,9 @@
 import React, { ReactElement, ReactNode, useCallback } from 'react'
 
 import { Redirect } from './links'
-import { useLocation } from './location'
-import { isRoute, routes as namedRoutes } from './router'
+import { InternalRouteProps, isRoute, routes as namedRoutes } from './router'
 import { useRouterState } from './router-context'
-import { flattenAll, matchPath } from './util'
+import { flattenAll } from './util'
 
 type WrapperType<WTProps> = (
   props: WTProps & { children: ReactNode }
@@ -46,7 +45,6 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
     ...rest
   } = props
   const routerState = useRouterState()
-  const location = useLocation()
   const { loading, isAuthenticated, hasRole } = routerState.useAuth()
 
   if (privateSet && !unauthenticated) {
@@ -62,53 +60,39 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   // Make sure `wrappers` is always an array with at least one wrapper component
   const wrappers = Array.isArray(wrap) ? wrap : [wrap ? wrap : IdentityWrapper]
   const flatChildArray = flattenAll(children)
-  const routes = flatChildArray
-    .filter(isRoute)
-    .filter((r) => typeof r.props.path !== 'undefined')
+  const route = flatChildArray.find(
+    (child): child is React.ReactElement<InternalRouteProps> => isRoute(child)
+  )
 
-  for (const route of routes) {
-    const path = route.props.path as string
+  if (privateSet && unauthorized()) {
+    if (loading) {
+      return route?.props?.whileLoading?.() || null
+    } else {
+      const currentLocation =
+        global.location.pathname + encodeURIComponent(global.location.search)
 
-    const { match } = matchPath(path, location.pathname, routerState.paramTypes)
-    if (!match) {
-      continue
-    }
+      // We already have a check for !unauthenticated further up
+      const unauthenticatedPath = namedRoutes[unauthenticated || '']()
 
-    if (privateSet && unauthorized()) {
-      if (loading) {
-        return route.props?.whileLoading?.() || null
-      } else {
-        const currentLocation =
-          global.location.pathname + encodeURIComponent(global.location.search)
-
-        // We already have a check for !unauthenticated further up
-        const unauthenticatedPath = namedRoutes[unauthenticated || '']()
-
-        if (!unauthenticatedPath) {
-          throw new Error(`We could not find a route named ${unauthenticated}`)
-        }
-
-        return (
-          <Redirect
-            to={`${unauthenticatedPath}?redirectTo=${currentLocation}`}
-          />
-        )
+      if (!unauthenticatedPath) {
+        throw new Error(`We could not find a route named ${unauthenticated}`)
       }
-    }
 
-    // Expand and nest the wrapped elements.
-    return (
-      wrappers.reduceRight<ReduceType>((acc, wrapper) => {
-        return React.createElement(wrapper, {
-          ...rest,
-          children: acc ? acc : children,
-        } as SetProps<WrapperProps>)
-      }, undefined) || null
-    )
+      return (
+        <Redirect to={`${unauthenticatedPath}?redirectTo=${currentLocation}`} />
+      )
+    }
   }
 
-  // No match, no render.
-  return null
+  // Expand and nest the wrapped elements.
+  return (
+    wrappers.reduceRight<ReduceType>((acc, wrapper) => {
+      return React.createElement(wrapper, {
+        ...rest,
+        children: acc ? acc : children,
+      } as SetProps<WrapperProps>)
+    }, undefined) || null
+  )
 }
 
 type PrivateProps<P> = Omit<

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -10,24 +10,22 @@ export interface ParamsContextProps {
 
 export const ParamsContext = createNamedContext<ParamsContextProps>('Params')
 
-export const ParamsProvider: React.FC = ({ children }) => {
-  const { routes, paramTypes } = useRouterState()
+interface Props {
+  path?: string
+}
+
+export const ParamsProvider: React.FC<Props> = ({ path, children }) => {
+  const { paramTypes } = useRouterState()
   const location = useLocation()
 
   let pathParams = {}
   const searchParams = parseSearch(location.search)
 
-  for (const route of routes) {
-    if (route.path) {
-      const { match, params } = matchPath(
-        route.path,
-        location.pathname,
-        paramTypes
-      )
+  if (path) {
+    const { match, params } = matchPath(path, location.pathname, paramTypes)
 
-      if (match && typeof params !== 'undefined') {
-        pathParams = params
-      }
+    if (match && typeof params !== 'undefined') {
+      pathParams = params
     }
   }
 

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -3,8 +3,6 @@ import React, { useReducer, createContext, useContext } from 'react'
 import { useAuth } from '@redwoodjs/auth'
 
 import type { ParamType } from 'src/internal'
-import { isRoute, PageType } from 'src/router'
-import { flattenAll } from 'src/util'
 
 const DEFAULT_PAGE_LOADING_DELAY = 1000 // milliseconds
 
@@ -12,7 +10,6 @@ export interface RouterState {
   paramTypes?: Record<string, ParamType>
   pageLoadingDelay?: number
   useAuth: typeof useAuth
-  routes: Array<{ name?: string; path?: string; page?: PageType }>
 }
 
 const RouterStateContext = createContext<RouterState | undefined>(undefined)
@@ -25,7 +22,7 @@ const RouterSetContext =
   createContext<React.Dispatch<Partial<RouterState>> | undefined>(undefined)
 
 export interface RouterContextProviderProps
-  extends Omit<RouterState, 'useAuth' | 'routes'> {
+  extends Omit<RouterState, 'useAuth'> {
   useAuth?: typeof useAuth
 }
 
@@ -39,19 +36,10 @@ export const RouterContextProvider: React.FC<RouterContextProviderProps> = ({
   pageLoadingDelay = DEFAULT_PAGE_LOADING_DELAY,
   children,
 }) => {
-  // Create an internal representation of all the routes and paths.
-  const routes = flattenAll(children)
-    .filter(isRoute)
-    .map((route) => {
-      const { name, path, page } = route.props
-      return { name, path, page }
-    })
-
   const [state, setState] = useReducer(stateReducer, {
     useAuth: customUseAuth || useAuth,
     paramTypes,
     pageLoadingDelay,
-    routes,
   })
 
   return (

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -205,6 +205,10 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
       paramTypes={paramTypes}
       pageLoadingDelay={pageLoadingDelay}
     >
+      {/* TS doesn't "see" the assignment to `activeRoute` inside the callback
+          above. So it's type is `never`. And you can't access attributes
+          (props in this case) on `never`. There is an open issue about not
+          seeing the assignment */}
       {/* @ts-expect-error - https://github.com/microsoft/TypeScript/issues/11498 */}
       <ParamsProvider path={activeRoute?.props?.path}>
         {!activeRoute && NotFoundPage ? (

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -51,7 +51,7 @@ interface NotFoundRouteProps {
   prerender?: boolean
 }
 
-type InternalRouteProps = Partial<
+export type InternalRouteProps = Partial<
   RouteProps & RedirectRouteProps & NotFoundRouteProps
 >
 
@@ -132,7 +132,25 @@ const Router: React.FC<RouterProps> = ({
   paramTypes,
   pageLoadingDelay,
   children,
+}) => (
+  <LocationProvider>
+    <LocationAwareRouter
+      useAuth={useAuth}
+      paramTypes={paramTypes}
+      pageLoadingDelay={pageLoadingDelay}
+    >
+      {children}
+    </LocationAwareRouter>
+  </LocationProvider>
+)
+
+const LocationAwareRouter: React.FC<RouterProps> = ({
+  useAuth,
+  paramTypes,
+  pageLoadingDelay,
+  children,
 }) => {
+  const { pathname } = useLocation()
   const flatChildArray = flattenAll(children)
   const shouldShowSplash =
     flatChildArray.length === 1 &&
@@ -158,22 +176,51 @@ const Router: React.FC<RouterProps> = ({
     }
   })
 
+  let activeRoute = undefined
+  let NotFoundPage: PageType | undefined = undefined
+
+  const activeChildren = activeRouteTree(children, (child) => {
+    if (child.props.path) {
+      const { match } = matchPath(child.props.path, pathname, paramTypes)
+
+      if (match) {
+        activeRoute = child
+
+        // No need to loop further. As soon as we have a matching route we have
+        // all the info we need
+        return true
+      }
+    }
+
+    if (child.props.notfound && child.props.page) {
+      NotFoundPage = child.props.page
+    }
+
+    return false
+  })
+
   return (
     <RouterContextProvider
       useAuth={useAuth}
       paramTypes={paramTypes}
       pageLoadingDelay={pageLoadingDelay}
     >
-      <LocationProvider>
-        <ParamsProvider>
-          <RouteScanner>{children}</RouteScanner>
-        </ParamsProvider>
-      </LocationProvider>
+      {/* @ts-expect-error - https://github.com/microsoft/TypeScript/issues/11498 */}
+      <ParamsProvider path={activeRoute?.props?.path}>
+        {!activeRoute && NotFoundPage ? (
+          <PageLoader
+            spec={normalizePage(NotFoundPage)}
+            delay={pageLoadingDelay}
+          />
+        ) : (
+          activeRoute && activeChildren
+        )}
+      </ParamsProvider>
     </RouterContextProvider>
   )
 }
 
-/**
+/*
  * Find the active (i.e. first matching) route and discard any other routes.
  * Also, keep any <Set>s wrapping the active route.
  */
@@ -220,51 +267,6 @@ function activeRouteTree(
     },
     []
   )
-}
-
-const RouteScanner: React.FC = ({ children }) => {
-  const location = useLocation()
-  const routerState = useRouterState()
-
-  let foundMatchingRoute = false
-  let NotFoundPage: PageType | undefined = undefined
-
-  const filteredChildren = activeRouteTree(children, (child) => {
-    const { path } = child.props
-
-    if (path) {
-      const { match } = matchPath(
-        path,
-        location.pathname,
-        routerState.paramTypes
-      )
-
-      if (match) {
-        foundMatchingRoute = true
-
-        // No need to loop further. As soon as we have a matching route we have
-        // all the info we need
-        return true
-      }
-    }
-
-    if (child.props.notfound && child.props.page) {
-      NotFoundPage = child.props.page
-    }
-
-    return false
-  })
-
-  if (!foundMatchingRoute && NotFoundPage) {
-    return (
-      <PageLoader
-        spec={normalizePage(NotFoundPage)}
-        delay={routerState.pageLoadingDelay}
-      />
-    )
-  }
-
-  return <>{filteredChildren}</>
 }
 
 function isSpec(specOrPage: Spec | React.ComponentType): specOrPage is Spec {


### PR DESCRIPTION
Doing some reorganization and simplification of the code. This is a continuation of #2795 

* Remove RouteScanner and just move the functionality into a function instead
* Now that we only have the one active route as children, there is much less need of looping through all routes
* No need to store all routes in context anymore
* Added a couple of tests for things I ran into when refactoring


I've added some review comments to try and explain the changes I've made. Hope it helps.