### PR TITLE
Update Route param parser TS

### DIFF
--- a/packages/internal/src/generate/templates/web-routerRoutes.d.ts.template
+++ b/packages/internal/src/generate/templates/web-routerRoutes.d.ts.template
@@ -1,7 +1,12 @@
 import '@redwoodjs/router'
+import { A } from 'ts-toolbelt'
 
-type ParamType<constraint> = constraint extends "Int" ? number : constraint extends "Boolean" ? boolean : constraint extends "Float" ? number : string;
-type RouteParams<Route> = ${"Route extends `${string}/{${infer Param}:${infer Constraint}}/${infer Rest}` ? { [Entry in Param]: ParamType<Constraint> } & RouteParams<`/${Rest}`> : Route extends `${string}/{${infer Param}:${infer Constraint}}` ? { [Entry in Param]: ParamType<Constraint> } : Route extends `${string}/{${infer Param}}/${infer Rest}` ? { [Entry in Param]: string } & RouteParams<`/${Rest}`> : {}"}
+
+
+type RouteParams<Route> = ${"Route extends `${string}/${infer Rest}`"}
+  ? A.Compute<ParsedParams<Rest>>
+  : {}
+
 type QueryParams = Record<string | number, string | number | boolean>
 
 declare module '@redwoodjs/router' {
@@ -14,3 +19,40 @@ ${routes.map(
 ).join('\n')}
   }
 }
+
+type ParamType<constraint> = constraint extends 'Int'
+  ? number
+  : constraint extends 'Boolean'
+  ? boolean
+  : constraint extends 'Float'
+  ? number
+  : string
+
+// Path string parser for Redwood Routes
+type ParsedParams<PartialRoute> =
+  // {a:Int}/[...moar]
+  ${"PartialRoute extends `{${infer Param}:${infer Constraint}}/${infer Rest}`"}
+    ? // check for greedy match e.g. {b}/{c:Int}
+      // Param = b}/{c, Rest2 = {c, Constrait = Int so we reconstruct the old one {c + : + Int + }
+      ${"Param extends `${infer Param2}}/${infer Rest2}`"}
+      ? { [ParamName in Param2]: string } &
+          ${"ParsedParams<`${Rest2}:${Constraint}}`> &"}
+          ${"ParsedParams<`${Rest}`>"}
+      ${": { [Entry in Param]: ParamType<Constraint> } & ParsedParams<`${Rest}`>"}
+    : // has type, but at the end e.g.{d:Int}
+    ${"PartialRoute extends `{${infer Param}:${infer Constraint}}`"}
+    ? // Greedy match order 2
+      ${"Param extends `${infer Param2}}/${infer Rest2}`"}
+      ? { [ParamName in Param2]: string } &
+          ${"ParsedParams<`${Rest2}:${Constraint}}`>"}
+      : { [Entry in Param]: ParamType<Constraint> }
+    : // no type, but has stuff ater it {c}/{d}
+    ${"PartialRoute extends `{${infer Param}}/${infer Rest}`"}
+    ${"? { [ParamName in Param]: string } & ParsedParams<`${Rest}`>"}
+    : // last one with no type e.g. {d}
+    ${"PartialRoute extends `{${infer Param}}`"}
+    ? { [ParamName in Param]: string }
+    : // if theres a non param
+    ${"PartialRoute extends `${string}/${infer Rest}`"}
+    ${"? ParsedParams<`${Rest}`>"}
+    : {}


### PR DESCRIPTION
Fixes #2868

- Updates Route parser type to support more cases
- This time round, uses Compute to have a nicer hover experience

Tested with the following

```ts
type mixed = RouteParams<'/path/{b:Int}/{c}/{d}'>
type oneEach = RouteParams<'/path/{b:Int}/{c}/{d:Boolean}'>
type oneEachDiffOrder = RouteParams<'/path/{b}/{c:Int}/{d:Boolean}'>
type noTypesatall3 = RouteParams<'/path/{b}/{c}/{d}'>

type aftersOnly2 = RouteParams<'/path/{b}/{c}'>
type aftersOnly4 = RouteParams<'/path/{b}/{c}/{d}/{e}'>
type aftWithTypes = RouteParams<'/path/{b:Int}/{c}'>
type aftWithTypes2 = RouteParams<'/path/{b:Int}/{c:Boolean}'>

// greedy matching {b}/{c:Int}
type aftWithTypes3 = RouteParams<'/path/{b}/{c:Int}/{d:Boolean}'>

// greedy matching reversed {b:Int}/{c}
type aftWithTypes4 = RouteParams<'/path/{b:Int}/{c}/{d:Boolean}'>

type aftMIxed = RouteParams<'/path/{b:Int}/{c:Boolean}/{d}/{e:Int}'>
type aftMIxed2 = RouteParams<'/path/{b:Int}/{c:Boolean}/{d}/{e:String}/{f}'>

type nonParamsInTheMiddle =
  RouteParams<'/user/{userId}/edit/likes/{likeId:Int}'>

type badParams =
  RouteParams<'/mega/{bId:Int}/s/d/{year:Int}/{month:Int}/{monthDates}/e/{eId:Int}/s'>
```