### PR TITLE
Resolves Typescript errors in useRedwoodLogger plugin in GraphQL-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.icloud
 .idea
 .DS_Store
 node_modules

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -10,8 +10,8 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@envelop/apollo-server-errors": "1.0.0",
-    "@envelop/core": "1.0.0",
+    "@envelop/apollo-server-errors": "1.0.1",
+    "@envelop/core": "1.0.1",
     "@envelop/depth-limit": "1.0.0",
     "@envelop/disable-introspection": "1.0.0",
     "@envelop/filter-operation-type": "1.0.0",
@@ -37,6 +37,7 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
+    "@envelop/types": "1.0.1",
     "@redwoodjs/auth": "0.35.2",
     "@types/jsonwebtoken": "8.5.4",
     "@types/lodash.merge": "4.6.6",

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -51,11 +51,10 @@ import {
 
 /**
  * Used in Envelop Plugins when handling a result in the onExecuteDone event
- * because if the result might be just a single ExecutionResult or if a stream, or subscription
- * an AsyncIterator of ExecutionResult
+ * because the result might be just a single ExecutionResult or
+ * if a stream, or subscription then an AsyncIterator of ExecutionResult
  * @see https://github.com/dotansimha/envelop/blob/8021229cc19be4f0c1bcf5534fa0c0cfad4425aa/packages/core/src/graphql-typings.d.ts#L1
  */
-
 export function isAsyncIterable(
   maybeAsyncIterable: any
 ): maybeAsyncIterable is AsyncIterable<unknown> {
@@ -424,6 +423,8 @@ const useRedwoodLogger = (
 
       return {
         onExecuteDone({ result }) {
+          // we check the type of result because if in the case of a stream or subscription
+          // then the result is iterable ...
           if (isAsyncIterable(result)) {
             return {
               onNext: ({ result }) => {
@@ -431,6 +432,7 @@ const useRedwoodLogger = (
               },
             }
           }
+          // otherwise, the result is just a single ExecutionResult
           const executionResult = result as ExecutionResult
           handleResult({ result: executionResult })
           return undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,19 +1875,19 @@
     ts-node "^9"
     tslib "^2"
 
-"@envelop/apollo-server-errors@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@envelop/apollo-server-errors/-/apollo-server-errors-1.0.0.tgz#601f020308ecec7f05f451be18715d0e37c090c4"
-  integrity sha512-Yal9JCr+SLmSK9AXemCUPncY5SDjje5uaSmcDvNXuTsA3LtcwQw0OpZu3m6MGbDJxv5xcajNF2Bc3qVInaMdww==
+"@envelop/apollo-server-errors@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@envelop/apollo-server-errors/-/apollo-server-errors-1.0.1.tgz#b352dd9eafb807fb6faf1455c3041b67752dd38a"
+  integrity sha512-70yG+vwKT14Qf+4XxcQh0rm+KAClOZe1X7h+c9B0SLSWN2WYz4ZcH25uQ6gLufVaCmxq4aD2HCBep3OOrRf3Ww==
   dependencies:
     apollo-server-errors "3.0.1"
 
-"@envelop/core@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-1.0.0.tgz#2052bdce473e37df249bc718985141b47e87e6a5"
-  integrity sha512-RkByYgu77+mUJgDT56iXhd8lQno4/dneXNX0Q1WyidinOi6Xw6GcEzJAbtJfNIIShXYR39kdBn3zC9yJUcNkfg==
+"@envelop/core@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@envelop/core/-/core-1.0.1.tgz#85a37d5cd576487a3f78a2c752be28c3467d7107"
+  integrity sha512-uRvIJDeiB0UIZZ0RB9ITlkOkG/Azul84vJSgJhJ6L6Oilsd9/fik3LddyaTlikuW+rSqMM7pDsrV/Uke5j4qzw==
   dependencies:
-    "@envelop/types" "1.0.0"
+    "@envelop/types" "1.0.1"
 
 "@envelop/depth-limit@1.0.0":
   version "1.0.0"
@@ -1913,10 +1913,10 @@
   dependencies:
     tiny-lru "7.0.6"
 
-"@envelop/types@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-1.0.0.tgz#704af5b74df951c0559d6443fd2dcf6cb7368172"
-  integrity sha512-L3hHwDcDd5SO5Dck/iJxvbanRa3dx7nUZKelT8x+YcNfEgmAFvtB+y1u48ky43rygVVf7MFaFT2d0nggR1HxRg==
+"@envelop/types@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@envelop/types/-/types-1.0.1.tgz#f2b10ad63ecf002bf158ead763d98bf106e7ded9"
+  integrity sha512-2vOyCmZGfGvYMzuaxXy6kgG7oGi7QjR81O6g+zWMzTz1ANb21VBwMiX96SBDs6oUP+voOsC1p51zLeHW+sPZ+A==
 
 "@envelop/validation-cache@1.0.0":
   version "1.0.0"


### PR DESCRIPTION
Reworks https://github.com/redwoodjs/redwood/pull/3126
Fixes https://github.com/redwoodjs/redwood/issues/3125
Fixes https://github.com/redwoodjs/redwood/issues/3098

This PR reworks the `useRedwoodLogger` envelop plugin to better type the result.

The result can either be a single executionResult or an async integration of them (in streams and subscriptions).

Now that the result is properly type, a function handler will log the result(s) as needed - single or each one.

Small change: Since I have some project files in iCloud, from time to time .icloud files get sync'd and clutter up so now the .gitignore excludes there.