### PR TITLE
Fix add-directives codemod

### DIFF
--- a/packages/codemods/src/codemods/v0.37.x/addDirectives/addDirectives.ts
+++ b/packages/codemods/src/codemods/v0.37.x/addDirectives/addDirectives.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
+import fg from 'fast-glob'
 import fetch from 'node-fetch'
 
 import getRWPaths from '../../../lib/getRWPaths'
@@ -21,15 +22,15 @@ export const addDirectives = async () => {
 
   const dirs = {
     [requireAuthDir]: {
-      [path.join(requireAuthDir, 'requireAuth.ts')]:
+      [path.join(requireAuthDir, 'requireAuth')]:
         'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/requireAuth/requireAuth.ts',
-      [path.join(requireAuthDir, 'requireAuth.test.ts')]:
+      [path.join(requireAuthDir, 'requireAuth.test')]:
         'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/requireAuth/requireAuth.test.ts',
     },
     [skipAuthDir]: {
-      [path.join(skipAuthDir, 'skipAuth.ts')]:
+      [path.join(skipAuthDir, 'skipAuth')]:
         'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.ts',
-      [path.join(skipAuthDir, 'skipAuth.test.ts')]:
+      [path.join(skipAuthDir, 'skipAuth.test')]:
         'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.test.ts',
     },
   }
@@ -42,10 +43,14 @@ export const addDirectives = async () => {
   for (const [dir, filenamesToUrls] of Object.entries(dirs)) {
     fs.mkdirSync(dir)
 
+    const isTSProject =
+      fg.sync('api/tsconfig.json').length > 0 ||
+      fg.sync('web/tsconfig.json').length > 0
+
     for (const [filename, url] of Object.entries(filenamesToUrls)) {
       const res = await fetch(url)
       const text = await res.text()
-      fs.writeFileSync(filename, text)
+      fs.writeFileSync(`${filename}.${isTSProject ? '.ts' : 'js'}`, text)
     }
   }
 }

--- a/packages/codemods/src/codemods/v0.37.x/addDirectives/addDirectives.ts
+++ b/packages/codemods/src/codemods/v0.37.x/addDirectives/addDirectives.ts
@@ -28,9 +28,9 @@ export const addDirectives = async () => {
     },
     [skipAuthDir]: {
       [path.join(skipAuthDir, 'skipAuth.ts')]:
-        'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.test.ts',
-      [path.join(skipAuthDir, 'skipAuth.test.ts')]:
         'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.ts',
+      [path.join(skipAuthDir, 'skipAuth.test.ts')]:
+        'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/template/api/src/directives/skipAuth/skipAuth.test.ts',
     },
   }
 


### PR DESCRIPTION
The URLs were swapped for `skipAuth.ts` and `skipAuth.test.ts` and the codemod didn't respect the type of project.