### PR TITLE
Allow configuration of preset-react on the web side

### DIFF
--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -120,9 +120,30 @@ export const getWebSideOverrides = (
 }
 
 export const getWebSideBabelPresets = () => {
+  let reactPresetConfig = undefined
+
+  // This is a special case, where @babel/preset-react needs config
+  // And using extends doesn't work
+  if (getWebSideBabelConfigPath()) {
+    const userProjectConfig = require(getWebSideBabelConfigPath() as string)
+
+    userProjectConfig.presets?.forEach(
+      (preset: TransformOptions['presets']) => {
+        // If it isn't a preset with special config ignore it
+        if (!Array.isArray(preset)) {
+          return
+        }
+
+        const [presetName, presetConfig] = preset
+        if (presetName === '@babel/preset-react') {
+          reactPresetConfig = presetConfig
+        }
+      }
+    )
+  }
   return [
-    '@babel/preset-react',
-    '@babel/preset-typescript',
+    ['@babel/preset-react', reactPresetConfig],
+    ['@babel/preset-typescript', undefined, 'rwjs-babel-preset-typescript'],
     [
       '@babel/preset-env',
       {
@@ -139,6 +160,7 @@ export const getWebSideBabelPresets = () => {
           '@babel/plugin-proposal-private-methods',
         ],
       },
+      'rwjs-babel-preset-env',
     ],
   ]
 }


### PR DESCRIPTION
### What?
So turns out there's certain cases where you need to override some of the default babel config for the webside - such as using emotion ui with the `css` prop.

While most plugins/presets play nicely - it seems `@babel/preset-react` is sensitive to the order in which it is configured.

This PR allows users to pass preset-react config, by adding it to their `web/babel.config.js`. 

e.g. To configure emotion
```js
// ./web/babel.config.js 
{
  "presets": [
    [
      "@babel/preset-react",
      { "runtime": "automatic", "importSource": "@emotion/react" } // <--- this is the special config required for emotion
    ]
  ],
  "plugins": ["@emotion/babel-plugin"]
}
```

---
More reading: https://emotion.sh/docs/css-prop#babel-preset

