### PR TITLE
fix: generate scaffold routes when <Router> contains props

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -408,7 +408,7 @@ export const cleanupEmptyDirsTask = (files) => {
 
 const wrapWithSet = (routesContent, layout, routes, newLineAndIndent) => {
   const [_, indentOne, indentTwo] = routesContent.match(
-    /([ \t]*)<Router>[^<]*[\r\n]+([ \t]+)/
+    /([ \t]*)<Router.*?>[^<]*[\r\n]+([ \t]+)/
   ) || ['', 0, 2]
   const oneLevelIndent = indentTwo.slice(0, indentTwo.length - indentOne.length)
   const newRoutesWithExtraIndent = routes.map((route) => oneLevelIndent + route)
@@ -426,7 +426,8 @@ export const addRoutesToRouterTask = (routes, layout) => {
   const newRoutes = routes.filter((route) => !routesContent.match(route))
 
   if (newRoutes.length) {
-    const [routerStart, newLineAndIndent] = routesContent.match(/<Router>(\s*)/)
+    const [routerStart, newLineAndIndent] =
+      routesContent.match(/\s*<Router.*?>(\s*)/)
     const routesBatch = layout
       ? wrapWithSet(routesContent, layout, newRoutes, newLineAndIndent)
       : newRoutes.join(newLineAndIndent)

--- a/yarn.lock
+++ b/yarn.lock
@@ -16098,7 +16098,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
+resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.2.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
fixes #3056

This fixes the case where the scaffold generator would fail to generate routes if `<Routes>` contained props, e.g. `<Router useAuth={useAuth}>`