### PR TITLE
Used RHF get to retrieve errors

### DIFF
--- a/packages/forms/src/__tests__/form.test.tsx
+++ b/packages/forms/src/__tests__/form.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { toHaveFocus } from '@testing-library/jest-dom/matchers'
+import { toHaveFocus, toHaveClass } from '@testing-library/jest-dom/matchers'
 import {
   screen,
   render,
@@ -9,7 +9,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-expect.extend({ toHaveFocus })
+expect.extend({ toHaveFocus, toHaveClass })
 
 import {
   Form,
@@ -389,6 +389,7 @@ describe('Form', () => {
           defaultValue="George123"
           data-testid="streetField"
           validation={{ pattern: /^[a-zA-z]+$/i }}
+          errorClassName="border-red"
         />
         <FieldError name="address.street" data-testid="streetFieldError" />
         <Submit>Save</Submit>
@@ -406,8 +407,10 @@ describe('Form', () => {
 
       const phoneError = screen.getByTestId('phoneFieldError').textContent
       const streetError = screen.getByTestId('streetFieldError').textContent
+      const streetField = screen.getByTestId('streetField')
       expect(phoneError).toEqual('phone is not formatted correctly')
       expect(streetError).toEqual('address.street is not formatted correctly')
+      expect(streetField).toHaveClass('border-red', { exact: true })
     })
   })
 })

--- a/packages/forms/src/__tests__/form.test.tsx
+++ b/packages/forms/src/__tests__/form.test.tsx
@@ -21,6 +21,7 @@ import {
   DateField,
   SelectField,
   Submit,
+  FieldError,
 } from '../index'
 
 describe('Form', () => {
@@ -369,5 +370,44 @@ describe('Form', () => {
     )
 
     spy.mockRestore()
+  })
+
+  it('for a FieldError with name set to path', async () => {
+    const mockFn = jest.fn()
+
+    render(
+      <Form onSubmit={mockFn}>
+        <TextField
+          name="phone"
+          defaultValue="abcde"
+          data-testid="phoneField"
+          validation={{ pattern: /^[0-9]+$/i }}
+        />
+        <FieldError name="phone" data-testid="phoneFieldError" />
+        <TextField
+          name="address.street"
+          defaultValue="George123"
+          data-testid="streetField"
+          validation={{ pattern: /^[a-zA-z]+$/i }}
+        />
+        <FieldError name="address.street" data-testid="streetFieldError" />
+        <Submit>Save</Submit>
+      </Form>
+    )
+    fireEvent.click(screen.getByText('Save'))
+    // The validation should catch and prevent the onSubmit from being called
+    await waitFor(async () => {
+      await new Promise((res) =>
+        setTimeout(() => {
+          res(1)
+        }, 50)
+      )
+      expect(mockFn).not.toHaveBeenCalled()
+
+      const phoneError = screen.getByTestId('phoneFieldError').textContent
+      const streetError = screen.getByTestId('streetFieldError').textContent
+      expect(phoneError).toEqual('phone is not formatted correctly')
+      expect(streetError).toEqual('address.street is not formatted correctly')
+    })
   })
 })

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -2,6 +2,7 @@ import React, { useContext, forwardRef } from 'react'
 
 import pascalcase from 'pascalcase'
 import {
+  get,
   useForm,
   FormProvider,
   useFormContext,
@@ -213,7 +214,7 @@ interface FieldErrorProps extends React.HTMLProps<HTMLSpanElement> {
 
 const FieldError = (props: FieldErrorProps) => {
   const { errors } = useFormContext()
-  const validationError = errors[props.name]
+  const validationError = get(errors, props.name)
   const errorMessage =
     validationError &&
     (validationError.message ||

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -90,7 +90,7 @@ const inputTagProps = <T extends InputTagProps>(
   }, [contextError, props.name, setError])
 
   // any errors on this field
-  const validationError = errors[props.name]
+  const validationError = get(errors, props.name)
 
   // get errorStyle/errorClassName and replace style/className if present
   // Also remove dataType and transformValue from tagProps


### PR DESCRIPTION
A simple fix for #2979 to retrieve form `errors` using lodash like `get` utility from RHF 