### PR TITLE
Dont generate types for codemods, as its not a lib to import

### DIFF
--- a/packages/codemods/jest.setup.js
+++ b/packages/codemods/jest.setup.js
@@ -1,4 +1,4 @@
 global.matchTransformSnapshot =
-  require('./testUtils/matchTransformSnapshot').matchTransformSnapshot
+  require('./testUtils/index').matchTransformSnapshot
 global.matchInlineTransformSnapshot =
-  require('./testUtils/matchTransformSnapshot').matchInlineTransformSnapshot
+  require('./testUtils/index').matchInlineTransformSnapshot

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "build": "yarn build:js",
     "prepublishOnly": "yarn build",
-    "build:js": "babel src -d dist --extensions \".js,.ts\" --copy-files --no-copy-ignored --ignore \"src/**/__tests__/**\" --ignore \"src/**/__testfixtures__/**\"",
-    "build:watch": "nodemon --watch src --ignore dist,template --exec \"yarn build\"",
+    "build:js": "babel src -d dist --extensions \".js,.ts\" --ignore \"src/**/__tests__/**\" --ignore \"src/**/__testfixtures__/**\"",
+    "build:watch": "nodemon --watch src --ignore dist --exec \"yarn build\"",
     "test": "jest",
     "test:watch": "yarn test --watch"
   },

--- a/packages/codemods/testUtils.d.ts
+++ b/packages/codemods/testUtils.d.ts
@@ -31,3 +31,17 @@ declare module 'jscodeshift/dist/testUtils' {
     testOptions?: TestOptions
   ): string
 }
+
+import {
+  matchInlineTransformSnapshot,
+  matchTransformSnapshot,
+} from './testUtils/index'
+
+type MatchFunction = typeof matchTransformSnapshot
+type MatchInlineFunction = typeof matchInlineTransformSnapshot
+
+// This file gets loaded in jest setup, so becomes available globally in tests
+declare global {
+  const matchTransformSnapshot: MatchFunction
+  const matchInlineTransformSnapshot: MatchInlineFunction
+}

--- a/packages/codemods/testUtils/index.ts
+++ b/packages/codemods/testUtils/index.ts
@@ -89,13 +89,4 @@ export const matchInlineTransformSnapshot = (
   expect(formatCode(transformedContent)).toEqual(formatCode(expectedCode))
 }
 
-type MatchFunction = typeof matchTransformSnapshot
-type MatchInlineFunction = typeof matchInlineTransformSnapshot
-
-// This file gets loaded in jest setup, so becomes available globally in tests
-declare global {
-  const matchTransformSnapshot: MatchFunction
-  const matchInlineTransformSnapshot: MatchInlineFunction
-}
-
 export default matchTransformSnapshot

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -2,12 +2,10 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDirs": ["src", "testUtils"],
-    "outDir": "dist",
+    "rootDir": "src",
+    "emitDeclarationOnly": false,
+    "noEmit": true
   },
-  "include": ["src", "./testUtils.d.ts", "testUtils"],
-  "exclude": ["**/__testfixtures__"],
-  "references": [
-    { "internal": "../internal" },
-  ]
+  "include": ["src", "./testUtils.d.ts"],
+  "exclude": ["**/__testfixtures__"]
 }


### PR DESCRIPTION
Attempts to fix babel issues that happen when running codemods with np

## What was the issue?
The way I had tsconfig setup meant when the types were generated, it was creating stuff in dist/src.

I also removed the `--copy-files` flag from the build command, which may have also been the cause of our woes.