### PR TITLE
upgrade prisma v3.0.1

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@graphql-tools/merge": "7.0.0",
-    "@prisma/client": "2.30.0",
+    "@prisma/client": "3.0.1",
     "@types/pino": "6.3.11",
     "core-js": "3.16.1",
     "crypto-js": "4.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "2.30.0",
+    "@prisma/sdk": "3.0.1",
     "@redwoodjs/api-server": "0.36.2",
     "@redwoodjs/internal": "0.36.2",
     "@redwoodjs/prerender": "0.36.2",
@@ -40,7 +40,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.3.2",
-    "prisma": "2.30.0",
+    "prisma": "3.0.1",
     "prompts": "2.4.1",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -17,7 +17,7 @@
     "@graphql-tools/merge": "7.0.0",
     "@graphql-tools/schema": "8.0.3",
     "@graphql-tools/utils": "8.0.2",
-    "@prisma/client": "2.30.0",
+    "@prisma/client": "3.0.1",
     "@redwoodjs/api": "0.36.2",
     "@types/pino": "6.3.11",
     "graphql": "15.5.1",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "2.30.0",
+    "@prisma/sdk": "3.0.1",
     "@redwoodjs/internal": "0.36.2",
     "@types/line-column": "1.0.0",
     "camelcase": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3377,40 +3377,40 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@prisma/client@2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.30.0.tgz#b0ed9db67405f619e428577f2d45843104142e00"
-  integrity sha512-tjJNHVfgyNOwS2F+AkjMMCJGPnXzHuUCrOnAMJyidAu4aNzxbJ8jWwjt96rRMpyrg9Hwen3xqqQ2oA+ikK7nhQ==
+"@prisma/client@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-3.0.1.tgz#beb09349fae23a76f66d3ae07e766e35f63bcc54"
+  integrity sha512-o/5wd1LqI2nr0/8L8Tg0cm5/wL/z7FLx5pd0D7MbnUoBv62sxHP5wRgturjljUwCBm4GpfRnBZUTWTuKA610MA==
   dependencies:
-    "@prisma/engines-version" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/engines-version" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
 
-"@prisma/debug@2.29.1":
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.29.1.tgz#f5a6b480ea063844c6b1b40974402be8bda05fad"
-  integrity sha512-8OAh4ozVCvlcZU1HaP7QTWIA6Aqzs98nYgTYrxjDLqXJcytIvpIjHxfgqKhuPQ8MTkUm9cI5TJGswwcjJt0/0g==
+"@prisma/debug@2.30.3":
+  version "2.30.3"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.30.3.tgz#2c10a4aa4c99728d0f13d64036eca9521352b0d4"
+  integrity sha512-hMsCl6ZA718vgKuTRd1+qeetzGSVkZEIEUTfeT5rPtklgqDytQ01nRNN74gLeoSI64tyGg/pvSX1wgAioMuyiQ==
   dependencies:
     "@types/debug" "4.1.7"
     debug "4.3.2"
     ms "2.1.3"
 
-"@prisma/debug@2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-2.30.0.tgz#f9e25106a650b7e6c53b26a7f67195c24b2bc82d"
-  integrity sha512-PCEBFJxOmtLhPcl7VdLeVabSHJnlqWMCR4J1y6H+WvqtCt8oMwhgWu4z2Wgh2baphHC3T87+iQVU5BtZX+b5mA==
+"@prisma/debug@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/debug/-/debug-3.0.1.tgz#6b794ba015129eefce7e94292d6f4218a80f668d"
+  integrity sha512-jygNyhua6weT/pMmoTBHIcSV/eC6WZpyHZwlGtRqP+PCcQgSUvfxY4b1Il7itsd8rCLI/D6JuvBm5UsNdo5dXw==
   dependencies:
     "@types/debug" "4.1.7"
     debug "4.3.2"
     ms "2.1.3"
 
-"@prisma/engine-core@2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-2.30.0.tgz#26264a634ddfd9320dc1a46c0a9accdfe8a3bb76"
-  integrity sha512-wy9B1dJLGv5u/E6LbjobEjEfhCVf9++2L3OLAAk9hfg4cCqwY4629woJ1m3w5FWLy29HSnZKgpvQ/8lz1dUbMA==
+"@prisma/engine-core@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/engine-core/-/engine-core-3.0.1.tgz#5b037a6921e1042188921d166b2a01b579483f25"
+  integrity sha512-3gq2JFS458/MmBZ4k9nfRyw6P+RxkKC4lozOki4H3HJ8/97s6nRb/2l8i3XaXIuNWg7oCUK7JGoBbczqgeIo3Q==
   dependencies:
-    "@prisma/debug" "2.30.0"
-    "@prisma/engines" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-    "@prisma/generator-helper" "2.30.0"
-    "@prisma/get-platform" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/debug" "3.0.1"
+    "@prisma/engines" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+    "@prisma/generator-helper" "3.0.1"
+    "@prisma/get-platform" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
     chalk "4.1.2"
     execa "5.1.1"
     get-stream "6.0.1"
@@ -3420,23 +3420,23 @@
     terminal-link "2.1.1"
     undici "3.3.6"
 
-"@prisma/engines-version@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
-  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#1360113dc19e1d43d4442e3b638ccfa0e1711943"
-  integrity sha512-oThNpx7HtJ0eEmnvrWARYcNCs6dqFdAK3Smt2bJVDD6Go4HLuuhjx028osP+rHaFrGOTx7OslLZYtvvFlAXRDA==
+"@prisma/engines-version@2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db":
+  version "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz#c45323e420f47dd950b22c873bdcf38f75e65779"
+  integrity sha512-iArSApZZImVmT9oC/rGOjzvpG2AOqlIeqYcVnop9poA3FxD4zfVPbNPH9DTgOWhc06OkBHujJZeAcsNddVabIQ==
 
-"@prisma/engines@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
-  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#b4d91ff876662b1de83e0cc913149a1c088becc7"
-  integrity sha512-LPKq88lIbYezvX0OOc1PU42hHdTsSMPJWmK8lusaHK7DaLHyXjDp/551LbsVapypbjW6N3Jx/If6GoMDASSMSw==
+"@prisma/engines@2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db":
+  version "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz#b6cf70bc05dd2a62168a16f3ea58a1b011074621"
+  integrity sha512-Q9CwN6e5E5Abso7J3A1fHbcF4NXGRINyMnf7WQ07fXaebxTTARY5BNUzy2Mo5uH82eRVO5v7ImNuR044KTjLJg==
 
-"@prisma/fetch-engine@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
-  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#434c8fb3b7c631bc1f55abb87e16c03c60895ce3"
-  integrity sha512-62/gM4Gm+e1BQlgj4OFmdQKa22nWg5FZ6hNsoRHopcm45RRhnSHqYiD+9djo/98i1/+MYfwxCwPqhhJm28lJuw==
+"@prisma/fetch-engine@2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db":
+  version "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+  resolved "https://registry.yarnpkg.com/@prisma/fetch-engine/-/fetch-engine-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz#d5f5b18d273cb933eab134c46ca3bd65a006482c"
+  integrity sha512-MVlloe2gnnG8YpB9utDos0qnnHw05ud24OOu6jtXFcYIBJR4rd+7pmRTY5TgD76RnbWH4rNzD5NL1xAiXMTZKA==
   dependencies:
-    "@prisma/debug" "2.29.1"
-    "@prisma/get-platform" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/debug" "2.30.3"
+    "@prisma/get-platform" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
     chalk "^4.0.0"
     execa "^5.0.0"
     find-cache-dir "^3.3.1"
@@ -3453,34 +3453,34 @@
     temp-dir "^2.0.0"
     tempy "^1.0.0"
 
-"@prisma/generator-helper@2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-2.30.0.tgz#152f7381d7c4eb6022c7173f905d98a79f830728"
-  integrity sha512-7XKJM83LLrpDSqiDrINaBqtePUJomgxfiofIx0TM5pBIg2vmWwpe5Q+VDQxr88ypqVW83NW6BfPgTm7Qni4+mQ==
+"@prisma/generator-helper@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/generator-helper/-/generator-helper-3.0.1.tgz#dea642d8335c17aeec0ac6613474e7abd4b6a230"
+  integrity sha512-kjVkJHq/TvmQ4t4vgqVWMevBr1AoYaV8iiE3ydS6U5PRHrZuzYI2BinjNRTDnaKa6QIZRDJG+VviTinuBDMU2g==
   dependencies:
-    "@prisma/debug" "2.30.0"
+    "@prisma/debug" "3.0.1"
     "@types/cross-spawn" "6.0.2"
     chalk "4.1.2"
     cross-spawn "7.0.3"
 
-"@prisma/get-platform@2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb":
-  version "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb.tgz#6b2aa861c1c6383c39178d0e272d5bc53dc7bc30"
-  integrity sha512-gqB9defmpCvxvQM9HFNpo1s0G652eE556ckO+k9X1Kfbt1vaX6FuxtQD5IPcu0nDm42u3NTkX9lDR1Y0j5VPng==
+"@prisma/get-platform@2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db":
+  version "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+  resolved "https://registry.yarnpkg.com/@prisma/get-platform/-/get-platform-2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db.tgz#5a5e9efbdd5607d2fe31e8e7fdad4803d48f17ba"
+  integrity sha512-c3RYEv/l+n/i7wU/Ua2P3ZXWiKKKAmoZ832VHDe8eX5I8IlhTG+/8pwnGW/b3O/XDXMcYnSGMZqKszToqSYp5g==
   dependencies:
-    "@prisma/debug" "2.29.1"
+    "@prisma/debug" "2.30.3"
 
-"@prisma/sdk@2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-2.30.0.tgz#0c7d5bc4872d87b31831ce8ddd7ac5ab73c80471"
-  integrity sha512-bIYLphnGnfoguFfKiHon/RZhMTAk8gpElUos1+O7RHzDdzqPEusyl8T9lX123zxhmeVocyV0V2y/AxaD5USaxg==
+"@prisma/sdk@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/sdk/-/sdk-3.0.1.tgz#2e3faacfd85e1cdaf3ae95be4a3bb242e2ebc5af"
+  integrity sha512-QZ9yEt2OefK22SrGdAMxTYQyRYC5N9bu19IlTVUyO3ejnTtMn4+wDAebUcyrDVOFIquoAf4/KV8wvXDgBfLRzg==
   dependencies:
-    "@prisma/debug" "2.30.0"
-    "@prisma/engine-core" "2.30.0"
-    "@prisma/engines" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-    "@prisma/fetch-engine" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
-    "@prisma/generator-helper" "2.30.0"
-    "@prisma/get-platform" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/debug" "3.0.1"
+    "@prisma/engine-core" "3.0.1"
+    "@prisma/engines" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+    "@prisma/fetch-engine" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
+    "@prisma/generator-helper" "3.0.1"
+    "@prisma/get-platform" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
     "@timsuchanek/copy" "1.4.5"
     archiver "4.0.2"
     arg "5.0.1"
@@ -3504,7 +3504,7 @@
     string-width "4.2.2"
     strip-ansi "6.0.0"
     strip-indent "3.0.0"
-    tar "6.1.8"
+    tar "6.1.11"
     temp-dir "2.0.0"
     temp-write "4.0.0"
     tempy "1.0.1"
@@ -15550,12 +15550,12 @@ prettysize@^2.0.0:
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-2.0.0.tgz#902c02480d865d9cc0813011c9feb4fa02ce6996"
   integrity sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==
 
-prisma@2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-2.30.0.tgz#5b12091c480d538540b898d364b73651d44b4a01"
-  integrity sha512-2XYpSibcVpMd1JDxYypGDU/JKq0W2f/HI1itdddr4Pfg+q6qxt/ItWKcftv4/lqN6u/BVlQ2gDzXVEjpHeO5kQ==
+prisma@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-3.0.1.tgz#7f52b6533b562d0bb32e1b74403b146ee6d89029"
+  integrity sha512-ENmYAopd56nkds5/IOSTGixbkbUN2QdEzB4cp/mtaGB/G0OArbP6cnbA/9u02Pe29RdErbNOoIdCGASjpItJwQ==
   dependencies:
-    "@prisma/engines" "2.30.0-28.60b19f4a1de4fe95741da371b4c44a92f4d1adcb"
+    "@prisma/engines" "2.31.0-32.2452cc6313d52b8b9a96999ac0e974d0aedf88db"
 
 prismjs@^1.21.0, prismjs@~1.23.0:
   version "1.23.0"
@@ -17765,10 +17765,10 @@ tar-stream@^2.1.2:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.1.8:
-  version "6.1.8"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.8.tgz#4fc50cfe56511c538ce15b71e05eebe66530cbd4"
-  integrity sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==
+tar@6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -19655,4 +19655,3 @@ zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
   integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==
-


### PR DESCRIPTION
Bumps prisma from 2.30.2 (buildbot) to3.0.1

Release notes
Sourced from [prisma's releases]](https://github.com/prisma/prisma/releases/tag/3.0.1)

Prima 3.0.1 stable release 🎉

summary:

Referential Actions (now GA)
Named Constraints (now GA)
Microsoft SQL Server and Azure SQL Connector
Seeding with prisma db seed has been revamped
Node-API
Order by Aggregate in Group By (now GA)
Order by Relation (now GA)
Select Relation Count (now GA)

### Declared breaking changes:

Some of the features above introduce breaking changes. In this section, we cover the breaking changes in more detail with links to upgrade guides in the documentation. We recommend that you read through the breaking changes carefully and make sure that you've upgraded and tested your application.

##Named Constraints
Starting with Prisma 3, the names of database constraints and indexes are reflected in the Prisma schema. This means that Introspection with db pull as well as migrate and db push will work towards keeping your constraint and index names in sync between your schema and your database.

Additionally, a new convention for default constraint names is now built into the Prisma Schema Language logic. This ensures reasonable, consistent defaults for new greenfield projects. The new defaults are more consistent and friendlier to code generation. It also means that if you have an existing schema and/or database, you will either need to migrate the database to the new defaults, or introspect the existing names.

⚠️ This means you will have to make conscious choices about constraint names when you upgrade. Please read the Named Constraints upgrade guide for a detailed explanation and steps to follow. ⚠️

## Referential Actions
The default referential actions behaviors when you update or delete data changes between Prisma 2 and Prisma 3. This will lead to queries behaving differently in Prisma 3.x compared to Prisma 2.x.

In some cases, a delete operation will delete more data than previously. This is ****because in Prisma 2, cascading deletes and updates defined at the database level were prevented by Prisma Client, but will be allowed to happen in Prisma 3.

On relational databases, Prisma now relies on the database for referential actions — using db pull after you upgrade will reflect the actual behavior in your Prisma Schema.

Please read the Referential Actions upgrade guide for a detailed explanation and steps to follow.

Seeding with prisma db seed , prisma migrate dev, prisma migrate reset
The mechanism through which seeds are discovered changes. If you were already using seeding since Prisma 2.15.0, you will see a warning with steps to follow the next time seeding is triggered.

In summary, you will need to:

Add the script to prisma.seed in your package.json
Adapt the script to the new API.
See the example above in the Major Improvements section and read the seeding docs for a complete explanation.

⚠️ Please note that the breaking change applies if you have an existing seed file since Prisma 2.15.0 without using prisma db seed. You will have to switch to the new mechanism. ⚠️

##$queryRaw API changes
We’ve taken this opportunity to cleanup $queryRaw and $executeRaw. In Prisma 2.x, the Prisma Client had different behavior depending on how you called $queryRaw or $executeRaw:

Tagged Template: prisma.$queryRaw...``. This API sent a prepared statement and was safe from SQL injections.
Function Call: prisma.$queryRaw(...). This API sent a raw query string and was not safe from SQL injections.
This was too subtle. Starting with Prisma 3, we've split our raw query APIs into "safe" and "unsafe":

$queryRaw...``: Safe from SQL injections. Sends a prepared statement and returns the resulting rows.
$executeRaw...``: Safe from SQL injections. Sends a prepared statement and returns the result count.
$queryRawUnsafe(...): Not safe from SQL injections. Sends the query as a string and returns the resulting rows. Useful for queries that can't be prepared, like using a variable for the table name.
$executeRawUnsafe(...): Not safe from SQL injections. Sends the query as a string and returns the result count. Useful for queries that can't be prepared, like altering a column's data type.
To update your application, you can do a "Find All" in your codebase for $queryRaw( and $executeRaw(. Then you can either turn them into tagged templates or use the unsafe functions.

##Changes to how you query Null values on JSON fields
While Filtering on a Json field was in Preview, we learned from a community member that you couldn't filter a Json field by the JSON value null.

This is because { equals: null } checks if the value in the database is NULL, not if the value inside the column is a JSON null.

To fix this problem, we decided to split "null" on Json fields into JsonNull, DbNull and AnyNull:

JsonNull: Selects the null value in JSON.
DbNull: Selects the NULL value in the database.
AnyNull: Selects both null JSON values and NULL database values.
Given the following model in your Prisma Schema:

model Log {
  id   Int  @id
  meta Json
}
Starting in 3.0.1, you'll see a TypeError if you try to filter by null on a Json field:

prisma.log.findMany({
  where: {
    data: {
      meta: {
        equals: null
         //      ^ TypeError: Type 'null' is not assignable to type
        }
    },
  },
});
To fix this, you'll import and use one of the new null types:

import { Prisma } from '@prisma/client'

prisma.log.findMany({
  where: {
    data: {
      meta: {
        equals: Prisma.AnyNull,
      },
    },
  },
})
Learn more about JSON filtering in our documentation.

## Renamed Aggregate Fields
In 2.23.0, we announced that aggregate fields like count will be deprecated in favor of the prefixed notation, i.e. _count in order to avoid clashing with model fields names in your application.

For example:

const result = await prisma.user.groupBy({
  by: ['name'],
-   count: true,
+   _count: true,
})
In this release, we're removing the deprecated old notation. You now must prefix your aggregate fields with an underscore.

To help with this transition, we suggest searching your codebase for .aggregate({ and .groupBy({, and prefixing count, max, min, avg and sum are all prefixed with an underscore, i.e. _count, _max, _min, _avg , and _sum.

You can learn more about the original deprecation in the 2.23.0 Release Notes.

## The minimum required version of Node.js is v12.6
Up until this release, Prisma supported versions 12.2 of Node.js and up

Starting with this release, the minimum required version of Node.js is 12.6.


