### PR TITLE
fix generated service template (remove beforeResolvers)

### DIFF
--- a/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
+++ b/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
@@ -125,6 +125,12 @@ export const users = () => {
   return db.user.findMany()
 }
 
+export const user = ({ id }) => {
+  return db.user.findUnique({
+    where: { id },
+  })
+}
+
 export const User = {
   identity: (_obj, { root }) =>
     db.user.findUnique({ where: { id: root.id } }).identity(),
@@ -139,6 +145,12 @@ export const users = () => {
   return db.user.findMany()
 }
 
+export const user = ({ id }) => {
+  return db.user.findUnique({
+    where: { id },
+  })
+}
+
 export const User = {
   userProfiles: (_obj, { root }) =>
     db.user.findUnique({ where: { id: root.id } }).userProfiles(),
@@ -151,6 +163,12 @@ exports[`in javascript mode creates a single word service file with multiple rel
 
 export const users = () => {
   return db.user.findMany()
+}
+
+export const user = ({ id }) => {
+  return db.user.findUnique({
+    where: { id },
+  })
 }
 
 export const User = {
@@ -186,10 +204,7 @@ describe('users', () => {
 `;
 
 exports[`in typescript mode creates a multi word service file 1`] = `
-"import type { BeforeResolverSpecType } from '@redwoodjs/graphql-server'
-
-import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
+"import { db } from 'src/lib/db'
 
 export const userProfiles = () => {
   return db.userProfile.findMany()
@@ -268,10 +283,7 @@ describe('transactions', () => {
 `;
 
 exports[`in typescript mode creates a single word service file 1`] = `
-"import type { BeforeResolverSpecType } from '@redwoodjs/graphql-server'
-
-import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
+"import { db } from 'src/lib/db'
 
 export const users = () => {
   return db.user.findMany()
@@ -281,10 +293,8 @@ export const users = () => {
 
 exports[`in typescript mode creates a single word service file with CRUD actions 1`] = `
 "import type { Prisma } from '@prisma/client'
-import type { BeforeResolverSpecType } from '@redwoodjs/graphql-server'
 
 import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
 
 export const posts = () => {
   return db.post.findMany()
@@ -327,16 +337,18 @@ export const deletePost = ({ id }: Prisma.PostWhereUniqueInput) => {
 
 exports[`in typescript mode creates a single word service file with a belongsTo relation 1`] = `
 "import type { Prisma } from '@prisma/client'
-import type {
-  ResolverArgs,
-  BeforeResolverSpecType,
-} from '@redwoodjs/graphql-server'
+import type { ResolverArgs } from '@redwoodjs/graphql-server'
 
 import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
 
 export const users = () => {
   return db.user.findMany()
+}
+
+export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
+  return db.user.findUnique({
+    where: { id },
+  })
 }
 
 export const User = {
@@ -348,16 +360,18 @@ export const User = {
 
 exports[`in typescript mode creates a single word service file with a hasMany relation 1`] = `
 "import type { Prisma } from '@prisma/client'
-import type {
-  ResolverArgs,
-  BeforeResolverSpecType,
-} from '@redwoodjs/graphql-server'
+import type { ResolverArgs } from '@redwoodjs/graphql-server'
 
 import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
 
 export const users = () => {
   return db.user.findMany()
+}
+
+export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
+  return db.user.findUnique({
+    where: { id },
+  })
 }
 
 export const User = {
@@ -369,16 +383,18 @@ export const User = {
 
 exports[`in typescript mode creates a single word service file with multiple relations 1`] = `
 "import type { Prisma } from '@prisma/client'
-import type {
-  ResolverArgs,
-  BeforeResolverSpecType,
-} from '@redwoodjs/graphql-server'
+import type { ResolverArgs } from '@redwoodjs/graphql-server'
 
 import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
 
 export const users = () => {
   return db.user.findMany()
+}
+
+export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
+  return db.user.findUnique({
+    where: { id },
+  })
 }
 
 export const User = {

--- a/packages/cli/src/commands/generate/service/templates/service.ts.template
+++ b/packages/cli/src/commands/generate/service/templates/service.ts.template
@@ -1,18 +1,17 @@
 <% if (crud || relations.length > 0) { %>import type { Prisma } from '@prisma/client'<% } %>
-import type { <% if (relations.length) { %>ResolverArgs, <% } %>BeforeResolverSpecType } from '@redwoodjs/graphql-server'
+<% if (relations.length) { %>import type { ResolverArgs } from '@redwoodjs/graphql-server'<% } %>
 
 import { db } from 'src/lib/db'
-import { requireAuth } from 'src/lib/auth'
 
 export const ${pluralCamelName} = () => {
   return db.${singularCamelName}.findMany()
-}<% if (crud) { %>
+}<% if (crud || relations.length) { %>
 
 export const ${singularCamelName} = ({ id }: Prisma.${singularPascalName}WhereUniqueInput) => {
   return db.${singularCamelName}.findUnique({
     where: { id },
   })
-}
+}<% } %><% if (crud) { %>
 
 interface Create${singularPascalName}Args {
   input: Prisma.${singularPascalName}CreateInput

--- a/packages/create-redwood-app/template/api/src/lib/auth.ts
+++ b/packages/create-redwood-app/template/api/src/lib/auth.ts
@@ -1,8 +1,8 @@
 /**
  * Once you are ready to add authentication to your application
  * you'll build out requireAuth() with real functionality. For
- * now we just return `true` so that the beforeResolver() calls
- * in services have something to check against, simulating a logged
+ * now we just return `true` so that the calls in services
+ * have something to check against, simulating a logged
  * in user that is allowed to access that service.
  *
  * See https://redwoodjs.com/docs/authentication for more info.


### PR DESCRIPTION
The Services template still includes BeforeResolverSpecType and requireAuth, which are no longer needed per changes coming in v0.37 (and are currently throwing import eslint errors).

This removes the imports and updates the template logic to include Prisma type when needed (model relation and/or crud).