### PR TITLE
Fix styling of logo on splash page after tailwind setup

### DIFF
--- a/packages/router/src/splash-page.tsx
+++ b/packages/router/src/splash-page.tsx
@@ -138,6 +138,7 @@ const SplashPage: React.VFC<SplashPageProps> = ({
             .intro-logo {
               max-width: 23rem;
               margin: var(--space-4);
+              display: inline;
             }
 
             .intro-instructions-container {


### PR DESCRIPTION
This fixes the styling of the logo on the splash page after running the 'yarn rw setup tailwind' command. Tailwind's preflight (their version of reset.css )makes the default svg 'display' attribute 'block'. By giving the logo the web-default 'display: inline', it overrides the preflight to correct the styling.

Closes #3695 