### PR TITLE
Make onClick prop of NavLink optional.

### DIFF
--- a/packages/router/src/links.tsx
+++ b/packages/router/src/links.tsx
@@ -96,7 +96,7 @@ interface NavLinkProps {
   to: string
   activeClassName: string
   activeMatchParams?: FlattenSearchParams
-  onClick: React.MouseEventHandler<HTMLAnchorElement>
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
 
 const NavLink = forwardRef<


### PR DESCRIPTION
The onClick prop was recently added to the NavLinkProps.  I believe the prop should be optional.

@Tobbe , can I tag you on this?  Feel free to reassign.