### PR TITLE
feat(rw-toml): Support env var interpolation in redwood.toml

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -44,6 +44,7 @@
     "kill-port": "1.6.1",
     "prettier": "2.4.1",
     "rimraf": "3.0.2",
+    "string-env-interpolation": "1.0.1",
     "toml": "3.0.0"
   },
   "devDependencies": {

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -46,6 +46,7 @@ describe('getConfig', () => {
 
   it('interpolates environment variables correctly', () => {
     process.env.API_URL = '/bazinga'
+    process.env.APP_ENV = 'staging'
 
     const config = getConfig(
       path.join(__dirname, './fixtures/redwood.withEnv.toml')
@@ -56,7 +57,9 @@ describe('getConfig', () => {
 
     // Uses the env var if supplied
     expect(config.web.apiUrl).toBe('/bazinga')
+    expect(config.web.title).toBe('App running on staging')
 
     delete process.env['API_URL']
+    delete process.env['APP_ENV']
   })
 })

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -43,4 +43,20 @@ describe('getConfig', () => {
     const config = getConfig(path.join(__dirname, './fixtures/redwood.toml'))
     expect(config.web.port).toEqual(8888)
   })
+
+  it('interpolates environment variables correctly', () => {
+    process.env.API_URL = '/bazinga'
+
+    const config = getConfig(
+      path.join(__dirname, './fixtures/redwood.withEnv.toml')
+    )
+
+    // Fallsback to the defualt if env var not supplied
+    expect(config.web.port).toBe('8910') // remember env vars have to be stirngs
+
+    // Uses the env var if supplied
+    expect(config.web.apiUrl).toBe('/bazinga')
+
+    delete process.env['API_URL']
+  })
 })

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -53,7 +53,7 @@ describe('getConfig', () => {
     )
 
     // Fallsback to the defualt if env var not supplied
-    expect(config.web.port).toBe('8910') // remember env vars have to be stirngs
+    expect(config.web.port).toBe('8910') // remember env vars have to be strings
 
     // Uses the env var if supplied
     expect(config.web.apiUrl).toBe('/bazinga')

--- a/packages/internal/src/__tests__/fixtures/redwood.withEnv.toml
+++ b/packages/internal/src/__tests__/fixtures/redwood.withEnv.toml
@@ -1,0 +1,9 @@
+[web]
+  title = "Redwood App"
+  port = "${PORT:8910}"
+  apiUrl = "${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+[api]
+  port = 8911
+[browser]
+  open = true

--- a/packages/internal/src/__tests__/fixtures/redwood.withEnv.toml
+++ b/packages/internal/src/__tests__/fixtures/redwood.withEnv.toml
@@ -1,5 +1,5 @@
 [web]
-  title = "Redwood App"
+  title = "App running on ${APP_ENV}"
   port = "${PORT:8910}"
   apiUrl = "${API_URL:/.redwood/functions}" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 
 import merge from 'deepmerge'
+import { env as envInterpolation } from 'string-env-interpolation'
 import toml from 'toml'
 
 import { getConfigPath } from './paths'
@@ -104,7 +105,7 @@ const DEFAULT_CONFIG: Config = {
  */
 export const getConfig = (configPath = getConfigPath()): Config => {
   try {
-    const rawConfig = fs.readFileSync(configPath, 'utf8')
+    const rawConfig = envInterpolation(fs.readFileSync(configPath, 'utf8'))
     return merge(DEFAULT_CONFIG, toml.parse(rawConfig))
   } catch (e) {
     throw new Error(`Could not parse "${configPath}": ${e}`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4420,6 +4420,7 @@ __metadata:
     kill-port: 1.6.1
     prettier: 2.4.1
     rimraf: 3.0.2
+    string-env-interpolation: 1.0.1
     toml: 3.0.0
     typescript: 4.4.4
   bin:


### PR DESCRIPTION
Fixes #3692

Already discussed with @mojombo. Any thoughts on the implementation?

Adding you as a reviewer because I'm messing with TOML

## Context aka Why?
When deploying to multiple environments (staging,test, prod, etc.) it is sometimes necessary to override certain properties of the toml per environment. 

This is especially useful for using tools like GraphCDN

## What does this do?
Adds support for env var interpolation. Example syntax:

```toml
[web]
  title = "App running on ${APP_ENV}"
  port = "${PORT:8910}"
  apiUrl = "${API_URL:/.redwood/functions}"
  includeEnvironmentVariables = []
```

This will do the following:
- set value of **title** from the env var `$APP_TITLE`, and interpolate it
- read the value of **port** from `$PORT`, but fallback to 8910 if not present. Note that the fallback has to be a string
- read **apiUrl** from `$API_URL` but fallback to the default if not present
