### PR TITLE
dbAuth Vercel Fix

### DIFF
--- a/packages/api/src/functions/dbAuth/DbAuthHandler.ts
+++ b/packages/api/src/functions/dbAuth/DbAuthHandler.ts
@@ -298,7 +298,7 @@ export class DbAuthHandler {
           Buffer.from(this.event.body || '', 'base64').toString('utf-8')
         )
       } else {
-        return this.event.body && JSON.parse(this.event.body)
+        return JSON.parse(this.event.body)
       }
     } else {
       return {}

--- a/packages/api/src/functions/dbAuth/DbAuthHandler.ts
+++ b/packages/api/src/functions/dbAuth/DbAuthHandler.ts
@@ -292,12 +292,16 @@ export class DbAuthHandler {
 
   // parses the event body into JSON, whether it's base64 encoded or not
   _parseBody() {
-    if (this.event.isBase64Encoded) {
-      return JSON.parse(
-        Buffer.from(this.event.body || '', 'base64').toString('utf-8')
-      )
+    if (this.event.body) {
+      if (this.event.isBase64Encoded) {
+        return JSON.parse(
+          Buffer.from(this.event.body || '', 'base64').toString('utf-8')
+        )
+      } else {
+        return this.event.body && JSON.parse(this.event.body)
+      }
     } else {
-      return this.event.body && JSON.parse(this.event.body)
+      return {}
     }
   }
 

--- a/packages/api/src/functions/dbAuth/DbAuthHandler.ts
+++ b/packages/api/src/functions/dbAuth/DbAuthHandler.ts
@@ -485,7 +485,7 @@ export class DbAuthHandler {
   _ok(body: string, headers = {}, options = { statusCode: 200 }) {
     return {
       statusCode: options.statusCode,
-      body,
+      body: typeof body === 'string' ? body : JSON.stringify(body),
       headers: { 'Content-Type': 'application/json', ...headers },
     }
   }

--- a/packages/auth/src/authClients/dbAuth.ts
+++ b/packages/auth/src/authClients/dbAuth.ts
@@ -15,7 +15,12 @@ export const dbAuth = (): AuthClient => {
       `${global.__REDWOOD__API_PROXY_PATH}/auth?method=getToken`
     )
     const token = await response.text()
-    return token
+
+    if (token.length === 0) {
+      return null
+    } else {
+      return token
+    }
   }
 
   const login = async (attributes: LoginAttributes) => {

--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.function.js.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.function.js.template
@@ -65,5 +65,5 @@ export const handler = async (event, context) => {
     loginExpires: 60 * 60 * 24 * 365 * 10,
   })
 
-  return authHandler.invoke()
+  return await authHandler.invoke()
 }


### PR DESCRIPTION
Fixes two issues that Vercel was blowing up on:

1. Vercel does not like having a return body that's JSON and turning it into a string for us—it MUST be a string
2. If the body is empty, Vercel will still set `isBase64Encoded` to true, and you can't decode an empty string

Fixing these introduced another issue, where `getToken` returned an empty string which a client call for `getUserMetadata` interpreted as there being a user logged in and so would call the GraphQL endpoint for `getCurrentUser`, which then returned a 500. This is patched as well.

## (Potential) Breaking Change

Serverless functions may already wait for async code to complete before returning (this hasn't been an issue in dev or a serverfull deployment). But in case they don't, anyone already using dbAuth should update their `api/src/functions/auth.js` to include an `await` on the final line of code:

Before:

```javascript
return authHandler.invoke()
```

After:

```javascript
return await authHandler.invoke()
```