### PR TITLE
extend scenario with support for scenario.only

### DIFF
--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -34,52 +34,54 @@ const teardown = async () => {
   }
 }
 
-const buildScenario = (it) => (...args) => {
-  let scenarioName, testName, testFunc
+const buildScenario =
+  (it) =>
+  (...args) => {
+    let scenarioName, testName, testFunc
 
-  if (args.length === 3) {
-    ;[scenarioName, testName, testFunc] = args
-  } else if (args.length === 2) {
-    scenarioName = DEFAULT_SCENARIO
-    ;[testName, testFunc] = args
-  } else {
-    throw new Error('scenario() requires 2 or 3 arguments')
+    if (args.length === 3) {
+      ;[scenarioName, testName, testFunc] = args
+    } else if (args.length === 2) {
+      scenarioName = DEFAULT_SCENARIO
+      ;[testName, testFunc] = args
+    } else {
+      throw new Error('scenario() requires 2 or 3 arguments')
+    }
+
+    return it(testName, async () => {
+      const path = require('path')
+      const testFileDir = path.parse(global.testPath)
+      const testFilePath = `${testFileDir.dir}/${
+        testFileDir.name.split('.')[0]
+      }.scenarios`
+      let allScenarios, scenario, result
+
+      try {
+        allScenarios = require(testFilePath)
+      } catch (e) {
+        // ignore error if scenario file not found, otherwise re-throw
+        if (e.code !== 'MODULE_NOT_FOUND') {
+          throw e
+        }
+      }
+
+      if (allScenarios) {
+        if (allScenarios[scenarioName]) {
+          scenario = allScenarios[scenarioName]
+        } else {
+          throw (
+            ('UndefinedScenario',
+            `There is no scenario named "${scenarioName}" in ${testFilePath}.js`)
+          )
+        }
+      }
+
+      const scenarioData = await seedScenario(scenario)
+      result = await testFunc(scenarioData)
+
+      return result
+    })
   }
-
-  return it(testName, async () => {
-    const path = require('path')
-    const testFileDir = path.parse(global.testPath)
-    const testFilePath = `${testFileDir.dir}/${
-      testFileDir.name.split('.')[0]
-    }.scenarios`
-    let allScenarios, scenario, result
-
-    try {
-      allScenarios = require(testFilePath)
-    } catch (e) {
-      // ignore error if scenario file not found, otherwise re-throw
-      if (e.code !== 'MODULE_NOT_FOUND') {
-        throw e
-      }
-    }
-
-    if (allScenarios) {
-      if (allScenarios[scenarioName]) {
-        scenario = allScenarios[scenarioName]
-      } else {
-        throw (
-          ('UndefinedScenario',
-          `There is no scenario named "${scenarioName}" in ${testFilePath}.js`)
-        )
-      }
-    }
-
-    const scenarioData = await seedScenario(scenario)
-    result = await testFunc(scenarioData)
-
-    return result
-  })
-}
 
 global.scenario = buildScenario(global.it)
 global.scenario.only = buildScenario(global.it.only)

--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -34,7 +34,7 @@ const teardown = async () => {
   }
 }
 
-global.scenario = (...args) => {
+const buildScenario = (it) => (...args) => {
   let scenarioName, testName, testFunc
 
   if (args.length === 3) {
@@ -46,7 +46,7 @@ global.scenario = (...args) => {
     throw new Error('scenario() requires 2 or 3 arguments')
   }
 
-  return global.it(testName, async () => {
+  return it(testName, async () => {
     const path = require('path')
     const testFileDir = path.parse(global.testPath)
     const testFilePath = `${testFileDir.dir}/${
@@ -80,6 +80,9 @@ global.scenario = (...args) => {
     return result
   })
 }
+
+global.scenario = buildScenario(global.it)
+global.scenario.only = buildScenario(global.it.only)
 
 global.defineScenario = defineScenario
 


### PR DESCRIPTION
This was something that was bothering me when using scenarios.

This PR allows `scenario` to also be used with `scenario.only`

```
scenario('testName', () => {})
scenario.only('testName', () => {})
```
![2021-09-15 12 14 02](https://user-images.githubusercontent.com/6943688/133496516-4c38d9e7-cacf-4d25-8762-7d4d4ee40e9b.gif)

