### PR TITLE
fix(graphql-server): context exports from graphql-server

### DIFF
--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -19,4 +19,6 @@ export {
   ServicesCollection,
   SkipArgs,
   ValidatorCollection,
+  context,
+  setContext,
 } from '@redwoodjs/api'

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -12,6 +12,7 @@
   "include": ["src/**/*", "src/../package.json"],
   "references": [
     { "path": "../auth" },
+    { "path": "../api" },
     { "path": "../dev-server" }
   ]
 }


### PR DESCRIPTION
- Exports context correctly from @redwoodjs/api