### PR TITLE
Fix babel graphql-tag plugin

### DIFF
--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -48,3 +48,21 @@ test('api prebuild uses babel config', () => {
     console.log(dog);"
   `)
 })
+
+test('api prebuild transforms gql with `babel-plugin-graphql-tag`', () => {
+  // babel-plugin-graphql-tag should transpile the "gql" parts of our files,
+  // achieving the following:
+  // 1. removing the `graphql-tag` import
+  // 2. convert the gql syntax into graphql's ast.
+  //
+  // https://www.npmjs.com/package/babel-plugin-graphql-tag
+  const builtFiles = prebuildApiFiles(findApiFiles())
+  const p = builtFiles
+    .filter((x) => typeof x !== 'undefined')
+    .filter((p) => p.endsWith('todos.sdl.js'))
+    .pop()
+
+  const code = fs.readFileSync(p, 'utf-8')
+  expect(code.includes('import gql from "graphql-tag";')).toEqual(false)
+  expect(code.includes('gql`')).toEqual(false)
+})


### PR DESCRIPTION
We include the babel-plugin graphql tag module in our list of pretranspile plugins. This plugin is advertised as doing the following:

> Compiling GraphQL queries at the build time:
> 
> reduces the script initialization time; and
> removes the graphql-tag dependency
> Removing the graphql-tag dependency from the bundle saves approx. 50 KB.

At the moment it's not working, see the failing test case that's added in this PR.

https://www.npmjs.com/package/babel-plugin-graphql-tag