### PR TITLE
removed lng: 'en' from i18n template

### DIFF
--- a/packages/cli/src/commands/setup/i18n/templates/i18n.js.template
+++ b/packages/cli/src/commands/setup/i18n/templates/i18n.js.template
@@ -39,7 +39,7 @@ i18n
   .use(LanguageDetector)
   .init({
     interpolation: { escapeValue: false }, // React already does escaping
-    lng: 'en',
+    // lng: 'en', // Not needed when using i18next-browser-languageDetector
     fallbackLng: 'en',
     resources: {
       en: {

--- a/packages/cli/src/commands/setup/i18n/templates/i18n.js.template
+++ b/packages/cli/src/commands/setup/i18n/templates/i18n.js.template
@@ -39,7 +39,6 @@ i18n
   .use(LanguageDetector)
   .init({
     interpolation: { escapeValue: false }, // React already does escaping
-    // lng: 'en', // Not needed when using i18next-browser-languageDetector
     fallbackLng: 'en',
     resources: {
       en: {


### PR DESCRIPTION
Very simple PR to remove `lng: 'en'` from the `i18n.js` template, letting the language detection plugin do its job.

- [Issue justifying this change](https://github.com/i18next/i18next-browser-languageDetector/issues/183).
- [PR from this year reinforcing it as still valid](https://github.com/i18next/react-i18next-gitbook/pull/110).

With `lng: 'en'`:

![image](https://user-images.githubusercontent.com/25166787/135605274-367b489c-8a1a-40ec-9f8e-00d871767641.png)

Without:

![image](https://user-images.githubusercontent.com/25166787/135605324-2dcfdcd5-ea94-49db-b4e9-83a1ba65afb6.png)

I believe this would be a good place for a codemod for existing applications (I haven't the faintest clue how that works - happy to learn).