### PR TITLE
adds `request.id` passthrough from Fastify-request to AWS-event

### DIFF
--- a/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
+++ b/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
@@ -30,6 +30,7 @@ const lambdaEventForFastifyRequest = (
     path: request.urlData('path'),
     queryStringParameters: qs.parse(request.url.split(/\?(.+)/)[1]),
     requestContext: {
+      requestId: request.id,
       identity: {
         sourceIp: request.ip,
       },


### PR DESCRIPTION
Fastify generates a unique ID for each request for the (presumed) purpose of logging.

This PR passes that id from the Fastify `request` to the generated AWS `event`, and ultimately to any function-handlers. My intended purpose is to re-use this ID when logging from the application.

This ID gets added at `event.requestContext.requestId`, which I got from types in `@types/aws-lambda`.

---

@dthyresson I saw [your issue here](https://github.com/redwoodjs/redwood/pull/3877) related to the logger and using a custom ID generator. Just wanted to make sure this PR wouldn't step on your toes/lines up with that. Or if you want to add this to your [PR](https://github.com/redwoodjs/redwood/pull/3877), I can close this. Either way.