### PR TITLE
fix(gql-server): Allow query/mutate without directives

### DIFF
--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodDirective.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodDirective.test.ts
@@ -135,19 +135,6 @@ describe('Directives on Queries', () => {
     expect(result.data?.public).toBe('public')
   })
 
-  it('Should not allow execution without a directive', async () => {
-    const result = await testInstance.execute(`query { noDirectiveSpecified }`)
-
-    assertSingleExecutionValue(result)
-
-    expect(result.errors).toBeTruthy()
-    expect(result.errors[0].message).toMatchInlineSnapshot(
-      `"You must specify one of @requireAuth, @skipAuth or a custom directive"`
-    )
-
-    expect(result.data?.noDirectiveSpecified).toBeNull()
-  })
-
   it('Should not require Type fields (ie, not Query or Mutation root types) to have directives declared', async () => {
     const result = await testInstance.execute(`query { posts { title } }`)
 

--- a/packages/graphql-server/src/plugins/useRedwoodDirective.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodDirective.ts
@@ -7,16 +7,7 @@ import {
   GraphQLResolveInfo,
 } from 'graphql'
 
-// Just for consistent messaging
-import { DIRECTIVE_REQUIRED_ERROR_MESSAGE } from '@redwoodjs/internal'
-
 import { GlobalContext } from '../index'
-
-function isQueryOrMutation(info: GraphQLResolveInfo): boolean {
-  const { parentType } = info
-
-  return parentType.name === 'Query' || parentType.name === 'Mutation'
-}
 
 export interface DirectiveParams<FieldType = any> {
   root: unknown
@@ -128,10 +119,6 @@ export const useRedwoodDirective = (
     onExecute({ args: executionArgs }) {
       return {
         async onResolverCalled({ args, root, context, info }) {
-          if (isQueryOrMutation(info) && !hasDirective(info)) {
-            throw new Error(DIRECTIVE_REQUIRED_ERROR_MESSAGE)
-          }
-
           const directiveNode = getDirectiveByName(info, options.name)
           const directive = directiveNode
             ? executionArgs.schema.getDirective(directiveNode.name.value)


### PR DESCRIPTION
...because we now have build time and devtime checks

The run time check seems superflous!

