### PR TITLE
add Node v16 to CI matrix and template package.json engine

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        node-version: ['14']
+        node-version: ['14', '16']
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        node-version: ['14']
+        node-version: ['14', '16']
       fail-fast: true
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} | Node ${{ matrix.node-version }} latest

--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -15,7 +15,7 @@
     "root": true
   },
   "engines": {
-    "node": "14.x",
+    "node": ">=14.x <=16.x",
     "yarn": "1.x"
   }
 }


### PR DESCRIPTION
_for v0.38 release cycle_

Node.js v16 [transitions to Active LTS](https://nodejs.org/en/about/releases/) on October 26, 2021.

This PR:
- adds v16 to the CI matrix runs for Build/lint/test and E2E
- changes the crwa/template/package.json engine for node to be `"node": ">=14.x <=16.x",`


