### PR TITLE
Give Cells a displayName

### DIFF
--- a/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/cell/cell-with-commented-exports/output.js
+++ b/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/cell/cell-with-commented-exports/output.js
@@ -28,4 +28,5 @@ export default createCell({
   Loading,
   Failure,
   Success,
+  displayName: 'code',
 })

--- a/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/cell/cell-with-required-exports/output.js
+++ b/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/cell/cell-with-required-exports/output.js
@@ -30,4 +30,5 @@ export default createCell({
   Empty,
   Failure,
   Success,
+  displayName: 'code',
 })

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -63,6 +63,7 @@ export interface CreateCellProps<CellProps> {
   Failure?: React.FC<CellFailureProps & Partial<CellProps>>
   Empty?: React.FC<CellLoadingProps & Partial<CellProps>>
   Success: React.FC<CellSuccessProps & Partial<CellProps>>
+  displayName?: string
 }
 
 /**
@@ -135,6 +136,7 @@ export function createCell<CellProps = any>({
   Failure,
   Empty,
   Success,
+  displayName = 'Cell',
 }: CreateCellProps<CellProps>): React.FC<CellProps> {
   if (global.__REDWOOD__PRERENDERING) {
     // If its prerendering, render the Cell's Loading component
@@ -142,7 +144,7 @@ export function createCell<CellProps = any>({
     return (props) => <Loading {...(props as any)} />
   }
 
-  return (props) => {
+  const NamedCell = (props: React.PropsWithChildren<CellProps>) => {
     // destructuring to not pass children to beforeQuery
     const { children: _children, ...variables } = props
 
@@ -207,4 +209,8 @@ export function createCell<CellProps = any>({
       </Query>
     )
   }
+
+  NamedCell.displayName = displayName
+
+  return NamedCell
 }


### PR DESCRIPTION
Right now Cells are just called `Anonymous` in the React Component profiler:

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/32992335/142822430-5c8e74ab-6f07-4ada-b76c-81d5f021338d.png">

If you have multiple Cells on a page, this can make it really hard to find what you're looking for.

Why's this happening anyway? Because Cells are actually anonymous function components:

https://github.com/redwoodjs/redwood/blob/b56821466d9fc2ff788a0d19642bf3eb15651b3c/packages/web/src/components/createCell.tsx#L137-L147

It'd be great if they were named after the filename! That's what this PR does.

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/32992335/142822904-1b971ec6-47b2-4b21-af79-2b4e9bc4612b.png">
