### PR TITLE
Try fixing codemod execution on windows

### DIFF
--- a/tasks/test-project/package.json
+++ b/tasks/test-project/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "scripts": {
-    "transform": "node node_modules/.bin/jscodeshift --fail-on-error"
-  },
   "dependencies": {
     "jscodeshift": "^0.13.0"
   }

--- a/tasks/test-project/util.js
+++ b/tasks/test-project/util.js
@@ -4,16 +4,27 @@ const path = require('path')
 
 const execa = require('execa')
 
+// Similar to codemods package, but subtly different in where the binary is resolved
+const getCommand = () => {
+  if (process.platform === 'win32') {
+    return 'yarn jscodeshift'
+  } else {
+    return 'node node_modules/.bin/jscodeshift'
+  }
+}
+
 async function applyCodemod(codemod, target) {
-  const args = []
-  args.push(
+  const args = [
+    '--fail-on-error',
     '-t',
     `${path.resolve(__dirname, 'codemods', codemod)} ${target}`,
     '--parser',
-    'tsx'
-  )
+    'tsx',
+  ]
 
-  await execa('yarn transform', args, getExecaOptions(path.resolve(__dirname)))
+  args.push()
+
+  await execa(getCommand(), args, getExecaOptions(path.resolve(__dirname)))
 }
 
 /** @type {(string) => import('execa').Options} */


### PR DESCRIPTION
As title

### Why?
Well... it seems windows doesn't like executing via binary, and macOS/linux dont like executing via `yarn jscodeshift`. This PR adds an if statement to support both cases