### PR TITLE
Expose cache config for `RedwoodApolloProvider`

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -22,10 +22,14 @@ import {
 } from '../components/FetchConfigProvider'
 import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider'
 
+export type ApolloClientCacheConfig = apolloClient.InMemoryCacheConfig
+
 export type GraphQLClientConfigProp = Omit<
   ApolloClientOptions<unknown>,
   'cache'
->
+> & {
+  cacheConfig?: ApolloClientCacheConfig
+}
 
 export type UseAuthProp = () => AuthContextInterface
 
@@ -70,9 +74,11 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
 
   const httpLink = createHttpLink({ uri })
 
+  const { cacheConfig, ...forwardConfig } = config ?? {}
+
   const client = new ApolloClient({
-    cache: new InMemoryCache(),
-    ...config,
+    cache: new InMemoryCache(cacheConfig),
+    ...forwardConfig,
     link: ApolloLink.from([withToken, authMiddleware.concat(httpLink)]),
   })
 


### PR DESCRIPTION
Resolves #3144 

When using Apollo 3 as the GraphQL provider, a lot of advanced features require one be able to customize the caching policy to match your specific schema.

The ideal would be that Redwood could compute this for us in some way from the sdl. But until then, this PR exposes a pathway to customize the caching policy.

This enables features like merging single elements when performing mutations, rather than requiring you to refetch the whole query, and using smarter functions for expanding a query like `fetchMore`.