### PR TITLE
Fix generation of serverless.yml when using typescript Functions/lambdas

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/aws-serverless.js
+++ b/packages/cli/src/commands/setup/deploy/providers/aws-serverless.js
@@ -44,7 +44,7 @@ ${
   ${fs
     .readdirSync(path.resolve(getPaths().api.functions))
     .map((file) => {
-      const basename = path.basename(file, '.js')
+      const basename = path.parse(file).name
       return `${basename}:
     description: ${basename} function deployed on AWS Lambda
     package:


### PR DESCRIPTION
The current serverless.yml generator assumes all of the functions are written in `js` which means there is a lot of `.ts` polluting the generated file when typescript is used. It will then fail to deploy as the names don't match up.
See below for an example for the graphql function:
![image](https://user-images.githubusercontent.com/29681384/142603926-03c6d0ba-e72d-4340-885b-95c3bffc9f23.png)


I'm 95% sure this works but I had trouble testing as running `yarn rwfw project:sync`

I still rather certain because it's such a simple change I made the same change directly within `node_modules` and was able to generate a good file and then deploy to aws.

So not sure where to take it from here.
The error I got for `yarn rwfw project:sync` was:
```
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
(node:49602) UnhandledPromiseRejectionWarning: Error: Command failed with exit code 2: yarn build:types
    at makeError (/Users/kurthutten/other/redwood/tasks/framework-tools/node_modules/execa/lib/error.js:60:11)
    at Function.module.exports.sync (/Users/kurthutten/other/redwood/tasks/framework-tools/node_modules/execa/index.js:194:17)
    at buildPackages (file:///Users/kurthutten/other/redwood/tasks/framework-tools/src/lib/framework.mjs:179:9)
    at FSWatcher.<anonymous> (file:///Users/kurthutten/other/redwood/tasks/framework-tools/src/frameworkSyncToProject.mjs:69:5)
    at FSWatcher.emit (events.js:376:20)
    at /Users/kurthutten/other/redwood/tasks/framework-tools/node_modules/chokidar/index.js:381:35
    at processTicksAndRejections (internal/process/task_queues.js:77:11)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:49602) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:49602) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I also ran `yarn e2e` and it had 6 failures which were all timeout related.