### PR TITLE
Fix: allows @storybook/addon-essentials to be installed

### DIFF
--- a/packages/create-redwood-app/template/web/package.json
+++ b/packages/create-redwood-app/template/web/package.json
@@ -16,6 +16,7 @@
     "@redwoodjs/forms": "0.36.4",
     "@redwoodjs/router": "0.36.4",
     "@redwoodjs/web": "0.36.4",
+    "babel-loader": "8.2.2",
     "prop-types": "15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/packages/testing/config/storybook/main.js
+++ b/packages/testing/config/storybook/main.js
@@ -21,6 +21,7 @@ const baseConfig = {
   stories: [
     `${importStatementPath(rwjsPaths.web.src)}/**/*.stories.{tsx,jsx,js}`,
   ],
+  typescript: { reactDocgen: false },
   addons: [config.web.a11y && '@storybook/addon-a11y'].filter(Boolean),
   webpackFinal: (sbConfig, { configType }) => {
     // configType is 'PRODUCTION' or 'DEVELOPMENT', why shout?


### PR DESCRIPTION
Cool with this getting rejected.
Just showing where the hacky fixes can be made to get @storybook/addon-essentials running. See here: https://github.com/redwoodjs/redwood/issues/3339#issuecomment-922236087