### PR TITLE
Possible fix for renovate not updating yarn.locks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,9 +14,6 @@
     "terminal-link",
     "@types/node-fetch"
   ],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchUpdateTypes": [
@@ -26,7 +23,7 @@
       "automerge": true
     }
   ],
-  "reviewers": [
+  "assignees": [
     "@jtoar"
   ]
 }

--- a/tasks/framework-tools/lerna.json
+++ b/tasks/framework-tools/lerna.json
@@ -1,6 +1,7 @@
 {
   "version": "0.39.1",
   "npmClient": "yarn",
+  "useWorkspaces": true,
   "packages": [
     "../../packages/*"
   ],

--- a/tasks/framework-tools/package.json
+++ b/tasks/framework-tools/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "workspaces": [
+    "../../packages/*"
+  ],
   "devDependencies": {
     "@babel/cli": "7.16.0",
     "@babel/core": "7.16.0",


### PR DESCRIPTION
Renovate isn't updating `yarn.lock` files in its PRs, and the reason for that seems to be that it can't find yarn:
```
yarn: command not found
```
That line was taken from the logs of one of renovate's "Artifact update problem" comments[^art].

Based on the conversations in this thread[^thr], renovate can't find yarn because we're using lerna without the `"useWorkspaces"`[^useW] option configured. 

This PR configures the `"useWorkspaces"` option.

Since we're on yarn 3, it may be time to circle back to some of the ideas we had around lerna and framework-tools.

[^art]: https://github.com/redwoodjs/redwood/pull/3802#issuecomment-983147643
[^thr]: https://github.com/renovatebot/renovate/discussions/11241#discussioncomment-1191947
[^useW]: https://github.com/lerna/lerna/blob/main/commands/bootstrap/README.md#--use-workspaces.
