### PR TITLE
Fixes Type error with requireAuth roles in lib/auth template

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/auth.js.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth.js.template
@@ -36,19 +36,24 @@ export const getCurrentUser = async (
  *
  * @returns {boolean} - If the currentUser is authenticated
  */
-export const isAuthenticated = () => {
+export const isAuthenticated = (): boolean => {
   return !!context.currentUser
 }
 
 /**
+ * When checking role membership, roles can be a single value, a list, or none
+ */
+type AllowedRoles = string | string[] | undefined
+
+/**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param {string | string[]} roles - A single role or list of roles to check if the user belongs to
+ * @param roles: AllowedRoles - When checking role membership, roles can be a single value, a list, or none
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
  */
-export const hasRole = ({ roles }) => {
+export const hasRole = ({ roles }: { roles: AllowedRoles }): boolean => {
   if (!isAuthenticated()) {
     return false
   }
@@ -74,7 +79,7 @@ export const hasRole = ({ roles }) => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param {string= | string[]=} roles - A single role or list of roles to check if the user belongs to
+ * @param roles: AllowedRoles - When checking role membership, roles can be a single value, a list, or none
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
@@ -83,7 +88,7 @@ export const hasRole = ({ roles }) => {
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */
-export const requireAuth = ({ roles } = {}) => {
+export const requireAuth = ({ roles }: { roles: AllowedRoles }) => {
   if (!isAuthenticated()) {
     throw new AuthenticationError("You don't have permission to do that.")
   }

--- a/packages/cli/src/commands/setup/auth/templates/auth.js.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth.js.template
@@ -41,14 +41,15 @@ export const isAuthenticated = (): boolean => {
 }
 
 /**
- * When checking role membership, roles can be a single value, a list, or none
+ * When checking role membership, roles can be a single value, a list, or none.
+ * You can use Prisma enums too (if you're using them for roles), just import your enum type from `@prisma/client`
  */
 type AllowedRoles = string | string[] | undefined
 
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - When checking role membership, roles can be a single value, a list, or none
+ * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -79,7 +80,7 @@ export const hasRole = ({ roles }: { roles: AllowedRoles }): boolean => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param roles: AllowedRoles - When checking role membership, roles can be a single value, a list, or none
+ * @param roles: AllowedRoles - When checking role membership, these roles grant access.
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/3142

Before Resolvers are no longer used in the auth template.

However, these was a Typescript issue with roles:


![](https://user-images.githubusercontent.com/2951/133707470-0b86820e-d6db-412d-9b0e-6385349745d3.png)


This has been fixed by adding an "AllowedRoles" type that lets the value be a string (one role), a list (several roles), or undefined (none) when checking the role membership. 