### PR TITLE
Fix rwfw project:sync loop

### DIFF
--- a/tasks/framework-tools/src/lib/framework.mjs
+++ b/tasks/framework-tools/src/lib/framework.mjs
@@ -147,7 +147,7 @@ export function cleanPackages(packages = frameworkPkgJsonFiles()) {
   const packageNames = packages.map(packageJsonName)
 
   execa.sync(
-    'yarn build:clean',
+    'yarn lerna run build:clean',
     ['--parallel', `--scope={${packageNames.join(',') + ','}}`],
     {
       shell: true,
@@ -165,7 +165,7 @@ export function buildPackages(packages = frameworkPkgJsonFiles()) {
 
   // Build JavaScript.
   execa.sync(
-    'yarn build:js',
+    'yarn lerna run build:js',
     ['--parallel', `--scope={${packageNames.join(',') + ','}}`],
     {
       shell: true,


### PR DESCRIPTION
Pretty sure this is the fix for `project:sync` building in an infinite loop. I was overthinking the change at the time / misunderstanding which script `lerna run` targets. To be sure, I'll work on a feature with this branch, with `project:sync` on for a while.