### PR TITLE
Add ability to pre-transpile code.

### DIFF
--- a/packages/core/src/babelPlugins/__tests__/__fixtures__/src-alias/pages/HomePage/HomePage.js
+++ b/packages/core/src/babelPlugins/__tests__/__fixtures__/src-alias/pages/HomePage/HomePage.js
@@ -1,0 +1,1 @@
+// I am a stub.

--- a/packages/core/src/babelPlugins/__tests__/__fixtures__/src-alias/test.js
+++ b/packages/core/src/babelPlugins/__tests__/__fixtures__/src-alias/test.js
@@ -1,0 +1,1 @@
+// I am a stub.

--- a/packages/core/src/babelPlugins/__tests__/babel-plugin-redwood-src-alias.test.ts
+++ b/packages/core/src/babelPlugins/__tests__/babel-plugin-redwood-src-alias.test.ts
@@ -1,0 +1,40 @@
+import path from 'path'
+
+import * as babel from '@babel/core'
+
+import redwoodSrcAlias from '../babel-plugin-redwood-src-alias'
+
+const transpile = (code: string) => {
+  const result = babel.transform(code, {
+    babelrc: false,
+    filename: path.resolve(
+      './__tests__/__fixtures__/src-alias/pages/HomePage/HomePage.js'
+    ), // ordinarily provided by babel itself, but we fake it for the tests.
+    plugins: [
+      [
+        redwoodSrcAlias,
+        {
+          // This would usually be `web` or `api` src directory.
+          srcAbsPath: path.resolve('./__tests__/__fixtures__/src-alias/'),
+        },
+      ],
+    ],
+  })
+
+  return result?.code
+}
+
+test('importing and exporting from `src` alias works', () => {
+  // imports
+  expect(transpile(`import { Toolbar } from "src/components/Toolbar"`)).toEqual(
+    `import { Toolbar } from "../../components/Toolbar";`
+  )
+  expect(transpile(`import DEFAULT from "src/components/Toolbar"`)).toEqual(
+    `import DEFAULT from "../../components/Toolbar";`
+  )
+
+  // exports
+  expect(transpile(`export { Toolbar } from "src/components/Toolbar"`)).toEqual(
+    `export { Toolbar } from "../../components/Toolbar";`
+  )
+})

--- a/packages/core/src/babelPlugins/babel-plugin-redwood-src-alias.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-src-alias.ts
@@ -1,0 +1,67 @@
+import path from 'path'
+
+import type { PluginObj, types } from '@babel/core'
+
+export default function (
+  { types: t }: { types: typeof types },
+  options: {
+    /** absolute path to the `src` directory */
+    srcAbsPath: string
+  }
+): PluginObj {
+  return {
+    name: 'babel-plugin-redwood-src-alias',
+    visitor: {
+      ImportDeclaration(p, state) {
+        const { value } = p.node.source // import xyz from <value>
+        const { filename } = state.file.opts // the file where this import statement resides
+
+        // We only operate in "userland" so skip node_modules.
+        // Skip everything that's not a 'src/' alias import.
+        if (
+          !filename ||
+          filename?.includes('/node_modules/') ||
+          !value.startsWith('src/')
+        ) {
+          return
+        }
+
+        // remove `src/` and create an absolute path
+        const absPath = path.join(options.srcAbsPath, value.substr(4))
+        let newImport = path.relative(path.dirname(filename), absPath)
+        if (newImport.indexOf('.') !== 0) {
+          newImport = './' + newImport
+        }
+        const newSource = t.stringLiteral(newImport)
+
+        p.node.source = newSource
+      },
+
+      ExportDeclaration(p, state) {
+        // @ts-expect-error `source` does exist
+        if (!p?.node?.source) {
+          return
+        }
+
+        // @ts-expect-error `source` does exist
+        const { value } = p.node.source
+        const { filename } = state.file.opts
+
+        if (
+          !filename ||
+          filename?.includes('/node_modules/') ||
+          !value.startsWith('src/')
+        ) {
+          return
+        }
+
+        // remove `src/` and create an absolute path
+        const absPath = path.join(options.srcAbsPath, value.substr(4))
+        const newImport = path.relative(path.dirname(filename), absPath)
+        const newSource = t.stringLiteral(newImport)
+        // @ts-expect-error `source` does exist
+        p.node.source = newSource
+      },
+    },
+  }
+}

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -12,6 +12,7 @@
   "types": "dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
+    "@babel/register": "7.14.5",
     "@babel/parser": "7.14.4",
     "@babel/plugin-transform-typescript": "7.14.4",
     "@babel/runtime-corejs3": "7.14.0",

--- a/packages/internal/src/__tests__/paths.test.ts
+++ b/packages/internal/src/__tests__/paths.test.ts
@@ -1,21 +1,23 @@
 import path from 'path'
 
-import {
-  processPagesDir,
-  resolveFile,
-  ensurePosixPath,
-  importStatementPath,
-} from '../paths'
+import { processPagesDir, resolveFile, ensurePosixPath } from '../paths'
 
 describe('paths', () => {
   describe('processPagesDir', () => {
-    it('it accurately finds and names the pages', () => {
-      const pagesDir = path.resolve(
-        __dirname,
-        '../../../../__fixtures__/example-todo-main/web/src/pages'
-      )
+    const FIXTURE_PATH = path.resolve(
+      __dirname,
+      '../../../../__fixtures__/example-todo-main'
+    )
 
-      const pages = processPagesDir(pagesDir)
+    beforeAll(() => {
+      process.env.RWJS_CWD = FIXTURE_PATH
+    })
+    afterAll(() => {
+      delete process.env.RWJS_CWD
+    })
+
+    it('it accurately finds and names the pages', () => {
+      const pages = processPagesDir()
 
       expect(pages.length).toEqual(7)
 
@@ -24,45 +26,35 @@ describe('paths', () => {
       )
       expect(adminEditUserPage).not.toBeUndefined()
       expect(adminEditUserPage.importPath).toEqual(
-        importStatementPath(
-          path.join(pagesDir, 'admin/EditUserPage/EditUserPage')
-        )
+        './pages/admin/EditUserPage/EditUserPage'
       )
 
       const barPage = pages.find((page) => page.importName === 'BarPage')
       expect(barPage).not.toBeUndefined()
-      expect(barPage.importPath).toEqual(
-        importStatementPath(path.join(pagesDir, 'BarPage/BarPage'))
-      )
+      expect(barPage.importPath).toEqual('./pages/BarPage/BarPage')
 
       const fatalErrorPage = pages.find(
         (page) => page.importName === 'FatalErrorPage'
       )
       expect(fatalErrorPage).not.toBeUndefined()
       expect(fatalErrorPage.importPath).toEqual(
-        importStatementPath(
-          path.join(pagesDir, 'FatalErrorPage/FatalErrorPage')
-        )
+        './pages/FatalErrorPage/FatalErrorPage'
       )
 
       const fooPage = pages.find((page) => page.importName === 'FooPage')
       expect(fooPage).not.toBeUndefined()
-      expect(fooPage.importPath).toEqual(
-        importStatementPath(path.join(pagesDir, 'FooPage/FooPage'))
-      )
+      expect(fooPage.importPath).toEqual('./pages/FooPage/FooPage')
 
       const homePage = pages.find((page) => page.importName === 'HomePage')
       expect(homePage).not.toBeUndefined()
-      expect(homePage.importPath).toEqual(
-        importStatementPath(path.join(pagesDir, 'HomePage/HomePage'))
-      )
+      expect(homePage.importPath).toEqual('./pages/HomePage/HomePage')
 
       const notFoundPage = pages.find(
         (page) => page.importName === 'NotFoundPage'
       )
       expect(notFoundPage).not.toBeUndefined()
       expect(notFoundPage.importPath).toEqual(
-        importStatementPath(path.join(pagesDir, 'NotFoundPage/NotFoundPage'))
+        './pages/NotFoundPage/NotFoundPage'
       )
 
       const typeScriptPage = pages.find(
@@ -70,9 +62,7 @@ describe('paths', () => {
       )
       expect(typeScriptPage).not.toBeUndefined()
       expect(typeScriptPage.importPath).toEqual(
-        importStatementPath(
-          path.join(pagesDir, 'TypeScriptPage/TypeScriptPage')
-        )
+        './pages/TypeScriptPage/TypeScriptPage'
       )
     })
   })

--- a/packages/internal/src/__tests__/pretranspile.test.ts
+++ b/packages/internal/src/__tests__/pretranspile.test.ts
@@ -1,0 +1,58 @@
+import path from 'path'
+
+import { findCells } from '../files'
+import { getPaths } from '../paths'
+import { pretranspileFile, pretranspileWeb } from '../pretranspile'
+
+const FIXTURE_PATH = path.resolve(
+  __dirname,
+  '../../../../__fixtures__/example-todo-main'
+)
+
+beforeAll(() => {
+  process.env.RWJS_CWD = FIXTURE_PATH
+})
+afterAll(() => {
+  delete process.env.RWJS_CWD
+})
+
+test('`src` aliases and directory named modules are resolved', () => {
+  const rwjsPath = getPaths()
+  const result = pretranspileFile(rwjsPath.web.routes)
+  expect(result.code).toContain(
+    `import SetLayout from "./layouts/SetLayout/SetLayout";`
+  )
+})
+
+test('cell files are converted', () => {
+  const cellPath = findCells()[1]
+  const result = pretranspileFile(cellPath)
+  expect(result.code).toContain(
+    `export default createCell({ QUERY, afterQuery, Loading, Success });`
+  )
+})
+
+test('automatically imports gql and react', () => {
+  const cellPath = findCells()[1]
+  const result = pretranspileFile(cellPath)
+  expect(result.code).toContain(`gql from "graphql-tag"`)
+  // TODO: Test React.
+})
+
+test('gql template literal is transpiled to ast', () => {
+  const cellPath = findCells()[1]
+  const result = pretranspileFile(cellPath)
+  // TODO: This is not working...
+})
+
+test('pages are automatically imported', () => {
+  const rwjsPath = getPaths()
+  const result = pretranspileFile(rwjsPath.web.routes)
+  expect(result?.code).toContain(
+    `const FatalErrorPage = { name: "FatalErrorPage", loader: () => import("./pages/FatalErrorPage/FatalErrorPage") };`
+  )
+})
+
+test('pretranspiles all the web files', () => {
+  pretranspileWeb()
+})

--- a/packages/internal/src/pretranspile.ts
+++ b/packages/internal/src/pretranspile.ts
@@ -1,0 +1,121 @@
+// This file will only transpile the "magic parts" of RedwoodJS, leaving
+// everything else unchanged, the motivation for doing so is making
+// RedwoodJS easier to integrate with newer build tools.
+
+import fs from 'fs'
+import path from 'path'
+
+import { transform } from '@babel/core'
+import fg from 'fast-glob'
+
+import { isCellFile } from './files'
+import { getPaths } from './paths'
+
+export const pretranspileWeb = () => {
+  const rwjsPaths = getPaths()
+  const files = fg.sync('src/**/*.{js,jsx,ts,tsx}', {
+    cwd: rwjsPaths.web.base,
+  })
+  // hash files to understand if they've changed, and if we should re-transpile htem?
+  for (const srcPath of files) {
+    const result = pretranspileFile(path.join(rwjsPaths.web.base, srcPath))
+    if (!result?.code) {
+      // warn?
+      return undefined
+    }
+
+    // Allow this to be configureable.
+    const dstPath = path.join(
+      rwjsPaths.generated.pretranspile,
+      'web',
+      srcPath.replace('.tsx', '.js').replace('.ts', '.js')
+    )
+
+    fs.mkdirSync(path.dirname(dstPath), { recursive: true })
+    fs.writeFileSync(dstPath, result.code)
+  }
+}
+
+export const getBabelPlugins = (srcPath: string) => {
+  const rwjsPaths = getPaths()
+
+  const plugins = [
+    [
+      require('@redwoodjs/core/dist/babelPlugins/babel-plugin-redwood-src-alias'),
+      {
+        srcAbsPath: rwjsPaths.web.src,
+      },
+    ],
+    [
+      require('@redwoodjs/core/dist/babelPlugins/babel-plugin-redwood-directory-named-import'),
+    ],
+    [
+      '@babel/plugin-transform-typescript',
+      {
+        isTSX: true,
+        allExtensions: true,
+      },
+    ],
+    [
+      'babel-plugin-auto-import',
+      {
+        declarations: [
+          {
+            // import { React } from 'react'
+            default: 'React',
+            path: 'react',
+          },
+          {
+            // import PropTypes from 'prop-types'
+            default: 'PropTypes',
+            path: 'prop-types',
+          },
+          {
+            // import gql from 'graphql-tag'
+            default: 'gql',
+            path: 'graphql-tag',
+          },
+          {
+            // import { mockGraphQLQuery, mockGraphQLMutation, mockCurrentUser } from '@redwoodjs/testing'
+            members: [
+              'mockGraphQLQuery',
+              'mockGraphQLMutation',
+              'mockCurrentUser',
+            ],
+            path: '@redwoodjs/testing',
+          },
+        ],
+      },
+    ],
+    [
+      'babel-plugin-graphql-tag',
+      {
+        importSources: ['graphql-tag'],
+        onlyMatchImportSuffix: true,
+      },
+    ],
+    isCellFile(srcPath) && [
+      require('@redwoodjs/core/dist/babelPlugins/babel-plugin-redwood-cell'),
+    ],
+    rwjsPaths.web.routes === srcPath && [
+      require('@redwoodjs/core/dist/babelPlugins/babel-plugin-redwood-routes-auto-loader'),
+      {
+        useStaticImports: process.env.__REDWOOD__PRERENDERING === '1',
+      },
+    ],
+  ].filter(Boolean)
+
+  return plugins as Array<any>
+}
+
+export const pretranspileFile = (srcPath: string) => {
+  const code = fs.readFileSync(srcPath, 'utf-8')
+  const result = transform(code, {
+    cwd: getPaths().base,
+    filename: srcPath,
+    configFile: false,
+    plugins: getBabelPlugins(srcPath),
+    retainLines: true,
+  })
+  return result
+}


### PR DESCRIPTION
This PR takes all our "magic conventions" and _just_ transpiles that code into a separate directory. It also strips out TypeScript. So you're left with modern JS.

- [ ] Copy the non-source-code files: images, json, etc.
- [ ] Add a CLI command so that a person can invoke this
- [ ] Add a "web-vite-js" side.

