### PR TITLE
upgrade Prisma v2.25.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "6.2.14",
-    "@prisma/client": "2.24.1",
+    "@prisma/client": "2.25.0",
     "@types/pino": "6.3.8",
     "apollo-server-lambda": "2.25.0",
     "core-js": "3.13.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.24.1",
+    "@prisma/sdk": "2.25.0",
     "@redwoodjs/api-server": "0.34.1",
     "@redwoodjs/dev-server": "0.34.1",
     "@redwoodjs/internal": "0.34.1",
@@ -39,7 +39,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.3.1",
-    "prisma": "2.24.1",
+    "prisma": "2.25.0",
     "prompts": "2.4.1",
     "rimraf": "3.0.2",
     "terminal-link": "2.1.1",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -20,7 +20,7 @@
     "@graphql-tools/merge": "6.2.14",
     "@graphql-tools/schema": "7.1.5",
     "@graphql-tools/utils": "7.10.0",
-    "@prisma/client": "2.24.1",
+    "@prisma/client": "2.25.0",
     "@redwoodjs/api": "0.34.1",
     "@types/pino": "6.3.8",
     "core-js": "3.13.1",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.24.1",
+    "@prisma/sdk": "2.25.0",
     "@redwoodjs/internal": "0.34.1",
     "@types/line-column": "1.0.0",
     "camelcase": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,30 +2633,30 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.24.1.tgz#c4f26fb4d768dd52dd20a17e626f10e69cc0b85c"
-  integrity sha512-vllhf36g3oI98GF1Q5IPmnR5MYzBPeCcl/Xiz6EAi4DMOxE069o9ka5BAqYbUG2USx8JuKw09QdMnDrp3Kyn8g==
+"@prisma/client@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.25.0.tgz#a81cdf93ce93128eb35298cf8935480f3da6cca3"
+  integrity sha512-JDrAJ+oemiYAwgpYNJvCVT59S9bMbqkx78q2OT54xmmBoyYWWnn6t6oS6q8gKMiKHS6rzm/jdh3sy+2E0R+NAQ==
   dependencies:
-    "@prisma/engines-version" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
+    "@prisma/engines-version" "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
 
-"@prisma/debug@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.24.1.tgz#180f9ccaedc0ab1c2a4ecbd5c4be745529fd8498"
-  integrity sha512-rpcU9+wTCKzv/cFZlRsSUvGlfCM5pe9H39TuZjSlXAaxl2rOzXcXMBmZlybpFKpjA83ihvYgNXQpxsZfAX+xFg==
+"@prisma/debug@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.25.0.tgz#e4670663e891bb5162e4de595a1d3131bd13f3e7"
+  integrity sha512-2QVReYu1v1HtKeYIlggvs1VAqQxHHIyyPcL8K14FIylkZtiM5YjaNOj2BlKzV5WerzWKk9zAze6Mw91f4tWjVA==
   dependencies:
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.24.1.tgz#176f4674be3d3b64c2e51b8dc1cc00f74f8f41e5"
-  integrity sha512-BwqvtLqSU3qIGC+oaowAr4O9gwMI7SU63Vu8gocwIrl5H61z00KYfk/oAeo6W/biLXtkgDoHGIu8QKvCPusJ6Q==
+"@prisma/engine-core@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.25.0.tgz#01ce06f31beb762cb37c81b2330b466389093017"
+  integrity sha512-7eLdewTHSx+3bnOmYPhxMNRXhyVUokaMwbvyH/FsVX8WtPxe0zxxJHIcrEFHbxFFbElxjMnfjejyHcNcIfJBMA==
   dependencies:
-    "@prisma/debug" "2.24.1"
-    "@prisma/engines" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
-    "@prisma/generator-helper" "2.24.1"
-    "@prisma/get-platform" "2.24.1"
+    "@prisma/debug" "2.25.0"
+    "@prisma/engines" "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
+    "@prisma/generator-helper" "2.25.0"
+    "@prisma/get-platform" "2.25.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -2666,23 +2666,23 @@
     terminal-link "^2.1.1"
     undici "3.3.6"
 
-"@prisma/engines-version@2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4":
-  version "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4.tgz#2c5813ef98bcbe659b18b521f002f5c8aabbaae2"
-  integrity sha512-60Do+ByVfHnhJ2id5h/lXOZnDQNIf5pz3enkKWOmyr744Z2IxkBu65jRckFfMN5cPtmXDre/Ay/GKm0aoeLwrw==
+"@prisma/engines-version@2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922":
+  version "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922.tgz#b353576a97d0c1952fd4f4201189e845aaafbea8"
+  integrity sha512-uZaonv3ZzLYAi99AooOe2BOBmb3k+ibVsJyZ5J3F6U1uFHTtTI9AVzC51mE09iNcgq3ZBt2CZNi5CDQZedMWyA==
 
-"@prisma/engines@2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4":
-  version "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4.tgz#7e542d510f0c03f41b73edbb17254f5a0b272a4d"
-  integrity sha512-29/xO9kqeQka+wN5Ev10l5L4XQXNVXdPToJs1M29VZ2imQsNsL4rtz26m3qGM54IoGWwwfTVdvuVRxKnDl2rig==
+"@prisma/engines@2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922":
+  version "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922.tgz#68d7850d311df6d017e1b878adb19ec21483bcf0"
+  integrity sha512-vjLCk8AFRZu3D8h/SMcWDzTo0xkMuUDyXQzXekn8gzAGjb47B6LQXGR6rDoZ3/uPM13JNTLPvF62mtVaY6fVeQ==
 
-"@prisma/fetch-engine@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.24.1.tgz#491bf0af286f0cffde863c69262777ce612fbf33"
-  integrity sha512-yz9APYZ/0QCTXsBruySD5BRAKdFhtVwSLfNMdc1j1ZQdgPjGX50oNnet2vDwCdHOwEwZWRS9RM9h7SEicRwP6A==
+"@prisma/fetch-engine@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.25.0.tgz#a34afa01644377a83c6986c352e711c48cc5c1bc"
+  integrity sha512-GsmCqWtDCBLSxbJAh/mCWf3PjXbEVyBaXTQw4cOTUESdSEYaLJ3kZImqe3dn9RAzW79EH/tw9TcTTzjlCSBDlw==
   dependencies:
-    "@prisma/debug" "2.24.1"
-    "@prisma/get-platform" "2.24.1"
+    "@prisma/debug" "2.25.0"
+    "@prisma/get-platform" "2.25.0"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -2699,41 +2699,41 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.24.1.tgz#ba20215be00bba058d5a2916481e08f71a724c3f"
-  integrity sha512-GyjmBq6K2+rQlT6hnxa2VzEnvpaSWvjT3o4ve6futGZnLemJJmn394AiAJJh7LrIBVJQnMp68Ze4UAtqj4Ykqg==
+"@prisma/generator-helper@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.25.0.tgz#8ef2b7c33030c0b98187760eed152b07f2f2e974"
+  integrity sha512-Qe6f2IMqJUSYowAvVWn/GpGn1sYp04DKV4KICS1V54VW/1Wja4CYBXtljE3LBA/qWh0L+QA8CqzyYQX2ZoU6cQ==
   dependencies:
-    "@prisma/debug" "2.24.1"
+    "@prisma/debug" "2.25.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.24.1.tgz#298b53fd9eecb2ff8f4ebd3f0e5f364b097f0753"
-  integrity sha512-x4e9gOdXuJ8nPYFOd2tI3s/WA+8TKpz2QXQcV9HMzVCtG9AQ50JSeNWZ1HesYCJDtQbuEHwo2PuPBtK5k6ohPw==
+"@prisma/get-platform@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.25.0.tgz#cd118a93a7b3d443636ac461f49866ef6fd56622"
+  integrity sha512-51eE3PMN21mKsp3HGIaCE/dFx21lSJ6mbJ2kpHQC5iG3Sjtz8n9PKg3pmK/cd17ebKMnQfZcEM+3DQp6t7/iZg==
   dependencies:
-    "@prisma/debug" "2.24.1"
+    "@prisma/debug" "2.25.0"
 
-"@prisma/sdk@2.24.1":
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.24.1.tgz#be9d94c3d0dddf5670e8b86e7e2575e76bcf7754"
-  integrity sha512-pdJFw/XMzOI1ttz2V6+QG9tyYY+kC8vEtNbabxkgGAfFZgZ0U1j8XB7/ZEOFWD01BJgTQN//DP+uIfmLOkvX1A==
+"@prisma/sdk@2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.25.0.tgz#f3079173743269fb8d302ba8b025419a1c346901"
+  integrity sha512-RCEKzwcR/HcA9KY2ZSKBXCMfrgKv2HA6zRGW0REBGBmxuvwvpEvepMRoVX0SvWQkLILBC49/ODRenTubusoh0A==
   dependencies:
-    "@prisma/debug" "2.24.1"
-    "@prisma/engine-core" "2.24.1"
-    "@prisma/engines" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
-    "@prisma/fetch-engine" "2.24.1"
-    "@prisma/generator-helper" "2.24.1"
-    "@prisma/get-platform" "2.24.1"
+    "@prisma/debug" "2.25.0"
+    "@prisma/engine-core" "2.25.0"
+    "@prisma/engines" "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
+    "@prisma/fetch-engine" "2.25.0"
+    "@prisma/generator-helper" "2.25.0"
+    "@prisma/get-platform" "2.25.0"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
     chalk "4.1.1"
     checkpoint-client "1.1.20"
     cli-truncate "^2.1.0"
-    dotenv "^9.0.0"
+    dotenv "^10.0.0"
     execa "^5.0.0"
     find-up "5.0.0"
     global-dirs "^3.0.0"
@@ -2744,7 +2744,6 @@
     node-fetch "2.6.1"
     p-map "^4.0.0"
     read-pkg-up "^7.0.1"
-    resolve-from "^5.0.0"
     resolve-pkg "^2.0.0"
     rimraf "^3.0.2"
     shell-quote "^1.7.2"
@@ -8205,6 +8204,11 @@ dotenv-webpack@^1.7.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
@@ -8214,11 +8218,6 @@ dotenv@^8.0.0, dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
-dotenv@^9.0.0:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-9.0.2.tgz#dacc20160935a37dea6364aa1bef819fb9b6ab05"
-  integrity sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==
 
 downshift@^6.0.6:
   version "6.1.3"
@@ -14733,12 +14732,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.24.1:
-  version "2.24.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.24.1.tgz#f8f4cb8baf407a71800256160277f69603bd43a3"
-  integrity sha512-L+ykMpttbWzpTNsy+PPynnEX/mS1s5zs49euXBrMjxXh1M6/f9MYlTNAj+iP90O9ZSaURSpNa+1jzatPghqUcQ==
+prisma@2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.25.0.tgz#1ebfef3e945a22c673b3e3c5100f098da475700d"
+  integrity sha512-AdAlP+PShvugljIx62Omu+eLKu6Cozz06dehmClIHSb0/yFiVnyBtrRVV4LZus+QX6Ayg7CTDvtzroACAWl+Zw==
   dependencies:
-    "@prisma/engines" "2.24.1-2.18095475d5ee64536e2f93995e48ad800737a9e4"
+    "@prisma/engines" "2.25.0-36.c838e79f39885bc8e1611849b1eb28b5bb5bc922"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"


### PR DESCRIPTION
Prisma release notes:

[v2.25.0](https://github.com/prisma/prisma/releases/tag/2.25.0)

Highlights:
Human-readable drift diagnostics for prisma migrate dev

Notable Fixes:
[Resolves](https://github.com/prisma/prisma/issues/7091) the _count field not found when referenced in relation context

Breaking changes:
Dropping support for Node.js v10
