### PR TITLE
Make Apollo Client cache resilient to changes in Auth

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -93,7 +93,6 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
         notifyOnNetworkStatusChange: true,
       },
     },
-    ...forwardConfig,
     link: ApolloLink.from([withToken, authMiddleware.concat(httpLink)]),
   })
 

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -26,20 +26,13 @@ import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider'
 
 export type ApolloClientCacheConfig = apolloClient.InMemoryCacheConfig
 
-export type GraphQLClientConfigProp = Omit<
-  ApolloClientOptions<unknown>,
-  'cache'
-> & {
-  cacheConfig?: ApolloClientCacheConfig
-}
-
 export type UseAuthProp = () => AuthContextInterface
 
 const ApolloProviderWithFetchConfig: React.FunctionComponent<{
-  config?: GraphQLClientConfigProp
+  config: ApolloClientOptions<unknown>
   useAuth: UseAuthProp
   logLevel: F.Return<typeof setLogVerbosity>
-}> = ({ config = {}, children, useAuth, logLevel }) => {
+}> = ({ config, children, useAuth, logLevel }) => {
   /**
    * Should they run into it,
    * this helps users with the "Cannot render cell; GraphQL success but data is null" error.
@@ -85,15 +78,16 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
 
   const httpLink = createHttpLink({ uri })
 
-  const { cacheConfig, ...forwardConfig } = config ?? {}
-
   const client = new ApolloClient({
-    cache: new InMemoryCache(cacheConfig),
-    ...forwardConfig,
+    ...config,
     link: ApolloLink.from([withToken, authMiddleware.concat(httpLink)]),
   })
 
   return <ApolloProvider client={client}>{children}</ApolloProvider>
+}
+
+export type GraphQLClientConfigProp = ApolloClientOptions<unknown> & {
+  cacheConfig?: ApolloClientCacheConfig
 }
 
 export const RedwoodApolloProvider: React.FunctionComponent<{
@@ -106,10 +100,22 @@ export const RedwoodApolloProvider: React.FunctionComponent<{
   logLevel = 'debug',
   children,
 }) => {
+  /**
+   * Since Apollo Client gets re-instantiated on auth changes,
+   * we have to instantiate `InMemoryCache` here,
+   * so that it doesn't get wiped.
+   */
+  const { cacheConfig, ...config } = graphQLClientConfig ?? {}
+
+  const cache = new InMemoryCache(cacheConfig)
+
   return (
     <FetchConfigProvider useAuth={useAuth}>
       <ApolloProviderWithFetchConfig
-        config={graphQLClientConfig}
+        /**
+         * This order so that the user can still completely ovwrite the cache.
+         */
+        config={{ cache, ...config }}
         useAuth={useAuth}
         logLevel={logLevel}
       >


### PR DESCRIPTION
In this example:
- I'm using dbAuth
- I'm logged in
- Posts are public (i.e. `skipAuth`ed)

So why do I see `Loading...` twice? Aren't Cells configured to show stale data from the cache?

https://user-images.githubusercontent.com/32992335/142494018-bca4374c-756c-4a0f-bc0e-6ef9665b1f74.mp4

The answer is that the Apollo Client cache is getting completely wiped during changes to Auth. Here's the sequence of events:

- `App` mounts
- `AuthProvider` mounts; `AuthProvider` tries to see if it's authenticated or not
- `RedwoodApolloProvider` mounts and instantiates a client and cache
- Not a private route? Keep rendering
- `PostsCell` mounts, issues it's query
- The query comes back. Success!
- The `AuthProvider` has discovered it's authenticated. `setState` incoming—rerender everything!
- `RedwoodApolloProvider` gets completely re-instantiated. The cache has been thrown out
- `PostsCell` rerenders. It discovers it has no cache to fall back on, so it reissues the query and shows loading

This PR moves the cache up so that it doesn't get re-instantiated on changes to auth:

https://user-images.githubusercontent.com/32992335/142495615-0d62c359-244b-4a0b-8e6c-93ce0381a217.mp4



