### PR TITLE
Simplify template MetaTags description

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -14,12 +14,8 @@ import { MetaTags } from '@redwoodjs/web'
 const FooBarPage = () => {
   return (
     <>
-      <MetaTags
-        title="FooBar"
-        // description="FooBar description"
-        /* you should un-comment description and add a unique description, 155 characters or less
-        You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title="FooBar" description="FooBar page" />
+
       <h1>FooBarPage</h1>
       <p>
         Find me in <code>./web/src/pages/FooBarPage/FooBarPage.js</code>

--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
@@ -7,12 +7,7 @@ import { MetaTags } from '@redwoodjs/web'
 const HomePage = () => {
   return (
     <>
-      <MetaTags
-        title=\\"Home\\"
-        // description=\\"Home description\\"
-        /* you should un-comment description and add a unique description, 155 characters or less
-      You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title=\\"Home\\" description=\\"Home page\\" />
 
       <h1>HomePage</h1>
       <p>
@@ -37,12 +32,7 @@ import { MetaTags } from '@redwoodjs/web'
 const ContactUsPage = () => {
   return (
     <>
-      <MetaTags
-        title=\\"ContactUs\\"
-        // description=\\"ContactUs description\\"
-        /* you should un-comment description and add a unique description, 155 characters or less
-      You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title=\\"ContactUs\\" description=\\"ContactUs page\\" />
 
       <h1>ContactUsPage</h1>
       <p>
@@ -67,12 +57,7 @@ import { MetaTags } from '@redwoodjs/web'
 const CatsPage = () => {
   return (
     <>
-      <MetaTags
-        title=\\"Cats\\"
-        // description=\\"Cats description\\"
-        /* you should un-comment description and add a unique description, 155 characters or less
-      You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title=\\"Cats\\" description=\\"Cats page\\" />
 
       <h1>CatsPage</h1>
       <p>
@@ -97,12 +82,7 @@ import { MetaTags } from '@redwoodjs/web'
 const PostPage = ({ id }) => {
   return (
     <>
-      <MetaTags
-        title=\\"Post\\"
-        // description=\\"Post description\\"
-        /* you should un-comment description and add a unique description, 155 characters or less
-      You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title=\\"Post\\" description=\\"Post page\\" />
 
       <h1>PostPage</h1>
       <p>
@@ -228,12 +208,7 @@ import { MetaTags } from '@redwoodjs/web'
 const HomePage = () => {
   return (
     <>
-      <MetaTags
-        title=\\"Home\\"
-        // description=\\"Home description\\"
-        /* you should un-comment description and add a unique description, 155 characters or less
-      You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title=\\"Home\\" description=\\"Home page\\" />
 
       <h1>HomePage</h1>
       <p>
@@ -312,12 +287,7 @@ import { MetaTags } from '@redwoodjs/web'
 const PostPage = ({ id }) => {
   return (
     <>
-      <MetaTags
-        title=\\"Post\\"
-        // description=\\"Post description\\"
-        /* you should un-comment description and add a unique description, 155 characters or less
-      You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title=\\"Post\\" description=\\"Post page\\" />
 
       <h1>PostPage</h1>
       <p>

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -221,8 +221,20 @@ export const handler = async ({
         },
       },
       {
-        title: `Generating types ...`,
+        title: `Generating types...`,
         task: () => generateTypes,
+      },
+      {
+        title: 'One more thing...',
+        task: (ctx, task) => {
+          task.title =
+            `One more thing...\n\n` +
+            `   ${c.warning('Page created! A note about <MetaTags>:')}\n\n` +
+            `   At the top of your newly created page is a <MetaTags> component,\n` +
+            `   which contains the title and description for your page, essential\n` +
+            `   to good SEO. Check out this page for best practices: \n\n` +
+            `   https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets\n`
+        },
       },
     ].filter(Boolean),
     { collapse: false }

--- a/packages/cli/src/commands/generate/page/templates/page.tsx.template
+++ b/packages/cli/src/commands/generate/page/templates/page.tsx.template
@@ -8,12 +8,8 @@ type ${pascalName}PageProps = {
 const ${pascalName}Page = (<%- paramName === '' ? '' : `${propParam}: ${pascalName}PageProps` %>) => {
   return (
     <>
-      <MetaTags
-        title="${pascalName}"
-        // description="${pascalName} description"
-        /* you should un-comment description and add a unique description, 155 characters or less
-        You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
-      />
+      <MetaTags title="${pascalName}" description="${pascalName} page" />
+
       <h1>${pascalName}Page</h1>
       <p>
         Find me in <code>${outputPath}</code>


### PR DESCRIPTION
As I'm updating the tutorial for v1.0 I didn't love the "feel" of the default `<MetaTags>` component in the page template: the comment in there describing how to use it is really long and messes with the nice clean flow of the blank page:

```jsx
<MetaTags
  title="About"
  // description="About description"
  /* you should un-comment description and add a unique description, 155 characters or less
You can look at this documentation for best practices : https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets */
/>
```

(The weird indenting of the second line is actually present in the generated code.)

This PR removes the comment and actually enables the description which just reads "PageName page":

```jsx
<MetaTags title="About" description="About page" />
```

I've moved the comment content to the output of the page generator CLI script, as the epilogue after the generate is complete:

```bash
One more thing...

Page created! A note about <MetaTags>:
   
At the top of your newly created page is a <MetaTags> component,
which contains the title and description for your page, essential
to good SEO. Check out this page for best practices: 
  
https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets
```

(The `Page created! A note about <MetaTags>:` line is bold and orange.)

Having to clean up the comment in *every* page they generate in the future is an annoyance once they realize what it's there for. This way they get the info the first time they generate a page (and will be reminded of it for every page generated thereafter), but doesn't add extra text in the page to be removed each time.