### PR TITLE
fix(babel-check): Scope glob for babelrc check

### DIFF
--- a/packages/cli/src/middleware/checkForBabelConfig.js
+++ b/packages/cli/src/middleware/checkForBabelConfig.js
@@ -7,13 +7,13 @@ import c from '../lib/colors'
 
 const isUsingBabelRc = () => {
   return (
-    fg.sync('**/*/.babelrc(.*)?', {
+    fg.sync('{web,api}/.babelrc(.*)?', {
       cwd: getPaths().base,
-      ignore: 'node_modules',
+      ignore: '**/node_modules',
     }).length > 0
   )
 }
-const BABEL_SETTINGS_LINK = c.warning('https://redwoodjs.com/docs/builds')
+const BABEL_SETTINGS_LINK = c.warning('https://redwoodjs.com/docs/babel')
 
 const checkForBabelConfig = () => {
   if (isUsingBabelRc()) {
@@ -25,18 +25,14 @@ const checkForBabelConfig = () => {
       `the Redwood built-in config, more details here: ${BABEL_SETTINGS_LINK}`,
     ]
 
-    const errTitle = 'Incorrect project configuration'
-
     console.log(
       boxen(messages.join('\n'), {
-        title: errTitle,
+        title: 'Incorrect project configuration',
         padding: { top: 0, bottom: 0, right: 1, left: 1 },
         margin: 1,
         borderColor: 'red',
       })
     )
-
-    throw new Error(errTitle)
   }
 }
 


### PR DESCRIPTION
## What?
1 ) Say you have a project setup like this 

```
├── packages
├── someother
│   └── myModule.ts
│   └── .babelrc
├── web
│   ├── config
├── api
│   ├── config
```
The CLI will not run the dev server at all. 

2) It will also error out if you have node_modules with babelrc in them (and they're not hoisted).

3) It just prints out the warning now, isntead of erroring out