### PR TITLE
Fixes syntax error Firebase Auth template initializeApp

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/firebase.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/firebase.auth.ts.template
@@ -4,7 +4,7 @@ import admin from 'firebase-admin'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const adminApp = admin.initializeApp({
   projectId: process.env.FIREBASE_PROJECT_ID,
-}
+})
 
 /**
  * getCurrentUser returns the user information together with


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/3701

The `initializeApp` setup was missing a closing parentheses thus causing a syntax error when starting up the Redwood.

This PR fixes the error.