### PR TITLE
install latest tailwindcss during setup ui

### DIFF
--- a/packages/cli/src/commands/setup/ui/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/tailwindcss.js
@@ -55,12 +55,7 @@ const tailwindImportsAndNotes = [
 export const handler = async ({ force, install }) => {
   const rwPaths = getPaths()
 
-  const packages = [
-    'postcss',
-    'postcss-loader',
-    'tailwindcss',
-    'autoprefixer',
-  ]
+  const packages = ['postcss', 'postcss-loader', 'tailwindcss', 'autoprefixer']
 
   const tasks = new Listr([
     {

--- a/packages/cli/src/commands/setup/ui/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/tailwindcss.js
@@ -58,7 +58,7 @@ export const handler = async ({ force, install }) => {
   const packages = [
     'postcss',
     'postcss-loader',
-    'tailwindcss@next',
+    'tailwindcss',
     'autoprefixer',
   ]
 


### PR DESCRIPTION
Tailwind v3 has been published. This updates the setup ui tailwindcss command to use `latest` (instead of `next`)

https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.0.0