### PR TITLE
add uuid dep to api 'cause Netlify wants it

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,7 +17,8 @@
     "jsonwebtoken": "8.5.1",
     "jwks-rsa": "2.0.4",
     "pino": "6.13.2",
-    "pino-pretty": "5.1.3"
+    "pino-pretty": "5.1.3",
+    "uuid": "8.3.2"
   },
   "devDependencies": {
     "@redwoodjs/auth": "0.36.4",


### PR DESCRIPTION
more brute force diagnosing to get functions to run on Netlify