### PR TITLE
chore: ignore VS Code's `.code-workspace` so that personal settings used by devs are not committed to the codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ yarn-error.log
 tasks/.verdaccio
 tasks/e2e/cypress/fixtures/example.json
 tmp/
-.vscode/*
 blog-test-project/*
 .yarn/*
 **/.yarn/install-state.gz

--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,27 @@
+## VS Code Settings
+This directory includes global workspace settings for local development of the RedwoodJS Framework.
+
+See:
+- [VS Code Doc: User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings)
+- [What is a VS Code Workspace?](https://stackoverflow.com/questions/44629890/what-is-a-workspace-in-visual-studio-code)
+
+### Overriding Global Settings
+It is possible to create your own "local" settings, overriding the global, via a `.code-workspace` file. See:
+- [Workspace Settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_settings)
+- [Local settings overrides](https://github.com/microsoft/vscode/issues/37519)
+
+> `*.code-workspace` files are included in `.gitignore`
+
+For example, if you want a bright pink status background (and who doesn't?), create this file in the root of your project `mySettings.code-workspace`:
+```
+// mySettings.code-workspace
+
+"workbench.colorCustomizations": {
+     "statusBar.background": "#ff007f",
+   },
+
+```
+
+> **WARNING:** If you create a custom file that is ignored by git, then _anytime_ you run `git clean -fxd` the file will be permanently deleted. 
+> 
+> You can avoid this by using the option `-e`, e.g. `git clean -fxd -e mySettings.code-workspace`.


### PR DESCRIPTION
Was [leveraging `johnpapa.vscode-peacock`](https://marketplace.visualstudio.com/items?itemName=johnpapa.vscode-peacock) locally, which resulted in `.vscode/settings.json` file change friction.

Switched to use a local `.code-workspace` file ( `pc.code-workspace` in my environment ) and moved the local preferences there.

see:
* [#3526 (comment)](https://github.com/redwoodjs/redwood/pull/3526#issuecomment-939188174)
* https://code.visualstudio.com/docs/getstarted/settings
* https://stackoverflow.com/questions/44629890/what-is-a-workspace-in-visual-studio-code
* microsoft/vscode#37519

### Included in this PR:
- [x] removes .vscode from .gitignore
- [x] adds .vscode/README including local settings instructions and doc links
- [x] use a local `.code-workspace` file (included in .gitignore)

---
_Screenshot of Local Settings_
![image](https://user-images.githubusercontent.com/4303638/136388971-fea45a45-1e8c-40ba-8c06-9c0df0ba160e.png)
