### PR TITLE
fix: Fixes yarn build:test-project failing due to jscodeshift

### DIFF
--- a/tasks/test-project/package.json
+++ b/tasks/test-project/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "transform": "jscodeshift"
+    "transform": "node node_modules/.bin/jscodeshift"
   },
   "dependencies": {
     "jscodeshift": "^0.13.0"


### PR DESCRIPTION
This fixes 

`Command failed with exit code 127:`

which happens when running `yarn build:test-project`. This is to do with line endings, when jscodeshift runs. 