### PR TITLE
Adds descriptions to @requireAuth @skipAuth directives and its generator templates

### DIFF
--- a/packages/cli/src/commands/generate/directive/__tests__/__snapshots__/directive.test.ts.snap
+++ b/packages/cli/src/commands/generate/directive/__tests__/__snapshots__/directive.test.ts.snap
@@ -5,6 +5,9 @@ exports[`creates a JavaScript validator directive: js directive 1`] = `
 import { logger } from 'src/lib/logger'
 
 export const schema = gql\`
+  \\"\\"\\"
+  Use @requireAdmin to validate access to a field, query or mutation.
+  \\"\\"\\"
   directive @requireAdmin on FIELD_DEFINITION
 \`
 
@@ -68,6 +71,9 @@ exports[`creates a TypeScript transformer directive: ts directive 1`] = `
 import { logger } from 'src/lib/logger'
 
 export const schema = gql\`
+  \\"\\"\\"
+  Use @bazingaFooBar to transform the resolved value to return a modified result.
+  \\"\\"\\"
   directive @bazingaFooBar on FIELD_DEFINITION
 \`
 

--- a/packages/cli/src/commands/generate/directive/templates/transformer.directive.ts.template
+++ b/packages/cli/src/commands/generate/directive/templates/transformer.directive.ts.template
@@ -5,6 +5,9 @@ import {
 import { logger } from 'src/lib/logger'
 
 export const schema = gql`
+  """
+  Use @${camelName} to transform the resolved value to return a modified result.
+  """
   directive @${camelName} on FIELD_DEFINITION
 `
 

--- a/packages/cli/src/commands/generate/directive/templates/validator.directive.ts.template
+++ b/packages/cli/src/commands/generate/directive/templates/validator.directive.ts.template
@@ -5,6 +5,9 @@ import {
 import { logger } from 'src/lib/logger'
 
 export const schema = gql`
+  """
+  Use @${camelName} to validate access to a field, query or mutation.
+  """
   directive @${camelName} on FIELD_DEFINITION
 `
 

--- a/packages/create-redwood-app/template/api/src/directives/requireAuth/requireAuth.ts
+++ b/packages/create-redwood-app/template/api/src/directives/requireAuth/requireAuth.ts
@@ -5,6 +5,10 @@ import { createValidatorDirective } from '@redwoodjs/graphql-server'
 import { requireAuth as applicationRequireAuth } from 'src/lib/auth'
 
 export const schema = gql`
+  """
+  Use to check whether or not a user is authenticated and is associated
+  with an optional set of roles.
+  """
   directive @requireAuth(roles: [String]) on FIELD_DEFINITION
 `
 

--- a/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.ts
+++ b/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.ts
@@ -3,6 +3,9 @@ import gql from 'graphql-tag'
 import { createValidatorDirective } from '@redwoodjs/graphql-server'
 
 export const schema = gql`
+  """
+  Use to skip authentication checks and allow public access.
+  """
   directive @skipAuth on FIELD_DEFINITION
 `
 


### PR DESCRIPTION
Descriptions help document the GraphQL schema.

This PR adds comments to the built-in @requireAtuh and @skipAuth directives and also adds some boilerplate that can be edited for custom validator and transformer templates.

These use `string literals` ie (`"""`).

You can see the descriptions when introspecting the schema docs, seen here:

![image](https://user-images.githubusercontent.com/1051633/134924594-09edd5c3-b618-4b5d-b5e6-203fcf456326.png)

Note: Similar descriptions could be added to

* Redwood types

![image](https://user-images.githubusercontent.com/1051633/134926334-288f02ff-7d18-4633-a95c-420fdf3dc13b.png)


* SDL generators for Types and Query/Mutations


FYI: Descriptions like these appear in the schema. A comment (`#`) is a comment, but not shared when introspecting the schema.