### PR TITLE
Use data previously created in the scenario as input to other scenario data

### DIFF
--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -15,7 +15,12 @@ const seedScenario = async (scenario) => {
     for (const [model, namedFixtures] of Object.entries(scenario)) {
       scenarios[model] = {}
       for (const [name, createArgs] of Object.entries(namedFixtures)) {
-        scenarios[model][name] = await db[model].create(createArgs)
+        if (typeof createArgs === 'function') {
+          const args = createArgs(scenarios)
+          scenarios[model][name] = await db[model].create(args)
+        } else {
+          scenarios[model][name] = await db[model].create(createArgs)
+        }
       }
     }
     return scenarios

--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -16,8 +16,7 @@ const seedScenario = async (scenario) => {
       scenarios[model] = {}
       for (const [name, createArgs] of Object.entries(namedFixtures)) {
         if (typeof createArgs === 'function') {
-          const args = createArgs(scenarios)
-          scenarios[model][name] = await db[model].create(args)
+          scenarios[model][name] = await db[model].create(createArgs(scenarios))
         } else {
           scenarios[model][name] = await db[model].create(createArgs)
         }


### PR DESCRIPTION
This is a quick fix to allow scenarios to use other scenario data as input. #2422

It can be used like so.
```
export const standard = defineScenario({
  user: {
    one: { data: { email: 'String8522832' } },
    two: { data: { email: 'String9268083' } },
  },
  event: {
    one: (scenario) => {
      return {
        data: {
          name: 'testing',
          userId: scenario.user.one.id,
        },
      }
    },
  },
})
```
This should work in the order that the keys are defined in the scenario.
Since as of es2015 object keys are chronological https://tc39.es/ecma262/#sec-ordinaryownpropertykeys

Any part of the scenario whose key is created above should be accessible when you use a function to access the data.

Data returned from the function should be an object of the data that you want to be created.