### PR TITLE
Upgrades supabase-js to support Discord third party authentication

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "devDependencies": {
     "@auth0/auth0-spa-js": "1.15.0",
-    "@supabase/supabase-js": "1.13.1",
+    "@supabase/supabase-js": "1.18.0",
     "@types/netlify-identity-widget": "1.9.1",
     "@types/react": "17.0.9",
     "firebase": "8.6.5",

--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -14,7 +14,7 @@ export interface AuthClientSupabase extends AuthClient {
    * @param options.email The user's email address.
    * @param options.password The user's password.
    * @param options.refreshToken A valid refresh token that was returned on login.
-   * @param { 'apple' | 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter' } options.provider One of the providers supported by GoTrue.
+   * @param { 'apple' | 'azure' | 'bitbucket' | 'discord' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter' } options.provider One of the providers supported by GoTrue.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
    * @param scopes A space-separated list of scopes granted to the OAuth application.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,17 +4149,17 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@supabase/gotrue-js@^1.16.2":
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-1.16.2.tgz#38fc262ddbcdb6020109cef2ed7e6f2770365ad9"
-  integrity sha512-zIVPYTN2f4rDQA/6nK9OPxzWNZ0N9gJzd/U1cu2ugZnwM0L7oiqk3/3ijxC2huLYveTOwqC9NMpKYWsQsLf6Bg==
+"@supabase/gotrue-js@^1.16.6":
+  version "1.16.6"
+  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-1.16.6.tgz#d9d63740b11ad51d2f8d6c68e9ac16bb83439888"
+  integrity sha512-tLaG4G4sMW2P1hyq05Nr0jM/6AbdiWkjOPbM+QZsuVSsNbZ/z+BNxuE5q+6zHOnoP+YKEHup7x9xKR0zy2UqUQ==
   dependencies:
     cross-fetch "^3.0.6"
 
-"@supabase/postgrest-js@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-0.29.0.tgz#3d49b6675930b5010c7f36f0844f5797ce4d1d14"
-  integrity sha512-QvpzatmcOwPTbgCJacLqpwPPsbJ2erEA2ysS4+7avJIXT8C/WbmsM7KsQHD9JcEc6fqocMpqCm7YXJIFfUZTBw==
+"@supabase/postgrest-js@^0.33.0":
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-0.33.0.tgz#36e0bfd0f79a0fa01a4bb7c7881ee463fd7d60a8"
+  integrity sha512-og6Evdkan7Qp6+tOch7Pyq+ZWMnrCQtPHWwPpsN5A3iYQSro2yn21Yvazs9qAFoWAeTGNkuTOVpShT5Mbc9WcQ==
   dependencies:
     cross-fetch "^3.0.6"
 
@@ -4171,22 +4171,22 @@
     "@types/websocket" "^1.0.1"
     websocket "^1.0.34"
 
-"@supabase/storage-js@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-1.2.0.tgz#421f353761c7801bff8f620af9276145508c43ea"
-  integrity sha512-fyt99sqNcDGP7Y2ekQ1WDPOQLaGw24aCLAOnBwW0w/Lb7qBQihB+YVzQEQBYdx4YitAcDsgUCy1oHuZcKY40RA==
+"@supabase/storage-js@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-1.2.2.tgz#6eeef2d1365af2497b35ae6c6384f5dfbd75f5b6"
+  integrity sha512-EJ2BsfD7Mc+fXJqRef3YiWF8kg/GhBdxIil7EzmrAFBSJ3VCbN4sqzvCCUYK2dtNICUV3JOKh5SBX2RrgROIOA==
   dependencies:
     cross-fetch "^3.1.0"
 
-"@supabase/supabase-js@1.13.1":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-1.13.1.tgz#7ea5a97c06b6ab1e3ae0a2e341732241689fb222"
-  integrity sha512-ZxR7g1mdRdbieS92oatOsfEn0M4O54sUO96KDmqn1TwM3r1eUdh/ERgyrcONKt7qV2f5RQ+KdXe8X0A43f0DnA==
+"@supabase/supabase-js@1.18.0":
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-1.18.0.tgz#912d8ae6ab611cfb156aada4d15fcee59e8f6e36"
+  integrity sha512-0gkL4oDSsTNc0t0ks3aIuIoPzlqix4Jqc9lII3cczaaN8MYjZDKTo48MkWvnwXm0pYuoS8wAoGzRjQ6llXAUHw==
   dependencies:
-    "@supabase/gotrue-js" "^1.16.2"
-    "@supabase/postgrest-js" "^0.29.0"
+    "@supabase/gotrue-js" "^1.16.6"
+    "@supabase/postgrest-js" "^0.33.0"
     "@supabase/realtime-js" "^1.0.9"
-    "@supabase/storage-js" "^1.2.0"
+    "@supabase/storage-js" "^1.2.2"
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/2939

Supabase now supports authentication via Discord.

https://github.com/supabase/gotrue-js/blob/4575b2a116048b8226b5d4bd12a33777571b9b2a/src/lib/types.ts#L1

https://twitter.com/supabase_io/status/1410912532705943556?s=21

This PR upgrades to the latest Supabase JS client and supports Discord auth.