### PR TITLE
[setup tailwind] Include tailwind by adding directives to index.css

### DIFF
--- a/packages/cli/src/commands/setup/tailwind/tailwind.js
+++ b/packages/cli/src/commands/setup/tailwind/tailwind.js
@@ -27,13 +27,15 @@ export const builder = (yargs) => {
 }
 
 const tailwindImports = [
-  /@import "tailwindcss\/base";/,
-  /@import "tailwindcss\/components";/,
-  /@import "tailwindcss\/utilities";/,
+  '@import "tailwindcss/base";',
+  '@import "tailwindcss/components";',
+  '@import "tailwindcss/utilities";',
 ]
 
 const tailwindImportsExist = (indexCSS) =>
-  tailwindImports.every((tailwindDirective) => tailwindDirective.test(indexCSS))
+  tailwindImports
+    .map((el) => new RegExp(el))
+    .every((tailwindDirective) => tailwindDirective.test(indexCSS))
 
 const tailwindImportsAndNotes = [
   '/**',
@@ -158,7 +160,7 @@ export const handler = async ({ force, install }) => {
         if (tailwindImportsExist(indexCSS)) {
           task.skip('Imports already exist in index.css')
         } else {
-          const newIndexCSS = tailwindImportsAndNotes + indexCSS
+          const newIndexCSS = tailwindImportsAndNotes.join('\n') + indexCSS
           fs.writeFileSync(INDEX_CSS_PATH, newIndexCSS)
         }
       },

--- a/packages/cli/src/commands/setup/tailwind/tailwind.js
+++ b/packages/cli/src/commands/setup/tailwind/tailwind.js
@@ -159,7 +159,7 @@ export const handler = async ({ force, install }) => {
           task.skip('Imports already exist in index.css')
         } else {
           const newIndexCSS = tailwindImportsAndNotes + indexCSS
-          fs.writeFileSync(indexCSS, newIndexCSS)
+          fs.writeFileSync(INDEX_CSS_PATH, newIndexCSS)
         }
       },
     },


### PR DESCRIPTION
Closes #3149. This PR reverts part of the behavior of the setup tailwind command. To restore storybook compatibility, we include tailwind's css via directives in index.css instead of an import in App.js.

<a href="https://gitpod.io/#https://github.com/redwoodjs/redwood/pull/3181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

