### PR TITLE
fix: Snapshots updates weren't commited in test

### DIFF
--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -128,14 +128,16 @@ test('api prebuild uses babel config', () => {
   const p = prebuiltFiles.filter((p) => p.endsWith('dog.js')).pop()
   const code = fs.readFileSync(p, 'utf-8')
   const firstLine = stripInlineSourceMap(code).split('\n')[0]
-  expect(firstLine).toMatchInlineSnapshot()
+  expect(firstLine).toMatchInlineSnapshot(`"import dog from \\"dog-bless\\";"`)
 })
 
 test('Pretranspile polyfills unsupported functionality', () => {
   const p = prebuiltFiles.filter((p) => p.endsWith('polyfill.js')).pop()
   const code = fs.readFileSync(p, 'utf-8')
   const firstLine = stripInlineSourceMap(code).split('\n')[0]
-  expect(firstLine).toMatchInlineSnapshot()
+  expect(firstLine).toMatchInlineSnapshot(
+    `"import \\"core-js/modules/esnext.string.replace-all.js\\";"`
+  )
 })
 
 function stripInlineSourceMap(src: string): string {


### PR DESCRIPTION
Canaries can't be published because the tests update the snapshot during run. This should've been committed :) 