### PR TITLE
dbAuth: Resolved typos and inconsistencies in templates

### DIFF
--- a/packages/cli/src/commands/generate/dbAuth/templates/forgotPassword.tsx.template
+++ b/packages/cli/src/commands/generate/dbAuth/templates/forgotPassword.tsx.template
@@ -23,7 +23,7 @@ const ForgotPasswordPage = () => {
     const response = await forgotPassword(data.username)
 
     if (response.error) {
-      toast.success(response.error)
+      toast.error(response.error)
     } else {
       // The function `forgotPassword.handler` in api/src/functions/auth.js has
       // been invoked, let the user know how to get the link to reset their

--- a/packages/cli/src/commands/generate/dbAuth/templates/forgotPassword.tsx.template
+++ b/packages/cli/src/commands/generate/dbAuth/templates/forgotPassword.tsx.template
@@ -29,8 +29,8 @@ const ForgotPasswordPage = () => {
       // been invoked, let the user know how to get the link to reset their
       // password (sent in email, perhaps?)
       toast.success('A link to reset your password was sent to ' + response.email)
+      navigate(routes.login())
     }
-    navigate(routes.login())
   }
 
   return (

--- a/packages/cli/src/commands/generate/dbAuth/templates/forgotPassword.tsx.template
+++ b/packages/cli/src/commands/generate/dbAuth/templates/forgotPassword.tsx.template
@@ -14,7 +14,7 @@ const ForgotPasswordPage = () => {
     }
   }, [isAuthenticated])
 
-  const usernameRef = useRef()
+  const usernameRef = useRef<HTMLInputElement>()
   useEffect(() => {
     usernameRef.current.focus()
   }, [])

--- a/packages/cli/src/commands/generate/dbAuth/templates/resetPassword.tsx.template
+++ b/packages/cli/src/commands/generate/dbAuth/templates/resetPassword.tsx.template
@@ -34,7 +34,7 @@ const ResetPasswordPage = ({ resetToken }) => {
     validateToken()
   }, [])
 
-  const passwordRef = useRef()
+  const passwordRef = useRef<HTMLInputElement>()
   useEffect(() => {
     passwordRef.current.focus()
   }, [])


### PR DESCRIPTION
Resolves a few typos and a spot where ForgotPasswordPage had a dissimilar flow to other auth-templates.

* Adds a [generic](https://www.typescriptlang.org/docs/handbook/2/generics.html) to `passwordRef` on ResetPassword.
* Adds a generic to `usernameRef` on ForgotPassword.
* Updates toast-type on ForgotPassword error.
* Relocates `navigate()` to the success conditional of ForgotPassword.