### PR TITLE
adding missing dep for Netlify

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "2.30.3",
     "@redwoodjs/api": "0.36.4",
     "@types/pino": "6.3.11",
+    "core-js": "3.17.3",
     "graphql": "15.5.3",
     "graphql-helix": "1.7.0",
     "graphql-playground-html": "1.6.29",


### PR DESCRIPTION
First we fixed the bloated function on Netlify. Now it turns out Netlify isn't including core-js.

Adding it directly to graphql-server package.