### PR TITLE
fix(api-dev): Ensure dist, types and db paths are ignored on windows

### DIFF
--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -9,7 +9,12 @@ import chokidar from 'chokidar'
 import dotenv from 'dotenv'
 import { debounce } from 'lodash'
 
-import { getPaths, buildApi, getConfig } from '@redwoodjs/internal'
+import {
+  getPaths,
+  buildApi,
+  getConfig,
+  ensurePosixPath,
+} from '@redwoodjs/internal'
 
 const rwjsPaths = getPaths()
 
@@ -59,11 +64,18 @@ chokidar
     persistent: true,
     ignoreInitial: true,
     ignored: (file: string) => {
+      // NOTE: the file comes through as a unix path, even on windows
+      // So we need to convert the rwjsPaths
+
+      const IGNORED_API_PATHS = [
+        rwjsPaths.api.dist,
+        rwjsPaths.api.types,
+        rwjsPaths.api.db,
+      ].map((path) => ensurePosixPath(path))
+
       const x =
         file.includes('node_modules') ||
-        file.includes(rwjsPaths.api.dist) ||
-        file.includes(rwjsPaths.api.types) ||
-        file.includes(rwjsPaths.api.db) ||
+        IGNORED_API_PATHS.some((ignoredPath) => file.includes(ignoredPath)) ||
         [
           '.DS_Store',
           '.db',

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -59,20 +59,20 @@ const delayRestartServer = debounce(
     : 5
 )
 
+// NOTE: the file comes through as a unix path, even on windows
+// So we need to convert the rwjsPaths
+
+const IGNORED_API_PATHS = [
+  'api/dist', // use this, because using rwjsPaths.api.dist seems to not ignore on first build
+  rwjsPaths.api.types,
+  rwjsPaths.api.db,
+].map((path) => ensurePosixPath(path))
+
 chokidar
   .watch(rwjsPaths.api.base, {
     persistent: true,
     ignoreInitial: true,
     ignored: (file: string) => {
-      // NOTE: the file comes through as a unix path, even on windows
-      // So we need to convert the rwjsPaths
-
-      const IGNORED_API_PATHS = [
-        rwjsPaths.api.dist,
-        rwjsPaths.api.types,
-        rwjsPaths.api.db,
-      ].map((path) => ensurePosixPath(path))
-
       const x =
         file.includes('node_modules') ||
         IGNORED_API_PATHS.some((ignoredPath) => file.includes(ignoredPath)) ||


### PR DESCRIPTION
Fixes #3338

This 🤞 fixes the windows api dev server. 