### PR TITLE
Allow custom functions to serve binary data

### DIFF
--- a/packages/api-server/src/requestHandlers/awsLambda.ts
+++ b/packages/api-server/src/requestHandlers/awsLambda.ts
@@ -65,10 +65,14 @@ const expressResponseForLambdaResult = (
     }
   }
 
-  // The AWS lambda docs specify that the response object must be
-  // compatible with `JSON.stringify`, but the type definition specifices that
-  // it must be a string.
-  if (typeof body === 'string') {
+  if (lambdaResult.isBase64Encoded) {
+    // Correctly handle base 64 encoded binary data. See
+    // https://aws.amazon.com/blogs/compute/handling-binary-data-using-amazon-api-gateway-http-apis
+    expressResFn.send(Buffer.from(body, 'base64'))
+  } else if (typeof body === 'string') {
+    // The AWS lambda docs specify that the response object must be
+    // compatible with `JSON.stringify`, but the type definition specifies that
+    // it must be a string.
     expressResFn.send(body)
   } else {
     expressResFn.json(body)


### PR DESCRIPTION
AWS lambda functions can serve binary data (instead of a string or JSON) by returning a base64-encoded body and setting the `isBase64Encoded` optional response parameter to `true` (see https://aws.amazon.com/blogs/compute/handling-binary-data-using-amazon-api-gateway-http-apis/).

This change augments the API server to implement the same functionality.

Motivated by https://community.redwoodjs.com/t/serving-binary-files-in-a-custom-function/2340.