### PR TITLE
Align loose mode in babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -52,7 +52,6 @@ module.exports = {
      **/
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
     ['@babel/plugin-proposal-private-methods', { loose: true }],
   ],
   overrides: [

--- a/babel.config.js
+++ b/babel.config.js
@@ -52,6 +52,7 @@ module.exports = {
      **/
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
+    ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
     ['@babel/plugin-proposal-private-methods', { loose: true }],
   ],
   overrides: [

--- a/packages/codemods/.babelrc.js
+++ b/packages/codemods/.babelrc.js
@@ -1,1 +1,8 @@
-module.exports = { extends: '../../babel.config.js' }
+module.exports = {
+  extends: '../../babel.config.js',
+  overrides: [{
+    plugins: [
+      ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
+    ]
+  }]
+}


### PR DESCRIPTION
We get the following babel error when running codemods:
```
Error: 'loose' mode configuration must be the same for @babel/plugin-proposal-class-properties, 
@babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object 
(when they are enabled).
```

We enable loose mode for `@babel/plugin-proposal-class-properties` and `@babel/plugin-proposal-private-methods`, but not for `@babel/plugin-proposal-private-property-in-object`:

https://github.com/redwoodjs/redwood/blob/a8d0cf899a4a82c85230bd6a21ae638ba0f7deec/babel.config.js#L47-L56

According to the babel docs for `@babel/plugin-proposal-private-property-in-object`:

> Note: The loose mode configuration setting must be the same as @babel/proposal-class-properties.
>
> https://babeljs.io/docs/en/babel-plugin-proposal-private-property-in-object#options

It's not in our config; this PR aligns them.

Note that all of those plugins are included in the `@babel/preset-env`; loose is set to false by default so that's why they're listed explicitly, to override config.