### PR TITLE
Adds generate gql types to gitignore

### DIFF
--- a/packages/create-redwood-app/template/gitignore.template
+++ b/packages/create-redwood-app/template/gitignore.template
@@ -9,3 +9,5 @@ dist-babel
 node_modules
 yarn-error.log
 web/public/mockServiceWorker.js
+web/types/graphql.d.ts
+api/types/graphql.d.ts


### PR DESCRIPTION
Generated gql types should now be ignored.

### **Codemod for existing users**
1. Add the following lines to your `.gitignore`
```
web/types/graphql.d.ts
api/types/graphql.d.ts
```
2. Now lets remove tracking these generated types from your git history. In your terminal run
```
git rm --cached api/types/graphql.d.ts web/types/graphql.d.ts
```


**Note** supercedes PR from peter here: #2807