### PR TITLE
[v0.38.x] List codemods in kebab-case

### DIFF
--- a/packages/codemods/src/codemods/list.yargs.ts
+++ b/packages/codemods/src/codemods/list.yargs.ts
@@ -2,6 +2,8 @@ import fs from 'fs'
 import path from 'path'
 
 import yargs from 'yargs'
+// @ts-expect-error is actually exported, just not in types
+import { decamelize } from 'yargs-parser'
 
 export const command = 'list <rwVersion>'
 export const description = 'List available codemods for a specific version'
@@ -26,6 +28,8 @@ export const handler = ({ rwVersion }: { rwVersion: string }) => {
   const modsForVersion = fs.readdirSync(path.join(__dirname, rwVersion))
 
   modsForVersion.forEach((codemod) => {
-    console.log(`- npx @redwoodjs/codemods ${codemod}`)
+    // Use decamelize to match the usual yargs names,
+    // instead of having to load the .yargs files
+    console.log(`- npx @redwoodjs/codemods ${decamelize(codemod)}`)
   })
 }


### PR DESCRIPTION
### What?
Changes the codemods list output to list codemods in kebab-case (which is how they should be run).

Before: 
![image](https://user-images.githubusercontent.com/1521877/139105913-c7164e30-441d-436d-9f74-c1d6d2aa79f9.png)

After:
![image](https://user-images.githubusercontent.com/1521877/139106196-febb3686-63df-418c-85be-b3c74b21d344.png)
