### PR TITLE
Surface errors on the api side

### DIFF
--- a/packages/api-server/src/handler.ts
+++ b/packages/api-server/src/handler.ts
@@ -70,7 +70,6 @@ export const apiServerHandler = async ({
   })
   process.on('exit', () => {
     http?.close()
-    process.exit(0)
   })
 }
 


### PR DESCRIPTION
Some API side errors were not printed to the console, making it very difficult to debug.

Before:

```
$ yarn rw dev
yarn run v1.22.11
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\rw dev
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\rw-gen-watch
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\cross-env NODE_ENV=development webpack serve --config C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\@redwoodjs\core\
config\webpack.development.js
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --watch C:\Users\tobbe\dev\redwood\acm-store-
rw\redwood.toml --exec "yarn rw-api-server-watch"
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\nodemon --watch C:\Users\tobbe\dev\redwood\acm-store-rw\redwood.toml --exec "yarn rw-api-server-watch"
api | [nodemon] 2.0.12
api | [nodemon] to restart at any time, enter `rs`
api | [nodemon] watching path(s): redwood.toml
api | [nodemon] watching extensions: js,mjs,json
api | [nodemon] starting `yarn rw-api-server-watch`
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\rw-api-server-watch
gen | Generating TypeScript definitions and GraphQL schemas...
gen | 61 files generated
web |
web | "extendDefaultPlugins" utility is deprecated.
web | Use "preset-default" plugin with overrides instead.
web | For example:
web | {
web |   name: 'preset-default',
web |   params: {
web |     overrides: {
web |       // customize plugin options
web |       convertShapeToPath: {
web |         convertArcs: true
web |       },
web |       // disable plugins
web |       convertPathData: false
web |     }
web |   }
web | }
web |
api | Building... Took 1145 ms
api | Starting API Server... Took 4 ms
api | Listening on http://localhost:8911/
api | Importing Server Functions...
web | assets by path images/ 233 KiB
web |   assets by path images/categories/*.svg 83.9 KiB 25 assets
web |   assets by path images/*.png 25.8 KiB
web |     asset images/swish-logo.png 11.8 KiB [emitted] [from: public/images/swish-logo.png] [copied]
web |     asset images/acm-logo.png 7.13 KiB [emitted] [from: public/images/acm-logo.png] [copied]
web |     asset images/swish-logo-48.png 3.55 KiB [emitted] [from: public/images/swish-logo-48.png] [copied]
web |     asset images/paypal-logo-37.png 3.34 KiB [emitted] [from: public/images/paypal-logo-37.png] [copied]
web |   assets by path images/*.svg 123 KiB
web |     asset images/swish-logo.svg 121 KiB [emitted] [from: public/images/swish-logo.svg] [copied]
web |     asset images/spinner.svg 2.28 KiB [emitted] [from: public/images/spinner.svg] [copied]
web | assets by path static/ 3.76 MiB 15 assets
web | asset index.html 8.13 KiB [emitted]
web | asset README.md 1.9 KiB [emitted] [from: public/README.md] [copied]
web | asset favicon.png 1.83 KiB [emitted] [from: public/favicon.png] [copied]
web | asset robots.txt 24 bytes [emitted] [from: public/robots.txt] [copied]
web | Entrypoint app 3.19 MiB (3.12 MiB) = static/js/runtime-app.bundle.js 48.8 KiB static/js/app.bundle.js 3.14 MiB 3 auxiliary assets
web | orphan modules 1.31 MiB [orphan] 952 modules
web | runtime modules 32.7 KiB 17 modules
web | cacheable modules 2.82 MiB
web |   modules by path ../node_modules/ 2.61 MiB 756 modules
web |   modules by path ./src/ 220 KiB
web |     modules by path ./src/components/ 121 KiB 13 modules
web |     modules by path ./src/pages/ 29.7 KiB
web |       modules by path ./src/pages/HomePage/ 8.01 KiB 2 modules
web |     modules by path ./src/*.css 25.1 KiB 4 modules
web |     modules by path ./src/*.js 10.9 KiB 3 modules
web |     modules by path ./src/contexts/ 17.1 KiB 3 modules
web |     modules by path ./src/utils/*.js 4.12 KiB 3 modules
web |     ./src/providers/RedwoodReactQueryProvider.tsx 8.82 KiB [built] [code generated]
web |     ./src/layouts/PageLayout/PageLayout.js 3.25 KiB [built] [code generated]
web |     ./src/fonts/Quicksand-Regular.ttf 87 bytes [built] [code generated]
web | webpack 5.51.1 compiled successfully in 8969 ms
api | /jsonproduct 3 ms
api | /payment 2 ms
api | /paysonCallback 3 ms
api | /prisma 12 ms
api | /shipping 3 ms
api | /snipcartWebhooks 2 ms
api | /swishCallback 2 ms
api | /swishCheckout 3 ms
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
```

After

```
$ yarn rw dev
yarn run v1.22.11
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\rw dev
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --watch C:\Users\tobbe\dev\redwood\acm-store-
rw\redwood.toml --exec "yarn rw-api-server-watch"
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\rw-gen-watch
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\cross-env NODE_ENV=development webpack serve --config C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\@redwoodjs\core\
config\webpack.development.js
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\nodemon --watch C:\Users\tobbe\dev\redwood\acm-store-rw\redwood.toml --exec "yarn rw-api-server-watch"
api | [nodemon] 2.0.12
api | [nodemon] to restart at any time, enter `rs`
api | [nodemon] watching path(s): redwood.toml
api | [nodemon] watching extensions: js,mjs,json
api | [nodemon] starting `yarn rw-api-server-watch`
$ C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\.bin\rw-api-server-watch
gen | Generating TypeScript definitions and GraphQL schemas...
web |
web | "extendDefaultPlugins" utility is deprecated.
web | Use "preset-default" plugin with overrides instead.
web | For example:
web | {
web |   name: 'preset-default',
web |   params: {
web |     overrides: {
web |       // customize plugin options
web |       convertShapeToPath: {
web |         convertArcs: true
web |       },
web |       // disable plugins
web |       convertPathData: false
web |     }
web |   }
web | }
web |
gen | 61 files generated
api | Building... Took 1344 ms
api | Starting API Server... Took 4 ms
api | Listening on http://localhost:8911/
api | Importing Server Functions...
web | assets by path images/ 233 KiB
web |   assets by path images/categories/*.svg 83.9 KiB 25 assets
web |   assets by path images/*.png 25.8 KiB
web |     asset images/swish-logo.png 11.8 KiB [emitted] [from: public/images/swish-logo.png] [copied]
web |     asset images/acm-logo.png 7.13 KiB [emitted] [from: public/images/acm-logo.png] [copied]
web |     asset images/swish-logo-48.png 3.55 KiB [emitted] [from: public/images/swish-logo-48.png] [copied]
web |     asset images/paypal-logo-37.png 3.34 KiB [emitted] [from: public/images/paypal-logo-37.png] [copied]
web |   assets by path images/*.svg 123 KiB
web |     asset images/swish-logo.svg 121 KiB [emitted] [from: public/images/swish-logo.svg] [copied]
web |     asset images/spinner.svg 2.28 KiB [emitted] [from: public/images/spinner.svg] [copied]
web | assets by path static/ 3.77 MiB 15 assets
web | asset index.html 8.13 KiB [emitted]
web | asset README.md 1.9 KiB [emitted] [from: public/README.md] [copied]
web | asset favicon.png 1.83 KiB [emitted] [from: public/favicon.png] [copied]
web | asset robots.txt 24 bytes [emitted] [from: public/robots.txt] [copied]
web | Entrypoint app 3.19 MiB (3.12 MiB) = static/js/runtime-app.bundle.js 48.8 KiB static/js/app.bundle.js 3.14 MiB 3 auxiliary assets
web | orphan modules 1.31 MiB [orphan] 952 modules
web | runtime modules 32.7 KiB 17 modules
web | cacheable modules 2.82 MiB
web |   modules by path ../node_modules/ 2.61 MiB 756 modules
web |   modules by path ./src/ 220 KiB
web |     modules by path ./src/components/ 121 KiB 13 modules
web |     modules by path ./src/pages/ 29.7 KiB
web |       modules by path ./src/pages/HomePage/ 8.01 KiB 2 modules
web |     modules by path ./src/*.css 25.1 KiB 4 modules
web |     modules by path ./src/*.js 10.9 KiB 3 modules
web |     modules by path ./src/contexts/ 17.1 KiB 3 modules
web |     modules by path ./src/utils/*.js 4.12 KiB 3 modules
web |     ./src/providers/RedwoodReactQueryProvider.tsx 8.82 KiB [built] [code generated]
web |     ./src/layouts/PageLayout/PageLayout.js 3.28 KiB [built] [code generated]
web |     ./src/fonts/Quicksand-Regular.ttf 87 bytes [built] [code generated]
web | webpack 5.51.1 compiled successfully in 9401 ms
api | /jsonproduct 4 ms
api | /payment 1 ms
api | /paysonCallback 1 ms
api | /prisma 5 ms
api | /shipping 2 ms
api | /snipcartWebhooks 1 ms
api | /swishCallback 1 ms
api | /swishCheckout 1 ms
api | Error: Cannot find module 'src/lib/paypal'
api | Require stack:
api | - C:\Users\tobbe\dev\redwood\acm-store-rw\api\dist\services\paypal\paypal.js
api | - C:\Users\tobbe\dev\redwood\acm-store-rw\api\dist\functions\graphql.js
api | - C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\@redwoodjs\api-server\dist\middleware\withFunctions.js
api | - C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\@redwoodjs\api-server\dist\handler.js
api | - C:\Users\tobbe\dev\redwood\acm-store-rw\node_modules\@redwoodjs\api-server\dist\index.js
api |     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
api |     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
api |     at Module.require (node:internal/modules/cjs/loader:1005:19)
api |     at require (node:internal/modules/cjs/helpers:94:18)
api |     at Object.<anonymous> (C:\Users\tobbe\dev\redwood\acm-store-rw\api\src\services\paypal\paypal.js:3:22)
api |     at Module._compile (node:internal/modules/cjs/loader:1101:14)
api |     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
api |     at Module.load (node:internal/modules/cjs/loader:981:32)
api |     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
api |     at Module.require (node:internal/modules/cjs/loader:1005:19) {
api |   code: 'MODULE_NOT_FOUND',
api |   requireStack: [
api |     'C:\\Users\\tobbe\\dev\\redwood\\acm-store-rw\\api\\dist\\services\\paypal\\paypal.js',
api |     'C:\\Users\\tobbe\\dev\\redwood\\acm-store-rw\\api\\dist\\functions\\graphql.js',
api |     'C:\\Users\\tobbe\\dev\\redwood\\acm-store-rw\\node_modules\\@redwoodjs\\api-server\\dist\\middleware\\withFunctions.js',
api |     'C:\\Users\\tobbe\\dev\\redwood\\acm-store-rw\\node_modules\\@redwoodjs\\api-server\\dist\\handler.js',
api |     'C:\\Users\\tobbe\\dev\\redwood\\acm-store-rw\\node_modules\\@redwoodjs\\api-server\\dist\\index.js'
api |   ]
api | }
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
web | <e> [webpack-dev-server] [HPM] Error occurred while proxying request localhost:8910/graphql to http://[::1]:8911/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_
system_errors)
```

Notice that it very clearly says it can't find my paypal lib.

Fixes: #3352