### PR TITLE
Upgrade Prisma@3.3.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
   "types": "./dist/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "3.2.1",
+    "@prisma/client": "3.3.0",
     "@types/pino": "6.3.11",
     "core-js": "3.17.3",
     "crypto-js": "4.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "3.2.1",
+    "@prisma/sdk": "3.3.0",
     "@redwoodjs/api-server": "0.37.4",
     "@redwoodjs/internal": "0.37.4",
     "@redwoodjs/prerender": "0.37.4",
@@ -40,7 +40,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.4.1",
-    "prisma": "3.2.1",
+    "prisma": "3.3.0",
     "prompts": "2.4.1",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -17,7 +17,7 @@
     "@graphql-tools/merge": "8.1.2",
     "@graphql-tools/schema": "8.2.0",
     "@graphql-tools/utils": "8.2.2",
-    "@prisma/client": "3.2.1",
+    "@prisma/client": "3.3.0",
     "@redwoodjs/api": "0.37.4",
     "@types/pino": "6.3.11",
     "core-js": "3.17.3",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "3.2.1",
+    "@prisma/sdk": "3.3.0",
     "@redwoodjs/internal": "0.37.4",
     "@types/line-column": "1.0.0",
     "camelcase": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,28 +3831,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:3.2.1":
-  version: 3.2.1
-  resolution: "@prisma/client@npm:3.2.1"
+"@prisma/client@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@prisma/client@npm:3.3.0"
   dependencies:
-    "@prisma/engines-version": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
+    "@prisma/engines-version": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
   peerDependencies:
     prisma: "*"
   peerDependenciesMeta:
     prisma:
       optional: true
-  checksum: 6fd9fa352009d7e9ef08a83afd71ba4020e34879dbbf5b38d9752934f9e464d26485bd8f4db77d25574cbc208208880368f233c6bfd413dc62b58955d51ba25a
-  languageName: node
-  linkType: hard
-
-"@prisma/debug@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@prisma/debug@npm:3.2.0"
-  dependencies:
-    "@types/debug": 4.1.7
-    debug: 4.3.2
-    ms: 2.1.3
-  checksum: 215d8c11d813271b27b11ddf2a0031c35257bce507ce206f0b6f58270931b039fc2fbaaebf46ae2e305a6b9ff7459c29b5e1511f9ad5fdd267a6a676f72a82fa
+  checksum: 0797eebc9475085f5cd8865e85c5e36cf52f8a35a8f47a3d1a7899318f4234fc468581bcc470e3f4aa9aac35ae1c95075f5fe461fab071db69574328484ecfbe
   languageName: node
   linkType: hard
 
@@ -3867,14 +3856,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/engine-core@npm:3.2.1":
-  version: 3.2.1
-  resolution: "@prisma/engine-core@npm:3.2.1"
+"@prisma/debug@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@prisma/debug@npm:3.3.0"
   dependencies:
-    "@prisma/debug": 3.2.1
-    "@prisma/engines": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-    "@prisma/generator-helper": 3.2.1
-    "@prisma/get-platform": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
+    "@types/debug": 4.1.7
+    ms: 2.1.3
+  checksum: b31c6d27b490301ca1d4dc0c883e4aa5951501b0f25b532fe9ba0b34397b1694bc1ac71aebf426356ef22d515fa465022a111f7c46736fa07f34d8994de814cb
+  languageName: node
+  linkType: hard
+
+"@prisma/engine-core@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@prisma/engine-core@npm:3.3.0"
+  dependencies:
+    "@prisma/debug": 3.3.0
+    "@prisma/engines": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/generator-helper": 3.3.0
+    "@prisma/get-platform": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
     chalk: 4.1.2
     execa: 5.1.1
     get-stream: 6.0.1
@@ -3883,30 +3882,30 @@ __metadata:
     p-retry: 4.6.1
     terminal-link: 2.1.1
     undici: 3.3.6
-  checksum: 547e69e79b37139ef579871fa75dfd747efee22ce2a7a3ac663145be7677000fc97086afc2f9251f3357ce1a039583522e871bd78031461c519d6e61f848ad40
+  checksum: 076bc0303d2dafbe63607e70193db083a55565003bcc317d995ebf8aa3b0d9e68acbe97ce70bf95b037f0e16738663c7e69ccb8ca4fc6d829c06a014d1801208
   languageName: node
   linkType: hard
 
-"@prisma/engines-version@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c":
-  version: 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-  resolution: "@prisma/engines-version@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
-  checksum: db1f074b21f65c36c719289e8dd1e153618966671c40937a7be47149b4c078fde64ebb622bd35ee79f0c14eef4981895b6424896e35228d4cf668db806795aa1
+"@prisma/engines-version@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
+  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+  resolution: "@prisma/engines-version@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+  checksum: f90595ba084e62e00699147753c4d51d82f7e370e21f8527d831f9adc8e5948944006185aaf13c7a7bea9864eaf8330dba3d508c5f5304c9113cfdd60d565d41
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c":
-  version: 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-  resolution: "@prisma/engines@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
-  checksum: fad32325a6be491b46adb76dfa0781f1755b1432c6f5c621ed0aec9ea8c4ac2dc77a38d6c49cf6e8037aff686b5d164a67aa60d8a684533e38d2114c1a78e7ef
+"@prisma/engines@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
+  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+  resolution: "@prisma/engines@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+  checksum: 91a8d47858cf3de711aaf47bc75bbd3b80f1b61d25218b0ec168de74a63228cc815306799e4c04facdb5bfb048bea8f7d5dd8874da4b589fa4fc8ef65d2cbdcc
   languageName: node
   linkType: hard
 
-"@prisma/fetch-engine@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c":
-  version: 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-  resolution: "@prisma/fetch-engine@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
+"@prisma/fetch-engine@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
+  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+  resolution: "@prisma/fetch-engine@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
   dependencies:
-    "@prisma/debug": 3.2.0
-    "@prisma/get-platform": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
+    "@prisma/debug": 3.2.1
+    "@prisma/get-platform": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
     chalk: ^4.0.0
     execa: ^5.0.0
     find-cache-dir: ^3.3.1
@@ -3922,41 +3921,41 @@ __metadata:
     rimraf: ^3.0.2
     temp-dir: ^2.0.0
     tempy: ^1.0.0
-  checksum: 5e66ddf27739b68b6e1ed088b3fe08dd9d70a74c40bf2c5ae3cba89d8bce9ea99f178745a72110508535e1579383a9d8b45acbb45f185d9cf90036c465ed676c
+  checksum: 1bfd4c5a383ef4071fca0076bf7720e39887a25082702b8c91d0816cbcf4df200f1b93bd791ad62142b3e281dfa108a7f8050235047dddc5e8d1b741d56b0270
   languageName: node
   linkType: hard
 
-"@prisma/generator-helper@npm:3.2.1":
-  version: 3.2.1
-  resolution: "@prisma/generator-helper@npm:3.2.1"
+"@prisma/generator-helper@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@prisma/generator-helper@npm:3.3.0"
   dependencies:
-    "@prisma/debug": 3.2.1
+    "@prisma/debug": 3.3.0
     "@types/cross-spawn": 6.0.2
     chalk: 4.1.2
     cross-spawn: 7.0.3
-  checksum: 6f061b581b9e8409e2291ac1033faba79c3dddae7dc000bb195570eefb51ef4b10c81cc071b422fd719e4e175e502d0f3b98b1871f3c58c8ac798620354c57a8
+  checksum: b6c8d9c3f906557ee47fc73e5d10070f155c1449433ae8af9ea82764ebe1360445d6d3ccc0f1214591695725572e3fcbd0ad9993b5bb764d285bfee023e5056a
   languageName: node
   linkType: hard
 
-"@prisma/get-platform@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c":
-  version: 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-  resolution: "@prisma/get-platform@npm:3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c"
-  dependencies:
-    "@prisma/debug": 3.2.0
-  checksum: 98cce3567a7c3ab4d1aa7ef25819a644143856e7483611519925e8af01bdb58962fc448ad8bed10e5c7a43cded8f061f0aa1191a2300d24c73781be286e315f8
-  languageName: node
-  linkType: hard
-
-"@prisma/sdk@npm:3.2.1":
-  version: 3.2.1
-  resolution: "@prisma/sdk@npm:3.2.1"
+"@prisma/get-platform@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
+  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+  resolution: "@prisma/get-platform@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
   dependencies:
     "@prisma/debug": 3.2.1
-    "@prisma/engine-core": 3.2.1
-    "@prisma/engines": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-    "@prisma/fetch-engine": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
-    "@prisma/generator-helper": 3.2.1
-    "@prisma/get-platform": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
+  checksum: 31e8a6832ad3688a8bba797101a7f539ac9097806361cd584376d7d3d024c644dce57ff6a3f04c395ad23d272c3567a63ff35c6f643cc24bd655793f2343985a
+  languageName: node
+  linkType: hard
+
+"@prisma/sdk@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@prisma/sdk@npm:3.3.0"
+  dependencies:
+    "@prisma/debug": 3.3.0
+    "@prisma/engine-core": 3.3.0
+    "@prisma/engines": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/fetch-engine": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/generator-helper": 3.3.0
+    "@prisma/get-platform": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
     "@timsuchanek/copy": 1.4.5
     archiver: 4.0.2
     arg: 5.0.1
@@ -3964,6 +3963,7 @@ __metadata:
     checkpoint-client: 1.1.20
     cli-truncate: 2.1.0
     dotenv: 10.0.0
+    escape-string-regexp: 4.0.0
     execa: 5.1.1
     find-up: 5.0.0
     global-dirs: 3.0.0
@@ -3986,7 +3986,7 @@ __metadata:
     tempy: 1.0.1
     terminal-link: 2.1.1
     tmp: 0.2.1
-  checksum: 3c499c2e0e0c09528bcaa5226080a14866bdfb1110156b13f3cc26c884afb62f0af90ebbcc8ad6838a5a70b7b243f87558fb5d57bfd8b51bc8290c3f1d50ce95
+  checksum: eef1ec16a575ffaa5caf1b8e3ab955ec754477359866cbd1d83aab8d4cc18fe2ce415360786a415ed65755f815686efd6e779b39bf3a9ecbe371df347adea80f
   languageName: node
   linkType: hard
 
@@ -4143,7 +4143,7 @@ __metadata:
   resolution: "@redwoodjs/api@workspace:packages/api"
   dependencies:
     "@babel/cli": 7.15.4
-    "@prisma/client": 3.2.1
+    "@prisma/client": 3.3.0
     "@redwoodjs/auth": 0.37.4
     "@types/crypto-js": 4.0.2
     "@types/jsonwebtoken": 8.5.5
@@ -4195,7 +4195,7 @@ __metadata:
   resolution: "@redwoodjs/cli@workspace:packages/cli"
   dependencies:
     "@babel/cli": 7.15.4
-    "@prisma/sdk": 3.2.1
+    "@prisma/sdk": 3.3.0
     "@redwoodjs/api-server": 0.37.4
     "@redwoodjs/internal": 0.37.4
     "@redwoodjs/prerender": 0.37.4
@@ -4224,7 +4224,7 @@ __metadata:
     pascalcase: 1.0.0
     pluralize: 8.0.0
     prettier: 2.4.1
-    prisma: 3.2.1
+    prisma: 3.3.0
     prompts: 2.4.1
     rimraf: 3.0.2
     secure-random-password: 0.2.3
@@ -4383,7 +4383,7 @@ __metadata:
     "@graphql-tools/merge": 8.1.2
     "@graphql-tools/schema": 8.2.0
     "@graphql-tools/utils": 8.2.2
-    "@prisma/client": 3.2.1
+    "@prisma/client": 3.3.0
     "@redwoodjs/api": 0.37.4
     "@redwoodjs/auth": 0.37.4
     "@types/jsonwebtoken": 8.5.5
@@ -4500,7 +4500,7 @@ __metadata:
   resolution: "@redwoodjs/structure@workspace:packages/structure"
   dependencies:
     "@babel/cli": 7.15.4
-    "@prisma/sdk": 3.2.1
+    "@prisma/sdk": 3.3.0
     "@redwoodjs/internal": 0.37.4
     "@types/fs-extra": 9.0.12
     "@types/line-column": 1.0.0
@@ -12028,17 +12028,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:4.0.0, escape-string-regexp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "escape-string-regexp@npm:4.0.0"
+  checksum: 9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^1.0.2, escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: a968ad453dd0c2724e14a4f20e177aaf32bb384ab41b674a8454afe9a41c5e6fe8903323e0a1052f56289d04bd600f81278edf140b0fcc02f5cac98d0f5b5371
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "escape-string-regexp@npm:4.0.0"
-  checksum: 9497d4dd307d845bd7f75180d8188bb17ea8c151c1edbf6b6717c100e104d629dc2dfb687686181b0f4b7d732c7dfdc4d5e7a8ff72de1b0ca283a75bbb3a9cd9
   languageName: node
   linkType: hard
 
@@ -20492,15 +20492,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prisma@npm:3.2.1":
-  version: 3.2.1
-  resolution: "prisma@npm:3.2.1"
+"prisma@npm:3.3.0":
+  version: 3.3.0
+  resolution: "prisma@npm:3.3.0"
   dependencies:
-    "@prisma/engines": 3.2.1-1.b71d8cb16c4ddc7e3e9821f42fd09b0f82d7934c
+    "@prisma/engines": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
   bin:
     prisma: build/index.js
     prisma2: build/index.js
-  checksum: d518b7c422690a67abe5d0289c7fd9d9bff2012265375532d67331a590c8c5cbe8339d88424c12b6686af977b9648ab6c143e73c85e287f662366145eac6cd2f
+  checksum: a0f276f41eda20354690a3e4149912dc4eef6115f30a45cd6d32ea38479aceb463974f66e72b69d6a628d231b61d71a81a325926038babfc8334914bf6779107
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[v.3.3.0 Release Notes](https://github.com/prisma/prisma/releases/tag/3.3.0)
- Prisma Data Proxy support in Prisma Client in Early Access, now with support for Cloudflare Workers
- MongoDB
     - Support for ordering by relation fields
     - v5 is now supported