### PR TITLE
Typing services on makeMergedSchema

### DIFF
--- a/packages/api/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/api/src/makeMergedSchema/makeMergedSchema.ts
@@ -9,7 +9,7 @@ import type { GraphQLSchema, GraphQLFieldMap } from 'graphql'
 import merge from 'lodash.merge'
 import omitBy from 'lodash.omitby'
 
-import { Services, GraphQLTypeWithFields } from '../types'
+import { Services, ServicesCollection, GraphQLTypeWithFields } from '../types'
 
 import * as rootSchema from './rootSchema'
 
@@ -65,7 +65,7 @@ const mergeResolversWithServices = ({
 }: {
   schema: GraphQLSchema
   resolvers: { [key: string]: any }
-  services: Services
+  services: ServicesCollection
 }): IResolvers => {
   const mergedServices = merge(
     {},
@@ -190,7 +190,7 @@ export const makeMergedSchema = ({
       resolvers: Record<string, unknown>
     }
   }
-  services: Services
+  services: ServicesCollection
   /** @deprecated: Please use `schemaOptions` instead. */
   schemaDirectives?: IExecutableSchemaDefinition['schemaDirectives']
   /**

--- a/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
@@ -9,7 +9,11 @@ import type { GraphQLSchema, GraphQLFieldMap, DocumentNode } from 'graphql'
 import merge from 'lodash.merge'
 import omitBy from 'lodash.omitby'
 
-import { Services, GraphQLTypeWithFields } from '@redwoodjs/api'
+import {
+  Services,
+  ServicesCollection,
+  GraphQLTypeWithFields,
+} from '@redwoodjs/api'
 
 import * as rootSchema from './rootSchema'
 
@@ -65,7 +69,7 @@ const mergeResolversWithServices = ({
 }: {
   schema: GraphQLSchema
   resolvers: { [key: string]: any }
-  services: Services
+  services: ServicesCollection
 }): IResolvers => {
   const mergedServices = merge(
     {},
@@ -190,7 +194,7 @@ export const makeMergedSchema = ({
       resolvers: Record<string, unknown>
     }
   }
-  services: Services
+  services: ServicesCollection
   /** @deprecated: Please use `schemaOptions` instead. */
   schemaDirectives?: IExecutableSchemaDefinition['schemaDirectives']
   /**


### PR DESCRIPTION
Fix https://github.com/redwoodjs/redwood/issues/3114
Fix https://github.com/redwoodjs/redwood/issues/3123

In the app's `graphql.ts` function where we `createGraphQLHandler` there is a type issue in `services`:

```js
src/functions/graphql.ts:16:5 - error TS2322: Type 'ServicesCollection' is not assignable to type 'Services'.
  Index signatures are incompatible.
    Type 'Services' is not assignable to type 'Resolver'.
      Type 'Services' provides no match for the signature '(...args: unknown[]): unknown'.

16     services: makeServices({ services }),
       ~~~~~~~~

  ../node_modules/@redwoodjs/api/dist/makeMergedSchema/makeMergedSchema.d.ts:11:5
    11     services: Services;
           ~~~~~~~~
    The expected type comes from property 'services' which is declared here on type '{ schemas: { [key: string]: { schema: Record<string, unknown>; resolvers: Record<string, unknown>; }; }; services: Services; schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor; }; schemaOptions?: Partial<...>; }'
```

This PR corrects the type from Services to ServicesCollection.