### PR TITLE
Made the children prop optional for layout template

### DIFF
--- a/packages/cli/src/commands/generate/layout/__tests__/__snapshots__/layout.test.ts.snap
+++ b/packages/cli/src/commands/generate/layout/__tests__/__snapshots__/layout.test.ts.snap
@@ -38,7 +38,7 @@ import '@reach/skip-nav/styles.css'
  */
 
 type A11yLayoutProps = {
-  children: React.ReactNode
+  children?: React.ReactNode
 }
 
 const A11yLayout = ({ children }: A11yLayoutProps) => {

--- a/packages/cli/src/commands/generate/layout/templates/layout.tsx.a11yTemplate
+++ b/packages/cli/src/commands/generate/layout/templates/layout.tsx.a11yTemplate
@@ -8,7 +8,7 @@ import '@reach/skip-nav/styles.css'
  */
 
 type ${singularPascalName}LayoutProps = {
-  children: React.ReactNode
+  children?: React.ReactNode
 }
 
 const ${singularPascalName}Layout = ({ children }: ${singularPascalName}LayoutProps) => {

--- a/packages/cli/src/commands/generate/layout/templates/layout.tsx.template
+++ b/packages/cli/src/commands/generate/layout/templates/layout.tsx.template
@@ -1,5 +1,5 @@
 type ${singularPascalName}LayoutProps = {
-  children: React.ReactNode
+  children?: React.ReactNode
 }
 
 const ${singularPascalName}Layout = ({ children }: ${singularPascalName}LayoutProps) => {


### PR DESCRIPTION
close #3035 

@dac09 

### 2 fixes here:
1. change the test
2. change the type

The reason we go with solution 2 here is for the case where the content is gone after a conditional rendering. Usually, it will lead to ugly UI, but for MVP stage, highly likely it will happen