### PR TITLE
Add yarn constraint preventing carets in dependency ranges

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -12,3 +12,8 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange2, Depende
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, DependencyType),
   workspace_has_dependency(OtherWorkspaceCwd, DependencyIdent, DependencyRange2, DependencyType2),
   DependencyRange \= DependencyRange2.
+
+% Prevents a dependency from having a caret in its version
+gen_enforced_dependency(WorkspaceCwd, DependencyIdent, TargetDependencyRange, DependencyType) :-
+  workspace_has_dependency(WorkspaceCwd, DependencyIdent, CurrentDependencyRange, DependencyType),
+  atom_concat('^', TargetDependencyRange, CurrentDependencyRange).


### PR DESCRIPTION
We've gotten burned a few times the past week or so by dependencies specified with carets, so we're introducing a yarn constraint that checks that they're not there.

Shout to @merceyz for the help over in the yarn repo: https://github.com/yarnpkg/berry/discussions/3570.