### PR TITLE
babel-plugin-redwood-src-alias: Fix Windows paths

### DIFF
--- a/packages/core/src/babelPlugins/babel-plugin-redwood-src-alias.ts
+++ b/packages/core/src/babelPlugins/babel-plugin-redwood-src-alias.ts
@@ -2,6 +2,8 @@ import path from 'path'
 
 import type { PluginObj, types } from '@babel/core'
 
+import { importStatementPath } from '@redwoodjs/internal'
+
 export default function (
   { types: t }: { types: typeof types },
   options: {
@@ -32,7 +34,7 @@ export default function (
         if (newImport.indexOf('.') !== 0) {
           newImport = './' + newImport
         }
-        const newSource = t.stringLiteral(newImport)
+        const newSource = t.stringLiteral(importStatementPath(newImport))
 
         p.node.source = newSource
       },
@@ -57,8 +59,10 @@ export default function (
 
         // remove `src/` and create an absolute path
         const absPath = path.join(options.srcAbsPath, value.substr(4))
-        const newImport = path.relative(path.dirname(filename), absPath)
-        const newSource = t.stringLiteral(newImport)
+        const newExport = importStatementPath(
+          path.relative(path.dirname(filename), absPath)
+        )
+        const newSource = t.stringLiteral(newExport)
         // @ts-expect-error `source` does exist
         p.node.source = newSource
       },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30793/131900914-fd9f6f12-6e1a-4228-97f3-1eb9a501ca7f.png)

Those kind of paths won't work. This fix changes them to 

![image](https://user-images.githubusercontent.com/30793/131901021-7b2a8d3a-a69a-40a0-ac5e-44ec0dcd0572.png)
