### PR TITLE
Add help command to rwfw

### DIFF
--- a/packages/cli/src/rwfw.js
+++ b/packages/cli/src/rwfw.js
@@ -42,7 +42,8 @@ console.log(
 )
 
 let command = process.argv.slice(2)
-if (!command.length) {
+const helpCommands = ['help', '--help']
+if (!command.length || command.some((cmd) => helpCommands.includes(cmd))) {
   command = ['run']
 }
 


### PR DESCRIPTION
This PR will:

- [x] Makes `yarn rwfw --help|help` output the same as `yarn rwfw`

As mentioned in #3074, we should be able to run `yarn rwfw --help|help` and get the same output as `yarn rwfw`. This PR enables that. 😄 