### PR TITLE
fix(babel): Fix jest.mock module resolution

### DIFF
--- a/__fixtures__/example-todo-main/api/src/services/todos/todos.test.js
+++ b/__fixtures__/example-todo-main/api/src/services/todos/todos.test.js
@@ -1,0 +1,11 @@
+import dog from 'src/lib/dog'
+
+jest.mock('src/lib/dog', () => {
+  return {
+    mockedModule: true
+  }
+})
+
+test('should always pass', () => {
+  expect(dog.mockedModule).toBe(true)
+})

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -1,14 +1,20 @@
 import fs from 'fs'
 import path from 'path'
 
+import * as babel from '@babel/core'
+
 import {
   prebuildApiFiles,
   cleanApiBuild,
   generateProxyFilesForNestedFunction,
 } from '../build/api'
-import { getApiSideBabelConfigPath } from '../build/babel/api'
+import {
+  getApiSideBabelConfigPath,
+  getApiSideBabelPlugins,
+  getApiSideDefaultBabelConfig,
+} from '../build/babel/api'
 import { findApiFiles } from '../files'
-import { ensurePosixPath } from '../paths'
+import { ensurePosixPath, getPaths } from '../paths'
 
 const FIXTURE_PATH = path.resolve(
   __dirname,
@@ -186,4 +192,26 @@ test('Pretranspile uses corejs3 aliasing', () => {
   expect(code).toContain(
     `import _getIterator from "@babel/runtime-corejs3/core-js/get-iterator"`
   )
+})
+
+test('jest mock statements also handle', () => {
+  const pathToTest = path.join(getPaths().api.services, 'todos/todos.test.js')
+
+  const code = fs.readFileSync(pathToTest, 'utf-8')
+
+  const defaultOptions = getApiSideDefaultBabelConfig()
+
+  // Step 1: prebuild service/todos.test.js
+  const outputForJest = babel.transform(code, {
+    ...defaultOptions,
+    filename: pathToTest,
+    cwd: getPaths().api.base,
+    // We override the plugins, to match packages/testing/config/jest/api/index.js
+    plugins: getApiSideBabelPlugins({ forJest: true }),
+  }).code
+
+  // Step 2: check that output has correct import statement path
+  expect(outputForJest).toContain('import dog from "../../lib/dog"')
+  // Step 3: check that output has correct jest.mock path
+  expect(outputForJest).toContain('jest.mock("../../lib/dog"')
 })

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -7,7 +7,7 @@ import { moveSync, removeSync } from 'fs-extra'
 import { findApiFiles } from '../files'
 import { ensurePosixPath, getPaths } from '../paths'
 
-import { getApiSideBabelPlugins, prebuildFile } from './babel/api'
+import { getApiSideBabelPlugins, prebuildApiFile } from './babel/api'
 
 export const buildApi = () => {
   // TODO: Be smarter about caching and invalidating files,
@@ -113,7 +113,7 @@ export const prebuildApiFiles = (srcFiles: string[]) => {
       .join(rwjsPaths.generated.prebuild, relativePathFromSrc)
       .replace(/\.(ts)$/, '.js')
 
-    const result = prebuildFile(srcPath, dstPath, plugins)
+    const result = prebuildApiFile(srcPath, dstPath, plugins)
     if (!result?.code) {
       // TODO: Figure out a better way to return these programatically.
       console.warn('Error:', srcPath, 'could not prebuilt.')

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -50,7 +50,7 @@ export const getApiSideBabelPresets = (
   ].filter(Boolean) as TransformOptions['presets']
 }
 
-export const getApiSideBabelPlugins = () => {
+export const getApiSideBabelPlugins = ({ forJest } = { forJest: false }) => {
   const rwjsPaths = getPaths()
   // Plugin shape: [ ["Target", "Options", "name"] ],
   // a custom "name" is supplied so that user's do not accidently overwrite
@@ -100,6 +100,19 @@ export const getApiSideBabelPlugins = () => {
         version: RUNTIME_CORE_JS_VERSION,
       },
     ],
+    // // still needed for jest.mock
+    forJest && [
+      'babel-plugin-module-resolver',
+      {
+        alias: {
+          src: './src',
+        },
+        root: [rwjsPaths.api.base],
+        cwd: 'packagejson',
+        loglevel: 'silent', // to silence the unnecessary warnings
+      },
+      'rwjs-api-module-resolver',
+    ],
     [
       require('../babelPlugins/babel-plugin-redwood-src-alias').default,
       {
@@ -138,7 +151,7 @@ export const getApiSideBabelPlugins = () => {
       undefined,
       'rwjs-babel-glob-import-dir',
     ],
-  ].filter(Boolean)
+  ].filter(Boolean) as babel.PluginItem[]
 
   return plugins
 }
@@ -181,7 +194,7 @@ export const registerApiSideBabelHook = ({
   })
 }
 
-export const prebuildFile = (
+export const prebuildApiFile = (
   srcPath: string,
   // we need to know dstPath as well
   // so we can generate an inline, relative sourcemap

--- a/packages/testing/config/jest/api/index.js
+++ b/packages/testing/config/jest/api/index.js
@@ -4,6 +4,7 @@ const {
   getPaths,
   getApiSideDefaultBabelConfig,
   getApiSideBabelPresets,
+  getApiSideBabelPlugins,
 } = require('@redwoodjs/internal')
 
 const rwjsPaths = getPaths()
@@ -30,6 +31,7 @@ module.exports = {
       'babel-jest',
       {
         ...getApiSideDefaultBabelConfig(),
+        plugins: getApiSideBabelPlugins({ forJest: true }),
         presets: getApiSideBabelPresets({
           presetEnv: true, // jest needs code transpiled
         }),


### PR DESCRIPTION
Fixes the situation where you've used an alias in a jest mock

e.g.
```js
jest.mock('src/lib/s3', () => {
  return {
    getSignedUrl: jest.fn(() => 'https://mockedBucket.tape.sh?sign=xxx'),
  }
})
```

This is now transformed to the relative path correctly.

```js
jest.mock('../../src/lib/s3', () => {
  return {
    getSignedUrl: jest.fn(() => 'https://mockedBucket.tape.sh?sign=xxx'),
  }
})
```