### PR TITLE
Add missing dependency graphql-tag to graphql-server

### DIFF
--- a/packages/create-redwood-app/template/redwood.toml
+++ b/packages/create-redwood-app/template/redwood.toml
@@ -14,5 +14,3 @@
   port = 8911
 [browser]
   open = true
-[experimental]
-  esbuild = false

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -25,6 +25,7 @@
     "graphql-helix": "1.7.0",
     "graphql-playground-html": "1.6.29",
     "graphql-scalars": "1.10.1",
+    "graphql-tag": "2.12.5",
     "lodash.merge": "4.6.2",
     "lodash.omitby": "4.6.0",
     "node-fetch": "2.6.1",

--- a/tasks/framework-tools/yarn.lock
+++ b/tasks/framework-tools/yarn.lock
@@ -2723,10 +2723,10 @@
   resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
   integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
-"@redwoodjs/eslint-config@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/@redwoodjs/eslint-config/-/eslint-config-0.37.0.tgz#d46824473510dac25eeaaf1a9b16f0a75a3ac49c"
-  integrity sha512-IrGWIto7UnEaVJy0Gxw0srvDzZaBv2kjlSrT5Hyh7szowIJIwpRelgNPeftxlLUP0KanYqBoueinxCvPCAd+gg==
+"@redwoodjs/eslint-config@v0.37.1":
+  version "0.37.1"
+  resolved "https://registry.yarnpkg.com/@redwoodjs/eslint-config/-/eslint-config-0.37.1.tgz#0ad21eba620720f8d8976205c8831aa686075901"
+  integrity sha512-ILl+xwcx+RlAs4WLqxocnG4Jx9QjWdglURP83vUGRPLRUt+rNdwHHCefr/0WpGDSgNVS4zA6Odt26TkmIbTwUg==
   dependencies:
     "@babel/core" "^7.15.5"
     "@babel/eslint-parser" "^7.15.4"


### PR DESCRIPTION
There could be more to it than this, but this seems necessary. Closes #3494.