### PR TITLE
Secure Services: skip beforeResolver export check for files in root of api/src/services

### DIFF
--- a/packages/api/src/__tests__/makeServices.test.js
+++ b/packages/api/src/__tests__/makeServices.test.js
@@ -55,4 +55,17 @@ describe('makeServices', () => {
       'beforeResolver'
     )
   })
+
+  it('ignores services that are not in a subdirectory', () => {
+    process.env.REDWOOD_SECURE_SERVICES = '1'
+    let madeServices
+
+    expect(() => {
+      madeServices = makeServices({
+        services: { index: { foo: () => {} }, ...services },
+      })
+    }).not.toThrow()
+    // still exports those services
+    expect(Object.keys(madeServices)).toContain('index')
+  })
 })

--- a/packages/api/src/makeServices.ts
+++ b/packages/api/src/makeServices.ts
@@ -7,7 +7,6 @@ import { ServicesCollection, MakeServices, Services } from './types'
 export const makeServices: MakeServices = ({ services }) => {
   if (process.env.REDWOOD_SECURE_SERVICES !== '1') {
     console.warn('NOTICE: Redwood v1.0 will make resolvers secure by default.')
-
     console.warn(
       'To opt in to this behavior now, add `REDWOOD_SECURE_SERVICES=1` to your `.env.defaults` file. For more information: https://redwoodjs.com/docs/services'
     )
@@ -17,6 +16,15 @@ export const makeServices: MakeServices = ({ services }) => {
   const servicesCollection: ServicesCollection = {}
 
   for (const [name, resolvers] of Object.entries(services)) {
+    // if this "service" is actually from the root directory of api/src/services
+    // we don't need to check for `beforeResolver` export (it's probably an
+    // index file or other shared functionality) but we'll still add it to the
+    // collection as normal
+    if (!name.match(/_/)) {
+      servicesCollection[name] = resolvers
+      continue
+    }
+
     if (!resolvers?.beforeResolver) {
       throw new MissingBeforeResolverError(name)
     }


### PR DESCRIPTION
If you have any JS or TS file in the root of `api/src/services` in your app, an error will be raised that the file doesn't export any `beforeResolver()`. The root of this directory will not contain services (they should all be in a subdirectory named the same as the service file, otherwise they can't be used as GraphQL resolvers anyway) so it's safe to ignore any files here in the root and not require they contain beforeResolver rules.

Closes #2879 