### PR TITLE
Base64 encode smaller required images during prerender

### DIFF
--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -21,6 +21,7 @@
     "@redwoodjs/web": "0.38.0",
     "babel-plugin-ignore-html-and-css-imports": "0.1.0",
     "cheerio": "1.0.0-rc.10",
+    "mime-types": "2.1.33",
     "node-fetch": "2.6.1"
   },
   "repository": {
@@ -44,6 +45,7 @@
   "gitHead": "8be6a35c2dfd5aaeb12d55be4f0c77eefceb7762",
   "devDependencies": {
     "@babel/cli": "7.15.7",
+    "@types/mime-types": "2",
     "babel-plugin-tester": "10.1.0",
     "jest": "27.3.1",
     "typescript": "4.4.4"

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -45,7 +45,7 @@
   "gitHead": "8be6a35c2dfd5aaeb12d55be4f0c77eefceb7762",
   "devDependencies": {
     "@babel/cli": "7.15.7",
-    "@types/mime-types": "2",
+    "@types/mime-types": "2.1.1",
     "babel-plugin-tester": "10.1.0",
     "jest": "27.3.1",
     "typescript": "4.4.4"

--- a/packages/prerender/src/babelPlugins/__tests__/babel-plugin-redwood-prerender-media-imports.test.ts
+++ b/packages/prerender/src/babelPlugins/__tests__/babel-plugin-redwood-prerender-media-imports.test.ts
@@ -8,6 +8,7 @@ const mockDistDir = path.resolve(__dirname, './__fixtures__/distDir')
 
 jest.mock('@redwoodjs/internal', () => {
   return {
+    // @ts-expect-error Definitely can be spread..
     ...jest.requireActual('@redwoodjs/internal'),
     getPaths: () => {
       return {
@@ -15,6 +16,14 @@ jest.mock('@redwoodjs/internal', () => {
           dist: mockDistDir,
         },
       }
+    },
+  }
+})
+
+jest.mock('../utils', () => {
+  return {
+    convertToDataUrl: (assetPath) => {
+      return `data:image/jpg;base64,xxx-mock-b64-${assetPath}`
     },
   }
 })
@@ -77,7 +86,7 @@ describe('Should replace small img sources with blank data url', () => {
       {
         title: 'Url loaded image',
         code: `import img1 from './small.jpg'`,
-        output: `const img1 = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";`,
+        output: `const img1 = "data:image/jpg;base64,xxx-mock-b64-small.jpg";`,
       },
     ],
   })

--- a/packages/prerender/src/babelPlugins/utils.ts
+++ b/packages/prerender/src/babelPlugins/utils.ts
@@ -1,0 +1,18 @@
+import fs from 'fs'
+
+import mime from 'mime-types'
+
+// These functions are in a seprate file so that they can be mocked with jest
+
+// Its possible for sourceRoot to be undefined in the tests..
+// Not sure if possible in actually running builds
+export function convertToDataUrl(assetPath: string) {
+  try {
+    const base64AssetContents = fs.readFileSync(assetPath as string, 'base64')
+    const mimeType = mime.lookup(assetPath as string)
+    return `data:${mimeType};base64,${base64AssetContents}`
+  } catch (e) {
+    console.warn(`Could not read file ${assetPath} for conversion to data uri`)
+    return ''
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4438,10 +4438,12 @@ __metadata:
     "@redwoodjs/router": 0.38.0
     "@redwoodjs/structure": 0.38.0
     "@redwoodjs/web": 0.38.0
+    "@types/mime-types": 2
     babel-plugin-ignore-html-and-css-imports: 0.1.0
     babel-plugin-tester: 10.1.0
     cheerio: 1.0.0-rc.10
     jest: 27.3.1
+    mime-types: 2.1.33
     node-fetch: 2.6.1
     typescript: 4.4.4
   peerDependencies:
@@ -6239,6 +6241,13 @@ __metadata:
   dependencies:
     "@types/braces": "*"
   checksum: e557324460e658283778c77d0f8995ee95e371c4fd54474b3186e947486427cc4af66b841393304b65c09a7bb36710158260db7a7cf761384e1a9a728e82e6f4
+  languageName: node
+  linkType: hard
+
+"@types/mime-types@npm:2":
+  version: 2.1.1
+  resolution: "@types/mime-types@npm:2.1.1"
+  checksum: 131b33bfd89481f6a791996db9198c6c5ffccbb310e990d1dd9fab7a2287b5a0fd642bdd959a19281397c86f721498e09956e3892e5db17f93f38e726ca05008
   languageName: node
   linkType: hard
 
@@ -18363,7 +18372,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.0.8, mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.30, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24":
+"mime-types@npm:2.1.33, mime-types@npm:^2.0.8, mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.30, mime-types@npm:^2.1.31, mime-types@npm:~2.1.17, mime-types@npm:~2.1.24":
   version: 2.1.33
   resolution: "mime-types@npm:2.1.33"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,7 +4439,7 @@ __metadata:
     "@redwoodjs/router": 0.38.0
     "@redwoodjs/structure": 0.38.0
     "@redwoodjs/web": 0.38.0
-    "@types/mime-types": 2
+    "@types/mime-types": 2.1.1
     babel-plugin-ignore-html-and-css-imports: 0.1.0
     babel-plugin-tester: 10.1.0
     cheerio: 1.0.0-rc.10
@@ -6245,7 +6245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mime-types@npm:2":
+"@types/mime-types@npm:2.1.1":
   version: 2.1.1
   resolution: "@types/mime-types@npm:2.1.1"
   checksum: 131b33bfd89481f6a791996db9198c6c5ffccbb310e990d1dd9fab7a2287b5a0fd642bdd959a19281397c86f721498e09956e3892e5db17f93f38e726ca05008


### PR DESCRIPTION
Fixes #2509 

### Background
Imported assets i.e. png, bmp, etc. is handled during the webpack bundling process using Webpack's asset loader (https://webpack.js.org/guides/asset-modules/).

It is configured to:
1. Copy over assets with a specific file name to the assets folder for larger assets
2. To create dataUris for smaller images (https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.common.js)

Prerendering does _not_ use webpack - so we have to:
a) For larger images, lookup the path it generates from the build manifest (generated by the webpack manifest plugin) and use that path for the source e.g. `<img src="/path/from/webpack/manifest">`
b) But for smaller images (i.e. assets not found in the manifest), we were just rendering a blank gif and relying on React to update with the actual image. This behaviour must have changed in React 17, and the image src is never diffed - which is why prerendered pages would sometimes be missing.

This PR changes the process in (b)


### Explanation of changes
During Prerender:
When an asset is not found in the webpack manifest - implying that it was inlined as a data encoded uri, it will read the contents of the file and generate the data uri for it and inline it just like webpack does.