### PR TITLE
Fix directory named module imports mirror generation

### DIFF
--- a/packages/internal/src/__tests__/files.test.ts
+++ b/packages/internal/src/__tests__/files.test.ts
@@ -44,9 +44,18 @@ test('finds directory named modules', () => {
     Array [
       "api/src/services/todos/todos.js",
       "web/src/components/AddTodo/AddTodo.js",
+      "web/src/components/AddTodoControl/AddTodoControl.js",
       "web/src/components/Check/Check.js",
+      "web/src/components/TableCell/TableCell.js",
       "web/src/components/TodoItem/TodoItem.js",
       "web/src/layouts/SetLayout/SetLayout.js",
+      "web/src/pages/BarPage/BarPage.tsx",
+      "web/src/pages/FatalErrorPage/FatalErrorPage.js",
+      "web/src/pages/FooPage/FooPage.tsx",
+      "web/src/pages/HomePage/HomePage.tsx",
+      "web/src/pages/NotFoundPage/NotFoundPage.js",
+      "web/src/pages/TypeScriptPage/TypeScriptPage.tsx",
+      "web/src/pages/admin/EditUserPage/EditUserPage.jsx",
     ]
   `)
 })

--- a/packages/internal/src/__tests__/typeDefinitions.test.ts
+++ b/packages/internal/src/__tests__/typeDefinitions.test.ts
@@ -75,9 +75,18 @@ test('generate the correct mirror types for directory named modules', () => {
     Array [
       ".redwood/types/mirror/api/src/services/todos/index.d.ts",
       ".redwood/types/mirror/web/src/components/AddTodo/index.d.ts",
+      ".redwood/types/mirror/web/src/components/AddTodoControl/index.d.ts",
       ".redwood/types/mirror/web/src/components/Check/index.d.ts",
+      ".redwood/types/mirror/web/src/components/TableCell/index.d.ts",
       ".redwood/types/mirror/web/src/components/TodoItem/index.d.ts",
       ".redwood/types/mirror/web/src/layouts/SetLayout/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/BarPage/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/FatalErrorPage/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/FooPage/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/HomePage/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/NotFoundPage/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/TypeScriptPage/index.d.ts",
+      ".redwood/types/mirror/web/src/pages/admin/EditUserPage/index.d.ts",
     ]
   `)
 

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -26,13 +26,17 @@ export const findPages = (cwd: string = getPaths().web.pages) => {
 }
 
 export const findDirectoryNamedModules = (cwd: string = getPaths().base) => {
-  const modules = fg.sync('**/src/**/*[!Cell].{ts,js,jsx,tsx}', {
+  const modules = fg.sync('**/src/**/*.{ts,js,jsx,tsx}', {
     cwd,
     absolute: true,
     ignore: ['node_modules'],
   })
 
-  return modules.filter(isDirectoryNamedModuleFile)
+  // Cell's also follow use the directory-named-module pattern,
+  // but they get their own special type mirror file, so ignore them.
+  return modules
+    .filter(isDirectoryNamedModuleFile)
+    .filter((p) => !isCellFile(p))
 }
 
 export const findGraphQLSchemas = (cwd: string = getPaths().api.graphql) => {
@@ -69,7 +73,7 @@ export const isCellFile = (p: string) => {
 export const isPageFile = (p: string) => {
   const { dir, name } = path.parse(p)
 
-  // A page must end with "Page.{jsx, jsx,tsx}".
+  // A page must end with "Page.{jsx,js,tsx}".
   if (!name.endsWith('Page')) {
     return false
   }


### PR DESCRIPTION
I was excluding "Cell" files from directory named modules, and apparently
negative matches in fast glob don't seem to be working nicely, or I don't understand them very well, either way it was not a 100% correct way to determine if a file is a Cell.

This PR improves the logic and generates all the proper mirror files.