### PR TITLE
Properly merge typeDefs in makeMergedSchema

### DIFF
--- a/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
@@ -212,7 +212,7 @@ export const makeMergedSchema = ({
   const { typeDefs: schemaOptionsTypeDefs = [], ...otherSchemaOptions } =
     schemaOptions
   const schema = makeExecutableSchema({
-    typeDefs: [...typeDefs, ...schemaOptionsTypeDefs],
+    typeDefs: [typeDefs, schemaOptionsTypeDefs],
     ...otherSchemaOptions,
   })
 

--- a/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
@@ -186,7 +186,7 @@ const mergeTypes = (
 export const makeMergedSchema = ({
   sdls,
   services,
-  schemaOptions,
+  schemaOptions = {},
   directives,
 }: {
   sdls: SdlGlobImports
@@ -209,9 +209,11 @@ export const makeMergedSchema = ({
     { all: true }
   )
 
+  const { typeDefs: schemaOptionsTypeDefs = [], ...otherSchemaOptions } =
+    schemaOptions
   const schema = makeExecutableSchema({
-    typeDefs,
-    ...schemaOptions,
+    typeDefs: [...typeDefs, ...schemaOptionsTypeDefs],
+    ...otherSchemaOptions,
   })
 
   const resolvers: IResolvers = mergeResolversWithServices({


### PR DESCRIPTION
When I tried to add scalars from [`graphql-scalars`](https://www.graphql-scalars.dev/) I found that `typeDefs` passed to `schemaOptions` were overwriting the default ones.

For example:

```javascript
import { createGraphQLHandler } from "@redwoodjs/graphql-server";
import { CurrencyDefinition, CurrencyResolver } from "graphql-scalars";

export const handler = createGraphQLHandler({
  getCurrentUser,
  loggerConfig: { logger, options: {} },
  directives,
  sdls,
  services,
  onException: () => {
    db.$disconnect();
  },
  schemaOptions: {
    typeDefs: [CurrencyDefinition],  // <-- ISSUE
    resolvers: { Currency: CurrencyResolver },
  },
});
```

This PR should hopefully fix that behaviour.