### PR TITLE
add failure exit code for type generation cli command

### DIFF
--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -42,6 +42,7 @@ export const generateGraphQLSchema = async () => {
     )
     return f[0].filename
   } catch (e: any) {
+    process.exitCode = 1
     // `generate` outputs errors which are helpful.
     // This tries to clean up the output of those errors.
     console.error(e)

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -207,10 +207,10 @@ export const generateTypeDefGraphQLApi = async () => {
     })
     return f
   } catch (e) {
+    process.exitCode = 1
     console.error()
     console.error('Error: Could not generate GraphQL type definitions (api)')
     console.error()
-    process.exit(1)
   }
 }
 
@@ -232,6 +232,7 @@ export const generateTypeDefGraphQLWeb = async () => {
     })
     return f
   } catch (e) {
+    process.exitCode = 1
     console.error()
     console.error('Error: Could not generate GraphQL type definitions (web)')
     console.error()

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -210,7 +210,7 @@ export const generateTypeDefGraphQLApi = async () => {
     console.error()
     console.error('Error: Could not generate GraphQL type definitions (api)')
     console.error()
-    return []
+    process.exit(1)
   }
 }
 

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -211,6 +211,7 @@ export const generateTypeDefGraphQLApi = async () => {
     console.error()
     console.error('Error: Could not generate GraphQL type definitions (api)')
     console.error()
+    return []
   }
 }
 


### PR DESCRIPTION
This closes #3514

## Problem
Running `yarn rw g types ` would only log errors on the console making it unusable for CI.

## Soln
 Whenever we encounter an error we should log the error and exit the process with error code 1.
 We exit the process with error code 1 instead of returning an `[]` (previously).

**Sample Output**

```

Generating...

GraphQL Document Validation failed with 1 errors;
  Error 0: GraphQLDocumentError: Cannot query field "createPost" on type "Mutation". Did yo
u mean "updatePost", "deletePost", or "createContact"?
    at /path/web/src/components/Post/NewPost/NewPost.ts
x:3:5
GraphQL Document Validation failed with 1 errors;
  Error 0: GraphQLDocumentError: Cannot query field "createPost" on type "Mutation". Did yo
u mean "updatePost", "deletePost", or "createContact"?
    at /path/web/src/components/Post/NewPost/NewPost.ts
x:3:5

Error: Could not generate GraphQL type definitions (web)

error Command failed with exit code 1.
```
What do you think guys?