### PR TITLE
Fix invalid type in DbAuthHandler

### DIFF
--- a/packages/api/src/functions/dbAuth/DbAuthHandler.ts
+++ b/packages/api/src/functions/dbAuth/DbAuthHandler.ts
@@ -69,8 +69,8 @@ interface DbAuthHandlerOptions {
      * Object containing error strings
      */
     errors: {
-      fieldMissing: '${field} cannot be blank'
-      usernameTaken: 'Username ${username} already in use'
+      fieldMissing: string
+      usernameTaken: string
     }
   }
 }


### PR DESCRIPTION
Fixes typescript error `'${field} cannot be blank' is not type of string` 
The type should be type `string` instead of plain text.

Fixes #3391