### PR TITLE
Fix: Log error during GraphQL execution

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -342,30 +342,30 @@ const logResult =
 
     const options = {} as any
 
+    if (result.errors && result.errors.length > 0) {
+      envelopLogger.error(
+        {
+          errors: result.errors,
+        },
+        `GraphQL execution completed with errors:`
+      )
+    }
+
     if (result.data) {
       if (includeData) {
         options['data'] = result.data
       }
 
-      if (result.errors && result.errors.length > 0) {
-        envelopLogger.error(
-          {
-            errors: result.errors,
-          },
-          `GraphQL execution completed with errors:`
-        )
-      } else {
-        if (includeTracing) {
-          options['tracing'] = result.extensions?.envelopTracing
-        }
-
-        envelopLogger.debug(
-          {
-            ...options,
-          },
-          `GraphQL execution completed`
-        )
+      if (includeTracing) {
+        options['tracing'] = result.extensions?.envelopTracing
       }
+
+      envelopLogger.debug(
+        {
+          ...options,
+        },
+        `GraphQL execution completed`
+      )
     }
   }
 


### PR DESCRIPTION
Orignally reported by jan_mei on Discord: https://discord.com/channels/679514959968993311/716252919875240007/886349812147032124

Currently, if there's an error during GraphQL execution, there's no log of the actual error which makes debugging difficult. This PR attempts to fix this by logging that error.

![Screenshot 2021-09-12 at 7 16 58 PM](https://user-images.githubusercontent.com/2629902/132990093-228d54d7-a2c4-4bcc-90db-953d452a4934.png)
![Screenshot 2021-09-12 at 7 02 32 PM](https://user-images.githubusercontent.com/2629902/132990065-bf043312-9d89-4b11-b52c-c77dd906f767.png)


**Cause:**
In [`graphql-server/src/functions/graphql.ts`](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/functions/graphql.ts#L345), it currently checks if `result.data` exists before checking for the error but when the error happens the `data` key is null, that's why that error log becomes unreachable.

**Fix**:
Moved error check outside of `result.data` check.
![Screenshot 2021-09-12 at 7 02 04 PM](https://user-images.githubusercontent.com/2629902/132990083-87e290c5-2e73-4580-b695-0667ae5e849d.png)
