### PR TITLE
Try fixing e2e network flakiness

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,6 +23,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # For network flakiness. See https://github.com/vercel/next.js/pull/28264
+      - name: tune linux network
+        run: sudo ethtool -K eth0 tx off rx off
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       # For network flakiness. See https://github.com/vercel/next.js/pull/28264
-      - name: tune linux network
+      - name: Tune linux network
         run: sudo ethtool -K eth0 tx off rx off
 
       - name: Get yarn cache directory path


### PR DESCRIPTION
This is an attempt to fix network flakiness using the strategy in https://github.com/vercel/next.js/pull/28264. I tried this out on my fork of redwood and it seemed to actually work (PR here: https://github.com/jtoar/redwood/pull/155), but I have no idea what this really does. (The [original comment](https://github.com/actions/virtual-environments/issues/1187#issuecomment-686735760) says that it "disables TCP/UCP offloading", but I don't really know what that entails.)