### PR TITLE
Proposed change to contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,529 +1,245 @@
-# Contributing
+# Contributing to RedwoodJS
+Love RedwoodJS and want to get involved? You’re in the right place and in good company! As of this writing, there are more than [170 contributors](#contributorsList) who have helped make RedwoodJS awesome by helping [triage issues](https://github.com/redwoodjs/redwood/issues), contributing [code](#contributing-code), and contributing [docs](#contributing-docs). This doesn't include all of those who participate in our vibrant, helpful, and encouraging [Forums](https://community.redwoodjs.com/) and [Discord](https://discord.gg/jjSYEQd) channel, which are both great places to get started if you have any questions. And if any RedwoodJS slang is unfamiliar, you can find a quick definition in the [glossary](#glossary).
 
-Love Redwood and want to get involved? You’re in the right place!
+> Before interacting with the RedwoodJS community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct).
 
-Before interacting with the Redwood community, please read and understand our [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md).
-
-**Table of Contents**
-
-- [Contributing](#contributing)
-  - [Local Development](#local-development)
-    - [Code Organization](#code-organization)
-    - [Local Setup](#local-setup)
-      - [Redwood Framework](#redwood-framework)
-      - [Redwood App: Create a Functional Test Project](#redwood-app-create-a-functional-test-project)
-        - [Running the Test Project Script](#running-the-test-project-script)
-    - [Testing Framework code in your App](#testing-framework-code-in-your-app)
-      - [Option 1: Linking](#option-1-linking)
-      - [Option 2: Copy and Watch](#option-2-copy-and-watch)
-      - [Option 3: Copy (for Windows)](#option-3-copy-for-windows)
-      - [Specifying a RW_PATH](#specifying-a-rw_path)
-        - [On **Linux**](#on-linux)
-        - [On **MacOS**](#on-macos)
-        - [On **Windows**](#on-windows)
-    - [Local Package Registry Emulation](#local-package-registry-emulation)
-      - [Running a Local NPM Registry](#running-a-local-npm-registry)
-      - [Publishing a Package](#publishing-a-package)
-      - [Installing Published Packages in Your Redwood App](#installing-published-packages-in-your-redwood-app)
-  - [Running Your Redwood App's Local Server(s)](#running-your-redwood-apps-local-servers)
-  - [Integration tests](#integration-tests)
-  - [Releases](#releases)
+## Table of Contents
+  - [Short Links to Important Resources](#short-links-to-important-resources)
+    - [Community](#community)
+    - [Documentation](#documentation)
+    - [Bugs](#bugs)
+    - [Security](#security)
+  - [Getting Started](#getting-started)
+    - [The Basics of RedwoodJS, GitHub, and Git](#the_basics_of_redwood_git_and_github)
+    - [Setting Up a Local Framework Development Environment](#setting_up_a_local_framework_development_environment)
+    - [Building](#building)
+    - [Testing](#testing)
     - [Troubleshooting](#troubleshooting)
-  - [CLI Reference: `redwood-tools`](#cli-reference-redwood-tools)
-    - [redwood-tools (rwt)](#redwood-tools-rwt)
-    - [copy (cp)](#copy-cp)
-    - [copy:watch (cpw)](#copywatch-cpw)
-    - [fix-bins (fix)](#fix-bins-fix)
-    - [install (i)](#install-i)
-    - [link](#link)
-
-## Local Development
-
-### Code Organization
-
-As a Redwood user, you're already familiar with the codebase created by `yarn create redwood-app`. In this document, we'll refer to that codebase as a 'Redwood App'. As a contributor, you'll have to gain familiarity with another codebase: the Redwood Framework.
-
-The Redwood Framework lives in the monorepo `redwoodjs/redwood` (which is where you're probably reading this). It contains all the packages that make Redwood Apps work the way they do. In a typical Redwood App, you can find the Redwood Framework in `./node_modules/@redwoodjs`.
-
-Throughout this document, we'll assume your local copy of the Redwood Framework is in a directory called `redwood` and your Redwood App is in a directory called `redwood-app`.
-
-### Local Setup
-
-#### Redwood Framework
-
-Use `git clone` to make a local copy of the Redwood Framework. As mentioned above, we'll assume your local copy is in a directory called `redwood`. This is where you'll be making most of your changes.
-
-If you already have a local copy, make sure you've got the `main` branch's latest changes with `git pull`.
-
-Then run `yarn install` in the root directory to install all the dependencies:
-
-```terminal
-cd redwood
-yarn install
-```
-
-#### Redwood App: Create a Functional Test Project
-
-Most often, you'll need to test the functionality of your code in a local Redwood App. We'll assume your Redwood App is going to be a directory called `redwood-app`.
-
-There are several options:
-- run `yarn create redwood-app ./redwood-app` to install a fresh codebase (with no functionality)
-- `git clone` the [RedwoodJS Tutorial Blog](https://github.com/redwoodjs/redwood-tutorial)
-- use an App you already created
-- Or run `yarn run build:test-project` to create a functional test project 👀
-
-**Using the functional test project might be the easiest and fastest way to test your changes in Redwood.** You can create a Redwood project that contains a big range of functionality in a few minutes:
-1. it installs using the App template codebase in the current branch of your Framework
-2. with the current `canary` version of Redwood Packages (with the option to use the `latest` stable version)
-3. with a JavaScript language target (with the option for TypeScript)
-4. then applies code mods from the [Redwood tutorial](https://learn.redwoodjs.com/docs/tutorial/welcome-to-redwood/) to add functionality and styling
-5. and initializes a Prisma DB migration for SQLite
-
-At the end, you will have a fully working Redwood blog.
-
-##### Running the Test Project Script
-Run the following in the `redwood` folder root:
-
-```terminal
-yarn run build:test-project <path/to/redwood-app>
-```
-
-| Arguments & Options  | Description                                                          |
-|----------------------|----------------------------------------------------------------------|
-| `<project directory>` | Directory to build test project [default: "./blog-test-project"]    |
-| `--typescript, --ts` | Generate a TypeScript project [default: JavaScript]                  |
-| `--canary`           | Upgrade project to latest canary version [default: true]             |
-| `--help `            | Show help                                                            |
-
-**Example Use:**
-```terminal
-cd redwood/
-yarn run build:test-project ~/my-repos/redwood-app --typescript --canary
-```
-### Testing Framework code in your App
-
-As you make changes to your local copy of the Redwood Framework, you'll want to see the effects "live" in your Redwood App.
-
-Since we're always looking for ways to make contributing to Redwood easier, there are a few workflows we've come up with, but the one you'll want to use is `yarn rwt link`. You can fall back on any of the others if that one doesn't work, but once you've tried `yarn rwt link`, you won't want to.
-
-> **I've used `yarn rw` before, but what's `yarn rwt`?**
->
-> All workflows use `redwood-tools` (`rwt`), Redwood's companion CLI development tool.
-
-#### Option 1: Linking
-
-Now that everything's [up-to-date and installed](#local-setup), go to your `redwood-app` and run `yarn rwt link`:
-
-```bash
-cd redwood-app
-yarn rwt link ../path/to/redwood
-```
-
-> You can avoid having to provide the path to `redwood` by defining an `RW_PATH` environment variable on your system. See [Specifying a `RW_PATH`](#specifying-a-rw_path).
-
-`rwt link` will first add the redwood workspace to your Redwood App. Then you'll see a ton of output &mdash; `rwt link` is building the Redwood Framework, watching it for changes, and copying all that over into the new redwood workspace in your Redwood App.
-
-Your Redwood App isn't using the packages in `node_modules/@redwoodjs` anymore. It's now using the packages in the new workspace with your local changes. You can even install packages or upgrade dependencies &mdash; it's really that simple.
-
-`rwt link` won't return you to the command line. Once it sets everything up you should see:
-```terminal
-   ┌─────────────────────────────────────────────────────────────┐
-   │                                                             │
-   │   🚀 Go Forth and Contribute!                               │
-   │                                                             │
-   │   🔗  Your project is linked!                               │
-   │                                                             │
-   │   Contributing doc: https://redwoodjs.com/docs/contributing │
-   │                                                             │
-   └─────────────────────────────────────────────────────────────┘
-```
-
-you can open a new tab in your terminal, cd to `redwood-app` and launch your Redwood App from there. As you make changes in `redwood`, you will see those changes immediately in the behavior of your Redwood App.
-
-When you're done, go back to your `rwt link` tab and ctrl-c to quit. `rwt link` will ask you to run the `yarn rwt unlink` command. This will restore your Redwood App to its original state, reverting it to the version of Redwood that it originally had installed.
-
-Next time you want to contribute, just run `yarn rwt link` again!
+  - [Contributions](#contributions)
+    - [How to Submit a Pull Request](#how-to-submit-a-pull-request)
+    - [How to Open an Issue](#how-to-open-an-issue)
+    - [Finding Issues to Work On](finding-issues-to-work-on)
+    - [First Bugs for Contributors](#first-bugs-for-contributors)
+    - [Join a Contributing Project](#join_a_contributing_project)
+  - [Most Everything Else](#most-everything-else)
+    - [How to Request a New Feature](#how-to-request-a-new-feature)
+    - [Style Guide and Coding Conventions](#style-guide-and-coding-conventions)
+    - [Code of Conduct](#code-of-conduct)
+    - [TYIA! (thank you in advance)](#tyia!-\(thank-you-in-advance\))
+    - [How to Ask for Help](#where-can-i-ask-for-help)
+  - [See Who's Involved](#see-who-is-involved)
 
 
-*Flags for rwt link command:*
-| Flag | Description                              |
-| :------------------ | :--------------------------------------- |
-| `RW_PATH`              | Path to the framework repo. Required if RW_PATH environment var not set                         |
-| `--clean, -c`       | Clean the framework repo before linking? Set this to false to speed things up if you're sure your build folders are clean [default: true]                 |
-| `--watch, -w`           | Set this to false if you just want to link once and not watch for file changes [default: true]      |
-<br>
+
+## Short Links to Important Resources
+
+### 📢 Community
+This is your next step! There’s a vibrant, helpful community standing by to guide you toward your next step, whatever it may be. We hope you'll stop by and introduce yourself - just say hi! Ask a question - how can people help you take the next step? If you’re interested in contributing, please let us know what you’d like to help with.
+
+- [**RedwoodJS Forums**](https://community.redwoodjs.com)
+- [**Discourse Chat Channel**](https://discord.gg/jjSYEQd)
+- [**RedwoodJS on Twitter**](https://twitter.com/redwoodjs)
+
+### 📝 Documentation
+- The [**Framework Code Overview**](#framework-code-overview) gives you a quick rundown of the different packages used in the framework and how they fit together, as well as links to more detailed info
+- [**RedwoodJS Docs**](https://redwoodjs.com/docs/introduction) for reference while you're coding RedwoodJS apps
+- [**RedwoodJS Cookbooks**](https://redwoodjs.com/docs/cookbook) take you through the steps required to solve some example real-world problems
+- [**RedwoodJS Tutorials**](https://learn.redwoodjs.com/docs/tutorial/welcome-to-redwood/) take you by the hand through a series of steps to complete a RedwoodJS app
+
+### 🐛 Bugs
+- [**How to Report Bugs**](#bug-reports)
+- [**RedwoodJS's Issue Tracker**](https://github.com/redwoodjs/redwood/issues)
+
+### 🛡️ Security
+- [**RedwoodJS Security Policy**](#docs/security)
+- [**Report a Security Vulnerability**](mailto:security@redwoodjs.com)
 
 
-> Having trouble with `rwt link`? Check the [rwt link FAQ](https://github.com/redwoodjs/redwood/issues/2215). If that doesn't help, please try one of the legacy contributing flows below.
 
-#### Option 2: Copy and Watch
+## Getting Started
 
-`yarn rwt link` not working for you? That's ok &mdash; we have a few legacy contributing workflows that you can fall back on.
+As a RedwoodJS user, you're already familiar with the *Create Redwood App* (CRWA) codebase created when you run `yarn create <my-redwood-app-name>`. You'll see that codebase referred to as a **RedwoodJS app** in docs and discussions. As a contributor, you'll have to gain familiarity with another codebase: the **RedwoodJS framework**. The framework lives in the monorepo [`redwoodjs/redwood`](https://github.com/redwoodjs/redwood) and contains all the packages that make RedwoodJS apps work the way they do.
 
-After you've gotten everything [up-to-date and installed](#local-setup), make sure your Redwood App is on the latest canary release:
+The heart of the framework is the [create-redwood-app](https://github.com/redwoodjs/redwood/tree/main/packages/create-redwood-app) package. Yarn (the package management tool used by RedwoodJS) has [special handling](https://classic.yarnpkg.com/en/docs/cli/create/) for starter kits that follow a `create-*` naming convention. You can find the templates that are used to generate new RedwoodJS apps in this package.
+
+The other packages in the framework repo's `packages` directory are various libaries used by RedwoodJS apps, like the [cli](https://github.com/redwoodjs/redwood/tree/main/packages/cli) tool used for command line interaction with your RedwoodJS app or the [web](https://github.com/redwoodjs/redwood/tree/main/packages/web) library that provides hooks to use in your frontend React code.  These libraries are installed as part of the `yarn create <my-redwood-app-name>` workflow. In a typical RedwoodJS app, you can find the RedwoodJS framework library modules namespaced in the `./node_modules/@redwoodjs` directory.
+
+### 🪢The Basics of RedwoodJS, GitHub, and Git
+
+#### Learning RedwoodJS
+
+To contribute to framework code, you should have some familiarity with how RedwoodJS apps work and how to create one. The [RedwoodJS Tutorial](https://redwoodjs.com/tutorial) is the best, and most fun, way to learn RedwoodJS and the underlying tools and technologies. The [RedwoodJS Docs](https://redwoodjs.com/docs/introduction) have in-depth explanations of how to use the various pieces of the RedwoodJS framework in your app, like setting up [routing](https://redwoodjs.com/docs/redwood-router) and handling [assets](https://redwoodjs.com/docs/assets-and-files).
+
+These resources will help with understanding how the framework works from an end-user perspective. For a birds-eye overview of the framework code from a contributor PoV, we also have you covered with our [framework code overview](#framework-code-overview).
+
+#### GitHub (and Git)
+
+Understandably, diving into [Git](https://git-scm.com/) and the [GitHub](https://github.com/) workflow can feel intimidating if you haven’t experienced it before. There’s a lot of great material to help you learn. And, most of all, we're sure you’ll quickly get the hang of it and will be rockin’ commits and pushes with the best of ‘em.
+
+- [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github) (overview of concepts and workflow)
+- [First Day on GitHub](https://lab.github.com/githubtraining/first-day-on-github) (including Git)
+- [First Week on GitHub](https://lab.github.com/githubtraining/first-week-on-github) (parts 3 and 4 might be helpful)
+
+### 💻 Setting Up a Local Framework Development Environment
+
+#### Local Docs Development
+
+Helping to improve RedwoodJS's docs is easy, because your changes are made directly in the relevant repo (`redwood` for this document and package-specific docs, and `redwoodjs.com` for most everything else). Docs are kept in Markdown format. We have a [handy guide](#contributing-docs) with details of the Markdown syntax RedwoodJS uses and how the web and tutorial site static HTML generators are configured. There are also some [recommended tools](#recommended-tools) you might find helpful, like a Markdown WYSIWYG editor.
+
+#### Local Framework Development
+
+Some code changes in the Redwoodjs framework can be completed within a local copy of the [`redwoodjs/redwood`](https://github.com/redwoodjs/redwood) repo, without also needing a RedwoodJS app to test changes in. Examples include:
+
+- Changes to the CI / CD workflow for the repo using GitHub [Actions](https://docs.github.com/en/actions) and configured in the [`workflows`](https://github.com/redwoodjs/redwood/tree/main/.github/workflows) repo directory
+- Utility [scripts](https://github.com/redwoodjs/redwood/tree/main/tasks) for use with `yarn run` or `npx` (defined in a `package.json` file under the `scripts` key)
+
+Usually though, you'll want to see the effects of changes that you make to framework package library code in the context of a RedwoodJS app project. We have you covered! There's a special CLI tool (`redwood-tools`, aliased to `rwt`) that handles linking your local framework repo to a local app repo. Changes you make in the local framework repo show up immediately in your local app - [no muss, no fuss](https://www.ldoceonline.com/dictionary/no-muss-no-fuss). There are differences in setup based on your workstation platform (Windows, Mac, or Linux) and whether you want to use a default test app or a custom app.
+
+Next step? See our [detailed guide](#local-framework-development) to setting up a local framework development environment.
+
+#### Local CLI Development
+
+You can run a development version of the [CLI](https://github.com/redwoodjs/redwood/tree/main/packages/cli) tool directly from your local copy of the framework repo without syncing any files or node modules. This is useful if you're working on a framework package that uses the CLI as its point of entry, or working on the CLI itself. Check out our [notes](#local-cli-development) on local CLI development for more.
+
+### 🚇 Building
+
+Running the `web` and `api` local HTTP servers from a test app is definitely DX (a **d**elightful e**x**perience)  as you work on framework contributions.  When you're finished up and ready to share your work, you'll need to generate a production build of the framework packages and make sure it completes without error (the end-to-end tests mentioned below will also catch these kinds of build-time bugs).
+
+Build the packages and set up a watcher to rebuild when files change:
 
 ```terminal
-cd redwood-app
-yarn rw upgrade -t canary
-yarn install
-```
-
-Now you'll want to build-and-watch the files in the Redwood Framework for changes:
-
-```terminal
-cd redwood
-yarn build:watch
-```
-
-this will echo:
-
-```terminal
-@redwoodjs/api: $ nodemon --watch src -e ts,js --ignore dist --exec 'yarn build'
-@redwoodjs/core: $ nodemon --ignore dist --exec 'yarn build'
-create-redwood-app: $ nodemon --ignore dist --exec 'yarn build'
-```
-
-`build:watch` won't return you to the command line. Once it stops outputting to the terminal, you can open a new tab in your terminal, cd to `redwood-app` and run `rwt copy:watch` to get the changes in your local copy of the Redwood Framework:
-
-```terminal
-cd redwood-app
-yarn rwt copy:watch ../path/to/redwood
-```
-
-You can also use the alias `cpw`:
-
-```terminal
-cd redwood-app
-yarn rwt cpw ../path/to/redwood
-```
-
-> You can avoid having to provide the path to `redwood` by defining an `RW_PATH` environment variable on your system. See [Specifying a `RW_PATH`](#specifying-a-rw_path).
-
-this will echo:
-
-```terminal
-Redwood Framework Path:  /something/something/redwoodjs/redwood
-Trigger event:  add
-building file list ... done
-```
-
-`rwt copy:watch` won't return you to the command line. Once it stops outputting to the terminal, you can open a new tab in your terminal, cd to `redwood-app` and launch your Redwood App. As you make changes in `redwood`, you will see those changes immediately in the behavior of your Redwood App.
-
-Now any changes made in the framework will be copied into your app!
-
-When you're done, go back to your `build:watch` and `rwt copy:watch` tabs and ctrl-c to quit.
-
-Then, you can restore your Redwood App to its original state by deleting `./node_modules`, `web/node_modules`, and `api/node_modules`, then running `yarn install`.
-
-#### Option 3: Copy (for Windows)
-
-If you are on Windows and not using WSL, you will have to use `rwt cp` (this is tracked in [issue #701](https://github.com/redwoodjs/redwood/issues/701)). This method, unfortunately, will not let you see your changes live.
-
-Also, you most likely first have to [install `rsync`](https://tlundberg.com/blog/2020-06-15/installing-rsync-on-windows/).
-
-Finally, ensure that appropriate Windows permissions are available to create symbolic links. This can be accomplished via turning on Windows Developer Mode on Windows 10. Go to Settings and find the `For developers` page. Turn on the `Developer Mode` toggle. Alternately, running your shell or VSCode as an Administrator will also work, but is the less preferred option.
-
-Each time you make a change to your local Redwood Framework, you'll have to build it:
-
-```terminal
-cd redwood
 yarn build
 ```
 
-Then, you'll go to your Redwood App and copy the changes:
+There are also subcommands of `build` that you can run separately, for example to delete previous build artifacts. Check out the `scripts` key in the packages and root `package.json` file in your framework repo for options.
+
+### ⚠️ Testing
+
+You probably know that RedwoodJS has you "covered" when it comes to testing your apps. Our [testing](https://github.com/redwoodjs/redwood/tree/main/packages/testing) package uses [Jest](https://jestjs.io/) for test running, [RTL](https://testing-library.com/docs/react-testing-library/intro/) for testing React components, [Mock Service Worker](https://mswjs.io/) for API mocking, and [Storybook](https://storybook.js.org/) to build and test components and pages in isolation. We've collected helpful notes on testing RedwoodJS apps in our [Testing](https://redwoodjs.com/docs/testing) docs.
+
+You can use the following tools and commands to check the syntax and formatting of your framework code:
 
 ```terminal
-cd redwood-app
-yarn rwt cp ../path/to/redwood
+yarn lint
 ```
 
-Then you can test the effects of your changes. Unfortunately, each time you make a change to your local Redwood Framework, you'll have to manually run `build` and `rwt cp` again.
-
-When you're done, you can restore your Redwood App to its original state by deleting `./node_modules`, `web/node_modules`, and `api/node_modules`, then running `yarn install`.
-
-#### Option 4: Testing the CLI
-
-If you've made build or design time changes to RedwoodJS, that is if you have modified one of the following packages:
+To fix linting errors or warnings:
 
 ```terminal
-./packages/
-├ api-server
-├ cli
-├ core
-├ dev-server
-├ eslint-config
-├ internal
-├ prerender
-├ structure
-├ testing
+yarn lint:fix
 ```
 
-
-You can run a development version of the CLI directly from the framework's repo where you don't have to sync any files or node modules.
-
-(For all of the packages above the entry point is the CLI, these are what we consider "build time" and "design time" packages, rather than "run-time" packages which are web, auth, api, forms.)
-
-In order to do that you use the `--cwd` option to set the current working directory to your "test project":
+The RedwoodJS framework also uses Jest to run unit tests. To run unit tests for each package:
 
 ```terminal
-yarn build
-cd packages/cli
-yarn dev --cwd /path/to/your/project
-```
-The `yarn dev` will run the built CLI, and the `--cwd` option will make the command run in that directory. Remember to rebuild the packages if you have made a change to the code! (Tip: You can use `yarn build:watch` to automatically build the framework whilst you're making changes.)
-
-(Tip: --cwd is optional, it will reference the `__fixtures__/example-todo-main` project in the framework.)
-
-#### Specifying a RW_PATH
-
-You can avoid having to provide the path to `redwood` by defining an `RW_PATH` environment variable on your system.
-
-##### On **Linux**
-
-Add the following line to your `~/.bashrc`:
-
-```terminal
-export RW_PATH=”$HOME/path/to/redwood/framework”
+yarn test
 ```
 
-Where `/path/to/redwood/framework` is replaced by the path to your local copy of the Redwood Framework.
+There's more information on [testing framework code](#testing), including how to run the [Cypress](https://www.cypress.io/) end-to-end test suite.
 
-Then, in your Redwood App or example app, you can just run:
+### 📓 Troubleshooting
 
-```terminal
-yarn rwt link
-```
+If you run into problems with framework code you're putting together, start troubleshooting with the basics:
 
-or
+- Check that your Node version and Yarn version match RedwoodJS's [prerequisites](https://learn-redwood.netlify.app/docs/tutorial/prerequisites/). Versions are checked when you install the framework repo, but system updates or [Node Version Manager](https://github.com/nvm-sh/nvm) might have changed the versions you're currently using.
+- Make sure the framework builds by running `yarn build` in the root of the repo. It's possible your framework code runs when linked into an app but fails on a production build (and hopefully gives helpful output to identify the problem).
+- Pull the latest commits from the RedwoodJS framework repo (discussed in [local framework development](#local-framework-development)). Especially if you're working on cutting edge features, changes and bug fixes can happen quickly. You can also check the [issue tracker](https://github.com/redwoodjs/redwood/issues) to see if anyone else is experiencing similar problems, or reach out on our community [Forums](https://community.redwoodjs.com) and [Discord Chat](https://discord.gg/jjSYEQd).
+- Use the debugging tools in your code editor to zoom in on the problem. VS Code makes it really easy to set [breakpoints](https://code.visualstudio.com/docs/nodejs/nodejs-debugging) in your code and get a complete view of the environment at that point in your code, like the value of variables.
 
-```terminal
-yarn rwt copy:watch
-```
+Our community [Forums](https://community.redwoodjs.com) and [Discord Chat](https://discord.gg/jjSYEQd) are great places to reach out for help with troubleshooting.
 
-##### On **MacOS**
 
-Add the following line to your `~/.bash_profile`:
 
-```terminal
-export RW_PATH=”$HOME/path/to/redwood/framework”
-```
+## Contributions
 
-Where `/path/to/redwood/framework` is replaced by the path to your local copy of the Redwood Framework.
+Contributing to open source is a great way to learn, teach, and  build experience in a rainbow of skills. More than just committing code or docs and honing your technical skills, contributors become become part of a community where they can practice soft skills like  communication, giving and receiving feedback, and enhancing emotional intelligence. RedwoodJS is intentional about this process. We have a specific vision for the effect this project and community will have on you — it should give you superpowers to build and create,  build skillsets, and help advance your career. Our community mantra highlights these goals:
 
-Then, in your Redwood App or example app, you can just run:
+> ***“By helping each other be successful with Redwood, we make the RedwoodJS project successful”***
 
-```terminal
-yarn rwt link
-```
+We think successful contributors - more than any particular technical skill - will be people who value empathy, gratitude, and generosity. All of these are applicable in relation to both others *and* yourself. The goal of putting them into practice is to create *trust* that will be a catalyst for *risk-taking* (another word to describe this process is “learning”!). These are the ingredients necessary for productive and positive collaboration.
 
-or
+And you thought all this was just about opening a PR! Yes, it’s a super rewarding experience. But that’s just the beginning!
 
-```terminal
-yarn rwt copy:watch
-```
+### 🖋 How to Submit a Pull Request
+Some projects are really strict about their process for submitting PRs and issues. That's great in mature software domains, where governance, process management, and reporting are important for keeping the machine running without hiccups. We think of this approach as like planting a forest with future timber harvesting in mind. It's *efficient*, though maybe not *natural*.
 
-##### On **Windows**
+RedwoodJS lives on ground (roughly called "[Jamstack](https://jamstack.org/)") that is still growing into its ecological niche. There's a huge diversity of approaches sprouting all over this landscape, and enormous potential. We don't want to place unnatural barriers between our contributors and good ideas finding root in RedwoodJS. In general, we don’t have a formal structure for PRs. Our goal is to make it as efficient as possible for anyone to open a PR. But there are some good practices, which are definitely flexible. We've put together some tips and examples on writing good PRs, along with details on the mechanics of submitting PRs: check out our [pull request tips](#pull-requests) for more.
 
-> **TODO**
->
-> please contribute a PR if you can help.
+A common mistake new contributors make is waiting until their code is “perfect” before opening a PR. Assuming your PR has *some* code changes, it’s great practice to open a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) PR to start discussion and ask questions.
 
-### Local Package Registry Emulation
+### 🔥 How to Open an Issue
 
-Sometimes you'll want to test the full package-development workflow: building, publishing, and installing all the packages in your local copy of the Redwood Framework in your Redwood App. We accommodate this using a local NPM registry called [**Verdaccio**](https://github.com/verdaccio/verdaccio).
+Anyone can create a new Issue on the [tracker](https://github.com/redwoodjs/redwood/issues). If you’re not sure that your idea or feature is useful to work on, start the discussion with an Issue. Describe the problem or idea and proposed solution as clearly as possible, including examples or pseudo code if possible. It’s also very helpful to `@` mention a maintainer or Core Team member who share the same area of interest in your issue.
 
-You might also have to use this workflow if you've installed or upgraded one of Redwood's dependencies.
+Just know that there’s a *lot* of Issues that are opened every day. If no one replies, it’s only because people are busy. Reach out in the  [Forums](https://community.redwoodjs.com), [Discord Chat](https://discord.gg/jjSYEQd), or comment in the Issue. We intend to reply to every issue that’s opened. If yours doesn’t have a reply, then give us a nudge!
 
-#### Running a Local NPM Registry
+Lastly, it can often be helpful to start with brief discussion in the community Discord Chat or Forums. Sometimes that’s the quickest way to get feedback and a sense of priority before opening an Issue.
 
-First, install `Verdaccio`:
+### 🔍 Finding Issues to Work On
+> **Over the next few months, our focus is to achieve a v1.0.0 release of RedwoodJS. You can follow the status on our [Roadmap](https://redwoodjs.com/roadmap), which links to GitHub Project boards with associated tasks.**
 
-```terminal
-yarn global add verdaccio
-```
+Even if you know the mechanics, it’s hard to get started without a *place* to start. Our advice is to dive into the RedwoodJS Tutorial, read the docs, and build your own experiment with RedwoodJS. Along the way, you’ll find typos, out-of-date (or missing) documentation, code that could work better, or even opportunities for improving and adding features. You’ll be engaging in the Forums and Discord Chat and developing a feel for priorities and needs. This way, you’ll naturally follow your own interests. Sooner rather than later you'll find the intersection of “*things you’re interested in*” and “*ways to help improve RedwoodJS*”.
 
-Then, in your local copy of the Redwood Framework, run:
+Eventually, you'll end up on Redwood’s GitHub [Issues page](https://github.com/redwoodjs/redwood/issues). Here you’ll find open items that need help and that are organized by labels. Some labels that are great to focus on include:
 
-```terminal
-./tasks/run-local-npm
-```
+1. [Help Wanted](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3A"help+wanted"): these items especially need contribution help from the community.
+2. [v1 Priority](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3Av1-priority): to reach RedwoodJS v1.0.0, we need to close *all* Issues with this label.
 
-This starts `Verdaccio` (on http://localhost:4873) with our configuration file.
+The sweet spot is a [v1 Priority](https://github.com/redwoodjs/redwood/labels/v1%2Fpriority) Issue that’s either a [Good First Issue](https://github.com/redwoodjs/redwood/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Av1%2Fpriority) or [Help Wanted](https://github.com/redwoodjs/redwood/issues?q=is%3Aopen+label%3A%22help+wanted%22+label%3Av1%2Fpriority). Yes, *please!*
 
-#### Publishing a Package
+### ✅ First Bugs for Contributors
+A great way to get started with contributing to RedwoodJS is to find good first bugs. These are issues that can be solved with little experience. First bugs are also a great way for experienced contributors to learn a new domain or set of tools. They're not necessarily "easy," though some are. These bugs are meant to be well-contained and more likely to be an accessible entry point to the Framework. It’s less about skill level and more about focused scope.
 
-To build, unpublish, and publish all the Redwood packages to your local NPM registry with a "dev" tag, run:
+First bugs are labeled [Good First Issue](https://github.com/redwoodjs/redwood/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue"). The person who marked the ticket as a *Good First Issue* - as well as  other members of the community - will help you through this ticket by  providing feedback along the way. Start by making sure you understand the  problem and verifying that you can reproduce it. Next, draw up or mentally map a plan of  attack, create a patch, and submit a pull request. *Win, win!*
 
-```terminal
-./tasks/publish-local
-```
+### 🔌 Join a Contributing Project
+There are several self-contained contributing projects in the RedwoodJS ecosystem. Discussion on them is mostly taking place in the [Forums](https://community.redwoodjs.com)). These are high-priority needs that already have a defined scope and (mostly) don’t require working on the Framework codebase directly. Current contributing projects include:
 
-> This script is equivalent to running:
->
-> ```terminal
-> npm unpublish --tag dev --registry http://localhost:4873/ --force
-> npm publish --tag dev --registry http://localhost:4873/ --force
-> ```
+- [Redesign RedwoodJS’s 404 Not Found page](https://community.redwoodjs.com/t/find-time-to-redesign-redwoodjss-404-not-found-page/2052/4)
+- [RedwoodJS Splash Page](https://community.redwoodjs.com/t/give-the-redwoodjs-splashpage-more-splash/2051/2)
+- [Redesign Redwood’s Error Page](https://community.redwoodjs.com/t/hey-wha-happened-lets-redesign-redwoods-error-page/2053/7)
 
-Note that you can build a particular package by specifying the path to the package: `./tasks/publish-local ./packages/api`. For example, if you've made changes to the `@redwoodjs/dev-server` package, you would run:
+If you'd like to get involved with a contributing project, stop in the discussion in the respective Forum thread and say hi!
 
-```terminal
-./tasks/publish-local ./packages/dev-server
-```
 
-#### Installing Published Packages in Your Redwood App
 
-The last step is to install the package into your Redwood App.
+## Most Everything Else
 
-```terminal
-yarn rwt install @redwoodjs/dev-server
-```
+### 💬 How to Request a New Feature
+Don’t see a feature that you’d like to use to achieve your website-building goals? First stop is to check the [Roadmap](https://redwoodjs.com/roadmap) and see if it's already on the drawing board for a future release. If not, consider opening an issue to make your request known and to start a discussion about it. Keep in mind that a common problem with feature requests is that they are often very specific to the user who has requested it. Good feature requests benefit the majority of users and RedwoodJS as a whole.
 
-> This is equivalent to running:
->
-> ```terminal
-> rm -rf <APP_PATH>/node_modules/@redwoodjs/dev-server
-> yarn upgrade @redwoodjs/dev-server@dev --no-lockfile --registry http://localhost:4873/
-> ```
+To help others find your request, you can tag your issue with [`kind/discussion`](https://github.com/redwoodjs/redwood/labels/kind%2Fdiscussion) and an appropriate [`topic`](https://github.com/redwoodjs/redwood/labels/kind%2Fdiscussion) tag.
 
-## Running Your Redwood App's Local Server(s)
+### 👀 Style Guide and Coding Conventions
+RedwoodJS uses ESLint, Prettier, and the TypeScript compiler to help make sure the framework code can be easily understood and that consistency is maintained. The framework [`eslint-config`](https://github.com/redwoodjs/redwood/tree/main/packages/eslint-config) package is used both for framework configuration and RedwoodJS app (created with the [CRWA](https://github.com/redwoodjs/redwood/tree/main/packages/create-redwood-app) package) configuration.
 
-When developing Redwood Apps, you’re probably used to running both the API and Web servers with `yarn rw dev` and seeing your changes included immediately.
+Our configuration uses recommended rule presets, including those from [ESLint](https://eslint.org/docs/rules/), [React](https://www.npmjs.com/package/eslint-plugin-react#list-of-supported-rules), the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html), and [Jest](https://github.com/testing-library/eslint-plugin-jest-dom#supported-rules). We also override the presets with some stylistic preferences. Some of them are:
 
-But for local package development, your changes won’t be included automatically&mdash;you'll need to manually stop/start the respective server to include them.
+- [No semicolons](https://eslint.org/docs/rules/semi) at the end of statements
+- [Trailing commas](https://eslint.org/docs/rules/comma-dangle) in object and array literals
+- [Use single quotes](https://eslint.org/docs/rules/quotes) on strings wherever possible
+- [Use parentheses](https://eslint.org/docs/rules/arrow-parens)  around arrow function parameters
+- [Sort import declarations](https://eslint.org/docs/rules/sort-imports) by name
+- [Wrap block statements](https://eslint.org/docs/rules/curly) in curly braces
 
-In this case you might find it more convenient to run the servers for each of the yarn workspaces independently:
+For a full list of preset overrides, check out our [coding style](#coding-style) doc.
 
-```terminal
-yarn rw dev api
-yarn rw dev web
-```
+### 🧑‍🏫 Code of Conduct
+This project and everyone participating in it is governed by the Contributor Covenant [Code of Conduct](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported using the [procedure](https://github.com/redwoodjs/redwood/blob/main/CODE_OF_CONDUCT.md#enforcement-guidelines) detailed in the Code of Conduct. Please know that all community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
-## Integration tests
+### 💖 TYIA! (thank you in advance)
+If you've read the contributing docs to this point, we want to give you a full-hearted thank you! RedwoodJS isn't a private club. We're a community of people that are just like you. And we know that projects that you actively contribute to are also the projects you'll likely find yourself coming back to. We really believe in the RedwoodJS approach to app development, and hope you find it a great fit for your own work.
 
-We're using Cypress to test the steps that we recommend in the tutorial. Run the command by doing the following:
+### ❓ Where Can I Ask For Help?
+If you hit any roadblocks or need help with your contributions to RedwoodJS, we'd love to help! Everybody is new to RedwoodJS at some point, and even experienced contributors need to learn the ropes when they work in unfamiliar areas of the code base. By the same token, even longtime maintainers aren'tt always familiar with every aspect of the framework.
 
-```terminal
-./tasks/run-e2e
-```
+Great places to ask for help are the RedwoodJS [Forums](https://community.redwoodjs.com/) and [Discord Chat](https://discord.gg/jjSYEQd) channel. Stop by and say hi!
 
-This creates a new project in a temporary directory using `yarn create redwood-app ...` Once installed, it then upgrades the project to the most recent `canary` release, which means it will use the current code in the `main` branch. Once the upgrade is complete (and successful), it will start Cypress for the E2E tests.
+## See Who is Involved✨
+A gigantic "Thank YOU!" to everyone below who has contributed to one or more RedwoodJS projects:
 
+* [Framework](https://github.com/redwoodjs/redwood)
+* [Website](https://github.com/redwoodjs/redwoodjs.com)
+* [Create-RedwoodJS Template](https://github.com/redwoodjs/create-redwood-app)
 
-```terminal
-./tasks/run-e2e /path/to/app
-```
-
-Use this `path/to/app` option to run the same Cypress E2E tests against a local project. In this case, the command will _not_ upgrade the project to the `canary` release — it will use the project's installed packages. Chose this option if you have modified code (and packages) you want to test locally.
-
-
-> Windows Not Supported: The command for this is written in bash and will not work on Windows.
-
-## Releases
-
-To publish a new version of Redwood to NPM run the following commands:
-
-> NOTE: `<version>` should be formatted `v0.24.0` (for example)
-
-```bash
-git clean -dfx
-yarn install
-./tasks/update-package-versions <version>
-git commit -am "<version>"
-git tag -am <version> "<version>"
-git push && git push --tags
-yarn build
-yarn framework lerna publish from-package
-```
-
-This...
-  1) changes the version of **all the packages** (even those that haven't changed),
-  2) changes the version of the packages within the CRWA Template
-  3) Commits, Tags, and Pushes to GH
-  4) and finally publishes all packages to NPM.
-
-### Troubleshooting
-
-If something went wrong you can use `yarn lerna publish from-package` to publish the packages that aren't already in the registry.
-
-## CLI Reference: `redwood-tools`
-
-
-> This section covers the `redwood-tools` command options.
->
-> For `redwood` options, see the [CLI Reference on redwoodjs.com](https://redwoodjs.com/reference/command-line-interface).
-
-### redwood-tools (rwt)
-
-Redwood's companion CLI development tool. You'll be using this if you're contributing to Redwood.
-
-```
-yarn rwt <command>
-```
-
-|Command | Description|
-|:-|:-|
-|`copy` | Copy the Redwood Framework path to this project.|
-|`copy:watch` | Watch the Redwood Framework path for changes and copy them over to this project.|
-|`fix-bins` | Fix Redwood symlinks and permissions.|
-|`install` | Install a package from your local NPM registry.|
-|`link` | Link the Redwood Framework path to this project and watch it for changes.|
-
-### copy (cp)
-
-Copy the Redwood Framework path to this project.
-
-```terminal
-yarn rwt cp [RW_PATH]
-```
-
-You can avoid having to provide `RW_PATH` by defining an environment variable on your system. See [Specifying a `RW_PATH`](#specifying-a-rw_path).
-
-### copy:watch (cpw)
-
-Watch the Redwood Framework path for changes and copy them over to this project.
-
-```terminal
-yarn rwt cpw [RW_PATH]
-```
-
-You can avoid having to provide `RW_PATH` by defining an environment variable on your system. See [Specifying a `RW_PATH`](#specifying-a-rw_path).
-
-### fix-bins (fix)
-
-Fix Redwood symlinks and permissions.
-
-```terminal
-yarn rwt fix
-```
-
-The Redwood CLI has the following binaries:
-
-- `redwood`
-- `rw`
-- `redwood-tools`
-- `rwt`
-- `dev-server`
-
-When you're contributing, the permissions of these binaries can sometimes get mixed up. This makes them executable again.
-
-### install (i)
-
-Install a package from your local NPM registry.
-
-```terminal
-yarn rwt i <packageName>
-```
-
-You'll use this command if you're testing the full package-development workflow. See [Local Package Registry Emulation](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#local-package-registry-emulation).
-
-### link
-
-Link the Redwood Framework path to this project and watch it for changes.
-
-```terminal
-yarn rwt link [RW_PATH]
-```
-
-You can avoid having to provide `RW_PATH` by defining an environment variable on your system. See
-[Specifying a `RW_PATH`](#specifying-a-rw_path).
+RedwoodJS projects (mostly) follow the [all-contributions](https://allcontributors.org/) specification using the `all-contributors` CLI tool. This lets us track the [Framework](https://github.com/redwoodjs/redwood), [create-redwood-app](https://github.com/redwoodjs/create-redwood-app), and [Website](https://github.com/redwoodjs/redwoodjs.com) project contributors and display them in a nice grid with profile information. For more information and related code, see [`tasks/all-contributors/README.md`](#).


### PR DESCRIPTION
This proposal is a significant change to the contributing docs for RedwoodJS, so I'm submitting just my proposed `CONTRIBUTING.md` doc in a draft PR and asking for feedback on whether I should finish out the other pieces and submit them, plus any changes I should make.

There are several sets of contributing docs in the project currently:

- [**`CONTRIBUTING.md`**](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTORS.md) in the framework repo that has detailed instructions on contributing (setting up a local environment, testing, and the API for the `rwt` CLI tool).
- [**`contributing.md`**](https://github.com/redwoodjs/redwoodjs.com/blob/main/docs/contributing.md) in the website repo that has links to various resources like the issue tracker, a description of the framework packages, and details on how to contribute docs.
- [**`CONTRIBUTORS.md`**](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md) doc in the website repo that has a link to contributing docs on the website along with details on managing the `all-contributors` list, links to the forum and chat, and a link to the list of current contributors.

My proposal is to:

1. Make `CONTRIBUTING.md` in the framework repo the authoritative "`Introduction`" to contributing document, pulling it in from the framework repo to the website (similar to how `README.md` is pulled in now for `Docs` -> `Introduction`).
2. Make `Contributing` a first-class content area on the website similar to `Docs`, `Tutorial`, etc. This is the approach Gatsby's docs take.
3. Break out detailed instructions or supporting material into individual pages under the `Contributing` heading on the website, so that the main contributing doc stays focused and doesn't get excessively long.
4. Pull in all `packages`, `.github/workflows`, and `tasks` READMEs to the website in the same way that the root `redwood/README.md` file is done, and link to them from the "`Overview of Framework Code`" individual page mentioned below (they wouldn't show in the left-hand navigation on the website under "`Contributing`").
5. Delete the `redwood/CONTRIBUTORS.md` file (the information is duplicated in `redwood/tasks/all-contributors/README.md`) and add a `scripts` command `update-contributors` to the framework's `package.json`. The all-contributors description and links to the task for all contributors are mentioned at the very bottom of the proposed contributing file in this draft PR.

The initial supporting docs for a `Contributing` content area on the website (along with code to make it happen) that I'd submit in a PR to the `redwood.js` repo are:

- Introduction
- How to Contribute Docs
- How to Write and Send Pull Requests
- List of Contributors
- Overview of Framework Code
- Package Registry Emulation
- Recommended Dev Tools
- Redwood Tools API
- Setting Up For Local CLI Development
- Setting Up For Local Framework Development
- Testing Framework Code
- Glossary

The attached draft PR (just `CONTRIBUTING.md`) is a little rough. I haven't checked links. It hasn't been proofread or edited by someone else. I'll do so if I move this to a PR. Some other random things I jotted down while working on this:

-  (A) Right now the package `README.md` files are described as being the contributing docs for each package (mentioned in the current contributing documentation). Some are also API references (`cli` and `forms`). Others have detailed information on how to use the package or how the package works (like `dev-server`, `graphql-server`, and `structure` which also has a contributing document describing the VS Code extension). **Would it make sense to also add an `API` top-level content area** similar to the proposed `Contributing` area, and pull in just the package description and API info (for packages that have it) to individual pages? My thought is that it would be convenient to have detailed package-specific information available from the website. 
-  (B) How do you trigger a search re-index (Algolia) when the website repo has content updates?
-  (C) Is it worthwhile to add a GitHub Action in my final PR to the `redwood` framework repo that rebuilds `redwoodjs.com` repo when any pulled files (as proposed, `README.md` and `CONTRIBUTING.md`) are modified, so the documentation website stays in sync?
-  (D) Is it worthwhile to add docusaurus-like "next" and "last" buttons via StimulusJS on the bottom of pages to navigate through the Contributing documents, following the order they're linked to in the proposed `CONTRIBUTING.md` doc? They'd make sense with a short test description on each "next" and "last" button.
-  (E) I can create a SVG icon for "Contributing", but I'm not strong at design and it would probably be more of a placeholder. I couldn't find the icon set used on the website in any public icon library, and guessed they might have been developed by someone in the community.

Thanks for a great project and community!