### PR TITLE
add alias `dataMigrate` to data-migrate command

### DIFF
--- a/packages/cli/src/commands/data-migrate.js
+++ b/packages/cli/src/commands/data-migrate.js
@@ -1,5 +1,5 @@
 export const command = 'data-migrate <command>'
-export const aliases = ['dm']
+export const aliases = ['dm', 'dataMigrate']
 export const description = 'Migrate the data in your database'
 import terminalLink from 'terminal-link'
 


### PR DESCRIPTION
In https://github.com/redwoodjs/redwood/pull/2988 we incorrectly understood that Yargs would create the alias `dataMigrate`, making the PR backward compatible. Currently `dataMigrate` is referenced in the codebase. And, more importantly, Render Yaml requires calling this command explicitly — deprecating would mean projects would need to update Render.yaml manually. 

If we do choose to deprecate this alias, we will need to manage and message accordingly.