### PR TITLE
fix(webpack): Disable sourcemaps in prod

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -188,7 +188,14 @@ module.exports = (webpackEnv) => {
 
   return {
     mode: isEnvProduction ? 'production' : 'development',
-    devtool: isEnvProduction ? 'source-map' : 'cheap-module-source-map',
+    ...(isEnvProduction
+      ? {
+          // this is so that users can debug a production build by setting sourceMap = true in redwood.toml
+          devtool: redwoodConfig.web.sourceMap ? 'source-map' : false,
+        }
+      : {
+          devtool: 'cheap-module-source-map',
+        }),
     entry: {
       /**
        * Prerender requires a top-level component.

--- a/packages/internal/src/__tests__/config.test.ts
+++ b/packages/internal/src/__tests__/config.test.ts
@@ -32,6 +32,7 @@ describe('getConfig', () => {
           "host": "localhost",
           "path": "./web",
           "port": 8910,
+          "sourceMap": false,
           "target": "browser",
           "title": "Redwood App",
         },

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -53,6 +53,7 @@ interface BrowserTargetConfig {
 
   fastRefresh: boolean
   a11y: boolean
+  sourceMap: boolean
 }
 
 export interface Config {
@@ -80,6 +81,7 @@ const DEFAULT_CONFIG: Config = {
     apiUrl: '/.redwood/functions',
     fastRefresh: true,
     a11y: true,
+    sourceMap: false,
   },
   api: {
     title: 'Redwood App',


### PR DESCRIPTION
### What does this do?

Disable sourcemaps in prod for the web side unless explicitly enabled in toml

### How the toml setting works and why?

```toml
#redwood.toml
[web]
  #...
  sourceMap = true 
```

If you set sourceMap to true, it'll will build with source maps even in production. This might be useful in certain scenarios, where you're getting an error in production but not in dev.

Fixes #2416