### PR TITLE
Run netlify-build on release edit event

### DIFF
--- a/.github/workflows/netlify-build.yaml
+++ b/.github/workflows/netlify-build.yaml
@@ -9,6 +9,7 @@ on:
   release:
     types:
       - published
+      - edited
 
 jobs:
   deploy_hook:


### PR DESCRIPTION
Ref: https://github.com/redwoodjs/redwoodjs.com/pull/808#issuecomment-933857921

@thedavidprice Instead of adding trigger for new tags I've added for `edited` event of release. Current workflow was running on every release but for last patch release we `edited` instead of a new release.