### PR TITLE
Fix: Generate types when generating sdl

### DIFF
--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,7 +1,7 @@
 import pascalcase from 'pascalcase'
 import pluralize from 'pluralize'
 
-import { generate } from '@redwoodjs/internal'
+import { generate as generateTypes } from '@redwoodjs/internal'
 
 import { transformTSToJS } from '../../../lib'
 import { getSchema } from '../../../lib'
@@ -174,9 +174,7 @@ export const { command, description, builder, handler } =
       return [
         {
           title: `Generating types ...`,
-          task: async () => {
-            return generate()
-          },
+          task: () => generateTypes,
         },
       ]
     },

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -222,9 +222,7 @@ export const handler = async ({
       },
       {
         title: `Generating types ...`,
-        task: async () => {
-          return generateTypes()
-        },
+        task: () => generateTypes,
       },
     ].filter(Boolean),
     { collapse: false }

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -597,9 +597,7 @@ const tasks = ({ model, path, force, tests, typescript, javascript }) => {
       },
       {
         title: `Generating types ...`,
-        task: async () => {
-          return generateTypes()
-        },
+        task: () => generateTypes,
       },
     ],
     { collapse: false, exitOnError: true }

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -8,7 +8,7 @@ import pascalcase from 'pascalcase'
 import pluralize from 'pluralize'
 import terminalLink from 'terminal-link'
 
-import { getConfig } from '@redwoodjs/internal'
+import { getConfig, generate as generateTypes } from '@redwoodjs/internal'
 
 import {
   generateTemplate,
@@ -223,6 +223,12 @@ export const handler = async ({ model, crud, force, tests, typescript }) => {
         task: async () => {
           const f = await files({ name: model, tests, crud, typescript })
           return writeFilesTask(f, { overwriteExisting: force })
+        },
+      },
+      {
+        title: `Generating types ...`,
+        task: async () => {
+          return generateTypes()
         },
       },
     ].filter(Boolean),

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -227,9 +227,7 @@ export const handler = async ({ model, crud, force, tests, typescript }) => {
       },
       {
         title: `Generating types ...`,
-        task: async () => {
-          return generateTypes()
-        },
+        task: () => generateTypes,
       },
     ].filter(Boolean),
     { collapse: false, exitOnError: true }


### PR DESCRIPTION
Closes #3345.

Like @dac09 suggested, implemented exactly same of scaffold and other generators.