### PR TITLE
Improved `yarn rw console`

### DIFF
--- a/packages/cli/src/commands/console.js
+++ b/packages/cli/src/commands/console.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import repl from 'repl'
 
@@ -9,19 +10,51 @@ export const command = 'console'
 export const aliases = ['c']
 export const description = 'Launch an interactive Redwood shell (experimental)'
 
-const paths = getPaths().api
+const paths = getPaths()
 
-const mapDBToContext = (ctx) => {
-  const { db } = require(path.join(paths.lib, 'db'))
-  ctx.db = db
+const loadPrismaClient = (replContext) => {
+  const { db } = require(path.join(paths.api.lib, 'db'))
+  replContext.db = db
+}
+
+const loadUserConfig = (replContext) => {
+  const userConfigPath = path.join(paths.api.config, 'console')
+  try {
+    const userConfig = require(userConfigPath)
+    Object.assign(replContext, userConfig)
+  } catch (e) {
+    console.error(`Error loading user console config from ${userConfigPath}`)
+    throw e
+  }
+}
+
+const consoleHistoryFile = path.join(paths.generated.base, 'console_history')
+const persistConsoleHistory = (r) => {
+  fs.appendFileSync(
+    consoleHistoryFile,
+    r.lines.filter((line) => line.trim()).join('\n') + '\n',
+    'utf8'
+  )
+}
+
+const loadConsoleHistory = async (r) => {
+  try {
+    const history = await fs.promises.readFile(consoleHistoryFile, 'utf8')
+    history
+      .split('\n')
+      .reverse()
+      .map((line) => r.history.push(line))
+  } catch (e) {
+    // We can ignore this -- it just means the user doesn't have any history yet
+  }
 }
 
 export const handler = () => {
   // Transpile on the fly
   babelRequireHook({
-    extends: path.join(paths.base, '.babelrc.js'),
+    extends: path.join(paths.api.base, '.babelrc.js'),
     extensions: ['.js', '.ts'],
-    only: [paths.base],
+    only: [paths.api.base],
     ignore: ['node_modules'],
     cache: false,
   })
@@ -47,6 +80,14 @@ export const handler = () => {
     })
   }
 
+  // Persist console history to .redwood/console_history. See
+  // https://tjwebb.medium.com/a-custom-node-repl-with-history-is-not-as-hard-as-it-looks-3eb2ca7ec0bd
+  loadConsoleHistory(r)
+  r.addListener('close', () => persistConsoleHistory(r))
+
   // Make the project's db (i.e. Prisma Client) available
-  mapDBToContext(r.context)
+  loadPrismaClient(r.context)
+
+  // Load the user's custom console configuration
+  loadUserConfig(r.context)
 }


### PR DESCRIPTION
A functional REPL really boosts developer productivity. Redwood already has a REPL (`yarn rw console`) but it's missing some functionality that could make it much more useful. This PR adds two features to the Redwood console:

1. Persistent history. The Redwood REPL now stores history between sessions in a `.redwood/console_history` file. Old history can be navigated with the up/down arrows or searched with `ctrl+r` like normal.
2. User-defined config. This PR adds a new `api/src/config/console.[ts|js]` file. Any code written in this file gets run when the REPL starts, and any exported constants are made available at the REPL top-level.

There are a couple other improvements I think would be useful that I may add to this PR if I have time, or add at some point in the future:

1. Right now, project-relative imports (eg. `import foo from 'src/lib/foo'`) don't work from the `console.ts` file. Probably something about the Babel config needs to change to support this?
2. A top-level `reload()` function that reloads everything the user has imported to pick up new changes would facilitate a tighter REPL loop.