### PR TITLE
DevExp: Add node_modules and .redwood to vscode files exclusion list

### DIFF
--- a/packages/create-redwood-app/template/.vscode/settings.json
+++ b/packages/create-redwood-app/template/.vscode/settings.json
@@ -7,5 +7,9 @@
   },
   "[prisma]": {
     "editor.formatOnSave": true
+  },
+  "files.exclude": {
+    "**/node_modules": true,
+    ".redwood": true
   }
 }


### PR DESCRIPTION
Very opinionated, but helps someone setting up new vscode rw project...  to exclude the clutter and focus on app.

I was very confused why some directories were replicated.
![image](https://user-images.githubusercontent.com/1700776/125002357-1496a580-e098-11eb-8f57-7e5d750a6cca.png)

I was like.... I don't have this tracked in my repo!! 

DX first :) 

