### PR TITLE
Fix: Router white flash on first navigation to page

### DIFF
--- a/packages/router/src/ActivePageContext.tsx
+++ b/packages/router/src/ActivePageContext.tsx
@@ -1,5 +1,6 @@
 import { useContext } from 'react'
 
+import { LocationContextType } from './location'
 import { createNamedContext } from './util'
 
 export type LoadingState = 'PRE_SHOW' | 'SHOW_LOADING' | 'DONE'
@@ -8,6 +9,7 @@ export type LoadingStateRecord = Record<
   | {
       state: LoadingState
       page: React.ComponentType<unknown>
+      location: LocationContextType
     }
   | undefined
 >

--- a/packages/router/src/ActivePageContext.tsx
+++ b/packages/router/src/ActivePageContext.tsx
@@ -1,0 +1,33 @@
+import { useContext } from 'react'
+
+import { createNamedContext } from './util'
+
+export type LoadingState = 'PRE_SHOW' | 'SHOW_LOADING' | 'DONE'
+export type LoadingStateRecord = Record<
+  string,
+  | {
+      state: LoadingState
+      page: React.ComponentType<unknown>
+    }
+  | undefined
+>
+
+interface ActivePageState {
+  loadingState: LoadingStateRecord
+}
+
+const ActivePageContext = createNamedContext<ActivePageState>('ActivePage')
+
+export const ActivePageContextProvider = ActivePageContext.Provider
+
+export const useActivePageContext = () => {
+  const activePageContext = useContext(ActivePageContext)
+
+  if (!activePageContext) {
+    throw new Error(
+      'useActivePageContext must be used within a ActivePageContext provider'
+    )
+  }
+
+  return activePageContext
+}

--- a/packages/router/src/PageLoadingContext.tsx
+++ b/packages/router/src/PageLoadingContext.tsx
@@ -1,0 +1,24 @@
+import { useContext } from 'react'
+
+import { createNamedContext } from './util'
+
+export interface PageLoadingContextInterface {
+  loading: boolean
+}
+
+const PageLoadingContext =
+  createNamedContext<PageLoadingContextInterface>('PageLoading')
+
+export const PageLoadingContextProvider = PageLoadingContext.Provider
+
+export const usePageLoadingContext = () => {
+  const pageLoadingContext = useContext(PageLoadingContext)
+
+  if (!pageLoadingContext) {
+    throw new Error(
+      'usePageLoadingContext must be used within a PageLoadingContext provider'
+    )
+  }
+
+  return pageLoadingContext
+}

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1,3 +1,19 @@
+let mockDelay = 0
+jest.mock('../util', () => {
+  const actualUtil = jest.requireActual('../util')
+
+  return {
+    ...actualUtil,
+    normalizePage: (specOrPage: Spec | React.ComponentType<unknown>) => ({
+      name: specOrPage.name,
+      loader: () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ default: specOrPage }), mockDelay)
+        ),
+    }),
+  }
+})
+
 import React from 'react'
 
 import { render, waitFor, act, fireEvent } from '@testing-library/react'
@@ -17,6 +33,7 @@ import {
 } from '../'
 import { useParams } from '../params'
 import { Set } from '../Set'
+import { Spec } from '../util'
 
 function createDummyAuthContextValues(partial: Partial<AuthContextInterface>) {
   const authContextValues: AuthContextInterface = {
@@ -62,24 +79,162 @@ const AboutPage = () => <h1>About Page</h1>
 const PrivatePage = () => <h1>Private Page</h1>
 const RedirectPage = () => <Redirect to="/about" />
 const NotFoundPage = () => <h1>404</h1>
+const ParamPage = ({ value, q }: { value: string; q: string }) => {
+  const params = useParams()
+
+  return (
+    <div>
+      <p>param {`${value}${q}`}</p>
+      <p>hookparams {`${params.value}?${params.q}`}</p>
+    </div>
+  )
+}
 
 beforeEach(() => {
   window.history.pushState({}, null, '/')
   Object.keys(routes).forEach((key) => delete routes[key])
 })
 
+describe('slow imports', () => {
+  const HomePagePlaceholder = () => <>HomePagePlaceholder</>
+  const AboutPagePlaceholder = () => <>AboutPagePlaceholder</>
+  const ParamPagePlaceholder = () => <>ParamPagePlaceholder</>
+  const RedirectPagePlaceholder = () => <>RedirectPagePlaceholder</>
+  const PrivatePagePlaceholder = () => <>PrivatePagePlaceholder</>
+  const LoginPagePlaceholder = () => <>LoginPagePlaceholder</>
+
+  const TestRouter = ({ authenticated }: { authenticated?: boolean }) => (
+    <Router
+      useAuth={mockUseAuth({ isAuthenticated: authenticated })}
+      pageLoadingDelay={100}
+    >
+      <Route
+        path="/"
+        page={HomePage}
+        name="home"
+        whileLoadingPage={HomePagePlaceholder}
+      />
+      <Route
+        path="/about"
+        page={AboutPage}
+        name="about"
+        whileLoadingPage={AboutPagePlaceholder}
+      />
+      <Route
+        path="/redirect"
+        page={RedirectPage}
+        name="redirect"
+        whileLoadingPage={RedirectPagePlaceholder}
+      />
+      <Route path="/redirect2/{value}" redirect="/param-test/{value}" />
+      <Route
+        path="/login"
+        page={LoginPage}
+        name="login"
+        whileLoadingPage={LoginPagePlaceholder}
+      />
+      <Private unauthenticated="login">
+        <Route
+          path="/private"
+          page={PrivatePage}
+          name="private"
+          whileLoadingPage={PrivatePagePlaceholder}
+        />
+      </Private>
+      <Route
+        path="/param-test/{value}"
+        page={ParamPage}
+        name="params"
+        whileLoadingPage={ParamPagePlaceholder}
+      />
+      <Route notfound page={NotFoundPage} />
+    </Router>
+  )
+
+  beforeAll(() => {
+    mockDelay = 200
+  })
+
+  afterAll(() => {
+    mockDelay = 0
+  })
+
+  test('Basic home page', async () => {
+    const screen = render(<TestRouter />)
+    await waitFor(() => screen.getByText('HomePagePlaceholder'))
+    await waitFor(() => screen.getByText('Home Page'))
+  })
+
+  test('Navigation', async () => {
+    const screen = render(<TestRouter />)
+    // First we should render an empty page while waiting for pageLoadDelay to
+    // pass
+    expect(screen.container).toBeEmptyDOMElement()
+
+    // Then we should render whileLoadingPage
+    await waitFor(() => screen.getByText('HomePagePlaceholder'))
+
+    // Finally we should render the actual page
+    await waitFor(() => screen.getByText('Home Page'))
+
+    act(() => navigate('/about'))
+
+    // Now after navigating we should keep rendering the previous page until
+    // the new page has loaded, or until pageLoadDelay has passed. This
+    // ensures we don't show a "white flash", i.e. render an empty page, while
+    // navigating the page
+    expect(screen.container).not.toBeEmptyDOMElement()
+    await waitFor(() => screen.getByText('Home Page'))
+    expect(screen.container).not.toBeEmptyDOMElement()
+
+    // As for HomePage we first render the placeholder...
+    await waitFor(() => screen.getByText('AboutPagePlaceholder'))
+    // ...and then the actual page
+    await waitFor(() => screen.getByText('About Page'))
+  })
+
+  test('Redirect page', async () => {
+    act(() => navigate('/redirect'))
+    const screen = render(<TestRouter />)
+    await waitFor(() => screen.getByText('RedirectPagePlaceholder'))
+    await waitFor(() => screen.getByText('About Page'))
+  })
+
+  test('Redirect route', async () => {
+    const screen = render(<TestRouter />)
+    await waitFor(() => screen.getByText('HomePagePlaceholder'))
+    await waitFor(() => screen.getByText('Home Page'))
+    act(() => navigate('/redirect2/redirected?q=cue'))
+    await waitFor(() => screen.getByText('ParamPagePlaceholder'))
+    await waitFor(() => screen.getByText('param redirectedcue'))
+  })
+
+  test('Private page when not authenticated', async () => {
+    act(() => navigate('/private'))
+    const screen = render(<TestRouter />)
+    await waitFor(() => {
+      expect(
+        screen.queryByText('PrivatePagePlaceholder')
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText('Private Page')).not.toBeInTheDocument()
+      expect(screen.queryByText('LoginPagePlaceholder')).toBeInTheDocument()
+    })
+    await waitFor(() => screen.getByText('Login Page'))
+  })
+
+  test('Private page when authenticated', async () => {
+    act(() => navigate('/private'))
+    const screen = render(<TestRouter authenticated={true} />)
+
+    await waitFor(() => screen.getByText('PrivatePagePlaceholder'))
+    await waitFor(() => screen.getByText('Private Page'))
+    await waitFor(() => {
+      expect(screen.queryByText('Login Page')).not.toBeInTheDocument()
+    })
+  })
+})
+
 describe('inits routes and navigates as expected', () => {
-  const ParamPage = ({ value, q }: { value: string; q: string }) => {
-    const params = useParams()
-
-    return (
-      <div>
-        <p>param {`${value}${q}`}</p>
-        <p>hookparams {`${params.value}?${params.q}`}</p>
-      </div>
-    )
-  }
-
   const TestRouter = () => (
     <Router useAuth={mockUseAuth()}>
       <Route path="/" page={HomePage} name="home" />
@@ -95,8 +250,6 @@ describe('inits routes and navigates as expected', () => {
   )
 
   const getScreen = () => render(<TestRouter />)
-
-  // Run the actual tests:
 
   test('starts on home page', async () => {
     const screen = getScreen()
@@ -130,6 +283,9 @@ describe('inits routes and navigates as expected', () => {
 
   test('navigate to redirect2 should forward params', async () => {
     const screen = getScreen()
+
+    await waitFor(() => screen.getByText(/Home Page/i))
+
     act(() => navigate('/redirect2/redirected?q=cue'))
     await waitFor(() => screen.getByText(/param redirectedcue/i))
 
@@ -717,9 +873,9 @@ test('params should never be an empty object', async () => {
   render(<TestRouter />)
 })
 
-test('params should never be an empty object in Set', async () => {
+test('params should never be an empty object in Set (I)', async () => {
   const ParamPage = () => {
-    return null
+    return <div>Param Page</div>
   }
 
   const SetWithUseParams = ({ children }) => {
@@ -737,10 +893,41 @@ test('params should never be an empty object in Set', async () => {
   )
 
   act(() => navigate('/test/1'))
-  render(<TestRouter />)
+  const screen = render(<TestRouter />)
+  await waitFor(() => screen.getByText('Param Page'))
 })
 
-test('params should never be an empty object in Set', async () => {
+test('params should never be an empty object in Set with waitFor 1', async () => {
+  const ParamPage = () => {
+    const { documentId } = useParams()
+    return <>documentId: {documentId}</>
+  }
+
+  const SetWithUseParams = ({ children }) => {
+    const params = useParams()
+    // 1st run: { documentId: '1' }
+    // 2rd run: { documentId: '2' }
+    expect(params).not.toEqual({})
+    return children
+  }
+
+  const TestRouter = () => (
+    <Router>
+      <Set wrap={SetWithUseParams}>
+        <Route path="/test/{documentId}" page={ParamPage} name="param" />
+      </Set>
+      <Route path="/" page={() => <Redirect to="/test/2" />} name="home" />
+    </Router>
+  )
+
+  act(() => navigate('/test/1'))
+  const screen = render(<TestRouter />)
+  await waitFor(() => screen.getByText(/documentId: 1/))
+  act(() => navigate('/'))
+  await waitFor(() => screen.getByText(/documentId: 2/))
+})
+
+test('params should never be an empty object in Set without waitFor 1', async () => {
   const ParamPage = () => {
     const { documentId } = useParams()
     return <>documentId: {documentId}</>
@@ -771,13 +958,13 @@ test('params should never be an empty object in Set', async () => {
 
 test('Set is not rendered for unauthenticated user.', async () => {
   const ParamPage = () => {
-    // This should never be called. We should be redirect to login instead.
+    // This should never be called. We should be redirected to login instead.
     expect(false).toBe(true)
     return null
   }
 
   const SetWithUseParams = ({ children }) => {
-    // This should never be called. We should be redirect to login instead.
+    // This should never be called. We should be redirected to login instead.
     expect(false).toBe(true)
     return children
   }
@@ -787,15 +974,46 @@ test('Set is not rendered for unauthenticated user.', async () => {
       <Set private wrap={SetWithUseParams} unauthenticated="login">
         <Route path="/test/{documentId}" page={ParamPage} name="param" />
       </Set>
-      <Route path="/" page={() => <div>home</div>} name="home" />
+      <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={() => <div>auth thyself</div>} name="login" />
     </Router>
   )
 
+  // Go to home page and start loading
+  // Wait until it has loaded
+  // Go to /test/1 and start loading
+  // Get redirected to /login
   const screen = render(<TestRouter />)
-  act(() => navigate('/'))
+  await waitFor(() => screen.getByText('Home Page'))
   act(() => navigate('/test/1'))
+  await waitFor(() => screen.getByText(/auth thyself/))
+})
 
+test('Set is not rendered for unauthenticated user on direct navigation', async () => {
+  const ParamPage = () => {
+    // This should never be called. We should be redirected to login instead.
+    expect(false).toBe(true)
+    return null
+  }
+
+  const SetWithUseParams = ({ children }) => {
+    // This should never be called. We should be redirected to login instead.
+    expect(false).toBe(true)
+    return children
+  }
+
+  const TestRouter = () => (
+    <Router useAuth={mockUseAuth()}>
+      <Set private wrap={SetWithUseParams} unauthenticated="login">
+        <Route path="/test/{documentId}" page={ParamPage} name="param" />
+      </Set>
+      <Route path="/" page={HomePage} name="home" />
+      <Route path="/login" page={() => <div>auth thyself</div>} name="login" />
+    </Router>
+  )
+
+  act(() => navigate('/test/1'))
+  const screen = render(<TestRouter />)
   await waitFor(() => screen.getByText(/auth thyself/))
 })
 
@@ -846,9 +1064,9 @@ test('redirect to last page', async () => {
 
   await waitFor(() => {
     expect(screen.queryByText(/Private Page/i)).not.toBeInTheDocument()
+    screen.getByText('Login Page')
     expect(window.location.pathname).toBe('/login')
     expect(window.location.search).toBe('?redirectTo=/private')
-    screen.getByText(/Login Page/i)
   })
 })
 

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -96,7 +96,7 @@ beforeEach(() => {
   Object.keys(routes).forEach((key) => delete routes[key])
 })
 
-describe.only('slow imports', () => {
+describe('slow imports', () => {
   const HomePagePlaceholder = () => <>HomePagePlaceholder</>
   const AboutPagePlaceholder = () => <>AboutPagePlaceholder</>
   const ParamPagePlaceholder = () => <>ParamPagePlaceholder</>
@@ -246,7 +246,7 @@ describe.only('slow imports', () => {
     })
   })
 
-  test.only('useLocation', async () => {
+  test('useLocation', async () => {
     act(() => navigate('/location'))
     const screen = render(<TestRouter />)
     await waitFor(() => screen.getByText('Location Page'))
@@ -267,6 +267,44 @@ describe.only('slow imports', () => {
     // await waitFor(() => screen.getByText('/location'))
 
     // And then we'll render the placeholder...
+    await waitFor(() => screen.getByText('AboutPagePlaceholder'))
+    // ...followed by the actual page
+    await waitFor(() => screen.getByText('About Page'))
+  })
+
+  test('path params should never be empty', async () => {
+    const PathParamPage = ({ value }) => {
+      expect(value).not.toBeFalsy()
+      return <p>{value}</p>
+    }
+
+    const TestRouter = () => (
+      <Router pageLoadingDelay={100}>
+        <Route
+          path="/about"
+          page={AboutPage}
+          name="about"
+          whileLoadingPage={AboutPagePlaceholder}
+        />
+        <Route
+          path="/path-param-test/{value}"
+          page={PathParamPage}
+          name="params"
+          whileLoadingPage={ParamPagePlaceholder}
+        />
+      </Router>
+    )
+
+    act(() => navigate('/path-param-test/test_value'))
+    const screen = render(<TestRouter />)
+
+    // First we render the path parameter value "test_value"
+    await waitFor(() => screen.getByText('test_value'))
+
+    act(() => navigate('/about'))
+    // After navigating we should keep displaying the old path value...
+    await waitFor(() => screen.getByText('test_value'))
+    // ...until we switch over to render the about page loading component...
     await waitFor(() => screen.getByText('AboutPagePlaceholder'))
     // ...followed by the actual page
     await waitFor(() => screen.getByText('About Page'))

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -912,7 +912,7 @@ test('params should never be an empty object', async () => {
   render(<TestRouter />)
 })
 
-test('params should never be an empty object in Set (I)', async () => {
+test('params should never be an empty object in Set', async () => {
   const ParamPage = () => {
     return <div>Param Page</div>
   }
@@ -936,7 +936,7 @@ test('params should never be an empty object in Set (I)', async () => {
   await waitFor(() => screen.getByText('Param Page'))
 })
 
-test('params should never be an empty object in Set with waitFor 1', async () => {
+test('params should never be an empty object in Set with waitFor (I)', async () => {
   const ParamPage = () => {
     const { documentId } = useParams()
     return <>documentId: {documentId}</>
@@ -966,7 +966,7 @@ test('params should never be an empty object in Set with waitFor 1', async () =>
   await waitFor(() => screen.getByText(/documentId: 2/))
 })
 
-test('params should never be an empty object in Set without waitFor 1', async () => {
+test('params should never be an empty object in Set without waitFor (II)', async () => {
   const ParamPage = () => {
     const { documentId } = useParams()
     return <>documentId: {documentId}</>

--- a/packages/router/src/__tests__/set.test.tsx
+++ b/packages/router/src/__tests__/set.test.tsx
@@ -65,13 +65,6 @@ test('wraps components in other components', async () => {
             <h1>
               ChildB
             </h1>
-            <div
-              aria-atomic="true"
-              aria-live="assertive"
-              id="redwood-announcer"
-              role="alert"
-              style="position: absolute; top: 0px; width: 1px; height: 1px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
-            />
           </div>
           <footer>
             This is a footer
@@ -81,6 +74,13 @@ test('wraps components in other components', async () => {
           Custom Wrapper End
         </p>
       </div>
+      <div
+        aria-atomic="true"
+        aria-live="assertive"
+        id="redwood-announcer"
+        role="alert"
+        style="position: absolute; top: 0px; width: 1px; height: 1px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+      />
     </div>
   `)
 })
@@ -132,18 +132,18 @@ test('passes props to wrappers', async () => {
           <h1>
             ChildA
           </h1>
-          <div
-            aria-atomic="true"
-            aria-live="assertive"
-            id="redwood-announcer"
-            role="alert"
-            style="position: absolute; top: 0px; width: 1px; height: 1px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
-          />
           <footer>
             This is a footer
           </footer>
         </div>
       </div>
+      <div
+        aria-atomic="true"
+        aria-live="assertive"
+        id="redwood-announcer"
+        role="alert"
+        style="position: absolute; top: 0px; width: 1px; height: 1px; padding: 0px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+      />
     </div>
   `)
 })

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -190,6 +190,9 @@ export const ActiveRouteLoader = ({
     }
   }, [spec, delay, children, whileLoadingPage, path, location, isMounted])
 
+  // It might feel tempting to move this code further up in the file for an
+  // "early return", but React doesn't allow that because pretty much all code
+  // above is hooks, and they always need to come before any `return`
   if (global.__REDWOOD__PRERENDERING) {
     // babel auto-loader plugin uses withStaticImport in prerender mode
     // override the types for this condition

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -163,7 +163,7 @@ export const ActiveRouteLoader = ({
 
       // Only update all state if we're still interested (i.e. we're still
       // waiting for the page that just finished loading)
-      if (isMounted && name === waitingFor.current) {
+      if (isMounted() && name === waitingFor.current) {
         unstable_batchedUpdates(() => {
           setLoadingState((loadingState) => ({
             ...loadingState,

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -1,0 +1,260 @@
+import React, { useRef, useState, useContext, useEffect } from 'react'
+
+import { unstable_batchedUpdates } from 'react-dom'
+
+import { Spec } from './util'
+import {
+  createNamedContext,
+  getAnnouncement,
+  getFocus,
+  resetFocus,
+} from './util'
+
+import { ParamsProvider, useLocation } from '.'
+
+const DEFAULT_PAGE_LOADING_DELAY = 1000 // milliseconds
+
+export interface PageLoadingContextInterface {
+  loading: boolean
+}
+
+export const PageLoadingContext =
+  createNamedContext<PageLoadingContextInterface>('PageLoading')
+
+export const usePageLoadingContext = () => {
+  const pageLoadingContext = useContext(PageLoadingContext)
+
+  if (!pageLoadingContext) {
+    throw new Error(
+      'usePageLoadingContext must be used within a PageLoadingContext provider'
+    )
+  }
+
+  return pageLoadingContext
+}
+
+export type LoadingState = 'PRE_SHOW' | 'SHOW_LOADING' | 'DONE'
+type LoadingStateRecord = Record<
+  string,
+  {
+    state: LoadingState
+    page: React.ComponentType<unknown>
+  }
+>
+
+interface ActivePageState {
+  loadingState: LoadingStateRecord
+}
+
+const ActivePageContext = React.createContext<ActivePageState | undefined>(
+  undefined
+)
+
+export const useActivePageContext = () => {
+  const activePageContext = useContext(ActivePageContext)
+
+  if (!activePageContext) {
+    throw new Error(
+      'useActivePageContext must be used within a ActivePageContext provider'
+    )
+  }
+
+  return activePageContext
+}
+
+type synchronousLoaderSpec = () => { default: React.ComponentType<unknown> }
+
+interface Props {
+  path: string
+  spec: Spec
+  delay?: number
+  params?: Record<string, string>
+  whileLoadingPage?: () => React.ReactElement | null
+  children?: React.ReactNode
+}
+
+const ArlNullPage = () => null
+const ArlWhileLoadingNullPage = () => null
+
+export const ActiveRouteLoader = ({
+  path,
+  spec,
+  delay,
+  params,
+  whileLoadingPage,
+  children,
+}: Props) => {
+  const location = useLocation()
+  const [pageName, setPageName] = useState('')
+  const loadingTimeout = useRef<NodeJS.Timeout>()
+  const announcementRef = useRef<HTMLDivElement>(null)
+  const mounted = useRef(true)
+  const waitingFor = useRef<string>('')
+  const [loadingState, setLoadingState] = useState<LoadingStateRecord>({
+    [path]: { page: ArlNullPage, state: 'PRE_SHOW' },
+  })
+  const [renderedChildren, setRenderedChildren] = useState<
+    React.ReactNode | undefined
+  >(children)
+  const [renderedPath, setRenderedPath] = useState(path)
+  const [renderedLocation, setRenderedLocation] = useState({ ...location })
+
+  loadingState[path] = loadingState[path] || 'PRE_SHOW'
+
+  const clearLoadingTimeout = () => {
+    if (loadingTimeout.current) {
+      clearTimeout(loadingTimeout.current)
+    }
+  }
+
+  useEffect(() => {
+    mounted.current = true
+
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    global?.scrollTo(0, 0)
+
+    if (announcementRef.current) {
+      announcementRef.current.innerText = getAnnouncement()
+    }
+
+    const routeFocus = getFocus()
+    if (!routeFocus) {
+      resetFocus()
+    } else {
+      routeFocus.focus()
+    }
+  }, [pageName, params])
+
+  useEffect(() => {
+    const startPageLoadTransition = async (
+      { loader, name }: Spec,
+      delay: number = DEFAULT_PAGE_LOADING_DELAY
+    ) => {
+      setLoadingState((loadingState) => ({
+        ...loadingState,
+        [path]: {
+          page: ArlNullPage,
+          state: 'PRE_SHOW',
+        },
+      }))
+
+      // Update the context if importing the page is taking longer
+      // than `delay`.
+      // Consumers of the context can show a loading indicator
+      // to signal to the user that something is happening.
+      loadingTimeout.current = setTimeout(() => {
+        unstable_batchedUpdates(() => {
+          setLoadingState((loadingState) => ({
+            ...loadingState,
+            [path]: {
+              page: whileLoadingPage || ArlWhileLoadingNullPage,
+              state: 'SHOW_LOADING',
+            },
+          }))
+          setRenderedChildren(children)
+          setRenderedPath(path)
+          setRenderedLocation({ ...location })
+        })
+      }, delay)
+
+      // Wait to download and parse the page.
+      waitingFor.current = name
+      const module = await loader()
+
+      // Remove the timeout because the page has loaded.
+      clearLoadingTimeout()
+
+      // Only update all state if we're still interested (i.e. we're still
+      // waiting for the page that just finished loading)
+      if (mounted.current && name === waitingFor.current) {
+        unstable_batchedUpdates(() => {
+          setLoadingState((loadingState) => ({
+            ...loadingState,
+            [path]: {
+              page: module.default,
+              state: 'DONE',
+            },
+          }))
+          setRenderedLocation({ ...location })
+          setRenderedChildren(children)
+          setRenderedPath(path)
+          setPageName(name)
+        })
+      }
+    }
+
+    if (spec.name !== waitingFor.current) {
+      clearLoadingTimeout()
+      startPageLoadTransition(spec, delay)
+    }
+
+    return () => {
+      clearLoadingTimeout()
+    }
+  }, [spec, delay, children, whileLoadingPage, path, location])
+
+  if (global.__REDWOOD__PRERENDERING) {
+    // babel auto-loader plugin uses withStaticImport in prerender mode
+    // override the types for this condition
+    const syncPageLoader = spec.loader as unknown as synchronousLoaderSpec
+    const PageFromLoader = syncPageLoader().default
+
+    const prerenderLoadingState: LoadingStateRecord = {
+      [path]: {
+        state: 'DONE',
+        page: PageFromLoader,
+      },
+    }
+
+    return (
+      <ParamsProvider path={path} location={location}>
+        <PageLoadingContext.Provider value={{ loading: false }}>
+          <ActivePageContext.Provider
+            value={{ loadingState: prerenderLoadingState }}
+          >
+            {children}
+          </ActivePageContext.Provider>
+        </PageLoadingContext.Provider>
+      </ParamsProvider>
+    )
+  }
+
+  return (
+    <ParamsProvider path={renderedPath} location={renderedLocation}>
+      <ActivePageContext.Provider value={{ loadingState }}>
+        <PageLoadingContext.Provider
+          value={{ loading: loadingState[path].state === 'SHOW_LOADING' }}
+        >
+          {renderedChildren}
+          {loadingState[path].state === 'DONE' && (
+            <div
+              id="redwood-announcer"
+              style={{
+                position: 'absolute',
+                top: 0,
+                width: 1,
+                height: 1,
+                padding: 0,
+                overflow: 'hidden',
+                clip: 'rect(0, 0, 0, 0)',
+                whiteSpace: 'nowrap',
+                border: 0,
+              }}
+              role="alert"
+              aria-live="assertive"
+              aria-atomic="true"
+              ref={announcementRef}
+            ></div>
+          )}
+        </PageLoadingContext.Provider>
+      </ActivePageContext.Provider>
+    </ParamsProvider>
+  )
+
+  return null
+}

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -81,7 +81,7 @@ export const ActiveRouteLoader = ({
         [path]: {
           page: ArlNullPage,
           state: 'PRE_SHOW',
-          location: { ...location },
+          location,
         },
       }))
 
@@ -96,7 +96,7 @@ export const ActiveRouteLoader = ({
             [path]: {
               page: whileLoadingPage || ArlWhileLoadingNullPage,
               state: 'SHOW_LOADING',
-              location: { ...location },
+              location,
             },
           }))
           setRenderedChildren(children)
@@ -120,7 +120,7 @@ export const ActiveRouteLoader = ({
             [path]: {
               page: module.default,
               state: 'DONE',
-              location: { ...location },
+              location,
             },
           }))
           setRenderedChildren(children)
@@ -134,18 +134,11 @@ export const ActiveRouteLoader = ({
       clearLoadingTimeout()
       startPageLoadTransition(spec, delay)
     } else {
-      // Handle navigating to the same page again, but with different path params
+      // Handle navigating to the same page again, but with different path
+      // params (i.e. new `location`)
       setLoadingState((loadingState) => {
         const page = loadingState[path]?.page || ArlNullPage
-
-        return {
-          ...loadingState,
-          [path]: {
-            page,
-            state: 'DONE',
-            location: { ...location },
-          },
-        }
+        return { ...loadingState, [path]: { page, state: 'DONE', location } }
       })
     }
 
@@ -167,7 +160,7 @@ export const ActiveRouteLoader = ({
       [path]: {
         state: 'DONE',
         page: PageFromLoader,
-        location: { ...location },
+        location,
       },
     }
 

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -36,10 +36,11 @@ export const usePageLoadingContext = () => {
 export type LoadingState = 'PRE_SHOW' | 'SHOW_LOADING' | 'DONE'
 type LoadingStateRecord = Record<
   string,
-  {
-    state: LoadingState
-    page: React.ComponentType<unknown>
-  }
+  | {
+      state: LoadingState
+      page: React.ComponentType<unknown>
+    }
+  | undefined
 >
 
 interface ActivePageState {
@@ -98,8 +99,6 @@ export const ActiveRouteLoader = ({
   >(children)
   const [renderedPath, setRenderedPath] = useState(path)
   const [renderedLocation, setRenderedLocation] = useState({ ...location })
-
-  loadingState[path] = loadingState[path] || 'PRE_SHOW'
 
   const clearLoadingTimeout = () => {
     if (loadingTimeout.current) {
@@ -228,10 +227,10 @@ export const ActiveRouteLoader = ({
     <ParamsProvider path={renderedPath} location={renderedLocation}>
       <ActivePageContext.Provider value={{ loadingState }}>
         <PageLoadingContext.Provider
-          value={{ loading: loadingState[path].state === 'SHOW_LOADING' }}
+          value={{ loading: loadingState[path]?.state === 'SHOW_LOADING' }}
         >
           {renderedChildren}
-          {loadingState[path].state === 'DONE' && (
+          {loadingState[path]?.state === 'DONE' && (
             <div
               id="redwood-announcer"
               style={{

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState, useContext, useEffect } from 'react'
 
 import { unstable_batchedUpdates } from 'react-dom'
 
+import { useIsMounted } from './useIsMounted'
 import { Spec } from './util'
 import {
   createNamedContext,
@@ -89,7 +90,6 @@ export const ActiveRouteLoader = ({
   const [pageName, setPageName] = useState('')
   const loadingTimeout = useRef<NodeJS.Timeout>()
   const announcementRef = useRef<HTMLDivElement>(null)
-  const mounted = useRef(true)
   const waitingFor = useRef<string>('')
   const [loadingState, setLoadingState] = useState<LoadingStateRecord>({
     [path]: { page: ArlNullPage, state: 'PRE_SHOW' },
@@ -99,20 +99,13 @@ export const ActiveRouteLoader = ({
   >(children)
   const [renderedPath, setRenderedPath] = useState(path)
   const [renderedLocation, setRenderedLocation] = useState({ ...location })
+  const isMounted = useIsMounted()
 
   const clearLoadingTimeout = () => {
     if (loadingTimeout.current) {
       clearTimeout(loadingTimeout.current)
     }
   }
-
-  useEffect(() => {
-    mounted.current = true
-
-    return () => {
-      mounted.current = false
-    }
-  }, [])
 
   useEffect(() => {
     global?.scrollTo(0, 0)
@@ -170,7 +163,7 @@ export const ActiveRouteLoader = ({
 
       // Only update all state if we're still interested (i.e. we're still
       // waiting for the page that just finished loading)
-      if (mounted.current && name === waitingFor.current) {
+      if (isMounted && name === waitingFor.current) {
         unstable_batchedUpdates(() => {
           setLoadingState((loadingState) => ({
             ...loadingState,
@@ -195,7 +188,7 @@ export const ActiveRouteLoader = ({
     return () => {
       clearLoadingTimeout()
     }
-  }, [spec, delay, children, whileLoadingPage, path, location])
+  }, [spec, delay, children, whileLoadingPage, path, location, isMounted])
 
   if (global.__REDWOOD__PRERENDERING) {
     // babel auto-loader plugin uses withStaticImport in prerender mode

--- a/packages/router/src/links.tsx
+++ b/packages/router/src/links.tsx
@@ -149,7 +149,7 @@ const NavLink = forwardRef<
 )
 
 interface RedirectProps {
-  /** The name of the route to redirect to */
+  /** The path to redirect to */
   to: string
 }
 
@@ -157,7 +157,7 @@ interface RedirectProps {
  * A declarative way to redirect to a route name
  */
 const Redirect = ({ to }: RedirectProps) => {
-  useEffect(() => navigate(to), [to])
+  useEffect(() => void setTimeout(() => navigate(to)), [to])
   return null
 }
 

--- a/packages/router/src/links.tsx
+++ b/packages/router/src/links.tsx
@@ -157,7 +157,7 @@ interface RedirectProps {
  * A declarative way to redirect to a route name
  */
 const Redirect = ({ to }: RedirectProps) => {
-  useEffect(() => void setTimeout(() => navigate(to)), [to])
+  useEffect(() => navigate(to), [to])
   return null
 }
 

--- a/packages/router/src/location.tsx
+++ b/packages/router/src/location.tsx
@@ -21,7 +21,8 @@ interface LocationProviderProps {
 }
 
 class LocationProvider extends React.Component<LocationProviderProps> {
-  // When prerendering, there might be more than one level of location providers. Use the values from the one above.
+  // When prerendering, there might be more than one level of location
+  // providers. Use the values from the one above.
   static contextType = LocationContext
   HISTORY_LISTENER_ID: string | undefined = undefined
 
@@ -35,7 +36,8 @@ class LocationProvider extends React.Component<LocationProviderProps> {
     if (typeof window !== 'undefined') {
       const { pathname } = window.location
 
-      // Since we have to update the URL, we might as well handle the trailing slash here, before matching.
+      // Since we have to update the URL, we might as well handle the trailing
+      // slash here, before matching.
       //
       // - never -> strip trailing slashes ("/about/" -> "/about")
       // - always -> add trailing slashes ("/about" -> "/about/")

--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -29,7 +29,7 @@ export const usePageLoadingContext = () => {
   return pageLoadingContext
 }
 
-type synchonousLoaderSpec = () => { default: React.ComponentType }
+type synchronousLoaderSpec = () => { default: React.ComponentType }
 interface State {
   Page?: React.ComponentType
   pageName?: string
@@ -149,10 +149,10 @@ export class PageLoader extends React.Component<Props> {
     const { Page } = this.state
 
     if (global.__REDWOOD__PRERENDERING) {
-      // babel autoloader plugin uses withStaticImport in prerender mode
+      // babel auto-loader plugin uses withStaticImport in prerender mode
       // override the types for this condition
       const syncPageLoader = this.props.spec
-        .loader as unknown as synchonousLoaderSpec
+        .loader as unknown as synchronousLoaderSpec
       const PageFromLoader = syncPageLoader().default
 
       return (

--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -67,15 +67,11 @@ export class PageLoader extends React.Component<Props> {
     return !isEqual(s1.params, s2.params)
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: Props) {
     if (this.propsChanged(this.props, nextProps)) {
       this.clearLoadingTimeout()
       this.startPageLoadTransition(nextProps)
       return false
-    }
-
-    if (this.stateChanged(this.state, nextState)) {
-      return true
     }
 
     return true
@@ -146,8 +142,6 @@ export class PageLoader extends React.Component<Props> {
   }
 
   render() {
-    const { Page } = this.state
-
     if (global.__REDWOOD__PRERENDERING) {
       // babel auto-loader plugin uses withStaticImport in prerender mode
       // override the types for this condition
@@ -162,7 +156,13 @@ export class PageLoader extends React.Component<Props> {
       )
     }
 
-    if (Page) {
+    if (this.state.slowModuleImport && this.props.whileLoadingPage) {
+      return this.props.whileLoadingPage()
+    }
+
+    if (this.state.Page) {
+      const { Page } = this.state
+
       return (
         <PageLoadingContext.Provider
           value={{ loading: this.state.slowModuleImport }}
@@ -188,10 +188,8 @@ export class PageLoader extends React.Component<Props> {
           ></div>
         </PageLoadingContext.Provider>
       )
-    } else {
-      return this.state.slowModuleImport
-        ? this.props.whileLoadingPage?.() || null
-        : null
     }
+
+    return null
   }
 }

--- a/packages/router/src/page-loader.tsx
+++ b/packages/router/src/page-loader.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 import isEqual from 'lodash.isequal'
 
-import { Spec } from './router'
+import { Spec } from './util'
 import {
   createNamedContext,
   getAnnouncement,

--- a/packages/router/src/params.tsx
+++ b/packages/router/src/params.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 
-import { useLocation } from './location'
+import { LocationContextType, useLocation } from './location'
 import { useRouterState } from './router-context'
 import { createNamedContext, matchPath, parseSearch } from './util'
 
@@ -12,17 +12,27 @@ export const ParamsContext = createNamedContext<ParamsContextProps>('Params')
 
 interface Props {
   path?: string
+  location?: LocationContextType
 }
 
-export const ParamsProvider: React.FC<Props> = ({ path, children }) => {
+export const ParamsProvider: React.FC<Props> = ({
+  path,
+  location,
+  children,
+}) => {
   const { paramTypes } = useRouterState()
-  const location = useLocation()
+  const contextLocation = useLocation()
+  const internalLocation = location || contextLocation
 
   let pathParams = {}
-  const searchParams = parseSearch(location.search)
+  const searchParams = parseSearch(internalLocation.search)
 
   if (path) {
-    const { match, params } = matchPath(path, location.pathname, paramTypes)
+    const { match, params } = matchPath(
+      path,
+      internalLocation.pathname,
+      paramTypes
+    )
 
     if (match && typeof params !== 'undefined') {
       pathParams = params

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -4,11 +4,8 @@ import { useAuth } from '@redwoodjs/auth'
 
 import type { ParamType } from './util'
 
-const DEFAULT_PAGE_LOADING_DELAY = 1000 // milliseconds
-
 export interface RouterState {
   paramTypes?: Record<string, ParamType>
-  pageLoadingDelay?: number
   useAuth: typeof useAuth
 }
 
@@ -34,13 +31,11 @@ function stateReducer(state: RouterState, newState: Partial<RouterState>) {
 export const RouterContextProvider: React.FC<RouterContextProviderProps> = ({
   useAuth: customUseAuth,
   paramTypes,
-  pageLoadingDelay = DEFAULT_PAGE_LOADING_DELAY,
   children,
 }) => {
   const [state, setState] = useReducer(stateReducer, {
     useAuth: customUseAuth || useAuth,
     paramTypes,
-    pageLoadingDelay,
   })
 
   return (

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -109,7 +109,7 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
     )
   }
 
-  const Page = activePageContext.loadingState[path].page
+  const Page = activePageContext.loadingState[path]?.page || (() => null)
 
   // Level 3 (InternalRoute)
   return <Page {...allParams} />

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -112,7 +112,7 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
 
   const Page = activePageContext.loadingState[path]?.page || (() => null)
 
-  // Level 3 (InternalRoute)
+  // Level 3/3 (InternalRoute)
   return <Page {...allParams} />
 }
 
@@ -134,7 +134,7 @@ const Router: React.FC<RouterProps> = ({
   trailingSlashes = 'never',
   children,
 }) => (
-  // Level 1 (outer-most)
+  // Level 1/3 (outer-most)
   <LocationProvider trailingSlashes={trailingSlashes}>
     <LocationAwareRouter
       useAuth={useAuth}
@@ -236,7 +236,7 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
   const searchParams = parseSearch(location.search)
   const allParams = { ...searchParams, ...pathParams }
 
-  // Level 2 (LocationAwareRouter)
+  // Level 2/3 (LocationAwareRouter)
   return (
     <RouterContextProvider useAuth={useAuth} paramTypes={paramTypes}>
       {redirect && <Redirect to={replaceParams(redirect, allParams)} />}

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
-import { ActiveRouteLoader, useActivePageContext } from './active-route-loader'
+import { ActiveRouteLoader } from './active-route-loader'
+import { useActivePageContext } from './ActivePageContext'
 import { Redirect } from './links'
 import { useLocation, LocationProvider } from './location'
 import { PageLoader } from './page-loader'

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -277,11 +277,23 @@ function analyzeRouteTree(
         active = isActiveRoute(child)
 
         if (active) {
+          // All <Route>s have a key that React has generated for them.
+          // Something like '.1', '.2', etc
+          // But we know we'll only ever render one <Route>, so we can give
+          // all of them the same key. This will make React re-use the element
+          // between renders, which helps get rid of "white flashes" when
+          // navigating between pages. (The other half of that equation is in
+          // PageLoader)
+          const childWithKey = React.cloneElement(child, {
+            ...child.props,
+            key: '.rw-route',
+          })
+
           // Keep this child. It's the last one we'll keep since `active` is `true`
           // now
-          acc.push(child)
+          acc.push(childWithKey)
 
-          activeRoute = child
+          activeRoute = childWithKey
         }
       } else if (isReactElement(child) && child.props.children) {
         // We have a child element that's not a <Route ...>, and that has

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -257,12 +257,13 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
 /**
  * This function analyzes the routes and returns info pertaining to what to
  * render.
- *  - The element to render, i.e. the active route or the <Set>(s) wrapping it
- *  - The path for the active route
- *  - The NotFoundPage, if we find any. Even if there is a NotFoundPage
- *    specified we might not find it, but only if we first find the active
- *    route, and in that case we don't need the NotFoundPage, so it doesn't
- *    matter.
+ *  - root: The element to render, i.e. the active route or the <Set>(s)
+ *    wrapping it
+ *  - activeRoute: The route we should render (same as root for flat routes)
+ *  - NotFoundPage: The NotFoundPage, if we find any. Even if there is a
+ *    NotFoundPage specified we might not find it, but only if we first find
+ *    the active route, and in that case we don't need the NotFoundPage, so it
+ *    doesn't matter.
  */
 function analyzeRouterTree(
   children: React.ReactNode,

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -73,7 +73,6 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
   redirect,
   notfound,
 }) => {
-  const location = useLocation()
   const routerState = useRouterState()
   const activePageContext = useActivePageContext()
 
@@ -88,6 +87,12 @@ const InternalRoute: React.VFC<InternalRouteProps> = ({
 
   // Check for issues with the path.
   validatePath(path)
+
+  const location = activePageContext.loadingState[path]?.location
+
+  if (!location) {
+    throw new Error(`No location for route "${name}"`)
+  }
 
   const { params: pathParams } = matchPath(
     path,
@@ -240,7 +245,7 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
   return (
     <RouterContextProvider useAuth={useAuth} paramTypes={paramTypes}>
       {redirect && <Redirect to={replaceParams(redirect, allParams)} />}
-      {!redirect && (
+      {!redirect && page && (
         <ActiveRouteLoader
           path={path}
           spec={normalizePage(page)}
@@ -272,7 +277,7 @@ function analyzeRouterTree(
   paramTypes?: Record<string, ParamType>
 ): {
   root: React.ReactElement | undefined
-  activeRoute: React.ReactElement | undefined
+  activeRoute: React.ReactElement<InternalRouteProps> | undefined
   NotFoundPage: PageType | undefined
 } {
   let NotFoundPage: PageType | undefined = undefined

--- a/packages/router/src/useIsMounted.ts
+++ b/packages/router/src/useIsMounted.ts
@@ -1,15 +1,9 @@
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useCallback } from 'react'
 
 export const useIsMounted = () => {
   const isMounted = useRef(true)
 
-  useEffect(() => {
-    isMounted.current = true
+  useEffect(() => () => void (isMounted.current = false), [])
 
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
-
-  return isMounted.current
+  return useCallback(() => isMounted.current, [])
 }

--- a/packages/router/src/useIsMounted.ts
+++ b/packages/router/src/useIsMounted.ts
@@ -3,7 +3,11 @@ import { useRef, useEffect, useCallback } from 'react'
 export const useIsMounted = () => {
   const isMounted = useRef(true)
 
-  useEffect(() => () => void (isMounted.current = false), [])
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   return useCallback(() => isMounted.current, [])
 }

--- a/packages/router/src/useIsMounted.ts
+++ b/packages/router/src/useIsMounted.ts
@@ -1,0 +1,15 @@
+import { useRef, useEffect } from 'react'
+
+export const useIsMounted = () => {
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    isMounted.current = true
+
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  return isMounted.current
+}

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -362,3 +362,46 @@ export const resetFocus = () => {
   global?.document.body.focus()
   global?.document.body.removeAttribute('tabindex')
 }
+
+export interface Spec {
+  name: string
+  loader: () => Promise<{ default: React.ComponentType<unknown> }>
+}
+
+export function isSpec(
+  specOrPage: Spec | React.ComponentType
+): specOrPage is Spec {
+  return (specOrPage as Spec).loader !== undefined
+}
+
+/**
+ * Pages can be imported automatically or manually. Automatic imports are actually
+ * objects and take the following form (which we call a 'spec'):
+ *
+ *   const WhateverPage = {
+ *     name: 'WhateverPage',
+ *     loader: () => import('src/pages/WhateverPage')
+ *   }
+ *
+ * Manual imports simply load the page:
+ *
+ *   import WhateverPage from 'src/pages/WhateverPage'
+ *
+ * Before passing a "page" to the PageLoader, we will normalize the manually
+ * imported version into a spec.
+ */
+export function normalizePage(
+  specOrPage: Spec | React.ComponentType<unknown>
+): Spec {
+  if (isSpec(specOrPage)) {
+    // Already a spec, just return it.
+    return specOrPage
+  }
+
+  // Wrap the Page in a fresh spec, and put it in a promise to emulate
+  // an async module import.
+  return {
+    name: specOrPage.name,
+    loader: async () => ({ default: specOrPage }),
+  }
+}

--- a/packages/testing/src/web/__tests__/MockRouter.test.tsx
+++ b/packages/testing/src/web/__tests__/MockRouter.test.tsx
@@ -12,11 +12,11 @@ describe('MockRouter', () => {
   it('should correctly map routes', () => {
     render(
       <Router>
-        <Route name="a" path="/a" page={<FakePage />} />
-        <Route name="b" path="/b" page={<FakePage />} />
+        <Route name="a" path="/a" page={FakePage} />
+        <Route name="b" path="/b" page={FakePage} />
         <Private unauthenticated="a">
-          <Route name="c" path="/c" page={<FakePage />} />
-          <Route name="d" path="/d" page={<FakePage />} />
+          <Route name="c" path="/c" page={FakePage} />
+          <Route name="d" path="/d" page={FakePage} />
         </Private>
       </Router>
     )


### PR DESCRIPTION
This is an alternative attempt at a solution for #2124 

When I was reviewing @callingmedic911's PR for the same issue (#3767) I did some refactoring while getting myself up-to-speed on the code again. And while doing so (and after reading @jtoar's excellent link to the React beta docs) I came up with a (in my eyes) simpler solution to the problem.

This PR has two commits (as of writing this). The first one is just the refactoring I did. The second one is the actual solution to the linked issue.

The TL;DR of it is: Set a hard-coded `key` on the `<Route>`s so that `<PageLoader>` can keep its state while navigating.

Need to update the docs: https://redwoodjs.com/docs/prerender#flash-after-page-load