### PR TITLE
Pokemon 2 - The return of the Pokemons

### DIFF
--- a/packages/cli/src/commands/destroy/scaffold/scaffold.js
+++ b/packages/cli/src/commands/destroy/scaffold/scaffold.js
@@ -1,6 +1,5 @@
 import Listr from 'listr'
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 
 import { ensureUniquePlural } from '../../../commands/generate/helpers'
 import {
@@ -11,6 +10,7 @@ import {
   writeFile,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import { pluralize } from '../../../lib/rwPluralize'
 import {
   files,
   routes as scaffoldRoutes,

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -1,13 +1,13 @@
 import fs from 'fs'
 import path from 'path'
 
-import pluralize from 'pluralize'
 import prompts from 'prompts'
 
 // Setup test mocks
 global.__dirname = __dirname
 import '../../../lib/test'
 
+import { pluralize, singularize } from '../../../lib/rwPluralize'
 import * as helpers from '../helpers'
 import * as page from '../page/page'
 
@@ -466,8 +466,8 @@ test('ensureUniquePlural sets irregular rule from user input if singular is same
 
   await helpers.ensureUniquePlural({ model: uncountableModel })
 
-  expect(pluralize.singular(uncountableModel)).toBe(uncountableModel)
-  expect(pluralize.plural(uncountableModel)).toBe(userPluralInput)
+  expect(singularize(uncountableModel)).toBe(uncountableModel)
+  expect(pluralize(uncountableModel)).toBe(userPluralInput)
 })
 
 test('ensureUniquePlural skips any rule if singular and plural are already different', async () => {
@@ -477,19 +477,30 @@ test('ensureUniquePlural skips any rule if singular and plural are already diffe
 
   await helpers.ensureUniquePlural({ model: singular })
 
-  expect(pluralize.singular(singular)).toBe(singular)
-  expect(pluralize.plural(singular)).toBe(plural)
+  expect(singularize(singular)).toBe(singular)
+  expect(pluralize(singular)).toBe(plural)
 })
 
 test('ensureUniquePlural handles PascalCase models', async () => {
-  const uncountableModel = 'FarmEquipment'
-  const userPluralInput = 'FarmEquipments'
+  const uncountableModel = 'CustomPokemon'
+  const userPluralInput = 'CustomPokemonii'
   prompts.inject(userPluralInput)
 
   await helpers.ensureUniquePlural({ model: uncountableModel })
 
-  expect(pluralize.singular(uncountableModel)).toBe(uncountableModel)
-  expect(pluralize.plural(uncountableModel)).toBe(userPluralInput)
+  expect(singularize(uncountableModel)).toBe(uncountableModel)
+  expect(pluralize(uncountableModel)).toBe(userPluralInput)
+})
+
+test('ensureUniquePlural handles PascalCase models, with *List input', async () => {
+  const uncountableModel = 'FarmEquipment'
+  const userPluralInput = 'FarmEquipmentList'
+  prompts.inject(userPluralInput)
+
+  await helpers.ensureUniquePlural({ model: uncountableModel })
+
+  expect(singularize(uncountableModel)).toBe(uncountableModel)
+  expect(pluralize(uncountableModel)).toBe(userPluralInput)
 })
 
 describe('mapRouteParamTypeToTsType', () => {

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -1,10 +1,10 @@
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 
 import { generate as generateTypes } from '@redwoodjs/internal'
 
 import { transformTSToJS } from '../../../lib'
 import { getSchema } from '../../../lib'
+import { isPlural, singularize } from '../../../lib/rwPluralize'
 import { yargsDefaults } from '../../generate'
 import {
   templateForComponentFile,
@@ -62,8 +62,7 @@ export const files = async ({
   // Create a unique operation name.
 
   const shouldGenerateList =
-    (isWordPluralizable(name) ? pluralize.isPlural(name) : options.list) ||
-    options.list
+    (isWordPluralizable(name) ? isPlural(name) : options.list) || options.list
 
   if (shouldGenerateList) {
     cellName = forcePluralizeWord(name)
@@ -72,7 +71,7 @@ export const files = async ({
   } else {
     // needed for the singular cell GQL query find by id case
     try {
-      model = await getSchema(pascalcase(pluralize.singular(name)))
+      model = await getSchema(pascalcase(singularize(name)))
       idType = getIdType(model)
     } catch {
       // eat error so that the destroy cell generator doesn't raise when try to find prisma query engine in test runs

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -6,7 +6,6 @@ import humanize from 'humanize-string'
 import Listr from 'listr'
 import { paramCase } from 'param-case'
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 import terminalLink from 'terminal-link'
 
 import { getConfig, generate as generateTypes } from '@redwoodjs/internal'
@@ -25,6 +24,7 @@ import {
   transformTSToJS,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import { pluralize, singularize } from '../../../lib/rwPluralize'
 import { yargsDefaults } from '../../generate'
 import {
   customOrDefaultTemplatePath,
@@ -54,7 +54,7 @@ const getImportComponentNames = (
   nestScaffoldByModel = true
 ) => {
   const pluralName = pascalcase(pluralize(name))
-  const singularName = pascalcase(pluralize.singular(name))
+  const singularName = pascalcase(singularize(name))
   let componentPath
   let layoutPath
   if (scaffoldPath === '') {
@@ -85,7 +85,7 @@ const getImportComponentNames = (
 // Includes imports from getImportComponentNames()
 const getTemplateStrings = (name, scaffoldPath, nestScaffoldByModel = true) => {
   const pluralPascalName = pascalcase(pluralize(name))
-  const singularPascalName = pascalcase(pluralize.singular(name))
+  const singularPascalName = pascalcase(singularize(name))
 
   const pluralCamelName = camelcase(pluralPascalName)
   const singularCamelName = camelcase(singularPascalName)
@@ -122,7 +122,7 @@ export const files = async ({
   typescript = false,
   nestScaffoldByModel,
 }) => {
-  const model = await getSchema(pascalcase(pluralize.singular(name)))
+  const model = await getSchema(pascalcase(singularize(name)))
   if (typeof nestScaffoldByModel === 'undefined') {
     nestScaffoldByModel = getConfig().generate.nestScaffoldByModel
   }
@@ -221,7 +221,7 @@ const layoutFiles = (
   templateStrings
 ) => {
   const pluralName = pascalcase(pluralize(name))
-  const singularName = pascalcase(pluralize.singular(name))
+  const singularName = pascalcase(singularize(name))
   let fileList = {}
 
   const layouts = fs.readdirSync(
@@ -273,7 +273,7 @@ const pageFiles = async (
   templateStrings
 ) => {
   const pluralName = pascalcase(pluralize(name))
-  const singularName = pascalcase(pluralize.singular(name))
+  const singularName = pascalcase(singularize(name))
   const model = await getSchema(singularName)
   const idType = getIdType(model)
   const idTsType = mapPrismaScalarToPagePropTsType(idType)
@@ -336,7 +336,7 @@ const componentFiles = async (
   templateStrings
 ) => {
   const pluralName = pascalcase(pluralize(name))
-  const singularName = pascalcase(pluralize.singular(name))
+  const singularName = pascalcase(singularize(name))
   const model = await getSchema(singularName)
   const idType = getIdType(model)
   const intForeignKeys = intForeignKeysForModel(model)
@@ -481,7 +481,7 @@ export const routes = async ({
   }
 
   const templateNames = getTemplateStrings(name, scaffoldPath)
-  const singularPascalName = pascalcase(pluralize.singular(name))
+  const singularPascalName = pascalcase(singularize(name))
   const pluralPascalName = pascalcase(pluralize(name))
   const pluralParamName = paramCase(pluralPascalName)
   const model = await getSchema(singularPascalName)

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -5,7 +5,6 @@ import camelcase from 'camelcase'
 import chalk from 'chalk'
 import Listr from 'listr'
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 import terminalLink from 'terminal-link'
 
 import { getConfig, generate as generateTypes } from '@redwoodjs/internal'
@@ -19,6 +18,7 @@ import {
   getEnum,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import { pluralize, singularize } from '../../../lib/rwPluralize'
 import { yargsDefaults } from '../../generate'
 import {
   customOrDefaultTemplatePath,
@@ -150,7 +150,7 @@ const sdlFromSchemaModel = async (name, crud) => {
 
 export const files = async ({ name, crud, tests, typescript }) => {
   const { query, createInput, updateInput, idType, relations, enums } =
-    await sdlFromSchemaModel(pascalcase(pluralize.singular(name)), crud)
+    await sdlFromSchemaModel(pascalcase(singularize(name)), crud)
 
   let template = generateTemplate(
     customOrDefaultTemplatePath({

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -1,9 +1,9 @@
 import camelcase from 'camelcase'
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 import terminalLink from 'terminal-link'
 
 import { getSchema, transformTSToJS } from '../../../lib'
+import { pluralize, singularize } from '../../../lib/rwPluralize'
 import { yargsDefaults } from '../../generate'
 import {
   templateForComponentFile,
@@ -126,7 +126,7 @@ export const buildScenario = async (model) => {
 // outputs fields necessary to create an object in the test file
 export const fieldsToInput = async (model) => {
   const { scalarFields, foreignKeys } = await parseSchema(model)
-  const modelName = camelcase(pluralize.singular(model))
+  const modelName = camelcase(singularize(model))
   let inputObj = {}
 
   scalarFields.forEach((field) => {
@@ -147,7 +147,7 @@ export const fieldsToInput = async (model) => {
 // outputs fields necessary to update an object in the test file
 export const fieldsToUpdate = async (model) => {
   const { scalarFields, relations, foreignKeys } = await parseSchema(model)
-  const modelName = camelcase(pluralize.singular(model))
+  const modelName = camelcase(singularize(model))
   let field, newValue, fieldName
 
   // find an editable scalar field, ideally one that isn't a foreign key
@@ -228,7 +228,7 @@ export const files = async ({
   ...rest
 }) => {
   const componentName = camelcase(pluralize(name))
-  const model = pascalcase(pluralize.singular(name))
+  const model = pascalcase(singularize(name))
   const extension = 'ts'
   const serviceFile = templateForComponentFile({
     name,

--- a/packages/cli/src/lib/__tests__/rwPluralize.test.js
+++ b/packages/cli/src/lib/__tests__/rwPluralize.test.js
@@ -1,0 +1,110 @@
+import {
+  pluralize,
+  singularize,
+  isPlural,
+  isSingular,
+  addSingularPlural,
+} from '../rwPluralize'
+
+test('pluralize', () => {
+  expect(pluralize('books')).toEqual('books')
+
+  expect(pluralize('book')).toEqual('books')
+  expect(pluralize('Book')).toEqual('Books')
+  expect(pluralize('tooth')).toEqual('teeth')
+
+  expect(pluralize('equipment')).toEqual('equipment')
+  expect(pluralize('News')).toEqual('News')
+
+  expect(pluralize('Data')).toEqual('Data')
+
+  expect(pluralize('DataModel')).toEqual('DataModels')
+})
+
+test('singularize', () => {
+  expect(singularize('book')).toEqual('book')
+
+  expect(singularize('books')).toEqual('book')
+  expect(singularize('Books')).toEqual('Book')
+  expect(singularize('teeth')).toEqual('tooth')
+
+  expect(singularize('equipment')).toEqual('equipment')
+  expect(singularize('News')).toEqual('News')
+
+  expect(singularize('Data')).toEqual('Datum')
+
+  expect(singularize('DataModels')).toEqual('DataModel')
+  expect(singularize('CustomerData')).toEqual('CustomerDatum')
+})
+
+test('isPlural', () => {
+  expect(isPlural('books')).toEqual(true)
+  expect(isPlural('Books')).toEqual(true)
+  expect(isPlural('teeth')).toEqual(true)
+
+  expect(isPlural('book')).toEqual(false)
+  expect(isPlural('Book')).toEqual(false)
+  expect(isPlural('tooth')).toEqual(false)
+
+  expect(isPlural('News')).toEqual(true)
+  expect(isPlural('Data')).toEqual(true)
+})
+
+test('isSingular', () => {
+  expect(isSingular('book')).toEqual(true)
+  expect(isSingular('Book')).toEqual(true)
+  expect(isSingular('tooth')).toEqual(true)
+
+  expect(isSingular('books')).toEqual(false)
+  expect(isSingular('Books')).toEqual(false)
+  expect(isSingular('teeth')).toEqual(false)
+
+  expect(isSingular('News')).toEqual(true)
+  expect(isSingular('Data')).toEqual(false)
+  expect(isSingular('Datum')).toEqual(true)
+})
+
+test('addSingularPlural', () => {
+  expect(pluralize('Pokemon')).toEqual('Pokemon')
+  expect(singularize('Pokemon')).toEqual('Pokemon')
+  expect(pluralize('CustomPokemon')).toEqual('CustomPokemon')
+  expect(singularize('CustomPokemon')).toEqual('CustomPokemon')
+
+  // "Pokemons" is an unknown word, so it's handled by the default
+  // "For words that ends with an s, trim the s" rule
+  expect(singularize('Pokemons')).toEqual('Pokemon')
+
+  addSingularPlural('Pokemon', 'Pokemonii')
+
+  expect(pluralize('Pokemon')).toEqual('Pokemonii')
+  expect(singularize('Pokemonii')).toEqual('Pokemon')
+  expect(singularize('Pokemon')).toEqual('Pokemon')
+  expect(pluralize('CustomPokemon')).toEqual('CustomPokemonii')
+  expect(singularize('CustomPokemonii')).toEqual('CustomPokemon')
+  expect(singularize('CustomPokemon')).toEqual('CustomPokemon')
+  expect(singularize('CustomPokemons')).toEqual('CustomPokemon')
+
+  addSingularPlural('CustomPokemon', 'CustomPokemonList')
+
+  expect(pluralize('CustomPokemon')).toEqual('CustomPokemonList')
+  expect(singularize('CustomPokemonList')).toEqual('CustomPokemon')
+  expect(singularize('CustomPokemon')).toEqual('CustomPokemon')
+  expect(pluralize('Pokemon')).toEqual('Pokemonii')
+  expect(singularize('Pokemonii')).toEqual('Pokemon')
+  expect(singularize('Pokemon')).toEqual('Pokemon')
+  expect(singularize('Pokemons')).toEqual('Pokemon')
+
+  addSingularPlural('Pokemon', 'PokemonList')
+
+  expect(pluralize('Pokemon')).toEqual('PokemonList')
+  expect(singularize('PokemonList')).toEqual('Pokemon')
+  expect(singularize('Pokemon')).toEqual('Pokemon')
+  expect(singularize('Pokemons')).toEqual('Pokemon')
+  expect(pluralize('CustomPokemon')).toEqual('CustomPokemonList')
+  expect(singularize('CustomPokemonList')).toEqual('CustomPokemon')
+  expect(singularize('CustomPokemon')).toEqual('CustomPokemon')
+
+  // The Pokemonii rule has been replaced, and so we use the default rule for
+  // making words that end with i singular, which is to do nothing
+  expect(singularize('Pokemonii')).toEqual('Pokemonii')
+})

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -12,7 +12,6 @@ import VerboseRenderer from 'listr-verbose-renderer'
 import lodash from 'lodash/string'
 import { paramCase } from 'param-case'
 import pascalcase from 'pascalcase'
-import pluralize from 'pluralize'
 import { format } from 'prettier'
 
 import {
@@ -21,6 +20,7 @@ import {
 } from '@redwoodjs/internal'
 
 import c from './colors'
+import { pluralize, singularize } from './rwPluralize'
 
 /**
  * Used to memoize results from `getSchema` so we don't have to go through
@@ -127,7 +127,7 @@ export const getSchemaDefinitions = async () => {
  * pluralConstantName: FOO_BARS
 */
 export const nameVariants = (name) => {
-  const normalizedName = pascalcase(paramCase(pluralize.singular(name)))
+  const normalizedName = pascalcase(paramCase(singularize(name)))
 
   return {
     pascalName: pascalcase(paramCase(name)),

--- a/packages/cli/src/lib/rwPluralize.js
+++ b/packages/cli/src/lib/rwPluralize.js
@@ -1,0 +1,82 @@
+import * as plurals from 'pluralize'
+
+const mappings = {
+  toSingular: {},
+  toPlural: {},
+}
+
+/**
+ * Find Bar in FooBazBar
+ *
+ * @type {(str: string) => string }
+ */
+function lastWord(str) {
+  const capitals = str.match(/[A-Z]/g)
+  const lastIndex = str.lastIndexOf(capitals?.slice(-1))
+
+  return lastIndex >= 0 ? str.slice(lastIndex) : str
+}
+
+/**
+ * Returns the plural form of the given word
+ *
+ * @type {(word: string) => string }
+ */
+export function pluralize(word) {
+  if (mappings.toPlural[word]) {
+    return mappings.toPlural[word]
+  }
+
+  // Sometimes `word` is a PascalCased multi-word, like FarmEquipment
+  // In those cases we only want to pass the last word on to the `pluralize`
+  // library
+  const singular = lastWord(word)
+  const base = word.slice(0, word.length - singular.length)
+
+  if (mappings.toPlural[singular]) {
+    return base + mappings.toPlural[singular]
+  }
+
+  return base + plurals.plural(singular)
+}
+
+/**
+ * Returns the singular form of the given word
+ *
+ * @type {(word: string) => string }
+ */
+export function singularize(word) {
+  if (mappings.toSingular[word]) {
+    return mappings.toSingular[word]
+  }
+
+  const plural = lastWord(word)
+  const base = word.slice(0, word.length - plural.length)
+
+  if (mappings.toSingular[plural]) {
+    return base + mappings.toSingular[plural]
+  }
+
+  return base + plurals.singular(plural)
+}
+
+/** @type {(word: string) => boolean } */
+export function isPlural(word) {
+  return plurals.isPlural(lastWord(word))
+}
+
+/** @type {(word: string) => boolean } */
+export function isSingular(word) {
+  return plurals.isSingular(lastWord(word))
+}
+
+/** @type {(singular: string, plural: string) => undefined } */
+export function addSingularPlural(singular, plural) {
+  const existingPlural = Object.keys(mappings.toSingular).find(
+    (key) => mappings.toSingular[key] === singular
+  )
+  delete mappings.toSingular[existingPlural]
+
+  mappings.toPlural[singular] = plural
+  mappings.toSingular[plural] = singular
+}


### PR DESCRIPTION
# Issue

Our generators can't handle multi-word model names where the last name is uncountable, like "CustomPokemon"

![image](https://user-images.githubusercontent.com/30793/136561117-dbad1fc3-6d15-4d6d-85b2-75e192111721.png)

## Details

The problem is that the [pluralize](https://github.com/plurals/pluralize) library we use calls `toLowerString()` on the input, so the PascalCase information is lost. I work around that by only providing pluralization rules for the last word (Pokemon in CustomPokemon).