### PR TITLE
Provide logger option to fiter certain operations

### DIFF
--- a/packages/graphql-server/src/plugins/useRedwoodLogger.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodLogger.ts
@@ -18,6 +18,8 @@ import { RedwoodGraphQLContext } from '../functions/types'
  * @param query - Include the query. This is the query or mutation (with fields) made in the request.
  * @param tracing - Include the tracing and timing information.
  * @param userAgent - Include the browser (or client's) user agent.
+ * @param excludeOperations - Exclude the specified operations from being logged.
+ *
  */
 type GraphQLLoggerOptions = {
   /**
@@ -88,6 +90,14 @@ type GraphQLLoggerOptions = {
    * This can be helpful to know what type of client made the request to resolve issues when encountering errors or unexpected behavior.
    */
   userAgent?: boolean
+
+  /**
+   * @description Exclude operation from the log output.
+   *
+   * This is useful when you want to filter out certain operations from the log output.
+   * For example `IntrospectionQuery` from GraphQL playground.
+   */
+  excludeOperations?: string[]
 }
 
 /**
@@ -192,6 +202,7 @@ export const useRedwoodLogger = (
   const includeRequestId = loggerConfig?.options?.requestId
   const includeUserAgent = loggerConfig?.options?.userAgent
   const includeQuery = loggerConfig?.options?.query
+  const excludeOperations = loggerConfig.options?.excludeOperations
 
   return {
     onPluginInit(context) {
@@ -209,6 +220,10 @@ export const useRedwoodLogger = (
 
       const operationName =
         args.operationName || rootOperation.name?.value || 'Anonymous Operation'
+
+      if (excludeOperations?.includes(operationName)) {
+        return
+      }
 
       if (includeOperationName) {
         options['operationName'] = operationName


### PR DESCRIPTION
Attempts to close #3251.

@dthyresson This adds an option `excludeOperations` which accepts string array. Here's a Tape which show how it's printing with without filter and then with filter on `IntrospectionQuery` (polling 1 sec) and other operation: https://s.tape.sh/rmjU1Zim