### PR TITLE
fix: check no "ERR!" string is in stderr when running Storybook build

### DIFF
--- a/tasks/e2e/cypress/integration/03-storybook/storybook.spec.js
+++ b/tasks/e2e/cypress/integration/03-storybook/storybook.spec.js
@@ -36,7 +36,7 @@ describe(
         timeout: 300_0000,
       }) // Slow!
         .its('stderr')
-        .should('eq', '')
+        .should('not.contain', 'ERR!')
         .and()
         .its('code')
         .should('eq', 0)

--- a/tasks/e2e/cypress/integration/03-storybook/storybook.spec.js
+++ b/tasks/e2e/cypress/integration/03-storybook/storybook.spec.js
@@ -32,14 +32,14 @@ describe(
         Step2_2_BlogPostsCellMock
       )
 
+      // Slow!
       cy.exec(`cd ${BASE_DIR}; yarn rw storybook --build`, {
         timeout: 300_0000,
-      }) // Slow!
-        .its('stderr')
-        .should('not.contain', 'ERR!')
-        .and()
-        .its('code')
-        .should('eq', 0)
+      }).then((result) => {
+        const { code, stderr } = result
+        expect(code).to.eq(0)
+        expect(stderr).to.not.contain('ERR!')
+      })
     })
 
     it('1. Component: BlogPost', () => {


### PR DESCRIPTION
Avoid false positive. It seems `stderr` contains info as well as error, so just checking if it is `''` will not work.

See Also:

* #3508 
* https://github.com/redwoodjs/redwood/runs/3799459178?check_suite_focus=true

cc: @thedavidprice 

---

_note:_ while #3154 looks to fix the *"connection time out" error we were seeing in CI checks*; speaking from experience, there still can be inadvertent regressions added to the CI when upgrading Storybook, or other "unrelated" dependencies. This PR ( and #3508 even though the check was wrong ) makes sure that if there are build errors output, the `stderr` is surfaced to the CI so that maintainers can more easily see the potential issue. 