### PR TITLE
Supports SDL and Scaffold generation for Float scalar types 

### DIFF
--- a/packages/cli/src/commands/generate/service/__tests__/scenario.test.js
+++ b/packages/cli/src/commands/generate/service/__tests__/scenario.test.js
@@ -85,6 +85,13 @@ describe('the scenario generator', () => {
     expect(value).toEqual(parseFloat(value))
   })
 
+  test('scenarioFieldValue returns a float for Float types', () => {
+    const field = { type: 'Float' }
+    const value = service.scenarioFieldValue(field)
+
+    expect(value).toEqual(parseFloat(value))
+  })
+
   test('scenarioFieldValue returns a number for Int types', () => {
     const field = { type: 'Int' }
     const value = service.scenarioFieldValue(field)

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -52,6 +52,8 @@ export const scenarioFieldValue = (field) => {
       return true
     case 'Decimal':
       return randFloat
+    case 'Float':
+      return randFloat
     case 'Int':
       return randInt
     case 'DateTime':
@@ -184,6 +186,10 @@ export const fieldsToUpdate = async (model) => {
         break
       }
       case 'Decimal': {
+        newValue = newValue + 1.1
+        break
+      }
+      case 'Float': {
         newValue = newValue + 1.1
         break
       }


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/3214

Issue was that where generating a CRUD service, there was no mapping for Floats.

Float is a standard [GraphQL scalar](https://graphql.org/learn/schema/#scalar-types) type:

> GraphQL comes with a set of default scalar types out of the box:

* Int: A signed 32‐bit integer.
* Float: A signed double-precision floating-point value.
* String: A UTF‐8 character sequence.
* Boolean: true or false.
* ID: The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a String; however, defining it as an ID signifies that it is not intended to be human‐readable.

Now, when generating the scenario fields when creating a crud service (which the SDL --crud and scaffold) generators do, Floats are mapped and return float scenario values.

```

model Business {
  id   Int    @id @default(autoincrement())
  name String
  lat  Float
  lng  Float
}
```

Without mapping `yarn rw g sdl Business --crud --force`:

```
  ✖ Generating SDL files...
    → Cannot read property 'replace' of undefined
Cannot read property 'replace' of undefined
```

With mapping fix `yarn rw g sdl Business --crud --force`:

```
  ✔ Generating SDL files...
    ✔ Successfully wrote file `./api/src/graphql/businesses.sdl.js`
    ✔ Successfully wrote file `./api/src/services/businesses/businesses.scenarios.js`
    ✔ Successfully wrote file `./api/src/services/businesses/businesses.test.js`
    ✔ Successfully wrote file `./api/src/services/businesses/businesses.js`
✨  Done in 4.82s.
```

and the scenario file is:

```
export const standard = defineScenario({
  business: {
    one: { name: 'String', lat: 3006009.675865771, lng: 8660406.827194748 },
    two: { name: 'String', lat: 8864640.873826735, lng: 6263431.943506468 },
  },
})
```