### PR TITLE
fix(exec): Always disconnect prisma after exec

### DIFF
--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -12,6 +12,14 @@ import { generatePrismaClient } from 'src/lib/generatePrismaClient'
 const runScript = async (scriptPath, scriptArgs) => {
   const script = await import(scriptPath)
   await script.default({ args: scriptArgs })
+
+  try {
+    const { db } = await import(path.join(getPaths().api.lib, 'db'))
+    db.$disconnect()
+  } catch (e) {
+    // silence
+  }
+
   return
 }
 


### PR DESCRIPTION
### What does this do?
Fixes the issue where scripts would keep the shell active, even after they'd complete. 

### Why?
I believe prisma opens a socket, which is why it stays active, until `db.$disconnect` is called. 

Related to #2881 #2843