### PR TITLE
babel-plugin-redwood-import-dir: Fix regex and Windows paths

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19655,3 +19655,4 @@ zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
   integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==
+


### PR DESCRIPTION
The generated imports for services and schemas had "C:\Users\Tobbe\dev\Redwood\" style paths, but that doesn't work for imports. Need to be "C:/Users/Tobbe/dev/Redwood/". We already have a function for doing the conversion, so I just used that.

Also the regex for turning file paths into variable names had a slight bug that I fixed.