### PR TITLE
v0.36 fix(babel): Dont transform runtime for framework

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -53,18 +53,6 @@ module.exports = {
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-private-methods', { loose: true }],
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#core-js-aliasing
-        // Setting the version here also requires `@babel/runtime-corejs3`
-        corejs: { version: 3, proposals: true },
-        // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#version
-        // Transform-runtime assumes that @babel/runtime@7.0.0 is installed.
-        // Specifying the version can result in a smaller bundle size.
-        version: packageJSON.devDependencies['@babel/runtime-corejs3'],
-      },
-    ],
   ],
   overrides: [
     // ** WEB PACKAGES **

--- a/babel.config.js
+++ b/babel.config.js
@@ -91,6 +91,18 @@ module.exports = {
             ],
           },
         ],
+        [
+          '@babel/plugin-transform-runtime',
+          {
+            // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#core-js-aliasing
+            // Setting the version here also requires `@babel/runtime-corejs3`
+            corejs: { version: 3, proposals: true },
+            // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#version
+            // Transform-runtime assumes that @babel/runtime@7.0.0 is installed.
+            // Specifying the version can result in a smaller bundle size.
+            version: packageJSON.devDependencies['@babel/runtime-corejs3'],
+          },
+        ],
         // normally provided through preset-env detecting TARGET_BROWSER
         // but webpack 4 has an issue with this
         // see https://github.com/PaulLeCam/react-leaflet/issues/883

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,6 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "7.15.3",
     "@graphql-tools/merge": "7.0.0",
     "@prisma/client": "2.29.1",
     "@types/pino": "6.3.11",


### PR DESCRIPTION
Fixes #3216

## Why this change?
In v0.36, we've removed preset-env from the babel config, and instead are using esbuild to transform the code to the target. Which means, the module generated by `@babel/plugin-transform-runtime` does not exist (it used to be generated by babel, when you have preset-env and this plugin)

This change makes sure the code we ship within the framework does not rely on the generated modules anymore (trade off being a larger node_modules size, in the project I guess). 

