### PR TITLE
Uses current RW version for setup commands auth and deploy

### DIFF
--- a/packages/cli/src/commands/setup.js
+++ b/packages/cli/src/commands/setup.js
@@ -2,10 +2,13 @@ export const command = 'setup <commmand>'
 export const description = 'Initialize project config and install packages'
 import terminalLink from 'terminal-link'
 
+import detectRwVersion from '../middleware/detectProjectRwVersion'
+
 export const builder = (yargs) =>
   yargs
     .commandDir('./setup', { recurse: true, exclude: /\/ui\/.*\.js$/ })
     .demandCommand()
+    .middleware(detectRwVersion)
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -297,7 +297,7 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ provider, force }) => {
+export const handler = async ({ provider, force, rwVersion }) => {
   const providerData = await import(`./providers/${provider}`)
 
   // check if api/src/lib/auth.js already exists and if so, ask the user to overwrite
@@ -361,7 +361,7 @@ export const handler = async ({ provider, force }) => {
             'web',
             'add',
             ...providerData.webPackages,
-            '@redwoodjs/auth',
+            `@redwoodjs/auth@${rwVersion}`,
           ])
         },
       },

--- a/packages/cli/src/commands/setup/deploy/deploy.js
+++ b/packages/cli/src/commands/setup/deploy/deploy.js
@@ -71,7 +71,7 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ provider, force, database }) => {
+export const handler = async ({ provider, force, database, rwVersion }) => {
   const providerData = await import(`./providers/${provider}`)
   const apiDependencies = JSON.parse(
     fs.readFileSync('api/package.json').toString()
@@ -80,7 +80,12 @@ export const handler = async ({ provider, force, database }) => {
   const missingApiPackages = providerData?.apiPackages?.reduce(
     (missingPackages, apiPackage) => {
       if (!(apiPackage in apiDependencies)) {
-        missingPackages.push(apiPackage)
+        if (apiPackage.includes('@redwoodjs')) {
+          // Push the same version of the redwood package
+          missingPackages.push(`${apiPackage}@${rwVersion}`)
+        } else {
+          missingPackages.push(apiPackage)
+        }
       }
       return missingPackages
     },

--- a/packages/cli/src/middleware/detectProjectRwVersion.js
+++ b/packages/cli/src/middleware/detectProjectRwVersion.js
@@ -1,0 +1,12 @@
+import { getInstalledRedwoodVersion } from '../lib'
+
+const detectRwVersion = (argv) => {
+  if (!argv.rwVersion) {
+    return {
+      rwVersion: getInstalledRedwoodVersion(),
+    }
+  }
+  return {}
+}
+
+export default detectRwVersion


### PR DESCRIPTION
Fixes #3876
This adds a yargs middleware to pass the current redwood version to all setup commands.

I only found these two sub commainds affected:
- `rw setup auth xxxx`
- `rw setup deploy yyy`

Note that we would still not see this have any affect when using `rwfw`, becuase the current version of redwood is detected from the cli package.json.