### PR TITLE
Set Apollo's verbosity to debug and update Cell's error message

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -1,6 +1,7 @@
-import type { ApolloClientOptions } from '@apollo/client'
+import type { ApolloClientOptions, setLogVerbosity } from '@apollo/client'
 import * as apolloClient from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
+import type { F } from 'ts-toolbelt'
 // Note: Importing directly from `apollo/client` does not work properly in Storybook.
 const {
   ApolloProvider,
@@ -10,6 +11,7 @@ const {
   InMemoryCache,
   useQuery,
   useMutation,
+  setLogVerbosity: apolloSetLogVerbosity,
 } = apolloClient
 
 import type { AuthContextInterface } from '@redwoodjs/auth'
@@ -36,7 +38,10 @@ export type UseAuthProp = () => AuthContextInterface
 const ApolloProviderWithFetchConfig: React.FunctionComponent<{
   config?: GraphQLClientConfigProp
   useAuth: UseAuthProp
-}> = ({ config = {}, children, useAuth }) => {
+  logLevel: F.Return<typeof setLogVerbosity>
+}> = ({ config = {}, children, useAuth, logLevel }) => {
+  apolloSetLogVerbosity(logLevel)
+
   const { uri, headers } = useFetchConfig()
   const { getToken, type: authProviderType, isAuthenticated } = useAuth()
 
@@ -88,12 +93,19 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
 export const RedwoodApolloProvider: React.FunctionComponent<{
   graphQLClientConfig?: GraphQLClientConfigProp
   useAuth?: UseAuthProp
-}> = ({ graphQLClientConfig, useAuth = useRWAuth, children }) => {
+  logLevel?: F.Return<typeof setLogVerbosity>
+}> = ({
+  graphQLClientConfig,
+  useAuth = useRWAuth,
+  logLevel = 'debug',
+  children,
+}) => {
   return (
     <FetchConfigProvider useAuth={useAuth}>
       <ApolloProviderWithFetchConfig
         config={graphQLClientConfig}
         useAuth={useAuth}
+        logLevel={logLevel}
       >
         <GraphQLHooksProvider useQuery={useQuery} useMutation={useMutation}>
           {children}

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -170,7 +170,7 @@ export function createCell<CellProps = any>({
             return <Loading {...queryRest} {...props} />
           } else {
             console.warn(
-              'Check for debug log from Apollo, which might help explain the following error.'
+              `If you're using Apollo Client, check for its debug logs here in the console, which may help explain the error.`
             )
             throw new Error(
               'Cannot render cell: GraphQL success but `data` is null'

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -173,7 +173,7 @@ export function createCell<CellProps = any>({
               `If you're using Apollo Client, check for its debug logs here in the console, which may help explain the error.`
             )
             throw new Error(
-              'Cannot render cell: GraphQL success but `data` is null'
+              'Cannot render Cell: reached an unexpected state where the query succeeded but `data` is `null`. If this happened in Storybook, your query could be missing fields; otherwise this is most likely a GraphQL caching bug. Note that adding an `id` field to all the fields on your query may fix the issue.'
             )
           }
         }}

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -169,6 +169,9 @@ export function createCell<CellProps = any>({
           } else if (loading) {
             return <Loading {...queryRest} {...props} />
           } else {
+            console.warn(
+              'Check for debug log from Apollo, which might help explain the following error.'
+            )
             throw new Error(
               'Cannot render cell: GraphQL success but `data` is null'
             )


### PR DESCRIPTION
Helps with #2473.

- Add an option to set the log level of Apollo. Default `debug`. From [Apollo Client's changelog](https://github.com/apollographql/apollo-client/blob/main/CHANGELOG.md#improvements-16):
   > all logs, warnings, and errors are hidden in production.
- Adds a warning detailing possible next step if Cell throws an error due to query result's inconsistent state.