### PR TITLE
Adds reusable cell state components for Cell Loading, Empty, and Failures

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -30,7 +30,11 @@ export const Success = ({ equipmentList }) => {
 `;
 
 exports[`"equipment" withOUT list flag should find equipment by id 1`] = `
-"export const QUERY = gql\`
+"import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
+export const QUERY = gql\`
   query FindEquipmentQuery($id: Int!) {
     equipment: equipment(id: $id) {
       id
@@ -38,13 +42,11 @@ exports[`"equipment" withOUT list flag should find equipment by id 1`] = `
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
-)
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ equipment }) => {
   return <div>{JSON.stringify(equipment)}</div>
@@ -53,7 +55,11 @@ export const Success = ({ equipment }) => {
 `;
 
 exports[`creates a cell component with a camelCase word name 1`] = `
-"export const QUERY = gql\`
+"import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
+export const QUERY = gql\`
   query FindUserProfileQuery($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
@@ -61,13 +67,11 @@ exports[`creates a cell component with a camelCase word name 1`] = `
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
-)
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ userProfile }) => {
   return <div>{JSON.stringify(userProfile)}</div>
@@ -76,7 +80,11 @@ export const Success = ({ userProfile }) => {
 `;
 
 exports[`creates a cell component with a kebabCase word name 1`] = `
-"export const QUERY = gql\`
+"import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
+export const QUERY = gql\`
   query FindUserProfileQuery($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
@@ -84,13 +92,11 @@ exports[`creates a cell component with a kebabCase word name 1`] = `
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
-)
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ userProfile }) => {
   return <div>{JSON.stringify(userProfile)}</div>
@@ -99,7 +105,11 @@ export const Success = ({ userProfile }) => {
 `;
 
 exports[`creates a cell component with a multi word name 1`] = `
-"export const QUERY = gql\`
+"import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
+export const QUERY = gql\`
   query FindUserProfileQuery($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
@@ -107,13 +117,11 @@ exports[`creates a cell component with a multi word name 1`] = `
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
-)
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ userProfile }) => {
   return <div>{JSON.stringify(userProfile)}</div>
@@ -122,7 +130,11 @@ export const Success = ({ userProfile }) => {
 `;
 
 exports[`creates a cell component with a single word name 1`] = `
-"export const QUERY = gql\`
+"import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
+export const QUERY = gql\`
   query FindUserQuery($id: Int!) {
     user: user(id: $id) {
       id
@@ -130,13 +142,11 @@ exports[`creates a cell component with a single word name 1`] = `
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
-)
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ user }) => {
   return <div>{JSON.stringify(user)}</div>
@@ -145,7 +155,11 @@ export const Success = ({ user }) => {
 `;
 
 exports[`creates a cell component with a snakeCase word name 1`] = `
-"export const QUERY = gql\`
+"import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
+export const QUERY = gql\`
   query FindUserProfileQuery($id: Int!) {
     userProfile: userProfile(id: $id) {
       id
@@ -153,13 +167,11 @@ exports[`creates a cell component with a snakeCase word name 1`] = `
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
-)
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ userProfile }) => {
   return <div>{JSON.stringify(userProfile)}</div>

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,3 +1,5 @@
+import fs from 'fs'
+
 import pascalcase from 'pascalcase'
 import pluralize from 'pluralize'
 
@@ -85,16 +87,31 @@ export const files = async ({
     list: shouldGenerateList,
   })
 
+  const cellFileExtension = generateTypescript ? '.tsx' : '.js'
+
+  // use imported cell state components or inline
+  const emptyStatePath = `src/components/CellStates/EmptyState/EmptyState${cellFileExtension}`
+  const emptyStateComponentExists = fs.existsSync(emptyStatePath)
+
+  const failureStatePath = `src/components/CellStates/FailureState/FailureState${cellFileExtension}`
+  const failureStateComponentExists = fs.existsSync(failureStatePath)
+
+  const loadingStatePath = `src/components/CellStates/LoadingState/LoadingState${cellFileExtension}`
+  const loadingStateComponentExists = fs.existsSync(loadingStatePath)
+
   const cellFile = templateForComponentFile({
     name: cellName,
     suffix: COMPONENT_SUFFIX,
-    extension: generateTypescript ? '.tsx' : '.js',
+    extension: cellFileExtension,
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
     templatePath: `cell${templateNameSuffix}.tsx.template`,
     templateVars: {
       operationName,
       idType,
+      emptyStateComponentExists,
+      failureStateComponentExists,
+      loadingStateComponentExists,
     },
   })
 

--- a/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
@@ -1,6 +1,10 @@
 import type { ${operationName} } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
+import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
 export const QUERY = gql`
   query ${operationName}($id: ${idType}!) {
     ${camelName}: ${camelName}(id: $id) {
@@ -9,12 +13,12 @@ export const QUERY = gql`
   }
 `
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
 export const Failure = ({ error }: CellFailureProps) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
+  <FailureState error={error} />
 )
 
 export const Success = ({ ${camelName} }: CellSuccessProps<${operationName}>) => {

--- a/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
@@ -1,6 +1,15 @@
 import type { ${operationName} } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
+<% if (emptyStateComponentExists) { %>
+import EmptyState from 'src/components/CellStates/EmptyState'
+<% } %>
+<% if (failureStateComponentExists) { %>
+import FailureState from 'src/components/CellStates/FailureState'
+<% } %>
+<% if (loadingStateComponentExists) { %>
+import LoadingState from 'src/components/CellStates/LoadingState'
+<% } %>
 
 export const QUERY = gql`
   query ${operationName} {
@@ -9,13 +18,15 @@ export const QUERY = gql`
     }
   }
 `
-
-export const Loading = () => <div>Loading...</div>
-
-export const Empty = () => <div>Empty</div>
+<% if (emptyStateComponentExists) { %>
+export const Loading = () => <LoadingState />
+<% } %>
+<% if (failureStateComponentExists) { %>
+export const Empty = () => <EmptyState />
+<% } %>
 
 export const Failure = ({ error }: CellFailureProps) => (
-  <div style={{ color: 'red' }}>Error: {error.message}</div>
+  <FailureState error={error} />
 )
 
 export const Success = ({ ${camelName} }: CellSuccessProps<${operationName}>) => {

--- a/packages/create-redwood-app/jest.config.js
+++ b/packages/create-redwood-app/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/*.test.[jt]s?(x)'],
-  testPathIgnorePatterns: ['fixtures'],
+  testPathIgnorePatterns: ['fixtures', 'web/src'],
   moduleNameMapper: {
     'src/(.*)': '<rootDir>/src/$1',
   },

--- a/packages/create-redwood-app/template/web/src/components/CellStates/EmptyState/EmptyState.stories.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,7 @@
+import EmptyState from './EmptyState'
+
+export const generated = () => {
+  return <EmptyState />
+}
+
+export default { title: 'Components/EmptyState' }

--- a/packages/create-redwood-app/template/web/src/components/CellStates/EmptyState/EmptyState.test.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@redwoodjs/testing'
+
+import EmptyState from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<EmptyState />)
+    }).not.toThrow()
+  })
+})

--- a/packages/create-redwood-app/template/web/src/components/CellStates/EmptyState/EmptyState.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/EmptyState/EmptyState.tsx
@@ -1,0 +1,5 @@
+const EmptyState = () => {
+  return <div>Empty</div>
+}
+
+export default EmptyState

--- a/packages/create-redwood-app/template/web/src/components/CellStates/FailureState/FailureState.stories.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/FailureState/FailureState.stories.tsx
@@ -1,0 +1,7 @@
+import FailureState from './FailureState'
+
+export const generated = () => {
+  return <FailureState error={new Error('Oh no')}/>
+}
+
+export default { title: 'Components/FailureState' }

--- a/packages/create-redwood-app/template/web/src/components/CellStates/FailureState/FailureState.test.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/FailureState/FailureState.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@redwoodjs/testing'
+
+import FailureState from './FailureState'
+
+describe('FailureState', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<FailureState error={new Error('Oh no')}/>)
+    }).not.toThrow()
+  })
+})

--- a/packages/create-redwood-app/template/web/src/components/CellStates/FailureState/FailureState.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/FailureState/FailureState.tsx
@@ -1,0 +1,7 @@
+import type { CellFailureProps } from '@redwoodjs/web'
+
+const FailureState = ({ error }: CellFailureProps) => {
+  return <div style={{ color: 'red' }}>Error: {error.message}</div>
+}
+
+export default FailureState

--- a/packages/create-redwood-app/template/web/src/components/CellStates/LoadingState/LoadingState.stories.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/LoadingState/LoadingState.stories.tsx
@@ -1,0 +1,7 @@
+import LoadingState from './LoadingState'
+
+export const generated = () => {
+  return <LoadingState />
+}
+
+export default { title: 'Components/LoadingState' }

--- a/packages/create-redwood-app/template/web/src/components/CellStates/LoadingState/LoadingState.test.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/LoadingState/LoadingState.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@redwoodjs/testing'
+
+import LoadingState from './LoadingState'
+
+describe('LoadingState', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<LoadingState />)
+    }).not.toThrow()
+  })
+})

--- a/packages/create-redwood-app/template/web/src/components/CellStates/LoadingState/LoadingState.tsx
+++ b/packages/create-redwood-app/template/web/src/components/CellStates/LoadingState/LoadingState.tsx
@@ -1,0 +1,5 @@
+const LoadingState = () => {
+  return <div>Loading...</div>
+}
+
+export default LoadingState

--- a/tasks/e2e/cypress/integration/01-tutorial/codemods/Step5_1_ComponentsCellBlogPost.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/codemods/Step5_1_ComponentsCellBlogPost.js
@@ -1,6 +1,10 @@
 export default `
 // web/src/components/BlogPostsCell/BlogPostsCell.js
 
+import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
 export const QUERY = gql\`
 query {
   posts {
@@ -11,11 +15,11 @@ query {
 }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ posts }) => {
   return JSON.stringify(posts)

--- a/tasks/e2e/cypress/integration/01-tutorial/codemods/Step6_3_BlogPostCell.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/codemods/Step6_3_BlogPostCell.js
@@ -3,6 +3,10 @@ export default `
 
 import BlogPost from 'src/components/BlogPost'
 
+import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
 export const QUERY = gql\`
   query BlogPostQuery($id: Int!) {
     post(id: $id) {
@@ -13,11 +17,11 @@ export const QUERY = gql\`
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ post }) => {
   return <BlogPost post={post} />

--- a/tasks/e2e/cypress/integration/01-tutorial/codemods/Step6_5_BlogPostsCell.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/codemods/Step6_5_BlogPostsCell.js
@@ -3,6 +3,10 @@ export default `
 
 import BlogPost from 'src/components/BlogPost'
 
+import EmptyState from 'src/components/CellStates/EmptyState'
+import FailureState from 'src/components/CellStates/FailureState'
+import LoadingState from 'src/components/CellStates/LoadingState'
+
 export const QUERY = gql\`
   query {
     posts {
@@ -13,11 +17,11 @@ export const QUERY = gql\`
   }
 \`
 
-export const Loading = () => <div>Loading...</div>
+export const Loading = () => <LoadingState />
 
-export const Empty = () => <div>Empty</div>
+export const Empty = () => <EmptyState />
 
-export const Failure = ({ error }) => <div>Error: {error.message}</div>
+export const Failure = ({ error }) => <FailureState error={error} />
 
 export const Success = ({ posts }) => {
   return posts.map((post) => <BlogPost key={post.id} post={post} />)


### PR DESCRIPTION
Note: per discussion with @thedavidprice after a DX prototyping session

I often use custom Error, Empty and Loading components in may apps for bespoke error message styling, skeletons, and loading spinners.

But, since the cell templates inline the content for each of these cell lifecycle states, whenever I generate a cell I have to update those three areas of the generated template to use my custom components -- and that's a hassle and if I forget then I can create an inconsistent UI.

With these components, I can storybook and design each and also update so I have a common experience in all my generated cells.

This PR creates three "CellStates" components for LoadingState, FailureState, and EmptyState that are used by the template.

Also:

* component, stories and tests are added as part of create-redwood app
* jest config setup updated in create-redwood-app to ignore the tests when testing framework (jsx not enabled)
* e2e tests updated to use components