### PR TITLE
onClick should be optional on Link

### DIFF
--- a/packages/router/src/links.tsx
+++ b/packages/router/src/links.tsx
@@ -56,7 +56,7 @@ const useMatch = (pathname: string, options?: UseMatchOptions) => {
 
 interface LinkProps {
   to: string
-  onClick: React.MouseEventHandler<HTMLAnchorElement>
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
 
 const Link = forwardRef<


### PR DESCRIPTION
Spinning up the test project I noticed that `<Link>` had gotten red squiggles. I fixed it by making `onClick` optional in the TS typings. The code already handled it. It was just the types that were wrong.

Before

![image](https://user-images.githubusercontent.com/30793/142852828-7a02ff0b-df72-4617-9973-8fa760608e57.png)


After

![image](https://user-images.githubusercontent.com/30793/142852694-16fa2bb9-e56b-4b75-93c1-d39915f4c8e2.png)
