### PR TITLE
fix yarn engine requirements in CRWA package.json

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -107,6 +107,7 @@ const createProjectTasks = ({ newAppDir, overwrite }) => {
         return new Promise((resolve, reject) => {
           const { engines } = require(path.join(templateDir, 'package.json'))
 
+          // this checks all engine requirements, including Node.js and Yarn
           checkNodeVersion(engines, (_error, result) => {
             if (result.isSatisfied) {
               return resolve()

--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -16,7 +16,7 @@
   },
   "engines": {
     "node": ">=14.17 <=16.x",
-    "yarn": "1.x"
+    "yarn": ">=1.15 <2"
   },
   "prisma": {
     "seed": "yarn rw exec seed"


### PR DESCRIPTION
In the Redwood Tutorial, we've always stated the Yarn prerequisite is >=v1.15:
- https://learn.redwoodjs.com/docs/tutorial/prerequisites

And Redwood projects will not work with Yarn >=v2. 

This PR updates the yarn engine requirements to enforce these conditions.