### PR TITLE
Add TextDecoder as jest global

### DIFF
--- a/packages/testing/config/jest/web/index.js
+++ b/packages/testing/config/jest/web/index.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const { TextDecoder } = require('util')
 
 const { getPaths } = require('@redwoodjs/internal')
 
@@ -14,6 +15,7 @@ module.exports = {
   globals: {
     __REDWOOD__API_PROXY_PATH: '/',
     __REDWOOD__APP_TITLE: 'Redwood App',
+    TextDecoder,
   },
   setupFilesAfterEnv: [path.resolve(__dirname, './jest.setup.js')],
   moduleNameMapper: {


### PR DESCRIPTION
Out of nowhere, `yarn rw test` is failing in CI for the web side:
```
FAIL web web/src/pages/AboutPage/AboutPage.test.js
  ● Test suite failed to run

    ReferenceError: TextDecoder is not defined

      at Object.<anonymous> (../node_modules/meros/browser/index.js:2:17)
      at Object.<anonymous> (../node_modules/@graphql-tools/url-loader/index.js:43:17)
      at Object.<anonymous> (../node_modules/graphql-config/index.js:14:19)
      at Object.<anonymous> (../node_modules/@graphql-codegen/cli/index.js:41:23)
      at Object.<anonymous> (../node_modules/@redwoodjs/internal/dist/generate/graphqlSchema.js:8:12)
      at Object.<anonymous> (../node_modules/@redwoodjs/internal/dist/generate/generate.js:11:22)
      at Object.<anonymous> (../node_modules/@redwoodjs/internal/dist/index.js:93:17)
      at Object.<anonymous> (../node_modules/@redwoodjs/structure/dist/hosts.js:14:17)
      at Object.<anonymous> (../node_modules/@redwoodjs/structure/dist/index.js:39:14)
      at Object.<anonymous> (../node_modules/@redwoodjs/testing/config/jest/web/jest.setup.js:6:24)
```

While it seems like TextDecoder is something that should just be globally available, this PR resolves it manually.

This seems like another one of those dependency of a dependency upgraded scenarios, but I haven't been able to successfully track down what it could be yet.