### PR TITLE
[internal] fix: Cleans prisma types on build:clean | Logger types 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "build": "yarn framework build",
     "build:js": "yarn framework build:js",
     "build:types": "yarn framework build:types",
-    "build:clean": "yarn framework build:clean",
+    "build:clean": "yarn clean:prisma && yarn framework build:clean",
     "build:watch": "yarn framework build:watch",
     "test": "yarn framework test",
+    "clean:prisma": "rimraf node_modules/.prisma/client && node node_modules/@prisma/client/scripts/postinstall.js",
     "lint": "yarn framework lint",
     "lint:fix": "yarn framework lint:fix",
 

--- a/packages/api/src/logger/index.ts
+++ b/packages/api/src/logger/index.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from '@prisma/client'
 import pino, {
   BaseLogger,
   DestinationStream,
@@ -10,6 +9,10 @@ import pino, {
 import * as prettyPrint from 'pino-pretty'
 
 export type LogLevel = 'info' | 'query' | 'warn' | 'error'
+
+// @TODO use type from Prisma once the issue is solved
+// https://github.com/prisma/prisma/issues/8291
+type PrismaClient = any
 
 type LogDefinition = {
   level: LogLevel
@@ -350,6 +353,8 @@ interface PrismaLoggingConfig {
  */
 export const handlePrismaLogging = (config: PrismaLoggingConfig): void => {
   const logger = config.logger.child({
+    // @TODO Change this once this issue is resolved
+    // See https://github.com/prisma/prisma/issues/8290
     prisma: { clientVersion: config.db['_clientVersion'] },
   })
 


### PR DESCRIPTION
Fixes the prisma type error we get when trying to build the framework.

Somewhere in our execution flow, the prisma types are generated. `build:clean` now clears this to restore it to the default

**Note: this is a workaround till we have fixes for the following issues from Prisma**
- Generated types for `prisma.$on(..)` are incorrect: https://github.com/prisma/prisma/issues/8291
- Expose prisma client version in public var https://github.com/prisma/prisma/issues/8290