### PR TITLE
Fix: Flickering page on route navigation

### DIFF
--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -72,8 +72,13 @@ class PageLoaderWithRouterContext extends React.Component<Props> {
   stateChanged = (s1: State, s2: State) =>
     s1.slowModuleImport !== s2.slowModuleImport
 
-  pageNameChanged = (p1: Props, p2: Props) =>
-    p1.currentRoute?.pageName !== p2.currentRoute?.pageName
+  currentRouteChanged = (p1: Props, p2: Props) => {
+    if (p1.currentRoute?.pageName !== p2.currentRoute?.pageName) {
+      return true
+    }
+
+    return !isEqual(p1.currentRoute?.params, p2.currentRoute?.params)
+  }
 
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     if (this.propsChanged(this.props, nextProps)) {
@@ -83,7 +88,7 @@ class PageLoaderWithRouterContext extends React.Component<Props> {
     }
 
     if (
-      this.pageNameChanged(this.props, nextProps) ||
+      this.currentRouteChanged(this.props, nextProps) ||
       this.stateChanged(this.state, nextState)
     ) {
       return true
@@ -106,7 +111,7 @@ class PageLoaderWithRouterContext extends React.Component<Props> {
     }
 
     if (
-      this.pageNameChanged(prevProps, this.props) ||
+      this.currentRouteChanged(prevProps, this.props) ||
       this.stateChanged(prevState, this.state)
     ) {
       global?.scrollTo(0, 0)

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -10,6 +10,7 @@ export interface RouterState {
   paramTypes?: Record<string, ParamType>
   pageLoadingDelay?: number
   useAuth: typeof useAuth
+  currentPage?: React.ComponentType
 }
 
 const RouterStateContext = createContext<RouterState | undefined>(undefined)

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -10,7 +10,11 @@ export interface RouterState {
   paramTypes?: Record<string, ParamType>
   pageLoadingDelay?: number
   useAuth: typeof useAuth
-  currentPage?: React.ComponentType
+  activeRoute?: {
+    pageName: string
+    Page?: React.ComponentType
+    params?: Record<string, string>
+  }
 }
 
 const RouterStateContext = createContext<RouterState | undefined>(undefined)

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -242,9 +242,7 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
             delay={pageLoadingDelay}
           />
         ) : (
-          activeRoute && (
-            <Route {...(activeChildren?.[0] as React.ReactElement)?.props} />
-          )
+          activeRoute && activeChildren
         )}
       </ParamsProvider>
     </RouterContextProvider>

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -242,7 +242,9 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
             delay={pageLoadingDelay}
           />
         ) : (
-          activeRoute && activeChildren
+          activeRoute && (
+            <Route {...(activeChildren?.[0] as React.ReactElement)?.props} />
+          )
         )}
       </ParamsProvider>
     </RouterContextProvider>


### PR DESCRIPTION
Closes #2124.

**Why was this happening?**
`PageLoader` was getting unmounted on each route change. And when it remounts it switches to the default state - `page` is undefined. The cause of unmounting is from `activeRouteTree` (screenshot 1) in `router.tsx`. It swaps out the Route, so the whole subtree is unmounted.

![image](https://user-images.githubusercontent.com/2629902/142740269-284aa654-1623-4cb1-8be0-43d8b4de1fe4.png)

This PR is the possible fix that updates the `LocationAwareRouter` to maintain a single route element and copy all attributes/props from the active route. So, react can, well, _react_.

**Things to consider now:**
- [ ] Is this a good approach to fix this? **EDIT:** Tests are failing, clearly I missed something. Will look into it. **EDIT2:** Using different approach now.
- [ ] ~~Do we need to copy over anything else apart from `props`, `children` or other properties of active`Route` element?~~
- [ ] Finalize approach for testing.