### PR TITLE
Upgrade webpack dev server

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "webpack": "5.65.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.9.1",
-    "webpack-dev-server": "4.7.1",
+    "webpack-dev-server": "^4.7.2",
     "webpack-manifest-plugin": "4.0.2",
     "webpack-merge": "5.8.0",
     "webpack-retry-chunk-load-plugin": "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,7 +5459,7 @@ __metadata:
     webpack: 5.65.0
     webpack-bundle-analyzer: 4.5.0
     webpack-cli: 4.9.1
-    webpack-dev-server: 4.7.1
+    webpack-dev-server: ^4.7.2
     webpack-manifest-plugin: 4.0.2
     webpack-merge: 5.8.0
     webpack-retry-chunk-load-plugin: 3.0.0
@@ -28980,9 +28980,9 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:4.7.1":
-  version: 4.7.1
-  resolution: "webpack-dev-server@npm:4.7.1"
+"webpack-dev-server@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "webpack-dev-server@npm:4.7.2"
   dependencies:
     "@types/bonjour": ^3.5.9
     "@types/connect-history-api-fallback": ^1.3.5
@@ -29020,7 +29020,7 @@ resolve@^2.0.0-next.3:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: d0f2e73cf7f330017464d7a0c491091b29a0542cdd42cbd132ae054581be9dd27934052c7d6d272856a3a94a104fd84f2d57136de09f9e49fd1bf9ff4339749c
+  checksum: 862cba6576f5e187e3e6d90a5abb63076f8d2385bde7122d8ee503f5cd0b264d99ab63478cbb4a317880af4d9cb4eda52714ee9bb31cbc3218894c0eca3544fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Seeing as https://github.com/redwoodjs/redwood/pull/4073 didn't matter, reverting my reversion.