### PR TITLE
Windows babel fixes for v0.39.x

### DIFF
--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -94,7 +94,7 @@ export const getWebSideOverrides = (
     // Automatically import files in `./web/src/pages/*` in to
     // the `./web/src/Routes.[ts|jsx]` file.
     {
-      test: /web\/src\/Routes.(js|tsx)$/,
+      test: ['./web/src/Routes.js', './web/src/Routes.tsx'],
       plugins: [
         [
           require('../babelPlugins/babel-plugin-redwood-routes-auto-loader')

--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -17,7 +17,6 @@ export const getWebSideBabelPlugins = () => {
 
   const plugins: TransformOptions['plugins'] = [
     ...getCommonPlugins(),
-
     // === Import path handling
     [
       'babel-plugin-module-resolver',
@@ -28,7 +27,11 @@ export const getWebSideBabelPlugins = () => {
             // the `cwd`: https://github.com/facebook/jest/issues/7359
             process.env.NODE_ENV !== 'test' ? './src' : rwjsPaths.web.src,
         },
+        root: [rwjsPaths.web.base],
+        cwd: 'packagejson',
+        loglevel: 'silent', // to silence the unnecessary warnings
       },
+      'rwjs-module-resolver',
     ],
     [
       require('../babelPlugins/babel-plugin-redwood-src-alias').default,

--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -20,6 +20,17 @@ export const getWebSideBabelPlugins = () => {
 
     // === Import path handling
     [
+      'babel-plugin-module-resolver',
+      {
+        alias: {
+          src:
+            // Jest monorepo and multi project runner is not correctly determining
+            // the `cwd`: https://github.com/facebook/jest/issues/7359
+            process.env.NODE_ENV !== 'test' ? './src' : rwjsPaths.web.src,
+        },
+      },
+    ],
+    [
       require('../babelPlugins/babel-plugin-redwood-src-alias').default,
       {
         srcAbsPath: rwjsPaths.web.src,

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -16,8 +16,6 @@ interface PrerenderParams {
   routerPath: string // e.g. /about, /dashboard/me
 }
 
-const rwWebPaths = getPaths().web
-
 export const runPrerender = async ({
   routerPath,
 }: PrerenderParams): Promise<string | void> => {
@@ -28,20 +26,6 @@ export const runPrerender = async ({
       {
         plugins: [
           ['ignore-html-and-css-imports'], // webpack/postcss handles CSS imports
-          [
-            'babel-plugin-module-resolver',
-            {
-              alias: {
-                src: rwWebPaths.src,
-              },
-              root: [getPaths().web.base],
-              // needed for respecting users' custom aliases in web/.babelrc
-              // See https://github.com/tleunen/babel-plugin-module-resolver/blob/master/DOCS.md#cwd
-              cwd: 'babelrc',
-              loglevel: 'silent', // to silence the unnecessary warnings
-            },
-            'prerender-module-resolver', // add this name, so it doesn't overwrite custom module resolvers in users' web/.babelrc
-          ],
           [mediaImportsPlugin],
         ],
       },


### PR DESCRIPTION
This PR includes 2 fixes:

**1. Routes autoloader plugin**
Fixes #3814
On v0.39.1, the routes autoloader plugin doesn't run because of the test regex, which doesn't work due to the different path syntax on Windows.

I'm switching back to the string form (which I've confirmed works), because I don't want to mess around with regexes.

**2. Module resolver**
Module resolution seems to be broken on windows. See repro here: https://github.com/jtoar/babel-windows-repro

To fix this, I've re-added the `babel-module-resolver` plugin. We totally want to move away from this longer term, but clearly our custom plugins aren't ready to operate without this plugin.