### PR TITLE
fix(project-generator): Add RW_PATH to execa options

### DIFF
--- a/tasks/test-project/util.js
+++ b/tasks/test-project/util.js
@@ -16,8 +16,6 @@ async function applyCodemod(codemod, target) {
   await execa('yarn transform', args, getExecaOptions(path.resolve(__dirname)))
 }
 
-const RW_FRAMEWORKPATH = path.join(__dirname, '../../')
-
 /** @type {(string) => import('execa').Options} */
 const getExecaOptions = (cwd) => ({
   shell: true,
@@ -25,7 +23,7 @@ const getExecaOptions = (cwd) => ({
   cleanup: true,
   cwd,
   env: {
-    RW_PATH: RW_FRAMEWORKPATH,
+    RW_PATH: path.join(__dirname, '../../'),
   },
 })
 

--- a/tasks/test-project/util.js
+++ b/tasks/test-project/util.js
@@ -16,12 +16,17 @@ async function applyCodemod(codemod, target) {
   await execa('yarn transform', args, getExecaOptions(path.resolve(__dirname)))
 }
 
+const RW_FRAMEWORKPATH = path.join(__dirname, '../../')
+
 /** @type {(string) => import('execa').Options} */
 const getExecaOptions = (cwd) => ({
   shell: true,
   stdio: 'inherit',
   cleanup: true,
   cwd,
+  env: {
+    RW_PATH: RW_FRAMEWORKPATH,
+  },
 })
 
 module.exports = {


### PR DESCRIPTION
This adds RW_PATH to the environment so the rwfw `project:copy` and `:sync` work even if you don't have the value set on your profile