### PR TITLE
fix: duplicate scaffold import

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -535,13 +535,17 @@ const addLayoutImport = ({ model: name, path: scaffoldPath = '' }) => {
   const routesPath = getPaths().web.routes
   const routesContent = readFile(routesPath).toString()
 
-  const newRoutesContent = routesContent.replace(
-    /['"]@redwoodjs\/router['"](\s*)/,
-    `'@redwoodjs/router'\n${importLayout}$1`
-  )
-  writeFile(routesPath, newRoutesContent, { overwriteExisting: true })
+  if (!routesContent.match(importLayout)) {
+    const newRoutesContent = routesContent.replace(
+      /['"]@redwoodjs\/router['"](\s*)/,
+      `'@redwoodjs/router'\n${importLayout}$1`
+    )
+    writeFile(routesPath, newRoutesContent, { overwriteExisting: true })
 
-  return 'Added layout import to Routes.{js,tsx}'
+    return 'Added layout import to Routes.{js,tsx}'
+  } else {
+    return 'Layout import already exists in Routes.{js,tsx}'
+  }
 }
 
 const addSetImport = (task) => {


### PR DESCRIPTION
Fixes #3237

Checks for existing import before adding, which resolves --force duplication as well as any instance where import already exists.