### PR TITLE
Resolve react-hook-form in webpack explicitly

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -195,6 +195,11 @@ module.exports = (webpackEnv) => {
         ),
         '~redwood-app-root': path.resolve(redwoodPaths.web.app),
         react: path.resolve(redwoodPaths.base, 'node_modules', 'react'),
+        'react-hook-form': path.resolve(
+          redwoodPaths.base,
+          'node_modules',
+          'react-hook-form'
+        ),
       },
     },
     plugins: [


### PR DESCRIPTION
Closes #3265. In v0.36, we upgraded a whole host of packages. While we're not sure if it was webpack v5 or react-hook-form v7 (or some combination of the two), imports got mixed up—the `@redwoodjs/forms` library imported one version of react-hook-form (the `.cjs.js` version), while a user importing straight from react-hook-form got another version, the `.esm.js` one.

What we need is for webpack to resolve the same one, and this PR tries to do that by explicitly listing how to resolve react-hook-form.