### PR TITLE
[WIP] Added Social, SMS and Webauthn to Magic.Link

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,6 +13,8 @@
     "@clerk/clerk-js": "1.33.0",
     "@clerk/clerk-sdk-node": "0.5.2",
     "@clerk/types": "1.13.0",
+    "@magic-ext/oauth": "^0.10.0",
+    "@magic-ext/webauthn": "^0.2.0",
     "@supabase/supabase-js": "1.22.6",
     "@types/netlify-identity-widget": "1.9.2",
     "@types/react": "17.0.21",

--- a/packages/auth/src/authClients/magicLink.ts
+++ b/packages/auth/src/authClients/magicLink.ts
@@ -1,28 +1,104 @@
 import type { Magic, MagicUserMetadata } from 'magic-sdk'
-
+import { OAuthRedirectConfiguration } from '@magic-ext/oauth'
 import type { AuthClient } from './'
 
 export type MagicLink = Magic
 export type MagicUser = MagicUserMetadata
 export interface AuthClientMagicLink extends AuthClient {
-  login(options: { email: string; showUI?: boolean }): Promise<any>
+  login(options: LoginProps): Promise<any>
+  signup(options: LoginProps): Promise<any>
 }
+
+type SocialProps = { type: 'social'; } & OAuthRedirectConfiguration
+
+type WebAuthnProps = {
+  type: 'webauthn';
+  authType: 'login';
+  username: string;
+} | {
+  type: 'webauthn';
+  authType: 'signup';
+  username: string;
+  nickname: string;
+}
+
+type LoginProps =
+  | { type: 'email'; email: string; showUI?: boolean; }
+  | { type: 'phoneNumber'; phoneNumber: string; }
+  | SocialProps
+  | WebAuthnProps
 
 export const magicLink = (client: MagicLink): AuthClientMagicLink => {
   let token: string | null
   let expireTime = 0
+
+  let authFlow = async (options: LoginProps) => {
+    switch (options.type) {
+      case "email": {
+        let { email, showUI } = options
+        return await client.auth.loginWithMagicLink({ email, showUI })
+      }
+      case "phoneNumber": {
+        let { phoneNumber } = options
+        return await client.auth.loginWithSMS({
+          phoneNumber
+        })
+      }
+      case "social": {
+        let { provider,
+          redirectURI,
+          scope,
+          loginHint } = options
+        if (!client.oauth) {
+          console.error("please install the OAuth2 NPM Package https://magic.link/docs/login-methods/social-logins/oauth-implementation/web")
+        }
+        //@ts-ignore
+        return await client.oauth.loginWithRedirect({
+          provider,
+          redirectURI,
+          scope,
+          loginHint,
+        });
+      }
+      case "webauthn": {
+        if (!client.oauth) {
+          console.error("please install the OAuth2 NPM Package https://magic.link/docs/login-methods/social-logins/oauth-implementation/web")
+        }
+        switch (options.authType) {
+          case 'login': {
+            let { username, } = options
+            //@ts-ignore
+            return await client.webauthn.login({
+              username,
+            });
+          }
+          case 'signup': {
+            let { username,
+              nickname } = options
+            //@ts-ignore
+            return await client.webauthn.registerNewUser({
+              username,
+              nickname,
+            });
+          }
+        }
+      }
+      default:
+        console.error(`please provide an "type"`)
+        break;
+    }
+  }
+
   return {
     type: 'magicLink',
     client,
-    login: async ({ email, showUI = true }) =>
-      await client.auth.loginWithMagicLink({ email, showUI }),
+    login: async (options) => await authFlow(options),
     logout: async () => {
       token = null
       expireTime = 0
       await client.user.logout()
     },
-    signup: async ({ email, showUI = true }) =>
-      await client.auth.loginWithMagicLink({ email, showUI }),
+    signup: async (options) => await authFlow(options),
     getToken: async () => {
       if (!token || Date.now() <= expireTime) {
         expireTime = Date.now() + 600 // now + 10 min

--- a/packages/auth/src/authClients/magicLink.ts
+++ b/packages/auth/src/authClients/magicLink.ts
@@ -1,6 +1,5 @@
-import type { Magic, MagicUserMetadata } from 'magic-sdk'
-
 import { OAuthRedirectConfiguration } from '@magic-ext/oauth'
+import type { Magic, MagicUserMetadata } from 'magic-sdk'
 
 import type { AuthClient } from './'
 
@@ -11,22 +10,24 @@ export interface AuthClientMagicLink extends AuthClient {
   signup(options: LoginProps): Promise<any>
 }
 
-type SocialProps = { type: 'social'; } & OAuthRedirectConfiguration
+type SocialProps = { type: 'social' } & OAuthRedirectConfiguration
 
-type WebAuthnProps = {
-  type: 'webauthn';
-  authType: 'login';
-  username: string;
-} | {
-  type: 'webauthn';
-  authType: 'signup';
-  username: string;
-  nickname: string;
-}
+type WebAuthnProps =
+  | {
+      type: 'webauthn'
+      authType: 'login'
+      username: string
+    }
+  | {
+      type: 'webauthn'
+      authType: 'signup'
+      username: string
+      nickname: string
+    }
 
 type LoginProps =
-  | { type: 'email'; email: string; showUI?: boolean; }
-  | { type: 'phoneNumber'; phoneNumber: string; }
+  | { type: 'email'; email: string; showUI?: boolean }
+  | { type: 'phoneNumber'; phoneNumber: string }
   | SocialProps
   | WebAuthnProps
 
@@ -36,23 +37,22 @@ export const magicLink = (client: MagicLink): AuthClientMagicLink => {
 
   const authFlow = async (options: LoginProps) => {
     switch (options.type) {
-      case "email": {
+      case 'email': {
         const { email, showUI } = options
         return await client.auth.loginWithMagicLink({ email, showUI })
       }
-      case "phoneNumber": {
+      case 'phoneNumber': {
         const { phoneNumber } = options
         return await client.auth.loginWithSMS({
-          phoneNumber
+          phoneNumber,
         })
       }
-      case "social": {
-        const { provider,
-          redirectURI,
-          scope,
-          loginHint } = options
+      case 'social': {
+        const { provider, redirectURI, scope, loginHint } = options
         if (!client.oauth) {
-          console.error("please install the OAuth2 NPM Package https://magic.link/docs/login-methods/social-logins/oauth-implementation/web")
+          console.error(
+            'please install the OAuth2 NPM Package https://magic.link/docs/login-methods/social-logins/oauth-implementation/web'
+          )
         }
         //@ts-ignore
         return await client.oauth.loginWithRedirect({
@@ -60,34 +60,37 @@ export const magicLink = (client: MagicLink): AuthClientMagicLink => {
           redirectURI,
           scope,
           loginHint,
-        });
+        })
       }
-      case "webauthn": {
+      case 'webauthn': {
         if (!client.oauth) {
-          console.error("please install the OAuth2 NPM Package https://magic.link/docs/login-methods/social-logins/oauth-implementation/web")
+          console.error(
+            'please install the OAuth2 NPM Package https://magic.link/docs/login-methods/social-logins/oauth-implementation/web'
+          )
         }
         switch (options.authType) {
           case 'login': {
-            const { username, } = options
+            const { username } = options
+
             //@ts-ignore
             return await client.webauthn.login({
               username,
-            });
+            })
           }
           case 'signup': {
-            const { username,
-              nickname } = options
+            const { username, nickname } = options
+
             //@ts-ignore
             return await client.webauthn.registerNewUser({
               username,
               nickname,
-            });
+            })
           }
         }
       }
       default:
         console.error(`please provide an "type"`)
-        break;
+        break
     }
   }
 

--- a/packages/auth/src/authClients/magicLink.ts
+++ b/packages/auth/src/authClients/magicLink.ts
@@ -1,5 +1,7 @@
 import type { Magic, MagicUserMetadata } from 'magic-sdk'
+
 import { OAuthRedirectConfiguration } from '@magic-ext/oauth'
+
 import type { AuthClient } from './'
 
 export type MagicLink = Magic
@@ -32,20 +34,20 @@ export const magicLink = (client: MagicLink): AuthClientMagicLink => {
   let token: string | null
   let expireTime = 0
 
-  let authFlow = async (options: LoginProps) => {
+  const authFlow = async (options: LoginProps) => {
     switch (options.type) {
       case "email": {
-        let { email, showUI } = options
+        const { email, showUI } = options
         return await client.auth.loginWithMagicLink({ email, showUI })
       }
       case "phoneNumber": {
-        let { phoneNumber } = options
+        const { phoneNumber } = options
         return await client.auth.loginWithSMS({
           phoneNumber
         })
       }
       case "social": {
-        let { provider,
+        const { provider,
           redirectURI,
           scope,
           loginHint } = options
@@ -66,14 +68,14 @@ export const magicLink = (client: MagicLink): AuthClientMagicLink => {
         }
         switch (options.authType) {
           case 'login': {
-            let { username, } = options
+            const { username, } = options
             //@ts-ignore
             return await client.webauthn.login({
               username,
             });
           }
           case 'signup': {
-            let { username,
+            const { username,
               nickname } = options
             //@ts-ignore
             return await client.webauthn.registerNewUser({

--- a/tasks/test-project/yarn.lock
+++ b/tasks/test-project/yarn.lock
@@ -1267,7 +1267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscodeshift@npm:^0.13.0":
+"jscodeshift@npm:0.13.0":
   version: 0.13.0
   resolution: "jscodeshift@npm:0.13.0"
   dependencies:
@@ -1647,7 +1647,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redwoodjs-tutorial-codemods@workspace:."
   dependencies:
-    jscodeshift: ^0.13.0
+    jscodeshift: 0.13.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,6 +3548,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@magic-ext/oauth@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@magic-ext/oauth@npm:0.10.0"
+  dependencies:
+    "@magic-sdk/types": ^5.1.0
+    crypto-js: ^3.3.0
+  checksum: e90816be63a3dea999d2a1d3ebdce3a11f8403e219532ca3b318a49ce281e85685b7ee79da995b99a651f2403612a24565f2a733305fa3e3ffcd9b000100ae68
+  languageName: node
+  linkType: hard
+
+"@magic-ext/webauthn@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@magic-ext/webauthn@npm:0.2.0"
+  checksum: d6c60fd10e50718a22f46d4e7af68111c0930e3b0c120b845096edfa6bb79d420a4e010739b089f819938a662148dddca8285d6d25ad0236e8cc0df391e24967
+  languageName: node
+  linkType: hard
+
 "@magic-sdk/commons@npm:^2.0.5":
   version: 2.1.0
   resolution: "@magic-sdk/commons@npm:2.1.0"
@@ -4174,6 +4191,8 @@ __metadata:
     "@clerk/clerk-js": 1.33.0
     "@clerk/clerk-sdk-node": 0.5.2
     "@clerk/types": 1.13.0
+    "@magic-ext/oauth": ^0.10.0
+    "@magic-ext/webauthn": ^0.2.0
     "@supabase/supabase-js": 1.22.6
     "@types/netlify-identity-widget": 1.9.2
     "@types/react": 17.0.21
@@ -10495,6 +10514,13 @@ __metadata:
   version: 4.1.1
   resolution: "crypto-js@npm:4.1.1"
   checksum: 50cc66a35f2738171d9a6d80c85ba7d00cb6440b756db035ba9ccd03032c0a803029a62969ecd4c844106c980af87687c64b204dd967989379c4f354fb482d37
+  languageName: node
+  linkType: hard
+
+"crypto-js@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "crypto-js@npm:3.3.0"
+  checksum: 10b5d91bdc85095df9be01f9d0d954b8a3aba6202f143efa6215b8b3d5dd984e0883e10aeff792ef4a51b77cd4442320242b496acf6dce5069d0e0fc2e1d75d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Still WIP.

Need to work out the final step on [https://magic.link/docs/login-methods/social-logins/oauth-implementation/web](https://magic.link/docs/login-methods/social-logins/oauth-implementation/web)


@seemcat is there anything you can add to this?


```js

const result = await magic.oauth.getRedirectResult();

// Result has the following interface
interface OAuthRedirectResult {
  oauth: {
    provider: string;
    scope: string[];
    accessToken: string;
    userHandle: string;

    // `userInfo` contains the OpenID Connect profile information 
    // about the user. The schema of this object should match the 
    // OpenID spec, except that fields are `camelCased` instead 
    // of `snake_cased`. 
    // The presence of some fields may differ depending on the 
    // specific OAuth provider and the user's own privacy settings. 
    // See: https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims

    userInfo: ...;
  };

  magic: {
    idToken: string;
    userMetadata: MagicUserMetadata;
  };
}


```