### PR TITLE
upgrade prisma v2.30.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/runtime": "7.15.3",
     "@graphql-tools/merge": "7.0.0",
-    "@prisma/client": "2.29.0",
+    "@prisma/client": "2.30.0",
     "@types/pino": "6.3.11",
     "apollo-server-lambda": "2.25.2",
     "core-js": "3.16.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.29.0",
+    "@prisma/sdk": "2.30.0",
     "@redwoodjs/api-server": "0.35.2",
     "@redwoodjs/internal": "0.35.2",
     "@redwoodjs/prerender": "0.35.2",
@@ -40,7 +40,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.3.2",
-    "prisma": "2.29.0",
+    "prisma": "2.30.0",
     "prompts": "2.4.1",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -20,7 +20,7 @@
     "@graphql-tools/merge": "7.0.0",
     "@graphql-tools/schema": "8.0.3",
     "@graphql-tools/utils": "8.0.2",
-    "@prisma/client": "2.29.0",
+    "@prisma/client": "2.30.0",
     "@redwoodjs/api": "0.35.2",
     "@types/pino": "6.3.11",
     "core-js": "3.16.1",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.29.0",
+    "@prisma/sdk": "2.30.0",
     "@redwoodjs/internal": "0.35.2",
     "@types/line-column": "1.0.0",
     "camelcase": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3440,38 +3440,40 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.29.0.tgz#e236577e2a2b6ed718ecc606bac05e3603bf054c"
-  integrity sha512-te4dNyWI2ypZ7XCBtv42YZvsHDuwXqikepBFUhXsaoB7WFSZEtKDQp+xsEuMyk5NG4PQWVQx73jkcONFSHorJg==
+"@prisma/client@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.30.0.tgz#b0ed9db67405f619e428577f2d45843104142e00"
+  integrity sha512-tjJNHVfgyNOwS2F+AkjMMCJGPnXzHuUCrOnAMJyidAu4aNzxbJ8jWwjt96rRMpyrg9Hwen3xqqQ2oA+ikK7nhQ==
   dependencies:
-    "@prisma/engines-version" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
+    "@prisma/engines-version" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
 
-"@prisma/debug@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.28.0.tgz#bb56e0b1baf91fe7732f8cf14759b1d035180315"
-  integrity sha512-SKihAtTPDqfm/iyLVs5xf1uLu4Ev+zcFLc8vdiGofpHTkeiu3qU1OSDPnrQ0nwn0IJsp3SeRbV0NRWTwL5Z71w==
+"@prisma/debug@2.29.1":
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.29.1.tgz#f5a6b480ea063844c6b1b40974402be8bda05fad"
+  integrity sha512-8OAh4ozVCvlcZU1HaP7QTWIA6Aqzs98nYgTYrxjDLqXJcytIvpIjHxfgqKhuPQ8MTkUm9cI5TJGswwcjJt0/0g==
   dependencies:
-    debug "4.3.2"
-    ms "^2.1.3"
-
-"@prisma/debug@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.29.0.tgz#1c2e0843f6e286251dbbe1a168f6dcdd6372f3fe"
-  integrity sha512-ZqhbExZXBVzDChStfGaLo6jaJqFc4EGuE8d6GBhUJkVVyg2C89cT2kD57TSbpuk17K3D7AeUVv6XilG+79buqA==
-  dependencies:
+    "@types/debug" "4.1.7"
     debug "4.3.2"
     ms "2.1.3"
 
-"@prisma/engine-core@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.29.0.tgz#c4c2d469f91172702cfbf37d3eb998fa12b75db1"
-  integrity sha512-w3x7xNLGJncG6lFO69gpk/bbikgxlWn9Jhkqi0zGWZua2HnGzacfmbbTFpQ7iSnn6Vl+Dtnv3HVgNINBd12Fig==
+"@prisma/debug@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.30.0.tgz#f9e25106a650b7e6c53b26a7f67195c24b2bc82d"
+  integrity sha512-PCEBFJxOmtLhPcl7VdLeVabSHJnlqWMCR4J1y6H+WvqtCt8oMwhgWu4z2Wgh2baphHC3T87+iQVU5BtZX+b5mA==
   dependencies:
-    "@prisma/debug" "2.29.0"
-    "@prisma/engines" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-    "@prisma/generator-helper" "2.29.0"
-    "@prisma/get-platform" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
+    "@types/debug" "4.1.7"
+    debug "4.3.2"
+    ms "2.1.3"
+
+"@prisma/engine-core@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.30.0.tgz#26264a634ddfd9320dc1a46c0a9accdfe8a3bb76"
+  integrity sha512-wy9B1dJLGv5u/E6LbjobEjEfhCVf9++2L3OLAAk9hfg4cCqwY4629woJ1m3w5FWLy29HSnZKgpvQ/8lz1dUbMA==
+  dependencies:
+    "@prisma/debug" "2.30.0"
+    "@prisma/engines" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/generator-helper" "2.30.0"
+    "@prisma/get-platform" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
     chalk "4.1.2"
     execa "5.1.1"
     get-stream "6.0.1"
@@ -3481,23 +3483,23 @@
     terminal-link "2.1.1"
     undici "3.3.6"
 
-"@prisma/engines-version@2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a":
-  version "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a.tgz#96db92f09714d4dd2a5e21054c28bd1c0820fa77"
-  integrity sha512-BU1DNNDhdzqjHtycpUzDrU8+jf6ZY+fbXvCV/rbqG+0JifljlIo4vbkHDMg97gBi1Do8pTLZGlTH16FlniKgAg==
+"@prisma/engines-version@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
+  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#1360113dc19e1d43d4442e3b638ccfa0e1711943"
+  integrity sha512-oThNpx7HtJ0eEmnvrWARYcNCs6dqFdAK3Smt2bJVDD6Go4HLuuhjx028osP+rHaFrGOTx7OslLZYtvvFlAXRDA==
 
-"@prisma/engines@2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a":
-  version "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a.tgz#0a44a6dcbee7e0a2850ea086675a8a4f4d627f9d"
-  integrity sha512-cgEoGK3dmKZkMp/sRbL8TsuVS50rHXYBHk2NY18DPUGr5//4ICno46EjzlayqAFVak8J6RtWZEs+8tE8j8frAQ==
+"@prisma/engines@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
+  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#b4d91ff876662b1de83e0cc913149a1c088becc7"
+  integrity sha512-LPKq88lIbYezvX0OOc1PU42hHdTsSMPJWmK8lusaHK7DaLHyXjDp/551LbsVapypbjW6N3Jx/If6GoMDASSMSw==
 
-"@prisma/fetch-engine@2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a":
-  version "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a.tgz#de40f3bd761f3da1f2e0e0af027514c845f58264"
-  integrity sha512-HsTHffo2xg0rZchdqWJHDvl7JaOi2U1rDockKYAYPf3grGZ14AnJ/ZVP292xMm0IiGLkb5YE3qkI5SKoGEUqMw==
+"@prisma/fetch-engine@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
+  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#434c8fb3b7c631bc1f55abb87e16c03c60895ce3"
+  integrity sha512-62/gM4Gm+e1BQlgj4OFmdQKa22nWg5FZ6hNsoRHopcm45RRhnSHqYiD+9djo/98i1/+MYfwxCwPqhhJm28lJuw==
   dependencies:
-    "@prisma/debug" "2.28.0"
-    "@prisma/get-platform" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
+    "@prisma/debug" "2.29.1"
+    "@prisma/get-platform" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3514,37 +3516,37 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.29.0.tgz#a4b537e6d4554b15e7fd4cd0b4814694cadcb513"
-  integrity sha512-1pG55jGXEB/DBpZ1LA6Ueo+Z0AMwD9tDLCe0+SCRUNkL5UpuRaiRdKx+0PctELmPtEXtNKz9hpF2eAst718MDQ==
+"@prisma/generator-helper@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.30.0.tgz#152f7381d7c4eb6022c7173f905d98a79f830728"
+  integrity sha512-7XKJM83LLrpDSqiDrINaBqtePUJomgxfiofIx0TM5pBIg2vmWwpe5Q+VDQxr88ypqVW83NW6BfPgTm7Qni4+mQ==
   dependencies:
-    "@prisma/debug" "2.29.0"
+    "@prisma/debug" "2.30.0"
     "@types/cross-spawn" "6.0.2"
     chalk "4.1.2"
     cross-spawn "7.0.3"
 
-"@prisma/get-platform@2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a":
-  version "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a.tgz#78e9200abdfa15446d4830c101e5b2d692bef7ab"
-  integrity sha512-eEuXFcELlo8bAszQOz3YOyVpoKMjD/RSml29P51WFaDaHZaudfqV6OkSpMV2Qchcyg6neI1mvT+0acutBpNXTw==
+"@prisma/get-platform@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
+  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#6b2aa861c1c6383c39178d0e272d5bc53dc7bc30"
+  integrity sha512-gqB9defmpCvxvQM9HFNpo1s0G652eE556ckO+k9X1Kfbt1vaX6FuxtQD5IPcu0nDm42u3NTkX9lDR1Y0j5VPng==
   dependencies:
-    "@prisma/debug" "2.28.0"
+    "@prisma/debug" "2.29.1"
 
-"@prisma/sdk@2.29.0":
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.29.0.tgz#e996f207ed871890bc624eea72fa33c1ae2b791c"
-  integrity sha512-b0iwLC4cyTrg6aXEOermRH4p0tmOaOogcXTnNcFT4b4hyFEZkpdO5u0Kjy2i82rj/ffd7mGartr/1H5uuBLUrg==
+"@prisma/sdk@2.30.0":
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.30.0.tgz#0c7d5bc4872d87b31831ce8ddd7ac5ab73c80471"
+  integrity sha512-bIYLphnGnfoguFfKiHon/RZhMTAk8gpElUos1+O7RHzDdzqPEusyl8T9lX123zxhmeVocyV0V2y/AxaD5USaxg==
   dependencies:
-    "@prisma/debug" "2.29.0"
-    "@prisma/engine-core" "2.29.0"
-    "@prisma/engines" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-    "@prisma/fetch-engine" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
-    "@prisma/generator-helper" "2.29.0"
-    "@prisma/get-platform" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
+    "@prisma/debug" "2.30.0"
+    "@prisma/engine-core" "2.30.0"
+    "@prisma/engines" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/fetch-engine" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/generator-helper" "2.30.0"
+    "@prisma/get-platform" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
     "@timsuchanek/copy" "1.4.5"
     archiver "4.0.2"
-    arg "5.0.0"
+    arg "5.0.1"
     chalk "4.1.2"
     checkpoint-client "1.1.20"
     cli-truncate "2.1.0"
@@ -3565,7 +3567,7 @@
     string-width "4.2.2"
     strip-ansi "6.0.0"
     strip-indent "3.0.0"
-    tar "6.1.6"
+    tar "6.1.8"
     temp-dir "2.0.0"
     temp-write "4.0.0"
     tempy "1.0.1"
@@ -4696,6 +4698,13 @@
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.0.2.tgz#4524325a175bf819fec6e42560c389ce1fb92c97"
   integrity sha512-sCVniU+h3GcGqxOmng11BRvf9TfN9yIs8KKjB8C8d75W69cpTfZG80gau9yTx5SxF3gvHGbJhdESzzvnjtf3Og==
 
+"@types/debug@4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#8dc390a7b4f9dd9f1284629efce982e41612116e"
@@ -5076,6 +5085,11 @@
   integrity sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==
   dependencies:
     "@types/node" "*"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/netlify-identity-widget@1.9.2":
   version "1.9.2"
@@ -6299,10 +6313,10 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-arg@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.0.tgz#a20e2bb5710e82950a516b3f933fee5ed478be90"
-  integrity sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==
+arg@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.1.tgz#eb0c9a8f77786cad2af8ff2b862899842d7b6adb"
+  integrity sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==
 
 arg@^4.1.0:
   version "4.1.3"
@@ -14349,7 +14363,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -15904,12 +15918,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.29.0.tgz#dbd801eab9b87cb1cb543f0baadac79cd658dd39"
-  integrity sha512-fOnPzF45X3eq4EFVC39MV7pJf1y6VNC8BMqHRJ5+vBvn2SDjxf0OskUM1DUDkZFIViqZykvDlB9HMPH3edOB/A==
+prisma@2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.30.0.tgz#5b12091c480d538540b898d364b73651d44b4a01"
+  integrity sha512-2XYpSibcVpMd1JDxYypGDU/JKq0W2f/HI1itdddr4Pfg+q6qxt/ItWKcftv4/lqN6u/BVlQ2gDzXVEjpHeO5kQ==
   dependencies:
-    "@prisma/engines" "2.29.0-34.1be4cd60b89afa04b192acb1ef47758a39810f3a"
+    "@prisma/engines" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"
@@ -18135,10 +18149,10 @@ tar-stream@^2.1.2:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.1.6:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@6.1.8:
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.8.tgz#4fc50cfe56511c538ce15b71e05eebe66530cbd4"
+  integrity sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
Prisma 2.30.0 [Release Notes](https://github.com/prisma/prisma/releases/tag/2.30.0):

Prisma Client
preview support for Full-Text Search on PostgreSQL - new search field key in search criteria!
[better] Validation errors for referential action cycles on Microsoft SQL Server