### PR TITLE
Implements a wrapper for serverless functions to support requireAuth

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth.ts.template
@@ -29,20 +29,20 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
  */
 export const getCurrentUser = async (
   decoded,
-  { _token, _type },
-  { _event, _context }
+  { token, type },
+  { event, context }
 ): Promise<RedwoodUser> => {
   if (!decoded) {
     return null
-
-    const { roles } = parseJWT({ decoded })
-
-    if (roles) {
-      return { ...decoded, roles }
-    }
-
-    return { ...decoded }
   }
+
+  const { roles } = parseJWT({ decoded })
+
+  if (roles) {
+    return { ...decoded, roles }
+  }
+
+  return { ...decoded }
 }
 
 /**

--- a/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
@@ -251,7 +251,7 @@ describe.only('useRequireAuth', () => {
     expect(response.statusCode).toEqual(401)
   })
 
-  it('is 401 Unauthenticated status if decoding JWT succeeds for netlify', async () => {
+  it('returns 200 if decoding JWT succeeds for netlify', async () => {
     const { useRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({

--- a/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
@@ -1,0 +1,352 @@
+import type { APIGatewayEvent, Context } from 'aws-lambda'
+
+import { parseJWT } from '@redwoodjs/api'
+
+import { AuthenticationError } from '../../errors'
+
+type RedwoodUser = Record<string, unknown> & { roles?: string[] }
+
+export const mockedAuthenticationEvent = ({
+  headers = {},
+}): APIGatewayEvent => {
+  return {
+    body: 'MOCKED_BODY',
+    headers,
+    multiValueHeaders: {},
+    httpMethod: 'POST',
+    isBase64Encoded: false,
+    path: '/MOCK_PATH',
+    pathParameters: null,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {
+      accountId: 'MOCKED_ACCOUNT',
+      apiId: 'MOCKED_API_ID',
+      authorizer: { name: 'MOCKED_AUTHORIZER' },
+      protocol: 'HTTP',
+      identity: {
+        accessKey: null,
+        accountId: null,
+        apiKey: null,
+        apiKeyId: null,
+        caller: null,
+        clientCert: null,
+        cognitoAuthenticationProvider: null,
+        cognitoAuthenticationType: null,
+        cognitoIdentityId: null,
+        cognitoIdentityPoolId: null,
+        principalOrgId: null,
+        sourceIp: '123.123.123.123',
+        user: null,
+        userAgent: null,
+        userArn: null,
+      },
+      httpMethod: 'POST',
+      path: '/MOCK_PATH',
+      stage: 'MOCK_STAGE',
+      requestId: 'MOCKED_REQUEST_ID',
+      requestTimeEpoch: 1,
+      resourceId: 'MOCKED_RESOURCE_ID',
+      resourcePath: 'MOCKED_RESOURCE_PATH',
+    },
+    resource: 'MOCKED_RESOURCE',
+  }
+}
+
+const handler = async (
+  _event: APIGatewayEvent,
+  _context: Context
+): Promise<any> => {
+  // @MARK
+  // Don't use globalContext until beforeAll runs
+  const globalContext = require('../../globalContext').context
+  const currentUser = globalContext.currentUser
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(currentUser),
+  }
+}
+
+const handlerWithError = async (
+  _event: APIGatewayEvent,
+  _context: Context
+): Promise<any> => {
+  // @MARK
+  // Don't use globalContext until beforeAll runs
+  const globalContext = require('../../globalContext').context
+  const currentUser = globalContext.currentUser
+
+  try {
+    throw new AuthenticationError('An error occurred in the handler')
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(currentUser),
+    }
+  } catch (error) {
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ error: error.message }),
+    }
+  }
+}
+
+const getCurrentUser = async (decoded, { token }): Promise<RedwoodUser> => {
+  if (!decoded && token) {
+    return { token }
+  }
+
+  const { roles } = parseJWT({ decoded }) // ?
+
+  if (roles) {
+    return { ...decoded, roles }
+  }
+
+  return { ...decoded }
+}
+
+const getCurrentUserWithError = async (
+  _decoded,
+  { _token }
+): Promise<RedwoodUser> => {
+  throw Error('Something went wrong getting the user info')
+}
+
+describe.only('useRequireAuth', () => {
+  beforeAll(() => {
+    process.env.DISABLE_CONTEXT_ISOLATION = '1'
+  })
+
+  afterAll(() => {
+    process.env.DISABLE_CONTEXT_ISOLATION = '0'
+  })
+
+  it('Updates context with output of current user', async () => {
+    // @MARK
+    // Because we use context inside useRequireAuth, we only want to import this function
+    // once we disable context isolation for our test
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    const headers = {
+      'auth-provider': 'custom',
+      authorization: 'Bearer myToken',
+    }
+
+    const output = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers }),
+      {}
+    )
+
+    const resBody = JSON.parse(output.body)
+    expect(resBody.token).toEqual('myToken')
+  })
+
+  it('Updates context with output of current user with roles', async () => {
+    // @MARK
+    // Because we use context inside useRequireAuth, we only want to import this function
+    // once we disable context isolation for our test
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    // The authorization JWT is valid and has roles in app metadata
+    // {
+    //   "sub": "1234567891",
+    //   "name": "John Editor",
+    //   "iat": 1516239022,
+    //   "app_metadata": {
+    //      "roles": ["editor"]
+    //   }
+    // }
+    const headersWithRoles = {
+      'auth-provider': 'netlify',
+      authorization:
+        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkxIiwibmFtZSI6IkpvaG4gRWRpdG9yIiwiaWF0IjoxNTE2MjM5MDIyLCJhcHBfbWV0YWRhdGEiOnsicm9sZXMiOlsiZWRpdG9yIl19fQ.Fhxe58-7BcjJDoYQAZluJYGwPTPLU0x6K5yA3zXKaX8',
+    }
+
+    const output = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: headersWithRoles }),
+      {}
+    ) // ?
+
+    const resBody = JSON.parse(output.body)
+    expect(resBody.name).toEqual('John Editor')
+    expect(resBody.roles).toContain('editor')
+  })
+  it('is 401 Unauthenticated status if an error occurs when getting current user info', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser: getCurrentUserWithError,
+    })
+
+    const customHeaders = {
+      'auth-provider': 'custom',
+      authorization: 'Bearer myToken',
+    }
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: customHeaders }),
+      {}
+    )
+
+    expect(response.statusCode).toEqual(401)
+  })
+
+  it('is 401 Unauthenticated status if no auth headers present', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    const missingHeaders = null
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: missingHeaders }),
+      {}
+    )
+
+    expect(response.statusCode).toEqual(401)
+  })
+
+  it('is 401 Unauthenticated status if the auth provider is unsupported', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    const unsupportedProviderHeaders = {
+      'auth-provider': 'this-auth-provider-is-unsupported',
+    }
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: unsupportedProviderHeaders }),
+      {}
+    )
+
+    expect(response.statusCode).toEqual(401)
+  })
+
+  it('is 401 Unauthenticated status if decoding JWT succeeds for netlify', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    // Note: The Bearer token JWT contains:
+    // {
+    //   "sub": "1234567890",
+    //   "name": "John Doe",
+    //   "iat": 1516239022
+    // }
+
+    const netlifyJWTHeaders = {
+      'auth-provider': 'netlify',
+      authorization:
+        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+    }
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: netlifyJWTHeaders }),
+      {}
+    )
+
+    const body = JSON.parse(response.body)
+
+    expect(response.statusCode).toEqual(200)
+    expect(body['sub']).toEqual('1234567890')
+    expect(body.name).toEqual('John Doe')
+  })
+
+  it('is 401 Unauthenticated status if decoding JWT fails for netlify', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    const invalidJWTHeaders = {
+      'auth-provider': 'netlify',
+      authorization: 'Bearer this-is-an-invalid-jwt',
+    }
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: invalidJWTHeaders }),
+      {}
+    )
+
+    expect(response.statusCode).toEqual(401)
+  })
+
+  it('is 401 Unauthenticated status if decoding JWT fails for supabase', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handler,
+      getCurrentUser,
+    })
+
+    const invalidJWTHeaders = {
+      'auth-provider': 'supabase',
+      authorization: 'Bearer this-is-an-invalid-jwt',
+    }
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: invalidJWTHeaders }),
+      {}
+    )
+
+    expect(response.statusCode).toEqual(401)
+  })
+
+  it('is 500 Server Error status if handler errors', async () => {
+    const { useRequireAuth } = require('../useRequireAuth')
+
+    const customHeaders = {
+      'auth-provider': 'custom',
+      authorization: 'Bearer myToken',
+    }
+
+    const handlerEnrichedWithAuthentication = useRequireAuth({
+      handlerFn: handlerWithError,
+      getCurrentUser,
+    })
+
+    const response = await handlerEnrichedWithAuthentication(
+      mockedAuthenticationEvent({ headers: customHeaders }),
+      {}
+    )
+
+    const message = JSON.parse(response.body).error
+
+    expect(response.statusCode).toEqual(500)
+    expect(message).toEqual('An error occurred in the handler')
+  })
+})

--- a/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
@@ -107,7 +107,7 @@ const getCurrentUser = async (decoded, { token }): Promise<RedwoodUser> => {
     return { token }
   }
 
-  const { roles } = parseJWT({ decoded }) // ?
+  const { roles } = parseJWT({ decoded })
 
   if (roles) {
     return { ...decoded, roles }
@@ -153,8 +153,8 @@ describe.only('useRequireAuth', () => {
       {}
     )
 
-    const resBody = JSON.parse(output.body)
-    expect(resBody.token).toEqual('myToken')
+    const response = JSON.parse(output.body)
+    expect(response.token).toEqual('myToken')
   })
 
   it('Updates context with output of current user with roles', async () => {
@@ -188,9 +188,9 @@ describe.only('useRequireAuth', () => {
       {}
     ) // ?
 
-    const resBody = JSON.parse(output.body)
-    expect(resBody.name).toEqual('John Editor')
-    expect(resBody.roles).toContain('editor')
+    const response = JSON.parse(output.body)
+    expect(response.name).toEqual('John Editor')
+    expect(response.roles).toContain('editor')
   })
   it('is 401 Unauthenticated status if an error occurs when getting current user info', async () => {
     const { useRequireAuth } = require('../useRequireAuth')
@@ -231,7 +231,7 @@ describe.only('useRequireAuth', () => {
     expect(response.statusCode).toEqual(401)
   })
 
-  it('is 401 Unauthenticated status if the auth provider is unsupported', async () => {
+  it('is 200 status with token if the auth provider is unsupported', async () => {
     const { useRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
@@ -241,6 +241,7 @@ describe.only('useRequireAuth', () => {
 
     const unsupportedProviderHeaders = {
       'auth-provider': 'this-auth-provider-is-unsupported',
+      authorization: 'Basic myToken',
     }
 
     const response = await handlerEnrichedWithAuthentication(
@@ -248,7 +249,10 @@ describe.only('useRequireAuth', () => {
       {}
     )
 
-    expect(response.statusCode).toEqual(401)
+    const body = JSON.parse(response.body)
+
+    expect(response.statusCode).toEqual(200)
+    expect(body.token).toEqual('myToken')
   })
 
   it('returns 200 if decoding JWT succeeds for netlify', async () => {

--- a/packages/graphql-server/src/functions/useRequireAuth.ts
+++ b/packages/graphql-server/src/functions/useRequireAuth.ts
@@ -1,0 +1,74 @@
+import type { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
+
+import { getAuthenticationContext } from '@redwoodjs/api'
+
+import {
+  getAsyncStoreInstance,
+  setContext,
+  context as globalContext,
+} from '../globalContext'
+
+import type { GetCurrentUser } from './types'
+
+export const useRequireAuth = ({
+  handlerFn,
+  getCurrentUser,
+}: {
+  handlerFn: any
+  getCurrentUser: GetCurrentUser
+}) => {
+  return (
+    event: APIGatewayProxyEvent,
+    context: LambdaContext,
+    ...rest: any
+  ): Promise<any> => {
+    const execFn = async ({
+      handlerFn,
+      getCurrentUser,
+    }: {
+      handlerFn: any
+      getCurrentUser: GetCurrentUser
+    }) => {
+      try {
+        let authContext = undefined
+
+        authContext = await getAuthenticationContext({
+          event: handlerFn.event,
+          context: handlerFn.context,
+        })
+
+        if (authContext) {
+          const currentUser = getCurrentUser
+            ? await getCurrentUser(
+                authContext[0],
+                authContext[1],
+                authContext[2]
+              )
+            : null
+
+          globalContext.currentUser = currentUser
+
+          setContext(globalContext)
+        }
+
+        return await handlerFn(event, context, ...rest)
+      } catch (e) {
+        console.error(e)
+
+        throw e
+      }
+    }
+
+    if (getAsyncStoreInstance()) {
+      // This must be used when you're self-hosting RedwoodJS.
+      return getAsyncStoreInstance().run(new Map(), execFn, {
+        handlerFn,
+        getCurrentUser,
+      })
+    } else {
+      // This is OK for AWS (Netlify/Vercel) because each Lambda request
+      // is handled individually.
+      return execFn({ handlerFn, getCurrentUser })
+    }
+  }
+}

--- a/packages/graphql-server/src/functions/useRequireAuth.ts
+++ b/packages/graphql-server/src/functions/useRequireAuth.ts
@@ -30,7 +30,6 @@ export const useRequireAuth = ({
       try {
         let authContext = undefined
 
-        // This is the part where headers are verified
         authContext = await getAuthenticationContext({
           event: event,
           context: context,
@@ -45,7 +44,7 @@ export const useRequireAuth = ({
               )
             : null
 
-          globalContext.currentUser = currentUser //?
+          globalContext.currentUser = currentUser
           setContext(globalContext)
         }
       } catch (e) {

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -5,6 +5,7 @@ export * from './globalContext'
 
 export * from './errors'
 export * from './functions/graphql'
+export * from './functions/useRequireAuth'
 export * from './makeMergedSchema/makeMergedSchema'
 export * from './types'
 


### PR DESCRIPTION
Fix: https://github.com/redwoodjs/redwood/issues/3727

This PR allows developers to have their serverless function support `requireAuth` and it's currentUser and role checking by wrapping the their function handler in a handler that will authenticate the request event and set the global context with the currentUser in the same manner that the GraphQLHandler does.

While we don't necessarily encourage tis behavior, we can support it. Rather, if your function needs auth, then it can simply be a GraphQL request -- or treat your serverless function like a webhook and use a known verifier method.

Note: the wrapper lives in `@redwoodjs/graphql-server` because 1) it mimics the graphQLHandler auth flow and 2) that's when globalContext lives

To support requireAuth in your serverless function:


```ts
import type { APIGatewayEvent, Context } from 'aws-lambda'

import { useRequireAuth } from '@redwoodjs/graphql-server'

import { getCurrentUser } from 'src/lib/auth'
import { logger } from 'src/lib/logger'

const myHandler = async (event: APIGatewayEvent, context: Context) => {
  logger.info('Invoked ${name} function')

  return {
    statusCode: 200,
    headers: {
      'Content-Type': 'application/json',
    },
    body: JSON.stringify({
      data: 'myHandler function',
    }),
  }
}

export const handler = useRequireAuth({
  handlerFn: myHandler,
   getCurrentUser,
})
```

This means that anywhere context is used such as in services or when using hasRole from auth, the global context will have the currentUser set.