### PR TITLE
fix yarn rw lint command

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@babel/cli": "7.15.4",
     "@babel/core": "7.15.5",
+    "@babel/eslint-plugin": "7.14.5",
     "@babel/node": "7.15.4",
     "@babel/plugin-proposal-class-properties": "7.14.5",
     "@babel/plugin-proposal-decorators": "7.15.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,6 +4270,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.15.4
     "@babel/core": 7.15.5
+    "@babel/eslint-plugin": 7.14.5
     "@babel/node": 7.15.4
     "@babel/plugin-proposal-class-properties": 7.14.5
     "@babel/plugin-proposal-decorators": 7.15.4


### PR DESCRIPTION
This adds @babel/eslint-plugin to the core package to fix the error when `yarn rw lint` is run.