### PR TITLE
TS: Fix missing properties in CellFailureProps type

### DIFF
--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -17,7 +17,7 @@ export type DataObject = { [key: string]: unknown }
 
 export type CellFailureProps = Partial<
   Omit<QueryOperationResult, 'data' | 'error' | 'loading'> & {
-    error: Pick<QueryOperationResult, 'error'> | Error // for tests and storybook
+    error: QueryOperationResult['error'] | Error // for tests and storybook
     updating: boolean
   }
 >

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -15,9 +15,12 @@ const Query = ({ children, query, ...rest }: QueryProps) => {
 
 export type DataObject = { [key: string]: unknown }
 
-export type CellFailureProps =
-  | (Omit<QueryOperationResult, 'data' | 'loading'> & { updating: boolean })
-  | { error: Error } // for tests and storybook
+export type CellFailureProps = Partial<
+  Omit<QueryOperationResult, 'data' | 'error' | 'loading'> & {
+    error: Pick<QueryOperationResult, 'error'> | Error // for tests and storybook
+    updating: boolean
+  }
+>
 
 export type CellLoadingProps = Omit<
   QueryOperationResult,

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -22,9 +22,8 @@ export type CellFailureProps = Partial<
   }
 >
 
-export type CellLoadingProps = Omit<
-  QueryOperationResult,
-  'error' | 'loading' | 'data'
+export type CellLoadingProps = Partial<
+  Omit<QueryOperationResult, 'error' | 'loading' | 'data'>
 >
 // @MARK not sure about this partial, but we need to do this for tests and storybook
 // `updating` is just `loading` renamed; since Cells default to stale-while-refetch,


### PR DESCRIPTION
**Problem:** 
Currently `CellFailureProps` allows usage of `error` field only, even though other nice fields from `QueryResult` are available like `refetch` function.

![Screenshot 2021-08-20 at 12 26 56 PM](https://user-images.githubusercontent.com/2629902/130193069-a6f7ca79-10bc-42df-9272-358497672003.png)

Expected behavior is to allow access of such other properties (without breaking test and stories).

@dac09 @thedavidprice 