### PR TITLE
fix(contributor-workflow): Adjust prebuild commands on gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,6 +16,7 @@ tasks:
     openMode: split-right
     before: export RW_PATH="/workspace/redwood"
     init: |
+      cd /workspace/redwood
       yarn install
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,9 +6,9 @@ tasks:
   - name: Terminal
     openMode: split-left
     init: |
-      mkdir ../rw-test-app
+      mkdir /workspace/rw-test-app
     command: |
-      cd ../rw-test-app
+      cd /workspace/rw-test-app
       echo -e "\n\n\033[94m ======================================================" && echo -e "\n\033[33mThe test project been linked. If you make further changes to the framework..." &&  echo -e "\033[33mRun \033[92m'yarn rwfw project:sync'\033[33m to watch & sync changes into the test project" &&  echo -e "\n\033[94m ======================================================\n\n"
 
 
@@ -19,7 +19,7 @@ tasks:
       yarn install
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
     command: |
-      cd ../rw-test-app
+      cd /workspace/rw-test-app
       yarn rw dev
 
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,7 +9,7 @@ tasks:
       mkdir /workspace/rw-test-app
     command: |
       cd /workspace/rw-test-app
-      echo -e "\n\n\033[94m ======================================================" && echo -e "\n\033[33mThe test project been linked. If you make further changes to the framework..." &&  echo -e "\033[33mRun \033[92m'yarn rwfw project:sync'\033[33m to watch & sync changes into the test project" &&  echo -e "\n\033[94m ======================================================\n\n"
+      echo -e "\n\n\033[94m ======================================================" && echo -e "\n\033[33m ⌛ Please wait until the dev server is running on the right-side terminal. \n "rw-test-app" is being generated & linked with latest framework code. \n\nIf you make further changes to the framework..." &&  echo -e "\033[33mRun \033[92m'yarn rwfw project:sync'\033[33m to watch & sync changes into the test project" &&  echo -e "\n\033[94m ======================================================\n\n"
 
 
   - name: "Dev Servers"


### PR DESCRIPTION
There must have been some changes in gitpod's prebuild, small changes to make sure its all working again

### What does this PR do?
a) Use absolute paths to mkdir/cd into
b) Before running yarn install/etc. making sure I'm in the redwood framework (It used to default there before I guess)
c) Improves terminal messaging to explain whats going on. Most contributors wont' have to wait though, its only when we push/merge to main that prebuild would rerun.