### PR TITLE
Fixes GraphQL Verification to check for directives on queries

### DIFF
--- a/packages/graphql-server/src/makeMergedSchema/__tests__/makeMergedSchema.test.ts
+++ b/packages/graphql-server/src/makeMergedSchema/__tests__/makeMergedSchema.test.ts
@@ -179,7 +179,7 @@ describe('makeMergedSchema', () => {
     })
   })
 
-  it('throws when directives not added to queries and mutations', () => {
+  it('throws when directives not added to queries', () => {
     const sdlsWithoutDirectives = {
       withoutDirective: {
         schema: parse(`
@@ -195,6 +195,145 @@ describe('makeMergedSchema', () => {
             redwood: Redwood
             bazinga: String
           }
+        `),
+        resolvers: {},
+      },
+    }
+
+    expect(() =>
+      makeMergedSchema({
+        sdls: sdlsWithoutDirectives,
+        services: makeServices({ services }),
+        directives: makeDirectivesForPlugin(directiveFiles),
+      })
+    ).toThrowError(DIRECTIVE_REQUIRED_ERROR_MESSAGE)
+  })
+
+  it('throws when directives not added to mutations', () => {
+    const sdlsWithoutDirectives = {
+      withoutDirective: {
+        schema: parse(`
+          scalar JSON
+
+          type Redwood {
+            version: String
+            currentUser: JSON
+            prismaVersion: String
+          }
+
+          type Query {
+            redwood: Redwood
+          }
+
+          type Mutation {
+            bazinga(id: Int): String
+          }
+
+        `),
+        resolvers: {},
+      },
+    }
+
+    expect(() =>
+      makeMergedSchema({
+        sdls: sdlsWithoutDirectives,
+        services: makeServices({ services }),
+        directives: makeDirectivesForPlugin(directiveFiles),
+      })
+    ).toThrowError(DIRECTIVE_REQUIRED_ERROR_MESSAGE)
+  })
+
+  it('throws when directives not added to queries and mutations', () => {
+    const sdlsWithoutDirectives = {
+      withoutDirective: {
+        schema: parse(`
+          scalar JSON
+
+          type Redwood {
+            version: String
+            currentUser: JSON
+            prismaVersion: String
+          }
+
+          type Query {
+            redwood: Redwood
+            myQuery: String!
+          }
+
+          type Mutation {
+            bazinga(id: Int): String!
+          }
+
+        `),
+        resolvers: {},
+      },
+    }
+
+    expect(() =>
+      makeMergedSchema({
+        sdls: sdlsWithoutDirectives,
+        services: makeServices({ services }),
+        directives: makeDirectivesForPlugin(directiveFiles),
+      })
+    ).toThrowError(DIRECTIVE_REQUIRED_ERROR_MESSAGE)
+  })
+
+  it('throws when directives not added to queries but is on a mutation', () => {
+    const sdlsWithoutDirectives = {
+      withoutDirective: {
+        schema: parse(`
+          scalar JSON
+
+          type Redwood {
+            version: String
+            currentUser: JSON
+            prismaVersion: String
+          }
+
+          type Query {
+            redwood: Redwood
+            myQuery: String!
+          }
+
+          type Mutation {
+            bazinga(id: Int): String! @foo
+          }
+
+        `),
+        resolvers: {},
+      },
+    }
+
+    expect(() =>
+      makeMergedSchema({
+        sdls: sdlsWithoutDirectives,
+        services: makeServices({ services }),
+        directives: makeDirectivesForPlugin(directiveFiles),
+      })
+    ).toThrowError(DIRECTIVE_REQUIRED_ERROR_MESSAGE)
+  })
+
+  it('throws when directives not added to mutations but is on a query', () => {
+    const sdlsWithoutDirectives = {
+      withoutDirective: {
+        schema: parse(`
+          scalar JSON
+
+          type Redwood {
+            version: String
+            currentUser: JSON
+            prismaVersion: String
+          }
+
+          type Query {
+            redwood: Redwood
+            myQuery: String! @foo
+          }
+
+          type Mutation {
+            bazinga(id: Int): String!
+          }
+
         `),
         resolvers: {},
       },

--- a/packages/graphql-server/src/makeMergedSchema/__tests__/makeMergedSchema.test.ts
+++ b/packages/graphql-server/src/makeMergedSchema/__tests__/makeMergedSchema.test.ts
@@ -1,6 +1,8 @@
 import { parse, GraphQLResolveInfo } from 'graphql'
 import gql from 'graphql-tag'
 
+import { DIRECTIVE_REQUIRED_ERROR_MESSAGE } from '@redwoodjs/internal'
+
 import {
   makeDirectivesForPlugin,
   createTransformerDirective,
@@ -181,7 +183,16 @@ describe('makeMergedSchema', () => {
     const sdlsWithoutDirectives = {
       withoutDirective: {
         schema: parse(`
+          scalar JSON
+
+          type Redwood {
+            version: String
+            currentUser: JSON
+            prismaVersion: String
+          }
+
           type Query {
+            redwood: Redwood
             bazinga: String
           }
         `),
@@ -195,7 +206,7 @@ describe('makeMergedSchema', () => {
         services: makeServices({ services }),
         directives: makeDirectivesForPlugin(directiveFiles),
       })
-    ).toThrowError()
+    ).toThrowError(DIRECTIVE_REQUIRED_ERROR_MESSAGE)
   })
 
   describe('Directives', () => {

--- a/packages/internal/src/validateSchema.ts
+++ b/packages/internal/src/validateSchema.ts
@@ -28,13 +28,11 @@ export function validateSchemaForDirectives(
           const isCurrentUserQuery =
             fieldName === 'currentUser' && fieldTypeName === 'Query'
           // skip validation for redwood query and currentUser
-          if (isRedwoodQuery || isCurrentUserQuery) {
-            return
-          }
-
-          const hasDirective = field.directives?.length
-          if (!hasDirective) {
-            validationOutput.push(`${fieldName} ${fieldTypeName}`)
+          if (!(isRedwoodQuery || isCurrentUserQuery)) {
+            const hasDirective = field.directives?.length
+            if (!hasDirective) {
+              validationOutput.push(`${fieldName} ${fieldTypeName}`)
+            }
           }
         }
       }


### PR DESCRIPTION
Currently, when no directives are declared on any mutation or query (for example in the test project app for Posts and Contacts), when building:

> `yarn rw build`

```terminal
  ✔ Generating Prisma Client...
  ✖ Verifying graphql schema...
    → - deletePost Mutation
    Building API...
    Cleaning Web...
    Building Web...
    Prerendering Web...
You must specify one of @requireAuth, @skipAuth or a custom directive for
- createContact Mutation
- createPost Mutation
- updatePost Mutation
- deletePost Mutation 
```

and when launching the dev server

> `yarn rw dev`

```terminal

api | [nodemon] 2.0.12
api | [nodemon] to restart at any time, enter `rs`
api | [nodemon] watching path(s): redwood.toml
api | [nodemon] watching extensions: js,mjs,json
api | [nodemon] starting `yarn rw-api-server-watch`
gen | Generating TypeScript definitions and GraphQL schemas...
gen | 37 files generated
api | Building... Took 444 ms
api | Starting API Server... Took 2 ms
api | Listening on http://localhost:8911/
api | Importing Server Functions... 
web | ...
api | FATAL [2021-09-24 17:51:18.811 +0000]: 
api |  ⚠️ GraphQL server crashed 
api | 
api |     Error: You must specify one of @requireAuth, @skipAuth or a custom directive for
api |     - contacts Query
api |     - posts Query
api |     - post Query
api |     - createContact Mutation
api |     - createPost Mutation
api |     - updatePost Mutation
api |     - deletePost Mutation 
```

None of the warnings appear for queries.

This was because once the verification encountered a `currentUser` or a `redwood` it would break for subsequent checks.

This PR fixes this (see test for including the root type and query) and afterwards:

> `yarn rw build`


```terminal
  ✔ Generating Prisma Client...
  ✖ Verifying graphql schema...
    → - deletePost Mutation
    Building API...
    Cleaning Web...
    Building Web...
    Prerendering Web...
You must specify one of @requireAuth, @skipAuth or a custom directive for
- contacts Query
- posts Query
- post Query
- createContact Mutation
- createPost Mutation
- updatePost Mutation
- deletePost Mutation 
```

> `yarn rw dev`


```terminal
web | webpack 5.53.0 compiled successfully in 3222 ms
api | FATAL [2021-09-24 18:41:49.700 +0000]: 
api |  ⚠️ GraphQL server crashed 
api | 
api |     Error: You must specify one of @requireAuth, @skipAuth or a custom directive for
api |     - contacts Query
api |     - posts Query
api |     - post Query
api |     - createContact Mutation
api |     - createPost Mutation
api |     - updatePost Mutation
api |     - deletePost Mutation 
```

Notice queries are present.



