### PR TITLE
upgrade Prisma v2.28

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@clerk/clerk-sdk-node": "^0.5.0",
     "@graphql-tools/merge": "6.2.14",
-    "@prisma/client": "2.27.0",
+    "@prisma/client": "2.28.0",
     "@types/pino": "6.3.9",
     "apollo-server-lambda": "2.25.2",
     "core-js": "3.15.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.27.0",
+    "@prisma/sdk": "2.28.0",
     "@redwoodjs/api-server": "0.35.2",
     "@redwoodjs/internal": "0.35.2",
     "@redwoodjs/prerender": "0.35.2",
@@ -40,7 +40,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.3.2",
-    "prisma": "2.27.0",
+    "prisma": "2.28.0",
     "prompts": "2.4.1",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -20,7 +20,7 @@
     "@graphql-tools/merge": "6.2.14",
     "@graphql-tools/schema": "7.1.5",
     "@graphql-tools/utils": "7.10.0",
-    "@prisma/client": "2.27.0",
+    "@prisma/client": "2.28.0",
     "@redwoodjs/api": "0.35.2",
     "@types/pino": "6.3.9",
     "core-js": "3.15.2",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.27.0",
+    "@prisma/sdk": "2.28.0",
     "@redwoodjs/internal": "0.35.2",
     "@types/line-column": "1.0.0",
     "camelcase": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,20 +3070,12 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.27.0.tgz#17d98e64deea29063bee1778d85b5f7edeb14a26"
-  integrity sha512-Sh2b1M8MGbOHbwG1FEqdWTUCrEX3p7gt2e7gpaBWou8yTIJvP1UZ4YlHgpuUcR1q4pEIR/JTZJeQk2l4iDyRBQ==
+"@prisma/client@2.28.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.28.0.tgz#6cd91a3c2757814a9454ea23d7e33cd2ff3952db"
+  integrity sha512-iwdxpy0Nz8N40MnhdlRvhZOBk8+GawpEsY5FU8Tfw1k9rvIeTAi+wBHrqhY8bXq6pneZkzrdQ1Hj3tqkrbRmoQ==
   dependencies:
-    "@prisma/engines-version" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-
-"@prisma/debug@2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.26.0.tgz#a6e7b6e752aacc793211d50ed30d815576e3132d"
-  integrity sha512-dBZPmxGKXP0VhDpKgpsFM3NhjFZZmP09MKRgV3oWfZmU+X1uA+crVscrajfZsOP0T6lbP1FCDLkFEEGyNCyuFA==
-  dependencies:
-    debug "4.3.2"
-    ms "^2.1.3"
+    "@prisma/engines-version" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
 
 "@prisma/debug@2.27.0":
   version "2.27.0"
@@ -3093,15 +3085,23 @@
     debug "4.3.2"
     ms "^2.1.3"
 
-"@prisma/engine-core@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.27.0.tgz#3bc0bbca4324f973340f869f8594caa2a3c3b6b3"
-  integrity sha512-Sx1bqYoalJcBGIKLR9w2wo9IThftsenlYkgM1iEZ4jSdQoue0U8JbToeFcpF+zn+FEvidtH2pC9GG397XT18yA==
+"@prisma/debug@2.28.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.28.0.tgz#bb56e0b1baf91fe7732f8cf14759b1d035180315"
+  integrity sha512-SKihAtTPDqfm/iyLVs5xf1uLu4Ev+zcFLc8vdiGofpHTkeiu3qU1OSDPnrQ0nwn0IJsp3SeRbV0NRWTwL5Z71w==
   dependencies:
-    "@prisma/debug" "2.27.0"
-    "@prisma/engines" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-    "@prisma/generator-helper" "2.27.0"
-    "@prisma/get-platform" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+    debug "4.3.2"
+    ms "^2.1.3"
+
+"@prisma/engine-core@2.28.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.28.0.tgz#9e1dcd11b88c55e48af292c272258a10cba8391f"
+  integrity sha512-J8lbA85PFpcwm2+u6bQHLomnbsrEnsJkq1PFrplthvJDlOK/tOl9CDuxU2IriJ9KHd+0Y0qaqcGmO+xXfFu3HA==
+  dependencies:
+    "@prisma/debug" "2.28.0"
+    "@prisma/engines" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+    "@prisma/generator-helper" "2.28.0"
+    "@prisma/get-platform" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
     chalk "^4.0.0"
     execa "^5.0.0"
     get-stream "^6.0.0"
@@ -3111,23 +3111,23 @@
     terminal-link "^2.1.1"
     undici "3.3.6"
 
-"@prisma/engines-version@2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb":
-  version "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz#60a34634fe26be9caca42556605a132e70810e3c"
-  integrity sha512-pwOsYdzw8+cwKlUrCzasiRh96RhNuJ/QcKr0HwjxxlUWTmbEayDKjqRRz5fsUYIpSv5fW1B3SsbzHOqVtFZ6XQ==
+"@prisma/engines-version@2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27":
+  version "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz#6dbccdce64f792dbc21c99daef80ec03020c110d"
+  integrity sha512-BWTvF1mGxjG8EtG215uhxdeW5Uf5aiH4xhfzcFPFC3Ux5BdEM1uEBrLIixX67mI+ZNhqNZSBPf0DSf2I1IsaZw==
 
-"@prisma/engines@2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb":
-  version "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz#22084a81e90b66665aa3aacde79ef5b1bc3587fe"
-  integrity sha512-AIbIhAxmd2CHZO5XzQTPrfk+Tp/5eoNoSledOG3yc6Dk97siLvnBuSEv7prggUbedCufDwZLAvwxV4PEw3zOlQ==
+"@prisma/engines@2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27":
+  version "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz#5a563ead03405fc6ccb33fe48f8b3a8712be391e"
+  integrity sha512-r3/EnwKjbu2qz13I98hPQQdeFrOEcwdjlrB9CcoSoqRCjSHLnpdVMUvRfYuRKIoEF7p941R7/Fov0/CxOLF/MQ==
 
-"@prisma/fetch-engine@2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb":
-  version "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz#a9b2b9813852a2d8b7a86b25cb4e2edad0f5a8ab"
-  integrity sha512-KdZZ5hUnMrCuImhvoHNnhnTlDY76mnKdEnM4QtaTF9HptwbPWaX/NZ5hwGC6WZf3PjWYr4BiQoC0v8Q7RF88Kg==
+"@prisma/fetch-engine@2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27":
+  version "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz#41de37f756e59dab8d50ecb5c7cdd521da19a689"
+  integrity sha512-o30L0+IrnK8ncT5qypnMW0AagpdTGCDL9eitDp59PA4KTPcfyusgcjcIgPm0qfcsiOrbvriBYCDmjXhNKNfaMA==
   dependencies:
-    "@prisma/debug" "2.26.0"
-    "@prisma/get-platform" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+    "@prisma/debug" "2.27.0"
+    "@prisma/get-platform" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3144,34 +3144,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.27.0.tgz#405ace2f7371ef309e1699786941e89b66ea4b94"
-  integrity sha512-ol5AkNxd4MNOl8Cqb81/uJ7ASOVLgMilzU0qz6q7M2k5ModW5rT1ZU6RWAh8qzt/Ba+N9suGHkw8GoRWFiRDiw==
+"@prisma/generator-helper@2.28.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.28.0.tgz#5444f3c5bf8334f234ba25ca3c2360408e7a1495"
+  integrity sha512-KaDFroGSVfDJBQRoKdXmDvP93Ukj3gI9DVjtABlQFl5FII4VCtsOix76VK+h/Hej4p0yrU6LCCU24Jmw4Enksg==
   dependencies:
-    "@prisma/debug" "2.27.0"
+    "@prisma/debug" "2.28.0"
     "@types/cross-spawn" "^6.0.1"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
 
-"@prisma/get-platform@2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb":
-  version "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb.tgz#1247d6758ddfd7703872c02048ce776495629105"
-  integrity sha512-N+akWuGHmgCaTfnD4YUum57wd4+GfOvKiTYYIMY2CIEJbxvFw/GF9v8rozl3WRZPgL+Hx3D0ZPB8E4NgvaLy0g==
-  dependencies:
-    "@prisma/debug" "2.26.0"
-
-"@prisma/sdk@2.27.0":
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.27.0.tgz#dc42fdd7a236725a9f3e00f6aae6191f026d5e08"
-  integrity sha512-CywUaCIfCkE5bDPxJkiE7gBoSS4VsqX2QIswjXhDIDrdZ7W4T6dFQd7Ozin9aA6yvKCY6weh0E1Ck7H8MDA3/w==
+"@prisma/get-platform@2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27":
+  version "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27.tgz#52904ae6b982fa162202220f7e03554daeacabca"
+  integrity sha512-OdTubLy4lVRYNvF3N9eODWxLxUhgh2oapDVvdMO3YmHQSeYQzzHHhYHBKoUY9zpCCAbAPBik+YIXgimJp3lqQQ==
   dependencies:
     "@prisma/debug" "2.27.0"
-    "@prisma/engine-core" "2.27.0"
-    "@prisma/engines" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-    "@prisma/fetch-engine" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
-    "@prisma/generator-helper" "2.27.0"
-    "@prisma/get-platform" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+
+"@prisma/sdk@2.28.0":
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.28.0.tgz#8c2f3c3fbcc53bfb1eb68944fd023e8870a5be7c"
+  integrity sha512-JlZiuREFWoElZHbH4aJ5wqij1qQGQGnnu6h+hULX8ZQjzwreyfyQ36QTGNak6FPeR4cjjIpOsQqRxvKvhETalw==
+  dependencies:
+    "@prisma/debug" "2.28.0"
+    "@prisma/engine-core" "2.28.0"
+    "@prisma/engines" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+    "@prisma/fetch-engine" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
+    "@prisma/generator-helper" "2.28.0"
+    "@prisma/get-platform" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
     "@timsuchanek/copy" "^1.4.5"
     archiver "^4.0.0"
     arg "^5.0.0"
@@ -15531,12 +15531,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.27.0:
-  version "2.27.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.27.0.tgz#45fdecb9c2470c7ad602e804ffed70dfa7c46ad1"
-  integrity sha512-/3H9C+IPlJmY5KArhfKHMpxKXqcZIBZ+LjM1b5FxvLCGQkq/mRC96SpHcKcLtiYgftNAX13nvlxg+cBw9Dbe8Q==
+prisma@2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.28.0.tgz#33adb56e336d4c4569ec2f49df9b606771df15d0"
+  integrity sha512-f83KPLy3xk07KMY4e5otNwP2I+GsdftjOfu3e8snXylnyAC1oEpRZNe7rmONr0vAI+Qgz3LFRArhWUE/dFjKIA==
   dependencies:
-    "@prisma/engines" "2.27.0-43.cdba6ec525e0213cce26f8e4bb23cf556d1479bb"
+    "@prisma/engines" "2.28.0-17.89facabd0366f63911d089156a7a70125bfbcd27"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"


### PR DESCRIPTION
**Release Notes:**
https://github.com/prisma/prisma/releases/tag/2.28.0

Best. News. Ever:
> Prisma Adopts Semantic Versioning (SemVer)
> 
> We are adjusting our release policy to adhere more strictly to Semantic Versioning.
> 
> In the future, breaking changes in the stable development surface i.e. [General Availability](https://www.prisma.io/docs/about/releases#generally-available-ga) will only be rolled out with major version increments.
> 
> You can learn more about the change in the announcement [blog post](https://www.prisma.io/blog/prisma-adopts-semver-strictly).