### PR TITLE
fix(types): Add aws-lambda to rwjs/testing so its available as dev ti…

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -24,6 +24,7 @@
     "@testing-library/jest-dom": "5.16.1",
     "@testing-library/react": "12.1.2",
     "@testing-library/user-event": "13.5.0",
+    "@types/aws-lambda": "8.10.88",
     "@types/babel-core": "6.25.7",
     "@types/jest": "27.0.3",
     "@types/node": "16.11.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5760,6 +5760,7 @@ __metadata:
     "@testing-library/jest-dom": 5.16.1
     "@testing-library/react": 12.1.2
     "@testing-library/user-event": 13.5.0
+    "@types/aws-lambda": 8.10.88
     "@types/babel-core": 6.25.7
     "@types/jest": 27.0.3
     "@types/node": 16.11.14


### PR DESCRIPTION
Closes #3693

### Why `@rwjs/testing`?
`rwjs/testing` is meant to be a "dev time" dependency. i.e. It contains a bunch of things you only need on your local machine. 

Until we become more platform agnostic, adding only @types/aws-lambda seems like a good compromise to me.

I tried to figure out the handful of types we use, but the package uses a heck load of generics, and it wasn't easy to figure out!