### PR TITLE
Makes it clearer in the logs when Rufus errors out

### DIFF
--- a/tasks/framework-tools/src/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/src/frameworkSyncToProject.mjs
@@ -23,7 +23,7 @@ import {
 const projectPath = process.argv?.[2] ?? process.env.RWJS_CWD
 if (!projectPath) {
   console.log('Error: Please specify the path to your Redwood Project')
-  console.log(`Usage: ${process.argv?.[1]} /path/to/rwjs/proect`)
+  console.log(`Usage: ${process.argv?.[1]} /path/to/rwjs/project`)
   process.exit(1)
 }
 
@@ -41,6 +41,10 @@ process.on('SIGINT', () => {
 
 function logStatus(m) {
   console.log(c.bgYellow(c.black('rwfw ')), c.yellow(m))
+}
+
+function logError(m) {
+  console.log(c.bgRed(c.black('rwfw ')), c.red(m))
 }
 
 chokidar
@@ -94,6 +98,8 @@ chokidar
     const packageName = packageJsonName(packageJsonPath)
     logStatus(c.magenta(packageName))
 
+    let hasHadError = false
+
     try {
       console.log()
       logStatus(`Cleaning ${packageName}...`)
@@ -107,12 +113,15 @@ chokidar
       logStatus(`Copying ${packageName}...`)
       copyFrameworkFilesToProject(projectPath, [packageJsonPath])
     } catch (error) {
+      hasHadError = true
       console.log()
-      logStatus(`Error building ${packageName}...`)
+      logError(`Error building ${packageName}...`)
       console.log(error)
     }
 
-    console.log()
-    logStatus(`Done, and waiting for changes...`)
-    console.log('-'.repeat(80))
+    if (!hasHadError) {
+      console.log()
+      logStatus(`Done, and waiting for changes...`)
+      console.log('-'.repeat(80))
+    }
   })

--- a/tasks/framework-tools/src/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/src/frameworkSyncToProject.mjs
@@ -114,9 +114,9 @@ chokidar
       copyFrameworkFilesToProject(projectPath, [packageJsonPath])
     } catch (error) {
       hasHadError = true
+      console.log(error)
       console.log()
       logError(`Error building ${packageName}...`)
-      console.log(error)
     }
 
     if (!hasHadError) {


### PR DESCRIPTION
### What was the problem?
Rufus would always say "done" even when it errored out, and was hard to spot unless you scrolled up in the console.

### What does it do?
When it errors out, doesn't print a success message, and uses red to make it easier to spot errors. 

This is what it looks like:
![image](https://user-images.githubusercontent.com/1521877/129373443-4a10f9bc-84fc-4900-b983-a8735e686e16.png)

