### PR TITLE
Fix issue where generate scaffold would crash if using double quotes

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -493,7 +493,7 @@ const addLayoutImport = ({ model: name, path: scaffoldPath = '' }) => {
   const routesContent = readFile(routesPath).toString()
 
   const newRoutesContent = routesContent.replace(
-    /'@redwoodjs\/router'(\s*)/,
+    /['"]@redwoodjs\/router['"](\s*)/,
     `'@redwoodjs/router'\n${importLayout}$1`
   )
   writeFile(routesPath, newRoutesContent, { overwriteExisting: true })
@@ -505,8 +505,13 @@ const addSetImport = () => {
   const routesPath = getPaths().web.routes
   const routesContent = readFile(routesPath).toString()
   const [redwoodRouterImport, importStart, spacing, importContent, importEnd] =
-    routesContent.match(/(import {)(\s*)([^]*)(} from '@redwoodjs\/router')/) ||
+    routesContent.match(/(import {)(\s*)([^]*)(} from ['"]@redwoodjs\/router['"])/) ||
     []
+
+  if (!redwoodRouterImport) {
+    return "Couldn't add Set import from @redwoodjs/router to Routes.{js,tsx}"
+  }
+
   const routerImports = importContent.replace(/\s/g, '').split(',')
   if (routerImports.includes(PACKAGE_SET)) {
     return 'Skipping Set import'

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -501,15 +501,19 @@ const addLayoutImport = ({ model: name, path: scaffoldPath = '' }) => {
   return 'Added layout import to Routes.{js,tsx}'
 }
 
-const addSetImport = () => {
+const addSetImport = (task) => {
   const routesPath = getPaths().web.routes
   const routesContent = readFile(routesPath).toString()
   const [redwoodRouterImport, importStart, spacing, importContent, importEnd] =
-    routesContent.match(/(import {)(\s*)([^]*)(} from ['"]@redwoodjs\/router['"])/) ||
-    []
+    routesContent.match(
+      /(import {)(\s*)([^]*)(} from ['"]@redwoodjs\/router['"])/
+    ) || []
 
   if (!redwoodRouterImport) {
-    return "Couldn't add Set import from @redwoodjs/router to Routes.{js,tsx}"
+    task.skip(
+      "Couldn't add Set import from @redwoodjs/router to Routes.{js,tsx}"
+    )
+    return undefined
   }
 
   const routerImports = importContent.replace(/\s/g, '').split(',')
@@ -579,7 +583,7 @@ const tasks = ({ model, path, force, tests, typescript, javascript }) => {
       },
       {
         title: 'Adding set import...',
-        task: async () => addSetImport({ model, path }),
+        task: async (_, task) => addSetImport(task),
       },
       {
         title: 'Adding scaffold routes...',


### PR DESCRIPTION
`yarn rw g scaffold Something` would crash if your Prettier config was set up to use `"` instead of `'` because of a regex that assumed `'` throughout the codebase.

This both corrects that regex so it is flexible between the quotation styles and also adds a guard so that the scaffold process will complete even if that regex fails to match in the future.

Resolves #3027 