### PR TITLE
Still allow generic Errors in redwood forms

### DIFF
--- a/packages/forms/src/FormError.tsx
+++ b/packages/forms/src/FormError.tsx
@@ -53,7 +53,7 @@ const FormError = ({
 
   let rootMessage = error.message
   const messages: string[] = []
-  const hasGraphQLError = !!error.graphQLErrors[0]
+  const hasGraphQLError = !!error.graphQLErrors?.[0]
   const hasNetworkError =
     !!error.networkError && Object.keys(error.networkError).length > 0
 


### PR DESCRIPTION
The form error property accepts `any`:

```
interface FormProps extends Omit<React.ComponentPropsWithRef<'form'>, 'onSubmit'> {
    error?: any;
```

But raises an exception if it doesn't conform to `RWGqlError` which is an internal type. The form does a validation check for the other possible property `networkError` (via the null check) but doesn't for `graphQLErrors`. This was the minimal case change, but I think a tighter change might be making:

```ts
interface RWGqlError {
  message: string
  graphQLErrors: ReadonlyArray<GraphQLError>
  networkError: Error | ServerParseError | ServerError | null
}
```
to
```ts
interface RWGqlError extends Error {
  graphQLErrors?: ReadonlyArray<GraphQLError>
  networkError?: Error | ServerParseError | ServerError | null
}
```