### PR TITLE
fix(mock-user): Add mockCurrentUser to api testing side

### DIFF
--- a/packages/create-redwood-app/template/api/tsconfig.json
+++ b/packages/create-redwood-app/template/api/tsconfig.json
@@ -16,7 +16,8 @@
         "./src/*",
         "../.redwood/types/mirror/api/src/*"
       ],
-      "types/*": ["./types/*"]
+      "types/*": ["./types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/api"]
     },
     "typeRoots": [
       "../node_modules/@types",

--- a/packages/create-redwood-app/template/web/tsconfig.json
+++ b/packages/create-redwood-app/template/web/tsconfig.json
@@ -16,7 +16,8 @@
         "./src/*",
         "../.redwood/types/mirror/web/src/*"
       ],
-      "types/*": ["./types/*"]
+      "types/*": ["./types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]
     },
     "typeRoots": ["../node_modules/@types", "./node_modules/@types"],
     "types": ["jest"],

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@redwoodjs/auth": "0.36.2",
     "@redwoodjs/internal": "0.36.2",
+    "@redwoodjs/graphql-server": "0.36.2",
     "@redwoodjs/router": "0.36.2",
     "@redwoodjs/web": "0.36.2",
     "@storybook/addon-a11y": "6.3.7",

--- a/packages/testing/src/api/index.ts
+++ b/packages/testing/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from './apiTestingMocks'
 export * from './scenario'
+export * from './mockContext'

--- a/packages/testing/src/api/mockContext.ts
+++ b/packages/testing/src/api/mockContext.ts
@@ -1,0 +1,19 @@
+import type { CurrentUser } from '@redwoodjs/auth'
+import { setContext } from '@redwoodjs/graphql-server'
+
+/**
+ * Use this function to mock currentUser in the graphql context.
+ *
+ * You can set other values in the context using mockGqlContext
+ *
+ * @param currentUser
+ */
+export const mockCurrentUser = (currentUser: CurrentUser) => {
+  setContext({
+    currentUser,
+  })
+}
+
+// There's really no difference between mocking context and setting context
+// But... the tests read way better this way
+export const mockGqlContext = setContext

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -17,5 +17,6 @@
     { "path": "../internal" },
     { "path": "../web" },
     { "path": "../auth" },
+    { "path": "../graphql-server" },
   ]
 }


### PR DESCRIPTION
> ⚠️ Note, this somewhat relies on graphql-server refactor, because in main, the auto imports for context are from @redwoodjs/api. In order to see this in action, you'll need to make sure in your service context is imported from graphql-server

### What does this do?
- Add aliases to tsconfig, so imports for rwjs/testing are resolved automatically
Note that jest already had module aliases https://github.com/redwoodjs/redwood/blob/main/packages/testing/config/jest/api/index.js#L18

Although the generator templates import from `@redwoodjs/testing/api` and `@redwoodjs/testing/web` - its an easy mistake to make, and this kind of guards against it - and its a really nice experience.


- Adds ability to `mockCurrentUser` from scenario/service tests, in exactly the same way we do for the web side (you don't even need to import from a different path with the above change)
https://redwoodjs.com/docs/testing#mockcurrentuser

#### See example here: 
https://gist.github.com/dac09/07589346f37b422f6e03acee851eb93e

Fixes #3258

