### PR TITLE
Revert webpack-dev-server upgrade

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "webpack": "5.65.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.1",
-    "webpack-dev-server": "4.7.2",
+    "webpack-dev-server": "4.7.1",
     "webpack-manifest-plugin": "4.0.2",
     "webpack-merge": "5.8.0",
     "webpack-retry-chunk-load-plugin": "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,7 +5459,7 @@ __metadata:
     webpack: 5.65.0
     webpack-bundle-analyzer: 4.5.0
     webpack-cli: 4.9.1
-    webpack-dev-server: 4.7.2
+    webpack-dev-server: 4.7.1
     webpack-manifest-plugin: 4.0.2
     webpack-merge: 5.8.0
     webpack-retry-chunk-load-plugin: 3.0.0
@@ -28980,9 +28980,9 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:4.7.2":
-  version: 4.7.2
-  resolution: "webpack-dev-server@npm:4.7.2"
+"webpack-dev-server@npm:4.7.1":
+  version: 4.7.1
+  resolution: "webpack-dev-server@npm:4.7.1"
   dependencies:
     "@types/bonjour": ^3.5.9
     "@types/connect-history-api-fallback": ^1.3.5
@@ -29020,7 +29020,7 @@ resolve@^2.0.0-next.3:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 862cba6576f5e187e3e6d90a5abb63076f8d2385bde7122d8ee503f5cd0b264d99ab63478cbb4a317880af4d9cb4eda52714ee9bb31cbc3218894c0eca3544fc
+  checksum: d0f2e73cf7f330017464d7a0c491091b29a0542cdd42cbd132ae054581be9dd27934052c7d6d272856a3a94a104fd84f2d57136de09f9e49fd1bf9ff4339749c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> Update: CI seems to be passing now, so TBD.

e2e tests have been flaky lately. One tends to pass while the other fails (usually the one running on node.js v14). This seemed to have started four days ago, after upgrading webpack-dev-server https://github.com/redwoodjs/redwood/pull/4032. This PR reverts the upgrade (it was only a semver patch).

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/32992335/148604046-ed3158b6-a42d-4410-ac28-eb4d535b6838.png">

https://github.com/redwoodjs/redwood/actions/workflows/e2e.yaml?page=10

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/32992335/148604070-0f236ac2-d840-4500-af2c-5bf8db8b24a8.png">

https://github.com/redwoodjs/redwood/actions/runs/1651259167
