### PR TITLE
Fix API sourcemaps (babel+esbuild) for debugging

### DIFF
--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -43,8 +43,15 @@ test('api prebuild uses babel config', () => {
     .pop()
 
   const code = fs.readFileSync(p, 'utf-8')
-  expect(code).toMatchInlineSnapshot(`
+  expect(stripInlineSourceMap(code)).toMatchInlineSnapshot(`
     "import dog from \\"dog-bless\\";
     console.log(dog);"
   `)
 })
+
+function stripInlineSourceMap(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !line.startsWith('//# sourceMappingURL='))
+    .join('\n')
+}

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -35,7 +35,11 @@ export const prebuildApiFiles = (srcFiles: string[]) => {
   const plugins = getBabelPlugins()
 
   return srcFiles.map((srcPath) => {
-    const result = prebuildFile(srcPath, plugins)
+    let dstPath = path.relative(rwjsPaths.base, srcPath)
+    dstPath = path.join(rwjsPaths.generated.prebuild, dstPath)
+    dstPath = dstPath.replace(/\.(ts)$/, '.js') // TODO: Figure out a better way to handle extensions
+
+    const result = prebuildFile(srcPath, dstPath, plugins)
     if (!result?.code) {
       // TODO: Figure out a better way to return these programatically.
       console.warn('Error:', srcPath, 'could not prebuilt.')
@@ -43,10 +47,6 @@ export const prebuildApiFiles = (srcFiles: string[]) => {
       return undefined
     }
 
-    let dstPath = path.relative(rwjsPaths.base, srcPath)
-    dstPath = path.join(rwjsPaths.generated.prebuild, dstPath)
-
-    dstPath = dstPath.replace(/\.(ts)$/, '.js') // TODO: Figure out a better way to handle extensions
     fs.mkdirSync(path.dirname(dstPath), { recursive: true })
     fs.writeFileSync(dstPath, result.code)
     return dstPath
@@ -66,6 +66,9 @@ export const getApiSideBabelConfigPath = () => {
 // needs to determine plugins on a per-file basis for web side.
 export const prebuildFile = (
   srcPath: string,
+  // we need to know dstPath as well
+  // so we can generate an inline, relative sourcemap
+  dstPath: string,
   plugins: TransformOptions['plugins']
 ) => {
   const code = fs.readFileSync(srcPath, 'utf-8')
@@ -73,6 +76,14 @@ export const prebuildFile = (
     cwd: getPaths().api.base,
     filename: srcPath,
     configFile: getApiSideBabelConfigPath(),
+    // we set the sourceFile (for the sourcemap) as a correct, relative path
+    // this is why this function (prebuildFile) must know about the dstPath
+    sourceFileName: path.relative(path.dirname(dstPath), srcPath),
+    // we need inline sourcemaps at this level
+    // because this file will eventually be fed to esbuild
+    // when esbuild finds an inline sourcemap, it tries to "combine" it
+    // so the final sourcemap (the one that esbuild generates) combines both mappings
+    sourceMaps: 'inline',
     plugins,
   })
   return result
@@ -137,7 +148,9 @@ export const transpileApi = (files: string[], options = {}) => {
     format: 'cjs',
     bundle: false,
     outdir: rwjsPaths.api.dist,
-    sourcemap: 'external', // figure out what's best during development.
+    // inline sourcemaps are preferrable while developing
+    // fewer opportunities for inconsitent states
+    sourcemap: 'inline',
     ...options,
   })
 }

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -148,9 +148,10 @@ export const transpileApi = (files: string[], options = {}) => {
     format: 'cjs',
     bundle: false,
     outdir: rwjsPaths.api.dist,
-    // inline sourcemaps are preferrable while developing
-    // fewer opportunities for inconsitent states
-    sourcemap: 'inline',
+    // setting this to 'true' will generate an external sourcemap x.js.map
+    // AND set the sourceMappingURL comment
+    // (setting it to 'external' will ONLY generate the file, but won't add the comment)
+    sourcemap: true,
     ...options,
   })
 }


### PR DESCRIPTION
This PR fixes sourcemaps (API side) so the VSCode debugger can resolve them correctly.

After making these changes I was able to run the VSCode extension + Debugging against the functional test project (`build:test-project ... --typescript`).

I can't be certain this doesn't break other parts of Redwood (ex: Jest errors, storybook). I believe not, because the final result is "correct". But this PR has to be reviewed by someone who has more visibility into other parts of the framework.

Details:

* The current transpilation process has two steps:
  * 1: Babel. Used to create "intermediate" files in `.redwood/prebuild/...`
  * 2: ESBuild. Used to transpile these intermediate files into `./dist`
* The strategy to make sourcemaps work is roughly the following:
  * 1: Babel
    * Ask babel to generate inline sourcemaps
    * Set the correct `source` attribute so it points, as a relative path, to the original file (this was broken)
  * 2: ESBuild
    * ESBuild's default behavior when it finds an inline sourcemap in an input file is to use it as a starting point for its own sourcemaps. So the final map is effectively pointing to the original file (not the ones in `.redwood/prebuild`). This is what we want.
    * Also, we ask ESBuild for inline sourcemaps instead of external maps. This isn't necessary but it removes one more opportunity for inconsistent states (external sourcemaps could linger from previous compilations after an upgrade, for example).