### PR TITLE
Running tests no longer warn about api and graphql-server multiple jest configurations

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -37,11 +37,6 @@
     "split2": "4.1.0",
     "typescript": "4.5.2"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "scripts": {
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "NODE_ENV=production yarn build",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -47,11 +47,6 @@
     "jest": "27.3.1",
     "typescript": "4.5.2"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "scripts": {
     "build": "yarn build:js && yarn build:types",
     "prepublishOnly": "NODE_ENV=production yarn build",


### PR DESCRIPTION
Remove jest testPathIgnorePatterns from api and graphql-server jest configs

When running `yarn test` the `api` and `graphql-server` runs were reporting the following warnings about jest confg:

```
redwoodjs/api: ● Multiple configurations found:
@redwoodjs/api:     * /Users/dthyresson/Dropbox/Code/redwoodjs/redwood/packages/api/jest.config.js
@redwoodjs/api:     * `jest` key in /Users/dthyresson/Dropbox/Code/redwoodjs/redwood/packages/api/package.json
@redwoodjs/api: 
@redwoodjs/api:   Implicit config resolution does not allow multiple configuration files.
@redwoodjs/api:   Either remove unused config files or select one explicitly with `--config`.
@redwoodjs/api: 
@redwoodjs/api:   Configuration Documentation:
@redwoodjs/api:   https://jestjs.io/docs/configuration.html

@redwoodjs/graphql-server: ● Multiple configurations found:
@redwoodjs/graphql-server:     * /Users/dthyresson/Dropbox/Code/redwoodjs/redwood/packages/graphql-server/jest.config.js
@redwoodjs/graphql-server:     * `jest` key in /Users/dthyresson/Dropbox/Code/redwoodjs/redwood/packages/graphql-server/package.json
@redwoodjs/graphql-server: 
@redwoodjs/graphql-server:   Implicit config resolution does not allow multiple configuration files.
@redwoodjs/graphql-server:   Either remove unused config files or select one explicitly with `--config`.
@redwoodjs/graphql-server: 
@redwoodjs/graphql-server:   Configuration Documentation:
@redwoodjs/graphql-server:   https://jestjs.io/docs/configuration.html
```

Both of these packages have:

```
  "jest": {
    "testPathIgnorePatterns": [
      "/dist/"
    ]
  },
```

which this PR removes.

Built and ran all tests and they succeeded/passed and the above warning no longer exists, but I don't know for certain if `testPathIgnorePatterns` is needed or not.