### PR TITLE
Move default watchQuery config out of Cells

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -89,6 +89,19 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
 
   const client = new ApolloClient({
     cache: new InMemoryCache(cacheConfig),
+    /**
+     * Default options for every Cell.
+     * Better to specify them here than in `beforeQuery`
+     * where it's too easy to overwrite them.
+     *
+     * @see {@link https://www.apollographql.com/docs/react/api/core/ApolloClient/#example-defaultoptions-object}
+     */
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: 'cache-and-network',
+        notifyOnNetworkStatusChange: true,
+      },
+    },
     ...forwardConfig,
     link: ApolloLink.from([withToken, authMiddleware.concat(httpLink)]),
   })

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -112,11 +112,7 @@ const isEmpty = (data: DataObject) => {
 }
 
 export function createCell<CellProps = any>({
-  beforeQuery = (props) => ({
-    variables: props,
-    fetchPolicy: 'cache-and-network',
-    notifyOnNetworkStatusChange: true,
-  }),
+  beforeQuery = (props) => ({ variables: props }),
   QUERY,
   afterQuery = (data) => ({ ...data }),
   Loading = () => <>Loading...</>,


### PR DESCRIPTION
Right now, if you export your own `beforeQuery` in one of your Cells, you better include all of Redwood's defaults too if you want Cells to still work the way they do. This is pretty annoying because you basically have to look up the defaults from the source every time you want to make a simple change to `beforeQuery`.

It turns out we can include all of that Cell config in `RedwoodApolloProvider` itself. So this PR moves that config up and out of the way so that you don't accidentally break Cells while trying to write your own `beforeQuery`.