### PR TITLE
Rename the CLI "rw typeCheck" for "rw typecheck"

### DIFF
--- a/packages/cli/src/commands/__tests__/type-check.test.js
+++ b/packages/cli/src/commands/__tests__/type-check.test.js
@@ -39,7 +39,7 @@ import execa from 'execa'
 
 import { runCommandTask } from 'src/lib'
 
-import { handler } from '../typeCheck'
+import { handler } from '../typecheck'
 
 afterEach(() => {
   jest.clearAllMocks()

--- a/packages/cli/src/commands/__tests__/type-check.test.js
+++ b/packages/cli/src/commands/__tests__/type-check.test.js
@@ -39,7 +39,7 @@ import execa from 'execa'
 
 import { runCommandTask } from 'src/lib'
 
-import { handler } from '../typecheck'
+import { handler } from '../typeCheck'
 
 afterEach(() => {
   jest.clearAllMocks()

--- a/packages/cli/src/commands/typeCheck.js
+++ b/packages/cli/src/commands/typeCheck.js
@@ -11,7 +11,7 @@ import { getPaths } from 'src/lib'
 import c from 'src/lib/colors'
 import { generatePrismaClient } from 'src/lib/generatePrismaClient'
 
-export const command = 'typeCheck [sides..]'
+export const command = 'typecheck [sides..]'
 export const aliases = ['tsc', 'tc', 'type-check']
 export const description = 'Run a TypeScript compiler check on your project'
 export const builder = (yargs) => {


### PR DESCRIPTION
This simply change the CLI for typecheck to keep it in lowercase like the [doc](https://redwoodjs.com/docs/typescript#running-type-checks) 
fix #2904 