### PR TITLE
fix(setup): Fix handling of nested setup commands

### DIFF
--- a/packages/cli/src/commands/setup.js
+++ b/packages/cli/src/commands/setup.js
@@ -1,12 +1,22 @@
-export const command = 'setup <commmand>'
-export const description = 'Initialize project config and install packages'
 import terminalLink from 'terminal-link'
 
 import detectRwVersion from '../middleware/detectProjectRwVersion'
 
+export const command = 'setup <commmand>'
+export const description = 'Initialize project config and install packages'
+
 export const builder = (yargs) =>
   yargs
-    .commandDir('./setup', { recurse: true, exclude: /\/ui\/.*\.js$/ })
+    .commandDir('./setup', {
+      recurse: true,
+      /*
+      @NOTE This regex will ignore all double nested commands
+      e.g. /setup/hi.js & setup/hi/hi.js are picked up,
+      but setup/hi/hello/bazinga.js will be ignored
+      The [\/\\] bit is for supporting both windows and unix style paths
+      */
+      exclude: /setup[\/\\]+.*[\/\\]+.*[\/\\]/,
+    })
     .demandCommand()
     .middleware(detectRwVersion)
     .epilogue(

--- a/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
@@ -1,13 +1,12 @@
 import execa from 'execa'
 import Listr from 'listr'
 
-import c from '../../../lib/colors'
-
+import c from '../../../../lib/colors'
 import {
   checkStorybookStatus,
   configureStorybook,
-} from './tasks/configure-storybook'
-import { checkSetupStatus, wrapWithChakraProvider } from './tasks/setup-chakra'
+} from '../tasks/configure-storybook'
+import { checkSetupStatus, wrapWithChakraProvider } from '../tasks/setup-chakra'
 
 export const command = 'chakra-ui'
 export const description = 'Set up Chakra UI'

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -5,8 +5,8 @@ import execa from 'execa'
 import { outputFileSync } from 'fs-extra'
 import Listr from 'listr'
 
-import { getPaths } from '../../../lib'
-import c from '../../../lib/colors'
+import { getPaths } from '../../../../lib'
+import c from '../../../../lib/colors'
 
 export const command = 'tailwindcss'
 export const aliases = ['tailwind', 'tw']
@@ -93,7 +93,7 @@ export const handler = async ({ force, install }) => {
           )
         } else {
           const postCSSConfig = fs.readFileSync(
-            path.join(__dirname, 'templates', 'postcss.config.js.template'),
+            path.join(__dirname, '../templates/postcss.config.js.template'),
             'utf-8'
           )
 

--- a/packages/cli/src/commands/setup/ui/ui.js
+++ b/packages/cli/src/commands/setup/ui/ui.js
@@ -4,7 +4,7 @@ export const command = 'ui <library>'
 export const description = 'Set up a UI design or style library'
 export const builder = (yargs) =>
   yargs
-    .commandDir('./ui')
+    .commandDir('./libraries')
     .demandCommand()
     .epilogue(
       `Also see the ${terminalLink(


### PR DESCRIPTION
Fixes #3956
Duplicates, in a different implementation #4036

### What does it do? 
Changes the setup command to ignore double nested commands. Examples
- `setup/ui/libraries/chakra-ui` ignored when you just do `yarn rw`, but configured to be picked up in `yarn rw setup ui`
- `setup/bazinga/bazinga.js` - ignored by root `yarn rw`, but available in `yarn rw setup` 
- `setup/foobar.js` - ignored by root `yarn rw` but available in `yarn rw setup`

