### PR TITLE
Fix Storybook stories path on Windows

### DIFF
--- a/packages/testing/config/storybook/main.js
+++ b/packages/testing/config/storybook/main.js
@@ -4,7 +4,11 @@ const path = require('path')
 const { merge } = require('webpack-merge')
 
 const { getSharedPlugins } = require('@redwoodjs/core/config/webpack.common.js')
-const { getConfig, getPaths } = require('@redwoodjs/internal')
+const {
+  importStatementPath,
+  getConfig,
+  getPaths,
+} = require('@redwoodjs/internal')
 
 const config = getConfig()
 
@@ -14,7 +18,9 @@ const baseConfig = {
   core: {
     builder: 'webpack5',
   },
-  stories: [`${rwjsPaths.web.src}/**/*.stories.{tsx,jsx,js}`],
+  stories: [
+    `${importStatementPath(rwjsPaths.web.src)}/**/*.stories.{tsx,jsx,js}`,
+  ],
   addons: [config.web.a11y && '@storybook/addon-a11y'].filter(Boolean),
   webpackFinal: (sbConfig, { configType }) => {
     // configType is 'PRODUCTION' or 'DEVELOPMENT', why shout?


### PR DESCRIPTION
Storybook takes the path in the `stories` config setting and uses that to import the stories to run. On Windows our config ended up being a path with a mix of `\\` and `/` path separators. This PR makes sure we use only `/` which works for importing files on both Windows and Posix. See the three linked issues/PRs for more info.

Fixes #3046 

BTW, I've already fixed this once before in #1324 (Which fixed my issue #954)
