### PR TITLE
Set env variables on Gitpod per terminal

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,7 @@ tasks:
       mkdir /workspace/rw-test-app
     command: |
       cd /workspace/rw-test-app
-      echo -e "\n\n\033[94m ======================================================" && echo -e "\n\033[33m ⌛ Please wait until the dev server is running on the right-side terminal. \n "rw-test-app" is being generated & linked with latest framework code. \n\nIf you make further changes to the framework..." &&  echo -e "\033[33mRun \033[92m'yarn rwfw project:sync'\033[33m to watch & sync changes into the test project" &&  echo -e "\n\033[94m ======================================================\n\n"
+      echo -e "\n\n\033[94m ======================================================" && echo -e "\n\033[33m ⌛ Please wait until the dev server is running on the right-side terminal. \n "rw-test-app" is being generated & linked with latest framework code. \n\nIf you make further changes to the framework..." &&  echo -e "1. \033[33mEnsure env vars are set \033[92m'export RWFW_PATH="/workspace/redwood" RWJS_DEV_API_URL="http://localhost"'\033[33m" && echo -e "2. \033[33mRun \033[92m'yarn rwfw project:sync'\033[33m to watch & sync changes into the test project" &&  echo -e "\n\033[94m ======================================================\n\n"
 
 
   - name: "Dev Servers"


### PR DESCRIPTION
This is a follow-up to a discussion on Discord ([message link](https://discord.com/channels/679514959968993311/747258086569541703/898324682162454569)).

The `before` start task makes sure the env variables are available for the `init` and `command` tasks in both terminals.

Please give that a go for a while and do let me know if you still see flaky behaviour with env vars.