### PR TITLE
Add path for web generators via path/name or --path

### DIFF
--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -88,6 +88,7 @@ export const files = async ({
     name: cellName,
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.tsx' : '.js',
+    subSection: options.path,
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
     templatePath: `cell${templateNameSuffix}.tsx.template`,
@@ -102,6 +103,7 @@ export const files = async ({
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.test.tsx' : '.test.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'cell',
     templatePath: 'test.js.template',
   })
@@ -111,6 +113,7 @@ export const files = async ({
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.stories.tsx' : '.stories.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'cell',
     templatePath: 'stories.js.template',
   })
@@ -120,6 +123,7 @@ export const files = async ({
     suffix: COMPONENT_SUFFIX,
     extension: generateTypescript ? '.mock.ts' : '.mock.js',
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'cell',
     templatePath: `mock${templateNameSuffix}.js.template`,
   })

--- a/packages/cli/src/commands/generate/component/component.js
+++ b/packages/cli/src/commands/generate/component/component.js
@@ -11,6 +11,7 @@ export const files = ({ name, typescript = false, ...options }) => {
   const componentFile = templateForComponentFile({
     name,
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     extension,
     generator: 'component',
     templatePath: 'component.tsx.template',
@@ -19,6 +20,7 @@ export const files = ({ name, typescript = false, ...options }) => {
     name,
     extension: `.test${extension}`,
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'component',
     templatePath: 'test.tsx.template',
   })
@@ -26,6 +28,7 @@ export const files = ({ name, typescript = false, ...options }) => {
     name,
     extension: `.stories${extension}`,
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'component',
     templatePath: 'stories.tsx.template',
   })

--- a/packages/cli/src/commands/generate/layout/layout.js
+++ b/packages/cli/src/commands/generate/layout/layout.js
@@ -14,6 +14,7 @@ export const files = ({ name, typescript = false, ...options }) => {
     name,
     suffix: COMPONENT_SUFFIX,
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     extension,
     generator: 'layout',
     templatePath: options.skipLink
@@ -25,6 +26,7 @@ export const files = ({ name, typescript = false, ...options }) => {
     suffix: COMPONENT_SUFFIX,
     extension: `.test${extension}`,
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'layout',
     templatePath: 'test.tsx.template',
   })
@@ -33,6 +35,7 @@ export const files = ({ name, typescript = false, ...options }) => {
     suffix: COMPONENT_SUFFIX,
     extension: `.stories${extension}`,
     webPathSection: REDWOOD_WEB_PATH_NAME,
+    subSection: options.path,
     generator: 'layout',
     templatePath: 'stories.tsx.template',
   })


### PR DESCRIPTION
This PR adds a path argument for most of the web generators to customize where files are written. The alternate syntaxes are:

```
yarn rw g component ui/button
yarn rw g component button --path ui
```

If a path is specified both ways, the flag takes priority.

Generators supported so far:
- [x] component
- [x] cell
- [x] layout
- [ ] page
- [x] scaffold

### Preferring already-existing paths

If a path already exists that "case-insensitively" matches the one specified, we use that instead. E.g., say the user's project has a `UI` directory in `web/src/components`:

```
web/src/components/
└── UI
```

Regardless of the casing used, the generator will use that path if it's specified

```
yarn rw g component ui/button
yarn rw g component UI/button
yarn rw g component Ui/button
yarn rw g component uI/button

# given an already-existing directory named "UI", 
# all of these result in the same dir structure:

web/src/components/
└── UI
    └── Button
        ├── Button.js
        ├── Button.stories.js
        └── Button.test.js
```

### Page-generator Caveat

The page generator already has a `--path` flag (for specifying the Route's path), so you can only specify where the files are written using the slash syntax.

### Generating a Component/Cell in a Page

You can't specify just any path—it's scoped to the generator's "section" (components, layouts, pages). But @Tobbe suggested generating Components/Cells in Pages and I plan to support it and get feedback: https://community.redwoodjs.com/t/perfect-file-structure-for-redwood-web/1575/15