### PR TITLE
Upgrades Envelop to 0.3.1

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@envelop/apollo-tracing": "0.1.0",
-    "@envelop/core": "0.3.0",
+    "@envelop/core": "0.3.1",
     "@envelop/depth-limit": "0.1.0",
     "@envelop/disable-introspection": "0.0.1",
     "@envelop/filter-operation-type": "0.1.0",

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -375,8 +375,6 @@ export const createGraphQLHandler = ({
         contextFactory: enveloped.contextFactory,
       })
 
-      // logger.debug({ result }, '>>> processRequest result')
-
       if (result.type === 'RESPONSE') {
         lambdaResponse = {
           body: JSON.stringify(result.payload),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,12 +1338,12 @@
   dependencies:
     apollo-tracing "^0.12.2"
 
-"@envelop/core@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-0.3.0.tgz#43bd27fd338c5d3242c936ecb934823d34a0cda6"
-  integrity sha512-O2ydpp7JiX558wf3kS3UPSn/fQ7QORy4WQ/8ALEE1zCFxt/Ilynm+Gu2rU1mMEKXUd0th23i3ZbjBhsrNDH3QA==
+"@envelop/core@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-0.3.1.tgz#ecc5312714fbc3c42639d95f03403c8ae491eef3"
+  integrity sha512-+5i1fu+OAHkzTKEQwbBM79mQ69JwoQ7lS6rODMB0UXHgEQVX1AVdhHWc1oqQHkdWghmegIAiBHokbnAS4opq2Q==
   dependencies:
-    "@envelop/types" "0.2.0"
+    "@envelop/types" "0.2.1"
 
 "@envelop/depth-limit@0.1.0":
   version "0.1.0"
@@ -1369,10 +1369,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@envelop/types@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-0.2.0.tgz#d66f850a04032270ef55bcc128e6de113dcb0b33"
-  integrity sha512-rwK2zSui7d7hTZc0XZFOwV2AiU/n2NYT3z6TrkYbACNI3SV5bhPb6H1/WZOFK65VBCGIobFtnoWf/NmlFf7m9Q==
+"@envelop/types@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-0.2.1.tgz#a278492acb09998d06a7685a1188dfbd9b47a057"
+  integrity sha512-7BmiQsprpe2WrmJJi31xPk52z8QKR/up5xnU4MT3ksYWHtoAJ6V56lYwY0hAZKB1SumVHVs5QnlDY24n49hcuA==
 
 "@envelop/validation-cache@0.1.0":
   version "0.1.0"


### PR DESCRIPTION
This PR upgrades envelop/core to 0.3.1 used by the graphql-server.