### PR TITLE
add RedwoodProvider to mockProviders for unit testing 

### DIFF
--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import type { AuthContextInterface } from '@redwoodjs/auth'
 import { AuthProvider } from '@redwoodjs/auth'
 import { LocationProvider } from '@redwoodjs/router'
+import { RedwoodProvider } from '@redwoodjs/web'
 import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
 
 import { mockedUserMeta } from './mockRequests'
@@ -53,10 +54,12 @@ export const mockAuthClient = {
 export const MockProviders: React.FunctionComponent = ({ children }) => {
   return (
     <AuthProvider client={mockAuthClient} type="custom">
-      <RedwoodApolloProvider useAuth={fakeUseAuth}>
-        <UserRouterWithRoutes />
-        <LocationProvider>{children}</LocationProvider>
-      </RedwoodApolloProvider>
+      <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+        <RedwoodApolloProvider useAuth={fakeUseAuth}>
+          <UserRouterWithRoutes />
+          <LocationProvider>{children}</LocationProvider>
+        </RedwoodApolloProvider>
+      </RedwoodProvider>
     </AuthProvider>
   )
 }


### PR DESCRIPTION
This fix #3268 
Not sure how to handle `titleTemplate`.  Right now I use the one in CRA, but if we want to test the title in a project we need the real `titleTemplate` configuration. 🤔