### PR TITLE
Support and format custom GraphQL Scalar validation error messages

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -42,6 +42,8 @@ import { useRedwoodGlobalContextSetter } from '../plugins/useRedwoodGlobalContex
 import { useRedwoodLogger } from '../plugins/useRedwoodLogger'
 import { useRedwoodPopulateContext } from '../plugins/useRedwoodPopulateContext'
 
+import { ValidationError } from '../errors'
+
 import type { GraphQLHandlerOptions } from './types'
 /**
  * Extracts and parses body payload from event with base64 encoding check
@@ -77,6 +79,17 @@ export function normalizeRequest(event: APIGatewayProxyEvent): Request {
  **/
 export const formatError: FormatErrorHandler = (err: any, message: string) => {
   const allowErrors = [EnvelopError, RedwoodError]
+
+  // If using graphql-scalars, when validating input
+  // the original TypeError is wrapped in an GraphQLError object.
+  // We extract out and present the portion of the original error's
+  // validation message that is friendly to send to the end user
+  // @see https://github.com/Urigo/graphql-scalars and their validate method
+  if (err && err instanceof GraphQLError) {
+    if (err.originalError && err.originalError instanceof TypeError) {
+      return new ValidationError(err.originalError.message)
+    }
+  }
 
   if (
     err.originalError &&


### PR DESCRIPTION
After https://github.com/redwoodjs/redwood/pull/3884 you can now merge in and use custom [graphql-scalars ](https://www.graphql-scalars.dev/docs) (eg, Currency, EmailAddress, PositiveInt, etc).

The how to will be documented as part of a fix for https://github.com/redwoodjs/redwoodjs.com/issues/925.

But the error masking was suppressing the validation message.

This PR updates the masked error format method to better check if the original error was a type error (which is what the scalar raises in its validate method) and then uses the original message.

In the example below, we use the [`Currency`](https://github.com/Urigo/graphql-scalars/blob/master/src/scalars/Currency.ts) scalar that validates if it is a string of one of the [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) cods like `EUR` or `USD`.

### Implement

1. Add the scalar definition in a sdl file `scalars.sdl.ts` (this is a convention to put all of them there but can be elsewhere in your SDL and types

```
// api/src/graphql/scalars.sdl.ts

export const schema = gql`
  scalar Currency
`

```

2. Import the scalar and provide to the GraphQLHandler in `schemaOptions`

```ts
// api/src/functions/graphql.ts
import { CurrencyDefinition, CurrencyResolver } from 'graphql-scalars'

...

export const handler = createGraphQLHandler({
  loggerConfig: { logger, options: {} },
  directives,
  sdls,
  services,
  schemaOptions: { // <<---- here
    typeDefs: [CurrencyDefinition],
    resolvers: { Currency: CurrencyResolver },
  },
  onException: () => {
    // Disconnect from your database with an unhandled exception.
    db.$disconnect()
  },
})

```

3. Use your scalar in your types

```ts
export const schema = gql`
  type Post {
    id: Int!
    title: String!
    body: String!
    currency_iso_4217: Currency! // <--- here, note: will check in the response returned in query
    createdAt: DateTime!
  }

  type Query {
    posts: [Post!]! @requireAuth
    post(id: Int!): Post @requireAuth
  }

  input CreatePostInput {
    title: String!
    body: String!
    currency_iso_4217: Currency! // <--- here, validate on mutation 
  }

  input UpdatePostInput {
    title: String
    body: String
    currency_iso_4217: Currency // <--- here, validate on mutation 
  }

  type Mutation {
    createPost(input: CreatePostInput!): Post! @requireAuth
    updatePost(id: Int!, input: UpdatePostInput!): Post! @requireAuth
    deletePost(id: Int!): Post! @requireAuth
  }
`
```

Note: Your Prisma schema is still just a Prisma scalar data type of String

```
model Post {
  id                  Int      @id @default(autoincrement())
  title               String
  body                String
  currency_iso_4217   String   @default("USD")
  createdAt           DateTime @default(now())
}

```


### Before:

<img width="550" alt="image" src="https://user-images.githubusercontent.com/1051633/148233674-95627129-cc5d-4fc8-8bfb-15d6328c508a.png">

```terminal
api | 09:26:08 🌲 incoming request POST xxx /graphql
api | 09:26:08 🐛 graphql-server GraphQL execution started: UpdatePostMutation
api | 09:26:08 🚨 graphql-server Variable "$input" got invalid value "Roobles" at "input.currency_iso_4217"; Expected type "Currency". Value is not a valid currency value: Roobles
api | 09:26:08 🌲 request completed 27ms
```

### After:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/1051633/148233391-a37032a6-7d9c-4c90-8c9e-478803e38f05.png">

```terminal
api | 09:04:38 🚨 graphql-server Variable "$input" got invalid value "Roobles" at "input.currency_iso_4217"; Expected type "Currency". Value is not a valid currency value: Roobles
api | 09:04:38 🌲 request completed 24ms
```

## Extra

See all scalars https://github.com/Urigo/graphql-scalars/blob/master/src/scalars and more info https://www.graphql-scalars.dev/docs
