### PR TITLE
added exports to form-component props

### DIFF
--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -286,7 +286,7 @@ interface ServerErrorsContextProps {
 
 const ServerErrorsContext = React.createContext({} as ServerErrorsContextProps)
 
-interface FormProps
+export interface FormProps
   extends Omit<React.ComponentPropsWithRef<'form'>, 'onSubmit'> {
   error?: any
   /**
@@ -365,7 +365,7 @@ const Form = forwardRef<HTMLFormElement, FormProps>(
   }
 )
 
-interface LabelProps
+export interface LabelProps
   extends Pick<FieldProps, 'errorClassName' | 'errorStyle'>,
     React.ComponentPropsWithoutRef<'label'> {
   name: string
@@ -399,7 +399,8 @@ const Label = ({
   )
 }
 
-interface FieldErrorProps extends React.ComponentPropsWithoutRef<'span'> {
+export interface FieldErrorProps
+  extends React.ComponentPropsWithoutRef<'span'> {
   /**
    * The name of the field the `<FieldError>`'s associated with.
    */
@@ -467,7 +468,7 @@ const FieldError = ({ name, ...rest }: FieldErrorProps) => {
   return validationError ? <span {...rest}>{errorMessage}</span> : null
 }
 
-interface TextAreaFieldProps
+export interface TextAreaFieldProps
   extends FieldProps<HTMLTextAreaElement>,
     Omit<React.ComponentPropsWithRef<'textarea'>, 'name'> {}
 
@@ -516,7 +517,7 @@ const TextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(
   }
 )
 
-interface SelectFieldProps
+export interface SelectFieldProps
   extends FieldProps<HTMLSelectElement>,
     Omit<React.ComponentPropsWithRef<'select'>, 'name'> {}
 
@@ -565,7 +566,7 @@ const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
   }
 )
 
-interface CheckboxFieldProps
+export interface CheckboxFieldProps
   extends FieldProps<HTMLInputElement>,
     Omit<React.ComponentPropsWithRef<'input'>, 'name' | 'type'> {}
 
@@ -672,7 +673,7 @@ const INPUT_TYPES = [
 
 type InputType = typeof INPUT_TYPES[number]
 
-interface InputFieldProps
+export interface InputFieldProps
   extends FieldProps<HTMLInputElement>,
     Omit<React.ComponentPropsWithRef<'input'>, 'name' | 'type'> {
   /**


### PR DESCRIPTION
This PR adds `export` statements to the prop-interfaces provided by `packages/forms`, making it easier to compose components which extend their functionality - or provide defaults on top of them.