### PR TITLE
[Actions] Use pull_request_target to handle forks

### DIFF
--- a/.github/workflows/projects_beta_automation.yml
+++ b/.github/workflows/projects_beta_automation.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types:
       - opened
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   add_new_issues_to_projects_beta:
@@ -31,10 +34,17 @@ jobs:
           echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
           echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name=="Status") | .id' project_data.json) >> $GITHUB_ENV
 
+      - name: Set env var for issue
+        if: github.event_name == 'issue'
+        run: echo 'CONTENT_ID='${{ github.event.issue.node_id }} >> $GITHUB_ENV
+
+      - name: Set env var for pull request
+        if: github.event_name == 'pull_request_target:'
+        run: echo 'CONTENT_ID='${{ github.event.pull_request.node_id }} >> $GITHUB_ENV
+
       - name: Add to project
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECTS_BETA_AUTOMATION }}
-          CONTENT_ID: ${{ github.env.issue.node_id }}
         run: |
           item_id="$(gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='
             mutation($projectId: ID!, $contentId: ID!) {
@@ -44,9 +54,9 @@ jobs:
                 }
               }
             }' -f projectId=$PROJECT_ID -f contentId=$CONTENT_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
-
+          
           echo 'ITEM_ID='$item_id >> $GITHUB_ENV
-
+          
       - name: Set status to "New issues"
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECTS_BETA_AUTOMATION }}


### PR DESCRIPTION
Turns out we can use a special event, `pull_request_target`, to run workflows for PRs coming from forked repositories safely: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/.