### PR TITLE
Pin @babel/eslint dependencies, add lint to e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,6 +78,10 @@ jobs:
           git restore . && git clean -df
         working-directory: ${{ steps.createpath.outputs.project_path }}
 
+      - name: Run `rw lint`
+        run: yarn rw lint
+        working-directory: ${{ steps.createpath.outputs.project_path }}
+
       - name: Run `rw test`
         run: yarn rw test --no-watch
         working-directory: ${{ steps.createpath.outputs.project_path }}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,9 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.15.5",
-    "@babel/eslint-parser": "^7.15.4",
-    "@babel/eslint-plugin": "^7.14.5",
+    "@babel/core": "7.15.5",
+    "@babel/eslint-parser": "7.15.4",
+    "@babel/eslint-plugin": "7.14.5",
     "@typescript-eslint/eslint-plugin": "4.31.1",
     "@typescript-eslint/parser": "4.31.1",
     "eslint": "7.32.0",


### PR DESCRIPTION
The `@babel/eslint` packages aren't being hoisted, meaning commands that use `yarn rw lint` fail. This PR removes the caret from the `@babel/eslint` packages in `@redwoodjs/eslint-config` so that the modules will be hoisted (a.k.a. flattened).

In the future we should reconsider where we list these dependencies.