### PR TITLE
bump CRWA node engine to 14.17

### DIFF
--- a/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/README.md
+++ b/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/README.md
@@ -21,7 +21,7 @@ In v0.38 we started supporting node 16. That means in the root package json of a
     },
     "engines": {
 -     "node": "14.x",
-+     "node": ">=14.x <=16.x",
++     "node": ">=14.17 <=16.x",
       "yarn": "1.x"
     },
     "prisma": {

--- a/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/updateNodeEngine.ts
+++ b/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/updateNodeEngine.ts
@@ -5,7 +5,7 @@ import getRootPackageJSON from '../../../lib/getRootPackageJSON'
 export const updateNodeEngine = () => {
   const [rootPackageJSON, rootPackageJSONPath] = getRootPackageJSON()
 
-  rootPackageJSON.engines.node = '>=14.x <=16.x'
+  rootPackageJSON.engines.node = '>=14.17 <=16.x'
 
   fs.writeFileSync(
     rootPackageJSONPath,

--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -15,7 +15,7 @@
     "root": true
   },
   "engines": {
-    "node": ">=14.x <=16.x",
+    "node": ">=14.17 <=16.x",
     "yarn": "1.x"
   },
   "prisma": {


### PR DESCRIPTION
closed #3728

A dependency of Jest, `jest-watch-typeahead` requires Node.js `^12.22.0 || ^14.17.0 || >=16.0.0`. Prior to this change, create-redwood-app would run up until yarn install, which would fail during the middle of the run.

This PR bumps the Node.js engine in the CRWA Template to:
```
"node": ">=14.17 <=16.x"
```