### PR TITLE
Glob param type should not include ellipsis in extracted variable name

### DIFF
--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -1,10 +1,21 @@
 import {
+  paramsForRoute,
   matchPath,
   parseSearch,
   validatePath,
   flattenSearchParams,
   replaceParams,
 } from '../util'
+
+describe('paramsForRoute', () => {
+  it.each([
+    ['/post/{slug}', [['slug', 'String', '{slug}']]],
+    ['/post/{slug...}', [['slug', 'Glob', '{slug...}']]],
+    ['/id/{id:Int}', [['id', 'Int', '{id:Int}']]],
+  ])('extracts name and type info', (route, info) => {
+    expect(paramsForRoute(route)).toEqual(info)
+  })
+})
 
 describe('matchPath', () => {
   it.each([
@@ -121,12 +132,45 @@ describe('matchPath', () => {
   })
 
   it('transforms a param for Globs', () => {
-    expect(
-      matchPath('/version/{globbyMcGlob...}', '/version/path/to/file')
-    ).toEqual({
+    //single
+    expect(matchPath('/version/{path...}', '/version/path/to/file')).toEqual({
       match: true,
       params: {
-        globbyMcGlob: 'path/to/file',
+        path: 'path/to/file',
+      },
+    })
+
+    //  multiple
+    expect(matchPath('/a/{a...}/b/{b...}/c', '/a/1/2/b/3/4/c')).toEqual({
+      match: true,
+      params: {
+        a: '1/2',
+        b: '3/4',
+      },
+    })
+
+    // adjacent
+    expect(matchPath('/a/{a...}{b...}/c', '/a/1/2/3/4/c')).toEqual({
+      match: true,
+      params: {
+        a: '1/2/3/4',
+        b: '',
+      },
+    })
+
+    // prefixed
+    expect(matchPath('/a-{a...}', '/a-1/2')).toEqual({
+      match: true,
+      params: {
+        a: '1/2',
+      },
+    })
+
+    // suffixed
+    expect(matchPath('/{a...}-a', '/1/2-a')).toEqual({
+      match: true,
+      params: {
+        a: '1/2',
       },
     })
   })

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -158,6 +158,15 @@ describe('matchPath', () => {
       },
     })
 
+    // adjacent with a slash
+    expect(matchPath('/a/{a...}/{b...}/c', '/a/1/2/3/4/c')).toEqual({
+      match: true,
+      params: {
+        a: '1/2/3',
+        b: '4',
+      },
+    })
+
     // prefixed
     expect(matchPath('/a-{a...}', '/a-1/2')).toEqual({
       match: true,

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -126,7 +126,7 @@ describe('matchPath', () => {
     ).toEqual({
       match: true,
       params: {
-        'globbyMcGlob...': 'path/to/file',
+        globbyMcGlob: 'path/to/file',
       },
     })
   })
@@ -139,7 +139,7 @@ describe('matchPath', () => {
       )
     ).toEqual({
       match: true,
-      params: { id: 44, version: 1.8, edit: false, 'path...': 'path/to/file' },
+      params: { id: 44, version: 1.8, edit: false, path: 'path/to/file' },
     })
   })
 })

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -8,7 +8,7 @@ const createNamedContext = <T>(name: string, defaultValue?: T) => {
 }
 
 /**
- * Get param name, type, and slug for a route.
+ * Get param name, type, and match for a route.
  *
  *  '/blog/{year}/{month}/{day:Int}/{filePath...}'
  *   => [
@@ -106,8 +106,8 @@ const matchPath = (
   let typeConstrainedRoute = route
 
   // Map all params from the route to their type constraint regex to create a
-  // "type-constrained route" regexp
-  for (const [_name, type, slug] of routeParams) {
+  // "type-constrained route" regex
+  for (const [_name, type, match] of routeParams) {
     // `undefined` constraint if `type` is not supported
     const constraint =
       allParamTypes[type as SupportedRouterParamTypes]?.constraint
@@ -115,7 +115,7 @@ const matchPath = (
     // Get the regex as a string, or default regex if no constraint
     const typeRegex = constraint?.source || '[^/]+'
 
-    typeConstrainedRoute = typeConstrainedRoute.replace(slug, `(${typeRegex})`)
+    typeConstrainedRoute = typeConstrainedRoute.replace(match, `(${typeRegex})`)
   }
 
   // Does the `pathname` match the route?


### PR DESCRIPTION
The current implementation of the Glob type in the router includes the `...` in the name of the prop that is passed down to the Page component. The expectation is that a route path like `/path/{path...}` would result in a prop called `path` not `path...`.

This PR also refactors the `paramsForRoute` function to have a more consistent and useful result that cleans up the `matchPath` code.

I've also added some more tests to make sure we're handling all the expected cases properly.

cc @macovedj since this affects the code you wrote recently.