### PR TITLE
Upgrade setup tailwind

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "param-case": "3.0.4",
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
-    "prettier": "2.3.1",
+    "prettier": "2.3.2",
     "prisma": "2.27.0",
     "prompts": "2.4.1",
     "rimraf": "3.0.2",

--- a/packages/cli/src/commands/setup/tailwind/templates/postcss.config.js.template
+++ b/packages/cli/src/commands/setup/tailwind/templates/postcss.config.js.template
@@ -2,7 +2,7 @@ const path = require('path')
 
 module.exports = {
   plugins: [
-    require('tailwindcss')(path.resolve(__dirname, '../tailwind.config.js')),
+    require('tailwindcss')(path.resolve(__dirname, 'tailwind.config.js')),
     require('autoprefixer'),
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15235,15 +15235,15 @@ prettier@2.3.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
   integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
-prettier@2.3.1, prettier@^2.0.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
-  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
-
-prettier@^2.2.1:
+prettier@2.3.2, prettier@^2.2.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
+prettier@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.1.tgz#76903c3f8c4449bc9ac597acefa24dc5ad4cbea6"
+  integrity sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==
 
 prettier@~2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This PR upgrades the setup tailwind command to 1) take advantage of postcss v8 compatibility and 2) enable jit mode by purging (effectively "watching") the correct files.

Todos:
- [x] we add `@tailwind` directives to index.css but there's other ways to do it. look more into the pros/cons of each
  - `import 'tailwind/tailwind.css'` is now added to App.{js|tsx} instead of adding the directive block to index.css; this is cleaner and keeps index.css just for index.css things
- [ ] write a migration guide for postcss-v7 compatible users
- [x] are there other settings we should configure by default in `tailwind.config.js`?
  - jit and purge are enough
- [x] make sure css is actually being built for production: https://tailwindcss.com/docs/installation#building-your-css

Other changes:
- we use the tailwind cli to initialize a postcss.config.js (instead of maintaining a template that we copy over)
- tailwind.config.js is moved to web/config because the extension recognizes it there now