### PR TITLE
Enable configuring fastify server using server.config.js

### DIFF
--- a/packages/api-server/src/app.ts
+++ b/packages/api-server/src/app.ts
@@ -1,18 +1,9 @@
-import Fastify, { FastifyInstance } from 'fastify'
+import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 
-export const createApp = (): FastifyInstance => {
-  const app = Fastify({
-    logger: {
-      prettyPrint: process.env.NODE_ENV === 'development' && {
-        colorize: true,
-        ignore: 'hostname,pid,responseTime,reqId,req,res',
-        levelFirst: true,
-        messageFormat:
-          '{reqId} {msg} {res.statusCode} {req.method} {responseTime}',
-        translateTime: true,
-      },
-    },
-  })
+export const createApp = (
+  options: FastifyServerOptions = {}
+): FastifyInstance => {
+  const app = Fastify(options)
 
   return app
 }

--- a/packages/api-server/src/app.ts
+++ b/packages/api-server/src/app.ts
@@ -1,9 +1,13 @@
 import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
 
-export const createApp = (
-  options: FastifyServerOptions = {}
-): FastifyInstance => {
-  const app = Fastify(options)
+const DEFAULT_OPTIONS = {
+  logger: {
+    level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
+  },
+}
+
+export const createApp = (options?: FastifyServerOptions): FastifyInstance => {
+  const app = Fastify(options || DEFAULT_OPTIONS)
 
   return app
 }

--- a/packages/create-redwood-app/template/api/server.config.js
+++ b/packages/create-redwood-app/template/api/server.config.js
@@ -1,0 +1,18 @@
+/**
+ * This config allows you to configure the fastify settings for the
+ * dev api server, but also if you are using `yarn rw serve`
+ *
+ *  See https://www.fastify.io/docs/latest/Reference/Server/#factory
+ *
+ * Note: They do not apply on serverless deploy
+ */
+
+/** @type {import('fastify').FastifyServerOptions} */
+const config = {
+  requestTimeout: 15000,
+  logger: {
+    level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
+  },
+}
+
+export default config

--- a/packages/create-redwood-app/template/api/server.config.js
+++ b/packages/create-redwood-app/template/api/server.config.js
@@ -15,4 +15,4 @@ const config = {
   },
 }
 
-export default config
+module.exports = config

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -21,6 +21,7 @@ export interface NodeTargetConfig {
   path: string
   target: TargetEnum.NODE
   schemaPath: string
+  serverConfig: string
 }
 
 interface BrowserTargetConfig {
@@ -88,6 +89,7 @@ const DEFAULT_CONFIG: Config = {
     path: './api',
     target: TargetEnum.NODE,
     schemaPath: './api/db/schema.prisma',
+    serverConfig: './api/server.config.js',
   },
   browser: {
     open: false,


### PR DESCRIPTION
Fixes #3909

### What does this do?
Allows user to configure the options passed to the fastify server by including a file `./api/server.config.js` in their project.

- If not `server.config.js` is present, it will fallback to defaults
- If a custom server config is specified in the redwood.toml e.g.
```toml
#...
[api]
  port = 8911
  serverConfig = './api/bazinga.server.conf.js'
```
It will use the specified file. (this will allow switching the config per environment, using env vars)

