### PR TITLE
[Renovate] Run dedupe after install

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,7 @@
       "automerge": true
     }
   ],
+  "postUpdateOptions": ["yarnDedupeHighest"],
   "assignees": [
     "@jtoar"
   ]


### PR DESCRIPTION
Right now renovate's failing on dedupe checks so this PR instructs it to run dedupe after install: https://docs.renovatebot.com/configuration-options/#postupdateoptions.

The "highest" strategy is appropriate for the version of yarn we're using:
```
dom@evaM1 ~/p/r/redwood (renovate/envelop-core-1.x)> yarn dedupe --check
➤ YN0000: ┌ Deduplication step
➤ YN0000: │ @envelop/core@npm:^1.6.1 can be deduped from @envelop/core@npm:1.6.2 to @envelop/core@npm:1.6.5
➤ YN0000: │ One package can be deduped using the highest strategy
➤ YN0000: └ Completed
```