### PR TITLE
Add missing type for `only` in scenario

### DIFF
--- a/packages/testing/src/api/scenario.ts
+++ b/packages/testing/src/api/scenario.ts
@@ -57,3 +57,7 @@ export interface Scenario {
     testFunction: TestFunctionWithScenario<any>
   ): void
 }
+
+export interface Scenario {
+  only: Scenario
+}


### PR DESCRIPTION
Though it's possible to do `scenario.only` to run a single scenario, it shows a TS error. This small PR adds that missing type.

Original error:
![Screenshot 2022-01-08 at 1 31 28 PM](https://user-images.githubusercontent.com/2629902/148636822-1affa400-7293-491a-a36c-2cf86958cfa6.png)
