### PR TITLE
Don't mask GraphQL errors when you're in the dev environment

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -209,8 +209,10 @@ export const createGraphQLHandler = ({
   // Must be "last" in plugin chain so can process any data added to results and extensions
   plugins.push(useRedwoodLogger(loggerConfig))
 
-  // Prevent unexpected error messages from leaking to the GraphQL clients.
-  plugins.push(useMaskedErrors({ formatError, errorMessage: defaultError }))
+  // Prevent unexpected error messages from leaking to the GraphQL clients in prod.
+  if (!isDevEnv) {
+    plugins.push(useMaskedErrors({ formatError, errorMessage: defaultError }))
+  }
 
   const corsContext = createCorsContext(cors)
 


### PR DESCRIPTION
The GraphQL error masking is useful in prod/staging environments, but not very valuable in dev environments. This also means that dev tooling can work with the original server error messages.

