### PR TITLE
Fix typo in projects beta workflow

### DIFF
--- a/.github/workflows/projects_beta_automation.yml
+++ b/.github/workflows/projects_beta_automation.yml
@@ -2,7 +2,7 @@ name: Projects Beta Automation
 
 on:
   issues:
-    type:
+    types:
       - opened
 
 jobs:


### PR DESCRIPTION
It's `types` not `type` per https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#issues