### PR TITLE
Ignore graphql-server TS errors

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -372,28 +372,35 @@ const useRedwoodLogger = (
         onExecuteDone({ result }) {
           const options = {} as any
 
-          if (includeData) {
-            options['data'] = result.data
-          }
-
-          if (result.errors && result.errors.length > 0) {
-            envelopLogger.error(
-              {
-                errors: result.errors,
-              },
-              `GraphQL execution completed with errors:`
-            )
-          } else {
-            if (includeTracing) {
-              options['tracing'] = result.extensions?.envelopTracing
+          // @ts-expect-error: Do not know where this is typed.
+          if (result.data) {
+            if (includeData) {
+              // @ts-expect-error: Do not know where this is typed.
+              options['data'] = result.data
             }
 
-            envelopLogger.info(
-              {
-                ...options,
-              },
-              `GraphQL execution completed`
-            )
+            // @ts-expect-error: Do not know where this is typed.
+            if (result.errors && result.errors.length > 0) {
+              envelopLogger.error(
+                {
+                  // @ts-expect-error: Do not know where this is typed.
+                  errors: result.errors,
+                },
+                `GraphQL execution completed with errors:`
+              )
+            } else {
+              if (includeTracing) {
+                // @ts-expect-error: Do not know where this is typed.
+                options['tracing'] = result.extensions?.envelopTracing
+              }
+
+              envelopLogger.info(
+                {
+                  ...options,
+                },
+                `GraphQL execution completed`
+              )
+            }
           }
         },
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "packages/router" },
     { "path": "packages/testing" },
     { "path": "packages/prerender" },
+    { "path": "packages/graphql-server" },
   ],
   "files": []
 }


### PR DESCRIPTION
This adds the `graphql-server` to `tsconfig.json` which builds the type definitions. I ignored the errors because I'm a bit pressed for time, but we should try and remove the errors that are ignored @dthyresson.

Related: #3125