### PR TITLE
[setup tailwind] Add ability to skip install

### DIFF
--- a/packages/cli/src/commands/setup/tailwind/tailwind.js
+++ b/packages/cli/src/commands/setup/tailwind/tailwind.js
@@ -17,6 +17,13 @@ export const builder = (yargs) => {
     description: 'Overwrite existing configuration',
     type: 'boolean',
   })
+
+  yargs.option('install', {
+    alias: 'i',
+    default: true,
+    description: 'Install packages',
+    type: 'boolean',
+  })
 }
 
 const tailwindImport = "import 'tailwindcss/tailwind.css'\n"
@@ -28,10 +35,11 @@ const addTailwindImport = (app) => {
   return app.substring(0, i) + tailwindImport + app.substring(i)
 }
 
-export const handler = async ({ force }) => {
+export const handler = async ({ force, install }) => {
   const tasks = new Listr([
     {
       title: 'Installing packages...',
+      skip: () => !install,
       task: () => {
         return new Listr([
           {


### PR DESCRIPTION
Using a setup command that installs packages doesn't gel with `yarn rwfw project:sync`. We discussed two ways around this: 
- have `yarn rwfw project:sync` copy over a dummy package with a postinstall script that runs `yarn rwfw project:copy`
- make a setup command's install step configurable, so that packages can be manually installed and manually followed up by a project:copy. This would look like...
  - `yarn add postcss postcss-loader tailwindcss autoprefixer`
  - `yarn rwfw projext:copy`
  - `yarn rw setup tailwind --no-install` 

This PR implements the second bullet point, only because I've tried to do the first and come up empty so far. Will keep trying, but as long as the install step isn't peculiar (i.e. installing ultra-specific versions) this seems like a viable option in the meantime and could be a precedent we implement for setup commands in general.