### PR TITLE
chore: test-project workaround for tailwind PostCSS error

### DIFF
--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -156,7 +156,7 @@ async function webTasks(outputPath, { link, verbose }) {
         // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
         task: () =>
           execa(
-            'yarn workspace web add postcss postcss-loader tailwindcss autoprefixer',
+            'yarn workspace web add postcss postcss-loader tailwindcss autoprefixer@^9.8.8',
             [],
             getExecaOptions(outputPath)
           ),


### PR DESCRIPTION
As of v0.41, the CI test-project fails (in context of GitPod) due to issue with tailwind and PostCSS. It's possibly related to Webpack changes (and/or Storybook). Here's some background that's helpful but from a non-tailwind PR topic:
- https://github.com/redwoodjs/redwood/pull/3515#issuecomment-1000974638

This PR adds the workaround to get CI running for near-term. Overall issue needs to be resolved before next release.