### PR TITLE
Skip `undefined` routes in splash page

### DIFF
--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -326,24 +326,27 @@ const SplashPage: React.VFC<SplashPageProps> = ({
                       <div className="pages">
                         <p className="pages-title">List of Pages by path:</p>
                         <ul className="pages-list">
-                          {routes.map((route) => {
-                            if (!route.props.notfound) {
-                              return (
-                                <li key={route.key} className="pages-item">
-                                  <code>
-                                    {`${route.props.name} -> `}
-                                    <a
-                                      href={route.props.path}
-                                      target="_blank"
-                                      rel="noreferrer"
-                                    >
-                                      {route.props.path}
-                                    </a>
-                                  </code>
-                                </li>
-                              )
+                          {routes.map((route, index) => {
+                            if (
+                              route.type.name !== 'Route' ||
+                              route.props.notfound
+                            ) {
+                              return
                             }
-                            return <div key={route.key}></div>
+                            return (
+                              <li key={index} className="pages-item">
+                                <code>
+                                  {`${route.props.name} -> `}
+                                  <a
+                                    href={route.props.path}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    {route.props.path}
+                                  </a>
+                                </code>
+                              </li>
+                            )
                           })}
                         </ul>
                       </div>


### PR DESCRIPTION
**Problem:**
Splash pages lists `undefined` as route if Routes are wrapped in `Set`. This PR changes to process only `Route` elements.

Problem Screenshot:
![Screenshot 2021-11-03 at 12 52 35 AM](https://user-images.githubusercontent.com/2629902/139935598-ca368ab5-7f55-40a0-be01-231e5a6a253d.png)
Routes:
![Screenshot 2021-11-03 at 12 52 48 AM](https://user-images.githubusercontent.com/2629902/139935729-7398396d-e9b9-4d25-9f50-b2c536c6a505.png)

After Fix:
![Screenshot 2021-11-03 at 12 53 53 AM](https://user-images.githubusercontent.com/2629902/139936003-2b4d7d4f-b53a-41f5-8357-574625e925b4.png)

@thedavidprice Okay for you to review?
