### PR TITLE
DbAuth: Fix TS error with authModelAccessor

### DIFF
--- a/packages/api/src/functions/dbAuth/DbAuthHandler.ts
+++ b/packages/api/src/functions/dbAuth/DbAuthHandler.ts
@@ -17,7 +17,7 @@ interface DbAuthHandlerOptions {
    * The name of the property you'd call on `db` to access your user table.
    * ie. if your Prisma model is named `User` this value would be `user`, as in `db.user`
    */
-  authModelAccessor: string
+  authModelAccessor: keyof PrismaClient
   /**
    *  A map of what dbAuth calls a field to what your database calls it.
    * `id` is whatever column you use to uniquely identify a user (probably


### PR DESCRIPTION
I was getting this error when trying to build the framework

![image](https://user-images.githubusercontent.com/30793/125907125-04f4c30d-2b09-4d6a-9e27-6434851b971c.png)

```
Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'PrismaClient<PrismaClientOptions, never, RejectOnNotFound | RejectPerOperation | undefined>'.
  No index signature with a parameter of type 'string' was found on type 'PrismaClient<PrismaClientOptions, never, RejectOnNotFound | RejectPerOperation | undefined>'.ts(7053)
```

This PR fixes the error by using the `keyof` types from `PrismaClient`