### PR TITLE
add storybook ci option to test start-storybook ok

### DIFF
--- a/packages/cli/src/commands/storybook.js
+++ b/packages/cli/src/commands/storybook.js
@@ -31,9 +31,15 @@ export const builder = (yargs) => {
       type: 'string',
       default: 'public/storybook',
     })
+    .option('ci', {
+      describe:
+        "CI mode plus Smoke-test (skip prompts, don't open browser, exit after successful start)",
+      type: 'boolean',
+      default: false,
+    })
 }
 
-export const handler = ({ open, port, build, buildDirectory }) => {
+export const handler = ({ open, port, build, buildDirectory, ci }) => {
   const cwd = getPaths().web.base
 
   const staticAssetsFolder = path.join(getPaths().web.base, 'public')
@@ -59,6 +65,7 @@ export const handler = ({ open, port, build, buildDirectory }) => {
       build &&
         `--output-dir "${path.join(getPaths().web.base, buildDirectory)}"`,
       !open && '--ci',
+      ci && '--ci --smoke-test',
     ].filter(Boolean),
     {
       stdio: 'inherit',


### PR DESCRIPTION
@peterp I'm exploring a way to test storybook server start via E2E.

In this PR, I'm trying the `start-storybook --smoke-test` (Exit after successful start). Strangely, running it works as described, but it throws with a exit code `1` — seems super unhelpful 🤔:
```
...
manager (webpack 5.44.0) compiled successfully in 7939 ms
<i> [webpack-dev-middleware] wait until bundle finished: /__webpack_hmr
99% done plugins webpack-hot-middlewarewebpack built preview e0d515b292be71f5422e in 9331ms
WARN preview: [object Object]
error Command failed with exit code 1.
```

Just running the `start-storybook --ci` might be another way if we can check the output for `Storybook 6.3.6 started `. Here's what that looks like:
```
...
info => Using cached manager
99% done plugins webpack-hot-middlewarewebpack built preview e0d515b292be71f5422e in 9039ms
╭────────────────────────────────────────────────╮
│                                                │
│   Storybook 6.3.6 started                      │
│   9.71 s for preview                           │
│                                                │
│    Local:            http://localhost:7910/    │
│    On your network:  http://192.0.2.2:7910/    │
│                                                │
╰────────────────────────────────────────────────╯
99% done plugins webpack-hot-middlewarewebpack built preview 4a36af37a4de190b352d in 784ms
```

---

Do you have any other thoughts/suggestions here? Maybe I'm missing something obvious...