### PR TITLE
Upgrade to Prisma v3.5.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime-corejs3": "7.15.4",
-    "@prisma/client": "3.3.0",
+    "@prisma/client": "3.5.0",
     "crypto-js": "4.1.1",
     "jsonwebtoken": "8.5.1",
     "jwks-rsa": "2.0.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/sdk": "3.3.0",
+    "@prisma/sdk": "3.5.0",
     "@redwoodjs/api-server": "0.38.3",
     "@redwoodjs/internal": "0.38.3",
     "@redwoodjs/prerender": "0.38.3",
@@ -44,7 +44,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.4.1",
-    "prisma": "3.3.0",
+    "prisma": "3.5.0",
     "prompts": "2.4.2",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -17,7 +17,7 @@
     "@graphql-tools/merge": "8.2.1",
     "@graphql-tools/schema": "8.3.1",
     "@graphql-tools/utils": "8.5.3",
-    "@prisma/client": "3.3.0",
+    "@prisma/client": "3.5.0",
     "@redwoodjs/api": "0.38.3",
     "core-js": "3.18.3",
     "graphql": "15.6.1",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -9,7 +9,7 @@
   ],
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@prisma/sdk": "3.3.0",
+    "@prisma/sdk": "3.5.0",
     "@redwoodjs/internal": "0.38.3",
     "@types/line-column": "1.0.0",
     "camelcase": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,49 +3756,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@prisma/client@npm:3.3.0"
+"@prisma/client@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@prisma/client@npm:3.5.0"
   dependencies:
-    "@prisma/engines-version": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/engines-version": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
   peerDependencies:
     prisma: "*"
   peerDependenciesMeta:
     prisma:
       optional: true
-  checksum: 0797eebc9475085f5cd8865e85c5e36cf52f8a35a8f47a3d1a7899318f4234fc468581bcc470e3f4aa9aac35ae1c95075f5fe461fab071db69574328484ecfbe
+  checksum: ee109139952f5615ed038d32c65694d850b9d3efaeed5179d01db8a76592fa705e9abdb0a0bf41d1b64508ab656ee38adb67f34177e8220ba3dfe5a592ac5b45
   languageName: node
   linkType: hard
 
-"@prisma/debug@npm:3.2.1":
-  version: 3.2.1
-  resolution: "@prisma/debug@npm:3.2.1"
-  dependencies:
-    "@types/debug": 4.1.7
-    debug: 4.3.2
-    ms: 2.1.3
-  checksum: 0a2986df9f10ee93b6ea96e0a28a8412eeb086d1df78c23e9f76cebccc6db101194ae6cd207837b32879541889373ad365c1b24012cd108f672fca1d343a4319
-  languageName: node
-  linkType: hard
-
-"@prisma/debug@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@prisma/debug@npm:3.3.0"
+"@prisma/debug@npm:3.4.2":
+  version: 3.4.2
+  resolution: "@prisma/debug@npm:3.4.2"
   dependencies:
     "@types/debug": 4.1.7
     ms: 2.1.3
-  checksum: b31c6d27b490301ca1d4dc0c883e4aa5951501b0f25b532fe9ba0b34397b1694bc1ac71aebf426356ef22d515fa465022a111f7c46736fa07f34d8994de814cb
+  checksum: 7615e05a09a534406ded1d5be0aaed7de8908361cc37521f0c7e3d5aef360e343c098d01750484eb97bfc8f8fe281694872dc7f3c313d371bc4f0d6d951f8727
   languageName: node
   linkType: hard
 
-"@prisma/engine-core@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@prisma/engine-core@npm:3.3.0"
+"@prisma/debug@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@prisma/debug@npm:3.5.0"
   dependencies:
-    "@prisma/debug": 3.3.0
-    "@prisma/engines": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-    "@prisma/generator-helper": 3.3.0
-    "@prisma/get-platform": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@types/debug": 4.1.7
+    ms: 2.1.3
+  checksum: 574b6034eb9a61e7fea257de5cc5babf3c465a13355a826c3e54ec0899074ec5f56bea70294f2e4aa5ab77aa8d6475563ea352d4e690a954b7de2f19d11f25c9
+  languageName: node
+  linkType: hard
+
+"@prisma/engine-core@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@prisma/engine-core@npm:3.5.0"
+  dependencies:
+    "@prisma/debug": 3.5.0
+    "@prisma/engines": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+    "@prisma/generator-helper": 3.5.0
+    "@prisma/get-platform": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
     chalk: 4.1.2
     execa: 5.1.1
     get-stream: 6.0.1
@@ -3807,30 +3806,30 @@ __metadata:
     p-retry: 4.6.1
     terminal-link: 2.1.1
     undici: 3.3.6
-  checksum: 076bc0303d2dafbe63607e70193db083a55565003bcc317d995ebf8aa3b0d9e68acbe97ce70bf95b037f0e16738663c7e69ccb8ca4fc6d829c06a014d1801208
+  checksum: 99894b2bf91ab46f0b4a97311c785af743973f525e5a608a9bb7cc19a43b41a01ac38dff033122d37f8d0aee8bded16eda7066af00c15f9865fbd0bf457f963e
   languageName: node
   linkType: hard
 
-"@prisma/engines-version@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-  resolution: "@prisma/engines-version@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
-  checksum: f90595ba084e62e00699147753c4d51d82f7e370e21f8527d831f9adc8e5948944006185aaf13c7a7bea9864eaf8330dba3d508c5f5304c9113cfdd60d565d41
+"@prisma/engines-version@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e":
+  version: 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+  resolution: "@prisma/engines-version@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
+  checksum: e1dc8757c27f73967d2ef395da226f33ab1e6cf7d08563690918f03dcad1edbac7b4c24e5e6de2a9fcfa1c58abfc73cdc1d146f7e691d40d692de757f2a1cb02
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-  resolution: "@prisma/engines@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
-  checksum: 91a8d47858cf3de711aaf47bc75bbd3b80f1b61d25218b0ec168de74a63228cc815306799e4c04facdb5bfb048bea8f7d5dd8874da4b589fa4fc8ef65d2cbdcc
+"@prisma/engines@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e":
+  version: 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+  resolution: "@prisma/engines@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
+  checksum: 053bc15cb2fd32df5f82bc11993248593272c7cbaf41d67fb08094a33ed8bd8ad41eef7e2ede3bcd0379e70ec3c1277d354bdd812ceca77f2edc5e90a473bef3
   languageName: node
   linkType: hard
 
-"@prisma/fetch-engine@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-  resolution: "@prisma/fetch-engine@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+"@prisma/fetch-engine@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e":
+  version: 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+  resolution: "@prisma/fetch-engine@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
   dependencies:
-    "@prisma/debug": 3.2.1
-    "@prisma/get-platform": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/debug": 3.4.2
+    "@prisma/get-platform": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
     chalk: ^4.0.0
     execa: ^5.0.0
     find-cache-dir: ^3.3.1
@@ -3846,41 +3845,41 @@ __metadata:
     rimraf: ^3.0.2
     temp-dir: ^2.0.0
     tempy: ^1.0.0
-  checksum: 1bfd4c5a383ef4071fca0076bf7720e39887a25082702b8c91d0816cbcf4df200f1b93bd791ad62142b3e281dfa108a7f8050235047dddc5e8d1b741d56b0270
+  checksum: 8c7378e6601025a956f64c1660aa01d4d69a3ccae9d2ec502291453805707fa2d742ec7d33cebc7845478328d8ce1f68c07176d1510fc7fa99dd1bd54c7e08ad
   languageName: node
   linkType: hard
 
-"@prisma/generator-helper@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@prisma/generator-helper@npm:3.3.0"
+"@prisma/generator-helper@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@prisma/generator-helper@npm:3.5.0"
   dependencies:
-    "@prisma/debug": 3.3.0
+    "@prisma/debug": 3.5.0
     "@types/cross-spawn": 6.0.2
     chalk: 4.1.2
     cross-spawn: 7.0.3
-  checksum: b6c8d9c3f906557ee47fc73e5d10070f155c1449433ae8af9ea82764ebe1360445d6d3ccc0f1214591695725572e3fcbd0ad9993b5bb764d285bfee023e5056a
+  checksum: 78d66e9a4114341ebaf9591f65ca2acc6db64c037cf45b441e2ea47ed1446047e1ae56d6fae7a5d47245073a3042545937cfae9be681dad215cea3699361b1a0
   languageName: node
   linkType: hard
 
-"@prisma/get-platform@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c":
-  version: 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-  resolution: "@prisma/get-platform@npm:3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c"
+"@prisma/get-platform@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e":
+  version: 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+  resolution: "@prisma/get-platform@npm:3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
   dependencies:
-    "@prisma/debug": 3.2.1
-  checksum: 31e8a6832ad3688a8bba797101a7f539ac9097806361cd584376d7d3d024c644dce57ff6a3f04c395ad23d272c3567a63ff35c6f643cc24bd655793f2343985a
+    "@prisma/debug": 3.4.2
+  checksum: 68d9ba8f99e0021f9f359d39b61f39a71f9f64e633c27ba1d4bc4e84c8191ddab0953a46e4fb268d52c013d3c146bdb8ba73a7cc70f0565eb37aceb2d4c5be5c
   languageName: node
   linkType: hard
 
-"@prisma/sdk@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@prisma/sdk@npm:3.3.0"
+"@prisma/sdk@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@prisma/sdk@npm:3.5.0"
   dependencies:
-    "@prisma/debug": 3.3.0
-    "@prisma/engine-core": 3.3.0
-    "@prisma/engines": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-    "@prisma/fetch-engine": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
-    "@prisma/generator-helper": 3.3.0
-    "@prisma/get-platform": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/debug": 3.5.0
+    "@prisma/engine-core": 3.5.0
+    "@prisma/engines": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+    "@prisma/fetch-engine": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
+    "@prisma/generator-helper": 3.5.0
+    "@prisma/get-platform": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
     "@timsuchanek/copy": 1.4.5
     archiver: 4.0.2
     arg: 5.0.1
@@ -3894,14 +3893,14 @@ __metadata:
     global-dirs: 3.0.0
     globby: 11.0.4
     has-yarn: 2.1.0
-    is-ci: 3.0.0
+    is-ci: 3.0.1
     make-dir: 3.1.0
-    node-fetch: 2.6.5
+    node-fetch: 2.6.6
     p-map: 4.0.0
     read-pkg-up: 7.0.1
     resolve: 1.20.0
     rimraf: 3.0.2
-    shell-quote: 1.7.2
+    shell-quote: 1.7.3
     string-width: 4.2.3
     strip-ansi: 6.0.1
     strip-indent: 3.0.0
@@ -3911,7 +3910,7 @@ __metadata:
     tempy: 1.0.1
     terminal-link: 2.1.1
     tmp: 0.2.1
-  checksum: eef1ec16a575ffaa5caf1b8e3ab955ec754477359866cbd1d83aab8d4cc18fe2ce415360786a415ed65755f815686efd6e779b39bf3a9ecbe371df347adea80f
+  checksum: 0593745f62a6a673ec60797e38d0385accf6ab6daa1b01374ee0fd520936ca9225b3d0b6362cbde764a54129326da6e922bef75fd3fb8848d9505b26e6442895
   languageName: node
   linkType: hard
 
@@ -4063,7 +4062,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.15.7
     "@babel/runtime-corejs3": 7.15.4
-    "@prisma/client": 3.3.0
+    "@prisma/client": 3.5.0
     "@redwoodjs/auth": 0.38.3
     "@types/crypto-js": 4.0.2
     "@types/jsonwebtoken": 8.5.5
@@ -4113,7 +4112,7 @@ __metadata:
   resolution: "@redwoodjs/cli@workspace:packages/cli"
   dependencies:
     "@babel/cli": 7.15.7
-    "@prisma/sdk": 3.3.0
+    "@prisma/sdk": 3.5.0
     "@redwoodjs/api-server": 0.38.3
     "@redwoodjs/internal": 0.38.3
     "@redwoodjs/prerender": 0.38.3
@@ -4143,7 +4142,7 @@ __metadata:
     pascalcase: 1.0.0
     pluralize: 8.0.0
     prettier: 2.4.1
-    prisma: 3.3.0
+    prisma: 3.5.0
     prompts: 2.4.2
     rimraf: 3.0.2
     secure-random-password: 0.2.3
@@ -4302,7 +4301,7 @@ __metadata:
     "@graphql-tools/merge": 8.2.1
     "@graphql-tools/schema": 8.3.1
     "@graphql-tools/utils": 8.5.3
-    "@prisma/client": 3.3.0
+    "@prisma/client": 3.5.0
     "@redwoodjs/api": 0.38.3
     "@redwoodjs/auth": 0.38.3
     "@types/lodash.merge": 4.6.6
@@ -4420,7 +4419,7 @@ __metadata:
   resolution: "@redwoodjs/structure@workspace:packages/structure"
   dependencies:
     "@babel/cli": 7.15.7
-    "@prisma/sdk": 3.3.0
+    "@prisma/sdk": 3.5.0
     "@redwoodjs/internal": 0.38.3
     "@types/fs-extra": 9.0.13
     "@types/line-column": 1.0.0
@@ -9475,7 +9474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^3.1.1, ci-info@npm:^3.2.0":
+"ci-info@npm:^3.2.0":
   version: 3.2.0
   resolution: "ci-info@npm:3.2.0"
   checksum: 9479fb1d835c277b388f02b6f46f1a9355c8dbc07b33b896552949ed0d4708b317bf7221ef9a3c86e975549982f76d3b84b2c7c99a8b26220218c2f3a9b657d4
@@ -10805,7 +10804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.3.2, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -15490,14 +15489,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-ci@npm:3.0.0":
-  version: 3.0.0
-  resolution: "is-ci@npm:3.0.0"
+"is-ci@npm:3.0.1":
+  version: 3.0.1
+  resolution: "is-ci@npm:3.0.1"
   dependencies:
-    ci-info: ^3.1.1
+    ci-info: ^3.2.0
   bin:
     is-ci: bin.js
-  checksum: 151a9cc5907a61d0b6805692d24fb55db5741ed073371f445ba7d0efd8c0a752f6a78734ef45580025288e026e15bfcbc03fc575e20ae07de624a39188ed866f
+  checksum: 0e81caa62f4520d4088a5bef6d6337d773828a88610346c4b1119fb50c842587ed8bef1e5d9a656835a599e7209405b5761ddf2339668f2d0f4e889a92fe6051
   languageName: node
   linkType: hard
 
@@ -18832,7 +18831,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5":
+"node-fetch@npm:2.6.6, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5":
   version: 2.6.6
   resolution: "node-fetch@npm:2.6.6"
   dependencies:
@@ -20736,15 +20735,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prisma@npm:3.3.0":
-  version: 3.3.0
-  resolution: "prisma@npm:3.3.0"
+"prisma@npm:3.5.0":
+  version: 3.5.0
+  resolution: "prisma@npm:3.5.0"
   dependencies:
-    "@prisma/engines": 3.3.0-30.33838b0f78f1fe9052cf9a00e9761c9dc097a63c
+    "@prisma/engines": 3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e
   bin:
     prisma: build/index.js
     prisma2: build/index.js
-  checksum: a0f276f41eda20354690a3e4149912dc4eef6115f30a45cd6d32ea38479aceb463974f66e72b69d6a628d231b61d71a81a325926038babfc8334914bf6779107
+  checksum: e1d741e0f7735dfcafff5d391ee6e8a4b4d440679c62ee862ead55c75489c3e79afa2fa85fa8551d138c21a3a4827f8a58be6bf23f651308b9b79407081dc777
   languageName: node
   linkType: hard
 
@@ -22724,6 +22723,13 @@ resolve@^2.0.0-next.3:
   version: 1.7.2
   resolution: "shell-quote@npm:1.7.2"
   checksum: 656aefdcdc394560ca091140a58b95e97f43d5e14bb60ff4a92556ca48841e49af6e837441e887c7890c7a86ae8542960c90e460a86799b68c53271784909edb
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:1.7.3":
+  version: 1.7.3
+  resolution: "shell-quote@npm:1.7.3"
+  checksum: cf997c325f49c4393a859074f1ee9ca3da7d9e1940225bab24a86f0266504c7d7e356b83f13c74932cb243d53125b5c8c57b714017c53490bf1fe10540422014
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Release Notes:
- [v3.4.0](https://github.com/prisma/prisma/releases/tag/3.4.0)
- [v3.4.1](https://github.com/prisma/prisma/releases/tag/3.4.1)
- [v3.4.2](https://github.com/prisma/prisma/releases/tag/3.4.2)
- [v3.5.0](https://github.com/prisma/prisma/releases/tag/3.5.0)

- Support for PostgreSQL 14
- MongoDB misc improvements
- Order by relevance in full text search (PostgreSQL)
- More configuration options for indexes and constraints in the Prisma schema (Preview)