### PR TITLE
Document setLogVerbosity in RedwoodApolloProvider

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -40,6 +40,12 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
   useAuth: UseAuthProp
   logLevel: F.Return<typeof setLogVerbosity>
 }> = ({ config = {}, children, useAuth, logLevel }) => {
+  /**
+   * Should they run into it,
+   * this helps users with the "Cannot render cell; GraphQL success but data is null" error.
+   *
+   * @see {@link https://github.com/redwoodjs/redwood/issues/2473}
+   */
   apolloSetLogVerbosity(logLevel)
 
   const { uri, headers } = useFetchConfig()


### PR DESCRIPTION
Just adds a comment explaining why that line is there since it's for a very specific reason.