### PR TITLE
[build:test-project] set canary as default

### DIFF
--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -43,9 +43,10 @@ const args = yargs
     describe: 'Delete existing directory, and recreate project',
   })
   .option('canary', {
-    default: false,
+    default: true,
     type: 'boolean',
-    describe: 'Upgrade project to latest canary version',
+    describe:
+      'Upgrade project to latest canary version. NOT compatible with --link.',
   })
   .help()
   .strict().argv


### PR DESCRIPTION
Reverts behavior to build project and upgrade to canary, which avoids the potential for breaking changes in CRWA template to conflict with installed packages.

Can still use latest packages via `--no-canary` option.