### PR TITLE
Fix prerender if run inside `web` directory

### DIFF
--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -28,11 +28,12 @@ export const registerWebSideBabelHook = ({
   // Even though we specify the config file, babel will still search for .babelrc
   // and merge them because we have specified the filename property, unless babelrc = false
   registerBabel({
+    root: getPaths().base,
     configFile: getWebSideBabelConfigPath(), // incase user has a custom babel.config.js in api
     babelrc: false,
     extensions: ['.js', '.ts', '.tsx', '.jsx'],
     plugins: [...plugins],
-    ignore: ['node_modules'],
+    ignore: [/node_modules/],
     cache: false,
     overrides,
   })

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 
 import React from 'react'
 
@@ -96,11 +97,15 @@ export const writePrerenderedHtmlFile = (
   outputHtmlPath: string,
   content: string
 ) => {
+  const outputHtmlAbsPath = path.join(getPaths().base, outputHtmlPath)
   // Copy default index.html to 200.html first
   // This is to prevent recursively rendering the home page
   if (outputHtmlPath === 'web/dist/index.html') {
-    fs.copyFileSync(outputHtmlPath, 'web/dist/200.html')
+    fs.copyFileSync(
+      outputHtmlAbsPath,
+      path.join(getPaths().base, 'web/dist/200.html')
+    )
   }
 
-  writeToDist(outputHtmlPath, content)
+  writeToDist(outputHtmlAbsPath, content)
 }


### PR DESCRIPTION
Closes #3042.

While registering babel, this PR:
- sets root as Redwood app project root, so it searches for babel at correct place when prerender is executed someplace other than root dir.
- updates `ignore` to use regex `node_modules` instead as string, which should match node_module anywhere.