### PR TITLE
AST parser should support TypeScript type-assertion-syntax

### DIFF
--- a/packages/internal/src/__tests__/ast.test.ts
+++ b/packages/internal/src/__tests__/ast.test.ts
@@ -6,6 +6,7 @@ import {
   getNamedExports,
   hasDefaultExport,
   getCellGqlQuery,
+  parse,
 } from '../ast'
 
 test('extracts named exports', () => {
@@ -109,4 +110,13 @@ test('Returns the all quries from a file using getGqlQueries', () => {
     }",
     ]
   `)
+})
+
+test('TypeScript cast syntax works in non-JSX files', () => {
+  const code = `
+  const from = await user({ id: <number>submittal.fromId })
+  const to = await user({ id: <number>submittal.toId })
+`
+
+  expect(() => parse(code)).not.toThrow()
 })


### PR DESCRIPTION
We parse the user's source code to provide generated types. TypeScript has grammar conflicts when used in JSX mode. It does not appear that we can force Babel to understand when a file is a JSX file or not.

Related issue: #2964