### PR TITLE
Use newer plugin syntax for babel-plugin-inline-react-svg

### DIFF
--- a/packages/core/config/babel-preset.js
+++ b/packages/core/config/babel-preset.js
@@ -1,8 +1,6 @@
 /**
  * This is the babel preset used in `create-redwood-app`
  */
-const { extendDefaultPlugins } = require('svgo')
-
 const { getPaths } = require('@redwoodjs/internal')
 
 const packageJSON = require('../package.json')
@@ -171,22 +169,24 @@ module.exports = () => {
             'inline-react-svg',
             {
               svgo: {
-                plugins: extendDefaultPlugins([
+                plugins: [
+                  {
+                    name: 'preset-default',
+                    params: {
+                      overrides: {
+                        // @TODO confirm this is the right thing
+                        // On my projects, this was needed for backwards compatibility
+                        removeViewBox: false,
+                      },
+                    },
+                  },
                   {
                     name: 'removeAttrs',
                     params: { attrs: '(data-name)' },
                   },
-                  {
-                    // @TODO confirm this is the right thing
-                    // On my projects, this was needed for backwards compatibility
-                    name: 'removeViewBox',
-                    active: false,
-                  },
-                  {
-                    // Otherwise having style="xxx" breaks
-                    name: 'convertStyleToAttrs',
-                  },
-                ]),
+                  // Otherwise having style="xxx" breaks
+                  'convertStyleToAttrs',
+                ],
               },
             },
           ],


### PR DESCRIPTION
Closes #3332. `removeViewBox` is actually the only default plugin we override; the rest are built-in but not part of the preset-default.
- [x] still need to confirm that this works with an actual svg