### PR TITLE
Add some missing @redwoodjs/internal dependencies

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -34,6 +34,7 @@
     "fs-extra": "10.0.0",
     "glob": "7.1.7",
     "graphql": "15.5.3",
+    "graphql-scalars": "1.10.1",
     "kill-port": "1.6.1",
     "prettier": "2.4.1",
     "rimraf": "3.0.2",


### PR DESCRIPTION
`@redwoodjs/codemods` relies on `@redwoodjs/internal` which was relying on some hoisted modules. They aren't there when it's just published alone so this PR adds them explicitly so it can work with npx.