### PR TITLE
Refactor `createCell`

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -191,7 +191,25 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
      */
     defaultOptions: {
       watchQuery: {
+        /**
+         * The `fetchPolicy` we expect:
+         *
+         * > Apollo Client executes the full query against both the cache and your GraphQL server.
+         * > The query automatically updates if the result of the server-side query modifies cached fields.
+         *
+         * @see {@link https://www.apollographql.com/docs/react/data/queries/#cache-and-network}
+         *
+         * @remarks
+         *
+         * Apollo's default `fetchPolicy` is `'cache-first'`.
+         * @see {@link https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy}
+         */
         fetchPolicy: 'cache-and-network',
+        /**
+         * So that Cells rerender when refetching.
+         *
+         * @see {@link https://www.apollographql.com/docs/react/data/queries/#inspecting-loading-states}
+         */
         notifyOnNetworkStatusChange: true,
       },
     },

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -198,17 +198,10 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
          * > The query automatically updates if the result of the server-side query modifies cached fields.
          *
          * @see {@link https://www.apollographql.com/docs/react/data/queries/#cache-and-network}
-         *
-         * @remarks
-         *
-         * Apollo's default `fetchPolicy` is `'cache-first'`.
-         * @see {@link https://www.apollographql.com/docs/react/data/queries/#setting-a-fetch-policy}
          */
         fetchPolicy: 'cache-and-network',
         /**
-         * So that Cells rerender when refetching.
-         *
-         * @see {@link https://www.apollographql.com/docs/react/data/queries/#inspecting-loading-states}
+         * So that Cells rerender when refetching: {@link https://www.apollographql.com/docs/react/data/queries/#inspecting-loading-states}
          */
         notifyOnNetworkStatusChange: true,
       },

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -9,7 +9,7 @@ import type { A } from 'ts-toolbelt'
 import { useQuery } from './GraphQLHooksProvider'
 
 /**
- * Cell component props which is the combination of Query variables and Success props.
+ * Cell component props which is the combination of query variables and Success props.
  */
 export type CellProps<
   CellSuccess extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
@@ -71,18 +71,6 @@ export interface CreateCellProps<CellProps> {
   /**
    * The GraphQL syntax tree to execute or function to call that returns it.
    * If `QUERY` is a function, it's called with the result of `beforeQuery`.
-   *
-   * @example
-   *
-   * ```js
-   * export const QUERY = gql`
-   *   posts {
-   *     id
-   *     title
-   *     body
-   *   }
-   * `
-   * ```
    */
   QUERY: DocumentNode | ((variables: Record<string, unknown>) => DocumentNode)
   /**
@@ -95,7 +83,7 @@ export interface CreateCellProps<CellProps> {
   afterQuery?: (data: DataObject) => DataObject
   /**
    * How to decide if the result of a query should render the `Empty` component.
-   * The default implementation checks that the first field isn't null or an empty array.
+   * The default implementation checks that the first field isn't `null` or an empty array.
    *
    * @example
    *
@@ -141,8 +129,7 @@ export interface CreateCellProps<CellProps> {
 }
 
 /**
- * The default `isEmpty` implementation.
- * Checks if the first field is `null` or an empty array.
+ * The default `isEmpty` implementation. Checks if the first field is `null` or an empty array.
  *
  * @remarks
  *
@@ -162,7 +149,7 @@ export interface CreateCellProps<CellProps> {
  * `
  * ```
  *
- * If either are empty, they return:
+ * If either are "empty", they return:
  *
  * ```js
  * {
@@ -178,7 +165,7 @@ export interface CreateCellProps<CellProps> {
  * }
  * ```
  *
- * Note that the latter can return null as well depending on the SDL (`posts: [Post!]`).
+ * Note that the latter can return `null` as well depending on the SDL (`posts: [Post!]`).
  *
  * @remarks
  *
@@ -291,6 +278,8 @@ export function createCell<CellProps = any>({
       /**
        * There really shouldn't be an `else` here, but like any piece of software, GraphQL clients have bugs.
        * If there's no `error` and there's no `data` and we're not `loading`, something's wrong. Most likely with the cache.
+       *
+       * @see {@link https://github.com/redwoodjs/redwood/issues/2473#issuecomment-971864604}
        */
       console.warn(
         `If you're using Apollo Client, check for its debug logs here in the console, which may help explain the error.`

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -4,8 +4,7 @@ import type { DocumentNode } from 'graphql'
 import type { A } from 'ts-toolbelt'
 
 /**
- * This is part of how we let users swap out their GraphQL client,
- * while staying compatible with Cells.
+ * This is part of how we let users swap out their GraphQL client while staying compatible with Cells.
  */
 import { useQuery } from './GraphQLHooksProvider'
 
@@ -86,9 +85,9 @@ export interface CreateCellProps<CellProps> {
    */
   QUERY: DocumentNode | ((variables: Record<string, unknown>) => DocumentNode)
   /**
-   * Parse props into query variables.
+   * Parse `props` into query variables.
    *
-   * Most of the time the props passed to a Cell are appropriate variables as is,
+   * Most of the time `props` are appropriate variables as is,
    * but if they're not, here's your chance.
    * */
   beforeQuery?: <TProps>(props: TProps) => { variables: TProps }
@@ -102,7 +101,7 @@ export interface CreateCellProps<CellProps> {
    *
    * @example
    *
-   * In the example below, only users is checked:
+   * In the example below, only `users` is checked:
    *
    * ```js
    * export const QUERY = gql`
@@ -181,8 +180,7 @@ export interface CreateCellProps<CellProps> {
  * }
  * ```
  *
- * Note that the latter can return null as well depending on the SDL.
- * (I.e. `posts: [Post!]`)
+ * Note that the latter can return null as well depending on the SDL (`posts: [Post!]`).
  *
  * @remarks
  *
@@ -217,7 +215,7 @@ const isDataEmpty = (data: DataObject) => {
 }
 
 /**
- * createCell—creates a Cell out of a GraphQL query and components that track to its lifecycle.
+ * Creates a Cell out of a GraphQL query and components that track to its lifecycle.
  */
 export function createCell<CellProps = any>({
   QUERY,

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -250,21 +250,6 @@ export function createCell<CellProps = any>({
     return (props) => <Loading {...(props as any)} />
   }
 
-  /**
-   * A Cell declaratively renders components based on the lifecycle of a GraphQL query.
-   *
-   * If the return's confusing, conider that a Cell's usually used in a Page like so:
-   *
-   * ```js
-   * import PostCell from 'src/components/PostCell'
-   *
-   * const PostsPage = ({ id }) => {
-   *   return <PostCell id={id} />
-   * }
-   * ```
-   *
-   * `PostCell` is actually this component.
-   */
   function NamedCell(props: React.PropsWithChildren<CellProps>) {
     /**
      * Right now, Cells don't render `children`.

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -9,7 +9,7 @@ import type { A } from 'ts-toolbelt'
 import { useQuery } from './GraphQLHooksProvider'
 
 /**
- * Cell component props which is the combination of Query variables and Success props
+ * Cell component props which is the combination of Query variables and Success props.
  */
 export type CellProps<
   CellSuccess extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
@@ -38,9 +38,12 @@ export type CellFailureProps = Partial<
   }
 >
 
-// @MARK not sure about this partial, but we need to do this for tests and storybook
-// `updating` is just `loading` renamed; since Cells default to stale-while-refetch,
-// this prop lets users render something like a spinner to show that a request is in-flight
+/**
+ * @MARK not sure about this partial, but we need to do this for tests and storybook.
+ *
+ * `updating` is just `loading` renamed; since Cells default to stale-while-refetch,
+ * this prop lets users render something like a spinner to show that a request is in-flight.
+ */
 export type CellSuccessProps<TData = any> = Partial<
   Omit<QueryOperationResult<TData>, 'loading' | 'error' | 'data'> & {
     updating: boolean
@@ -49,7 +52,7 @@ export type CellSuccessProps<TData = any> = Partial<
   A.Compute<TData> // pre-computing makes the types more readable on hover
 
 /**
- * A coarse type for the `data` prop returned from `useQuery`.
+ * A coarse type for the `data` prop returned by `useQuery`.
  *
  * ```js
  * {
@@ -83,11 +86,8 @@ export interface CreateCellProps<CellProps> {
    */
   QUERY: DocumentNode | ((variables: Record<string, unknown>) => DocumentNode)
   /**
-   * Parse `props` into query variables.
-   *
-   * Most of the time `props` are appropriate variables as is,
-   * but if they're not, here's your chance.
-   * */
+   * Parse `props` into query variables. Most of the time `props` are appropriate variables as is.
+   */
   beforeQuery?: <TProps>(props: TProps) => { variables: TProps }
   /**
    * Sanitize the data returned from the query.
@@ -289,11 +289,8 @@ export function createCell<CellProps = any>({
       return <Loading {...{ ...queryRest, ...props }} />
     } else {
       /**
-       * There really shouldn't be an `else` here, but like any piece of software,
-       * GraphQL clients have bugs.
-       *
-       * If there's no `error` and there's no `data` and we're not `loading`,
-       * something's wrong. Most likely with the cache.
+       * There really shouldn't be an `else` here, but like any piece of software, GraphQL clients have bugs.
+       * If there's no `error` and there's no `data` and we're not `loading`, something's wrong. Most likely with the cache.
        */
       console.warn(
         `If you're using Apollo Client, check for its debug logs here in the console, which may help explain the error.`

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -3,19 +3,15 @@ import type { ComponentProps, JSXElementConstructor } from 'react'
 import type { DocumentNode } from 'graphql'
 import type { A } from 'ts-toolbelt'
 
+/**
+ * This is part of how we let users swap out their GraphQL client,
+ * while staying compatible with Cells.
+ */
 import { useQuery } from './GraphQLHooksProvider'
 
-interface QueryProps {
-  query: DocumentNode
-  children: (result: QueryOperationResult) => React.ReactElement
-}
-
-const Query = ({ children, query, ...rest }: QueryProps) => {
-  const result = useQuery(query, rest)
-  return result ? children(result) : null
-}
-
-/** Cell component props which is the combination of Query variables and Success props */
+/**
+ * Cell component props which is the combination of Query variables and Success props
+ */
 export type CellProps<
   CellSuccess extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
   GQLResult,
@@ -28,79 +24,184 @@ export type CellProps<
     (GQLVariables extends { [key: string]: never } ? unknown : GQLVariables)
 >
 
-export type DataObject = { [key: string]: unknown }
+type ScrubbedQueryOperationResult = Omit<
+  QueryOperationResult,
+  'loading' | 'error' | 'data'
+> & {
+  updating: boolean
+}
+
+export type CellLoadingProps = Partial<
+  Omit<ScrubbedQueryOperationResult, 'updating'>
+>
 
 export type CellFailureProps = Partial<
-  Omit<QueryOperationResult, 'data' | 'error' | 'loading'> & {
+  ScrubbedQueryOperationResult & {
     error: QueryOperationResult['error'] | Error // for tests and storybook
+    /**
+     * @see {@link https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes}
+     */
     errorCode: string
-    updating: boolean
   }
 >
 
-export type CellLoadingProps = Partial<
-  Omit<QueryOperationResult, 'error' | 'loading' | 'data'>
->
 // @MARK not sure about this partial, but we need to do this for tests and storybook
 // `updating` is just `loading` renamed; since Cells default to stale-while-refetch,
 // this prop lets users render something like a spinner to show that a request is in-flight
-export type CellSuccessProps<TData = any> = Partial<
-  Omit<QueryOperationResult<TData>, 'error' | 'data'> & { updating: boolean }
-> &
-  A.Compute<TData> // pre-computing makes the types more readable on hover
+export type CellSuccessProps<TData = any> =
+  Partial<ScrubbedQueryOperationResult> & A.Compute<TData> // pre-computing makes the types more readable on hover
 
+/**
+ * A coarse type for the `data` prop returned from `useQuery`.
+ *
+ * ```js
+ * {
+ *   data: {
+ *     post: { ... }
+ *   }
+ * }
+ * ```
+ */
+export type DataObject = { [key: string]: unknown }
+
+/**
+ * The main interface.
+ */
 export interface CreateCellProps<CellProps> {
-  beforeQuery?: <TProps>(props: TProps) => { variables: TProps }
+  /**
+   * The GraphQL syntax tree to execute or function to call that returns it.
+   * If `QUERY` is a function, it's called with the result of `beforeQuery`.
+   *
+   * @example
+   *
+   * ```js
+   * export const QUERY = gql`
+   *   posts {
+   *     id
+   *     title
+   *     body
+   *   }
+   * `
+   * ```
+   */
   QUERY: DocumentNode | ((variables: Record<string, unknown>) => DocumentNode)
+  /**
+   * Parse props into query variables.
+   *
+   * Most of the time the props passed to a Cell are appropriate variables as is,
+   * but if they're not, here's your chance.
+   * */
+  beforeQuery?: <TProps>(props: TProps) => { variables: TProps }
+  /**
+   * Sanitize the data returned from the query.
+   */
+  afterQuery?: (data: DataObject) => DataObject
+  /**
+   * How to decide if the result of a query should render the `Empty` component.
+   * The default implementation checks that the first field isn't null or an empty array.
+   *
+   * @example
+   *
+   * In the example below, only users is checked:
+   *
+   * ```js
+   * export const QUERY = gql`
+   *   users {
+   *     name
+   *   }
+   *   posts {
+   *     title
+   *   }
+   * `
+   * ```
+   */
   isEmpty?: (
     response: DataObject,
     options: {
       isDataEmpty: (data: DataObject) => boolean
     }
   ) => boolean
-  afterQuery?: (data: DataObject) => DataObject
+  /**
+   * If the query's in flight and there's no stale data, render this.
+   */
   Loading?: React.FC<CellLoadingProps & Partial<CellProps>>
+  /**
+   * If something went wrong, render this.
+   */
   Failure?: React.FC<CellFailureProps & Partial<CellProps>>
-  Empty?: React.FC<CellLoadingProps & Partial<CellProps>>
+  /**
+   * If no data was returned, render this.
+   */
+  Empty?: React.FC<CellSuccessProps & Partial<CellProps>>
+  /**
+   * If data was returned, render this.
+   */
   Success: React.FC<CellSuccessProps & Partial<CellProps>>
+  /**
+   * What to call the Cell. Defaults to the filename.
+   */
   displayName?: string
 }
 
 /**
- * Is a higher-order-component that executes a GraphQL query and automatically
- * manages the lifecycle of that query. If you export named parameters that match
- * the required params of `createCell` it will be automatically wrapped in this
- * HOC via a babel-plugin.
+ * The default `isEmpty` implementation.
+ * Checks if the first field is `null` or an empty array.
  *
- * @param {string} QUERY - The graphQL syntax tree to execute
- * @param {function=} beforeQuery - Prepare the variables and options for the query
- * @param {function=} afterQuery - Sanitize the data return from graphQL
- * @param {Component=} Loading - Loading, render this component
- * @param {Component=} Empty - Loading, render this component
- * @param {Component=} Failure - Something went wrong, render this component
- * @param {Component} Success - Data has loaded, render this component
+ * @remarks
  *
- * @example
+ * Consider the following queries. The former returns an object, the latter a list:
+ *
  * ```js
- * // IMPLEMENTATION:
- * // `src/ExampleComponent/index.js`. This file is automatically dealt with
- * in webpack.
+ * export const QUERY = gql`
+ *   post {
+ *     title
+ *   }
+ * `
  *
- * import { createCell } from '@redwoodjs/web'
- * import * as cell from './ExampleComponent'
- *
- * export default createCell(cell)
+ * export const QUERY = gql`
+ *   posts {
+ *     title
+ *   }
+ * `
  * ```
  *
- * // USAGE:
- * // Now you have a cell component that will handle the lifecycle methods of
- * // a query
- * import ExampleComponent from 'src/ExampleComponent'
+ * If either are empty, they return:
  *
- * const ThingThatUsesExampleComponent = () => {
- *  return <div><ExampleComponent /></div>
+ * ```js
+ * {
+ *   data: {
+ *     post: null
+ *   }
  * }
+ *
+ * {
+ *   data: {
+ *     posts: []
+ *   }
+ * }
+ * ```
+ *
+ * Note that the latter can return null as well depending on the SDL.
+ * (I.e. `posts: [Post!]`)
+ *
+ * @remarks
+ *
+ * We only check the first field (in the example below, `users`):
+ *
+ * ```js
+ * export const QUERY = gql`
+ *   users {
+ *     name
+ *   }
+ *   posts {
+ *     title
+ *   }
+ * `
+ * ```
  */
+const dataField = (data: DataObject) => {
+  return data[Object.keys(data)[0]]
+}
 
 const isDataNull = (data: DataObject) => {
   return dataField(data) === null
@@ -111,103 +212,115 @@ const isDataEmptyArray = (data: DataObject) => {
   return Array.isArray(field) && field.length === 0
 }
 
-const dataField = (data: DataObject) => {
-  return data[Object.keys(data)[0]]
-}
-
 const isDataEmpty = (data: DataObject) => {
   return isDataNull(data) || isDataEmptyArray(data)
 }
 
+/**
+ * createCell—creates a Cell out of a GraphQL query and components that track to its lifecycle.
+ */
 export function createCell<CellProps = any>({
+  QUERY,
   beforeQuery = (props) => ({
     variables: props,
     /**
      * We're duplicating these props here due to a suspected bug in Apollo Client v3.5.4
      * (it doesn't seem to be respecting `defaultOptions` in `RedwoodApolloProvider`.)
+     *
+     * @see {@link https://github.com/apollographql/apollo-client/issues/9105}
      */
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
   }),
-  QUERY,
-  isEmpty = isDataEmpty,
   afterQuery = (data) => ({ ...data }),
+  isEmpty = isDataEmpty,
   Loading = () => <>Loading...</>,
   Failure,
   Empty,
   Success,
   displayName = 'Cell',
 }: CreateCellProps<CellProps>): React.FC<CellProps> {
+  /**
+   * If we're prerendering, render the Cell's Loading component and exit early.
+   */
   if (global.__REDWOOD__PRERENDERING) {
-    // If its prerendering, render the Cell's Loading component
-    // and exit early. The apolloclient loading props aren't available here, so 'any'
+    /**
+     * Apollo Client's props aren't available here, so 'any'.
+     */
     return (props) => <Loading {...(props as any)} />
   }
 
-  const NamedCell = (props: React.PropsWithChildren<CellProps>) => {
-    // destructuring to not pass children to beforeQuery
-    const { children: _children, ...variables } = props
+  /**
+   * A Cell declaratively renders components based on the lifecycle of a GraphQL query.
+   *
+   * If the return's confusing, conider that a Cell's usually used in a Page like so:
+   *
+   * ```js
+   * import PostCell from 'src/components/PostCell'
+   *
+   * const PostsPage = ({ id }) => {
+   *   return <PostCell id={id} />
+   * }
+   * ```
+   *
+   * `PostCell` is actually this component.
+   */
+  function NamedCell(props: React.PropsWithChildren<CellProps>) {
+    /**
+     * Right now, Cells don't render `children`.
+     */
+    const { children: _, ...variables } = props
 
-    return (
-      <Query
-        query={
-          typeof QUERY === 'function' ? QUERY(beforeQuery(variables)) : QUERY
-        }
-        {...beforeQuery(variables)}
-      >
-        {({ error, loading, data, ...queryRest }) => {
-          if (error) {
-            if (Failure) {
-              return (
-                <Failure
-                  error={error}
-                  /**
-                   * error code
-                   * @optional
-                   * @type {string}
-                   * @see https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes
-                   * The error code came from `error.graphQLErrors[0].extensions.code`
-                   */
-                  errorCode={
-                    error.graphQLErrors?.[0]?.extensions?.['code'] as string
-                  }
-                  {...{ updating: loading, ...queryRest, ...props }}
-                />
-              )
-            } else {
-              throw error
-            }
-          } else if (data) {
-            if (
-              typeof Empty !== 'undefined' &&
-              isEmpty(data, { isDataEmpty })
-            ) {
-              return (
-                <Empty
-                  {...{ ...data, updating: loading, ...queryRest, ...props }}
-                />
-              )
-            } else {
-              return (
-                <Success
-                  {...afterQuery(data)}
-                  {...{ updating: loading, ...queryRest, ...props }}
-                />
-              )
-            }
-          } else if (loading) {
-            return <Loading {...queryRest} {...props} />
-          } else {
-            console.warn(
-              `If you're using Apollo Client, check for its debug logs here in the console, which may help explain the error.`
-            )
-            throw new Error(
-              'Cannot render Cell: reached an unexpected state where the query succeeded but `data` is `null`. If this happened in Storybook, your query could be missing fields; otherwise this is most likely a GraphQL caching bug. Note that adding an `id` field to all the fields on your query may fix the issue.'
-            )
-          }
-        }}
-      </Query>
+    const options = beforeQuery(variables)
+
+    const { error, loading, data, ...queryRest } = useQuery(
+      typeof QUERY === 'function' ? QUERY(options) : QUERY,
+      options
     )
+
+    const commonProps = {
+      updating: loading,
+      ...queryRest,
+      ...props,
+    }
+
+    if (error) {
+      if (Failure) {
+        return (
+          <Failure
+            error={error}
+            errorCode={error.graphQLErrors?.[0]?.extensions?.['code'] as string}
+            {...commonProps}
+          />
+        )
+      } else {
+        throw error
+      }
+    } else if (data) {
+      const afterQueryData = afterQuery(data)
+
+      if (isEmpty(data, { isDataEmpty }) && Empty) {
+        return <Empty {...{ ...afterQueryData, ...commonProps }} />
+      } else {
+        return <Success {...{ ...afterQueryData, ...commonProps }} />
+      }
+    } else if (loading) {
+      return <Loading {...{ ...queryRest, ...props }} />
+    } else {
+      /**
+       * There really shouldn't be an `else` here, but like any piece of software,
+       * GraphQL clients have bugs.
+       *
+       * If there's no `error` and there's no `data` and we're not `loading`,
+       * something's wrong. Most likely with the cache.
+       */
+      console.warn(
+        `If you're using Apollo Client, check for its debug logs here in the console, which may help explain the error.`
+      )
+      throw new Error(
+        'Cannot render Cell: reached an unexpected state where the query succeeded but `data` is `null`. If this happened in Storybook, your query could be missing fields; otherwise this is most likely a GraphQL caching bug. Note that adding an `id` field to all the fields on your query may fix the issue.'
+      )
+    }
   }
 
   NamedCell.displayName = displayName

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -23,32 +23,30 @@ export type CellProps<
     (GQLVariables extends { [key: string]: never } ? unknown : GQLVariables)
 >
 
-type ScrubbedQueryOperationResult = Omit<
-  QueryOperationResult,
-  'loading' | 'error' | 'data'
-> & {
-  updating: boolean
-}
-
 export type CellLoadingProps = Partial<
-  Omit<ScrubbedQueryOperationResult, 'updating'>
+  Omit<QueryOperationResult, 'loading' | 'error' | 'data'>
 >
 
 export type CellFailureProps = Partial<
-  ScrubbedQueryOperationResult & {
+  Omit<QueryOperationResult, 'loading' | 'error' | 'data'> & {
     error: QueryOperationResult['error'] | Error // for tests and storybook
     /**
      * @see {@link https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes}
      */
     errorCode: string
+    updating: boolean
   }
 >
 
 // @MARK not sure about this partial, but we need to do this for tests and storybook
 // `updating` is just `loading` renamed; since Cells default to stale-while-refetch,
 // this prop lets users render something like a spinner to show that a request is in-flight
-export type CellSuccessProps<TData = any> =
-  Partial<ScrubbedQueryOperationResult> & A.Compute<TData> // pre-computing makes the types more readable on hover
+export type CellSuccessProps<TData = any> = Partial<
+  Omit<QueryOperationResult<TData>, 'loading' | 'error' | 'data'> & {
+    updating: boolean
+  }
+> &
+  A.Compute<TData> // pre-computing makes the types more readable on hover
 
 /**
  * A coarse type for the `data` prop returned from `useQuery`.


### PR DESCRIPTION
While the diff of this PR may be intimidating, this PR introduces no new features and instead just cleans up the `createCell` file, commenting as much as I could (let me know if that gets annoying but I feel like every decision should be explained) and getting rid of a few things that I think were there only for historical reasons (i.e. before react hooks).

The only new thing this PR intentionally introduces is more a concise component-listing in the dev tools. Notice that there's no intermediate `Query` component:

**Before**

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/32992335/143183710-4a53ddcb-1ca4-490a-980d-d843b906f555.png">

**After**

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/32992335/143183493-4f59b2c6-2ecf-45ec-83e6-0083ca57c53a.png">
