### PR TITLE
Add information about --cwd to contributors documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,39 @@ Then you can test the effects of your changes. Unfortunately, each time you make
 
 When you're done, you can restore your Redwood App to its original state by deleting `./node_modules`, `web/node_modules`, and `api/node_modules`, then running `yarn install`.
 
+#### Option 4: Testing the CLI
+
+If you've made build or design time changes to RedwoodJS, that is if you have modified one of the following packages:
+
+```terminal
+./packages/
+├ api-server
+├ cli
+├ core
+├ dev-server
+├ eslint-config
+├ internal
+├ prerender
+├ structure
+├ testing
+```
+
+
+You can run a development version of the CLI directly from the framework's repo where you don't have to sync any files or node modules.
+
+(For all of the packages above the entry point is the CLI, these are what we consider "build time" and "design time" packages, rather than "run-time" packages which are web, auth, api, forms.)
+
+In order to do that you use the `--cwd` option to set the current working directory to your "test project":
+
+```terminal
+yarn build
+cd packages/cli
+yarn dev --cwd /path/to/your/project
+```
+The `yarn dev` script will build the CLI package and the `--cwd` option will make the command run in that directory. Remember to rebuild the packages if you have made a change to the code! (Tip: You can use `yarn build:watch` to automatically build the framework whilst you're making changes.)
+
+(Tip: --cwd is optional, it will reference the `__fixtures__/example-todo-main` project in the framework.)
+
 #### Specifying a RW_PATH
 
 You can avoid having to provide the path to `redwood` by defining an `RW_PATH` environment variable on your system.


### PR DESCRIPTION
This adds the following to the contributors documentation:

----

#### Option 4: Testing the CLI

If you've made build or design time changes to RedwoodJS, that is if you have modified one of the following packages:

```terminal
./packages/
├ api-server
├ cli
├ core
├ dev-server
├ eslint-config
├ internal
├ prerender
├ structure
├ testing
```


You can run a development version of the CLI directly from the framework's repo where you don't have to sync any files or node modules.

(For all of the packages above the entry point is the CLI, these are what we consider "build time" and "design time" packages, rather than "run-time" packages which are web, auth, api, forms.)

In order to do that you use the `--cwd` option to set the current working directory to your "test project":

```terminal
yarn build
cd packages/cli
yarn dev --cwd /path/to/your/project
```
The `yarn dev` script will build the CLI package and the `--cwd` option will make the command run in that directory. Remember to rebuild the packages if you have made a change to the code! (Tip: You can use `yarn build:watch` to automatically build the framework whilst you're making changes.)

(Tip: --cwd is optional, it will reference the `__fixtures__/example-todo-main` project in the framework.)

----