### PR TITLE
Add GitHub Action requiring PRs to include one of the "release:*" labels

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,5 +27,6 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "assignees": [
     "@jtoar"
-  ]
+  ],
+  "labels": ["release:chore"]
 }

--- a/.github/workflows/require-PR-label.yaml
+++ b/.github/workflows/require-PR-label.yaml
@@ -1,0 +1,14 @@
+name: Require PR label "release:*"
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          labels: "release:chore, release::fix, release:feature, release:feature-breaking"


### PR DESCRIPTION
This is a step towards better automation of our release process. These labels will be used to categorize Release Notes. We can also set up additional triggers for `release:feature-breaking`, which in the future will mean a PR likely requires additional steps (e.g. copy for Release, deferred until next major release, etc.)

I'm using this GitHub Marketplace Action. In the future, we can customize if/as needed:
- https://github.com/marketplace/actions/require-labels

I’ve created the new labels:
<img width="362" alt="Screen Shot 2021-12-22 at 10 10 57 AM" src="https://user-images.githubusercontent.com/2951/147131562-545ca19e-f8dc-4a4a-8a30-1c6093bb9519.png">


## To Do
- [ ] when this is ready, set as Required CI check for `main` branch