### PR TITLE
revert change to `rw info` command; use glob

### DIFF
--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -20,7 +20,7 @@ export const handler = async () => {
       Binaries: ['Node', 'Yarn'],
       Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
       // yarn workspaces not supported :-/
-      npmPackages: ['@redwoodjs/cli'],
+      npmPackages: '@redwoodjs/*',
       Databases: ['SQLite'],
     })
     console.log(output)


### PR DESCRIPTION
The `rw info` command was looking for a specific `@redwoodjs/` package to report the version number, which became out of sync due to a change in #2769 that was reverted in #2825

Turns out we can use glob (which I should have done originally) to get any/all `@redwoodjs` packages in root package.json. Doing that now!