### PR TITLE
(Codemods) Use correct bin, paths for Windows

### DIFF
--- a/packages/codemods/src/codemods/v0.37.x/updateGraphQLFunction/updateGraphQLFunction.yargs.ts
+++ b/packages/codemods/src/codemods/v0.37.x/updateGraphQLFunction/updateGraphQLFunction.yargs.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import fg from 'fast-glob'
 import task from 'tasuku'
 
-import getRWPaths from '../../../lib/getRWPaths'
 import runTransform from '../../../lib/runTransform'
 
 export const command = 'update-graphql-function'
@@ -12,11 +11,9 @@ export const description =
 
 export const handler = () => {
   task('Updating the GraphQL Function', async () => {
-    const rwPaths = getRWPaths()
-
     runTransform({
       transformPath: path.join(__dirname, 'updateGraphQLFunction.js'),
-      targetPaths: fg.sync(path.join(rwPaths.api.functions, 'graphql.{js,ts}')),
+      targetPaths: fg.sync('api/src/functions/graphql.{js,ts}'),
     })
   })
 }

--- a/packages/codemods/src/codemods/v0.37.x/updateScenarios/updateScenarios.yargs.ts
+++ b/packages/codemods/src/codemods/v0.37.x/updateScenarios/updateScenarios.yargs.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import fg from 'fast-glob'
 import task from 'tasuku'
 
-import getRWPaths from '../../../lib/getRWPaths'
 import runTransform from '../../../lib/runTransform'
 
 export const command = 'update-scenarios'
@@ -25,11 +24,9 @@ export const description =
  */
 export const handler = () => {
   task('Updating Scenarios', async () => {
-    const rwPaths = getRWPaths()
-
     runTransform({
       transformPath: path.join(__dirname, 'updateScenarios.js'),
-      targetPaths: fg.sync(`${rwPaths.api.services}/**/*.scenarios.{js,ts}`),
+      targetPaths: fg.sync('api/src/services/**/*.scenarios.{js,ts}'),
     })
   })
 }

--- a/packages/codemods/src/lib/runTransform.ts
+++ b/packages/codemods/src/lib/runTransform.ts
@@ -62,32 +62,60 @@ export const runTransform = ({
    */
   const flags = Object.entries(options).map((key, val) => `--${key}=${val}`)
 
-  const jscodeshiftExecutable = path.resolve(
-    __dirname,
-    '../../node_modules/.bin/jscodeshift'
-  )
+  if (process.env.NODE_ENV === 'test') {
+    const { command, cmdArgs } = getExecaArgs()
 
-  try {
-    execa.sync(
-      jscodeshiftExecutable,
-      [
-        `--parser=${parser}`,
-        process.env.NODE_ENV === 'test' ? '--babel' : '--no-babel',
-        '--ignore-pattern=**/node_modules/**',
-        // Putting flags here lets them override all the defaults.
-        ...flags,
-        '-t',
-        transformPath,
-        ...targetPaths,
-      ],
-      {
-        stdio: 'inherit',
-      }
-    )
-  } catch (e: any) {
-    console.error('Transform Error', e.message)
+    try {
+      execa.sync(
+        command,
+        [
+          ...cmdArgs,
+          `--parser=${parser}`,
+          process.env.NODE_ENV === 'test' ? '--babel' : '--no-babel',
+          '--ignore-pattern=**/node_modules/**',
+          // Putting flags here lets them override all the defaults.
+          ...flags,
+          '-t',
+          transformPath,
+          ...targetPaths,
+        ],
+        {
+          stdio: 'inherit',
+        }
+      )
+    } catch (e: any) {
+      console.error('Transform Error', e.message)
 
-    throw new Error('Failed to invoke transform')
+      throw new Error('Failed to invoke transform')
+    }
+  } else {
+    try {
+      const jscodeshiftExecutable = path.resolve(
+        __dirname,
+        '../../node_modules/.bin/jscodeshift'
+      )
+
+      execa.sync(
+        jscodeshiftExecutable,
+        [
+          `--parser=${parser}`,
+          process.env.NODE_ENV === 'test' ? '--babel' : '--no-babel',
+          '--ignore-pattern=**/node_modules/**',
+          // Putting flags here lets them override all the defaults.
+          ...flags,
+          '-t',
+          transformPath,
+          ...targetPaths,
+        ],
+        {
+          stdio: 'inherit',
+        }
+      )
+    } catch (e: any) {
+      console.error('Transform Error', e.message)
+
+      throw new Error('Failed to invoke transform')
+    }
   }
 }
 

--- a/packages/codemods/src/lib/runTransform.ts
+++ b/packages/codemods/src/lib/runTransform.ts
@@ -62,13 +62,15 @@ export const runTransform = ({
    */
   const flags = Object.entries(options).map((key, val) => `--${key}=${val}`)
 
-  const { command, cmdArgs } = getExecaArgs()
+  const jscodeshiftExecutable = path.resolve(
+    __dirname,
+    '../../node_modules/.bin/jscodeshift'
+  )
 
   try {
     execa.sync(
-      command,
+      jscodeshiftExecutable,
       [
-        ...cmdArgs,
         `--parser=${parser}`,
         process.env.NODE_ENV === 'test' ? '--babel' : '--no-babel',
         '--ignore-pattern=**/node_modules/**',


### PR DESCRIPTION
Invoking jscodeshift with yarn seems to work for testing on Windows, but not when actually invoking the binary to do codemods via npx. This PR fixes that and fg.sync's paths by adding a pretty unfortunate/gnarly conditional to runTransform. 