### PR TITLE
fix(rw-exec): Pick up ts scripts too

### DIFF
--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -10,24 +10,6 @@ import c from 'src/lib/colors'
 import { generatePrismaClient } from 'src/lib/generatePrismaClient'
 
 const runScript = async (scriptPath, scriptArgs) => {
-  // Import babel config for running script
-  babelRequireHook({
-    extends: path.join(getPaths().api.base, '.babelrc.js'),
-    extensions: ['.js', '.ts'],
-    plugins: [
-      [
-        'babel-plugin-module-resolver',
-        {
-          alias: {
-            $api: getPaths().api.base,
-          },
-        },
-      ],
-    ],
-    ignore: ['node_modules'],
-    cache: false,
-  })
-
   const script = await import(scriptPath)
   await script.default({ args: scriptArgs })
   return
@@ -53,6 +35,25 @@ export const builder = (yargs) => {
 export const handler = async (args) => {
   const { name, ...scriptArgs } = args
   const scriptPath = path.join(getPaths().scripts, name)
+
+  // Import babel config for running script
+  babelRequireHook({
+    extends: path.join(getPaths().api.base, '.babelrc.js'),
+    extensions: ['.js', '.ts'],
+    plugins: [
+      [
+        'babel-plugin-module-resolver',
+        {
+          alias: {
+            $api: getPaths().api.base,
+          },
+        },
+      ],
+    ],
+    ignore: ['node_modules'],
+    cache: false,
+  })
+
   try {
     require.resolve(scriptPath)
   } catch {


### PR DESCRIPTION
In v0.34.0, `rw exec` doesn't pick up typescript scripts (how DARE it!?)

You need the babel config loaded for `require.resolve` to know how to handle TS files

I think I broke this when I "fixed" the prerender stuff.