### PR TITLE
Populate global.location when prerendering

### DIFF
--- a/packages/prerender/src/internal.ts
+++ b/packages/prerender/src/internal.ts
@@ -17,7 +17,7 @@ export const getRootHtmlPath = () => {
   }
 }
 
-export const registerShims = () => {
+export const registerShims = (routerPath: string) => {
   const rwjsConfig = getConfig()
   global.RWJS_API_GRAPHQL_URL =
     rwjsConfig.web.apiGraphQLUrl ?? `${rwjsConfig.web.apiUrl}graphql`
@@ -36,6 +36,12 @@ export const registerShims = () => {
   // Let routes auto loader plugin know
   process.env.__REDWOOD__PRERENDERING = '1'
 
+  // This makes code like global.location.pathname work also outside of the
+  // router
+  global.location = {
+    ...global.location,
+    pathname: routerPath,
+  }
   // Shim fetch in the node.js context
   // This is to avoid using cross-fetch when configuring apollo-client
   // which would cause the client bundle size to increase

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -32,7 +32,7 @@ export const runPrerender = async ({
     ],
   })
 
-  registerShims()
+  registerShims(routerPath)
 
   const indexContent = fs.readFileSync(getRootHtmlPath()).toString()
   const { default: App } = await import(getPaths().web.app)


### PR DESCRIPTION
I added some code to my i18n initialization that looks at the url to figure out what language to load. Unfortunately that broke prerendering.

This PR adds the prerendered path to `global.location.pathname`.
We already set the prerendered path in the location provider used by the router, but that's not enough for code that runs outside of the router, or even code inside the router that looks at the global location directly instead of using the `useLocation` hook. Now code like that should work.

I thought about the other properties on `location`, like href, hostname etc. Should we fake those? What hostname should we use in that case? localhost?

I left them out for now, mainly because it felt weird to make up a hostname.
