### PR TITLE
Unit tests for file ignore function in api-server watcher

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -43,7 +43,9 @@
     "prepublishOnly": "NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build && yarn fix:permissions\"",
-    "fix:permissions": "chmod +x dist/index.js; chmod +x dist/watch.js"
+    "fix:permissions": "chmod +x dist/index.js; chmod +x dist/watch.js",
+    "test": "jest src",
+    "test:watch": "yarn test --watch"
   },
   "gitHead": "8be6a35c2dfd5aaeb12d55be4f0c77eefceb7762"
 }

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -88,28 +88,30 @@ const IGNORED_API_PATHS = [
   rwjsPaths.api.db,
 ].map((path) => ensurePosixPath(path))
 
+export const shouldIgnoreFileForBuild = (file: string) => {
+  const x =
+    file.includes('node_modules') ||
+    IGNORED_API_PATHS.some((ignoredPath) => file.includes(ignoredPath)) ||
+    [
+      '.DS_Store',
+      '.db',
+      '.sqlite',
+      '-journal',
+      '.test.js',
+      '.test.ts',
+      '.scenarios.ts',
+      '.scenarios.js',
+      '.d.ts',
+      '.log',
+    ].some((ext) => file.endsWith(ext))
+  return x
+}
+
 chokidar
   .watch(rwjsPaths.api.base, {
     persistent: true,
     ignoreInitial: true,
-    ignored: (file: string) => {
-      const x =
-        file.includes('node_modules') ||
-        IGNORED_API_PATHS.some((ignoredPath) => file.includes(ignoredPath)) ||
-        [
-          '.DS_Store',
-          '.db',
-          '.sqlite',
-          '-journal',
-          '.test.js',
-          '.test.ts',
-          '.scenarios.ts',
-          '.scenarios.js',
-          '.d.ts',
-          '.log',
-        ].some((ext) => file.endsWith(ext))
-      return x
-    },
+    ignored: (file: string) => shouldIgnoreFileForBuild(file),
   })
   .on('ready', async () => {
     rebuildApiServer()

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
+import { shouldIgnoreFileForBuild } from '@redwoodjs/api-server/src/watch'
+
 import {
   prebuildApiFiles,
   cleanApiBuild,
@@ -138,6 +140,11 @@ test('Pretranspile polyfills unsupported functionality', () => {
   expect(firstLine).toMatchInlineSnapshot(
     `"import \\"core-js/modules/esnext.string.replace-all.js\\";"`
   )
+})
+
+test('should Ignore File For Build', () => {
+  console.log(shouldIgnoreFileForBuild(relativePaths))
+  expect(null).toMatchSnapshot()
 })
 
 function stripInlineSourceMap(src: string): string {


### PR DESCRIPTION
This is a tentative to add unit test for `shouldIgnoreFileForBuild`.

I think I'm block by the jest config :
> By default "node_modules" folder is ignored by transformers.

Since we first check `file.includes('node_modules') ` I think this cause some problem with Jest. 
And, also, `import type { ChildProcess } from 'child_process'`  that I don't really need for this test, but cause error in jest environment ?