### PR TITLE
fix(generator): Fix incorrect TS page param type on scaffold 

### DIFF
--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
@@ -329,10 +329,58 @@ export default Routes",
 
 exports[`generates typescript pages 1`] = `undefined`;
 
-exports[`generates typescript pages 2`] = `undefined`;
+exports[`generates typescript pages 2`] = `
+"import TsFilesPage from './TsFilesPage'
 
-exports[`generates typescript pages 3`] = `undefined`;
+export const generated = () => {
+  return <TsFilesPage />
+}
 
-exports[`generates typescript pages 4`] = `undefined`;
+export default { title: 'Pages/TsFilesPage' }
+"
+`;
 
-exports[`generates typescript pages 5`] = `undefined`;
+exports[`generates typescript pages 3`] = `
+"import { render } from '@redwoodjs/testing/web'
+
+import TsFilesPage from './TsFilesPage'
+
+describe('TsFilesPage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<TsFilesPage />)
+    }).not.toThrow()
+  })
+})
+"
+`;
+
+exports[`generates typescript pages 4`] = `
+"import { Link, routes } from '@redwoodjs/router'
+import { MetaTags } from '@redwoodjs/web'
+
+type TsParamFilesPageProps = {
+  id: string
+}
+
+const TsParamFilesPage = ({ id }: TsParamFilesPageProps) => {
+  return (
+    <>
+      <MetaTags title=\\"TsParamFiles\\" description=\\"TsParamFiles page\\" />
+
+      <h1>TsParamFilesPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TSParamFilesPage/TSParamFilesPage.tsx</code>
+      </p>
+      <p>
+        My default route is named <code>tsParamFiles</code>, link to me with \`
+        <Link to={routes.tsParamFiles({ id: '42' })}>TsParamFiles 42</Link>\`
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default TsParamFilesPage
+"
+`;

--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
@@ -384,3 +384,33 @@ const TsParamFilesPage = ({ id }: TsParamFilesPageProps) => {
 export default TsParamFilesPage
 "
 `;
+
+exports[`generates typescript pages 5`] = `
+"import { Link, routes } from '@redwoodjs/router'
+import { MetaTags } from '@redwoodjs/web'
+
+type TsParamTypeFilesPageProps = {
+  id: number
+}
+
+const TsParamTypeFilesPage = ({ id }: TsParamTypeFilesPageProps) => {
+  return (
+    <>
+      <MetaTags title=\\"TsParamTypeFiles\\" description=\\"TsParamTypeFiles page\\" />
+
+      <h1>TsParamTypeFilesPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TSParamTypeFilesPage/TSParamTypeFilesPage.tsx</code>
+      </p>
+      <p>
+        My default route is named <code>tsParamTypeFiles</code>, link to me with \`
+        <Link to={routes.tsParamTypeFiles({ id: 42 })}>TsParamTypeFiles 42</Link>\`
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default TsParamTypeFilesPage
+"
+`;

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -112,9 +112,11 @@ beforeAll(() => {
   typescriptParamTypeFiles = page.files({
     name: 'TSParamTypeFiles',
     typescript: true,
-    tests: true,
-    stories: true,
-    ...page.paramVariants(pathName('{id:Int}', 'typescript-param-with-type')),
+    tests: false,
+    stories: false,
+    ...page.paramVariants(
+      pathName('/bazinga-ts/{id:Int}', 'typescript-param-with-type')
+    ),
   })
 })
 
@@ -446,7 +448,7 @@ test('generates typescript pages', () => {
   expect(
     typescriptFiles[
       path.normalize(
-        '/path/to/project/web/src/pages/TsFilesPage/TsFilesPage.stories.tsx'
+        '/path/to/project/web/src/pages/TSFilesPage/TSFilesPage.stories.tsx'
       )
     ]
   ).toMatchSnapshot()
@@ -454,7 +456,7 @@ test('generates typescript pages', () => {
   expect(
     typescriptFiles[
       path.normalize(
-        '/path/to/project/web/src/pages/TsFilesPage/TsFilesPage.test.tsx'
+        '/path/to/project/web/src/pages/TSFilesPage/TSFilesPage.test.tsx'
       )
     ]
   ).toMatchSnapshot()
@@ -462,15 +464,7 @@ test('generates typescript pages', () => {
   expect(
     typescriptParamFiles[
       path.normalize(
-        '/path/to/project/web/src/pages/TsParamFilesPage/TsParamFilesPage.tsx'
-      )
-    ]
-  ).toMatchSnapshot()
-
-  expect(
-    typescriptParamTypeFiles[
-      path.normalize(
-        '/path/to/project/web/src/pages/TsParamTypeFilesPage/TsParamTypeFilesPage.tsx'
+        '/path/to/project/web/src/pages/TSParamFilesPage/TSParamFilesPage.tsx'
       )
     ]
   ).toMatchSnapshot()

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -468,4 +468,12 @@ test('generates typescript pages', () => {
       )
     ]
   ).toMatchSnapshot()
+
+  expect(
+    typescriptParamTypeFiles[
+      path.normalize(
+        '/path/to/project/web/src/pages/TSParamTypeFilesPage/TSParamTypeFilesPage.tsx'
+      )
+    ]
+  ).toMatchSnapshot()
 })

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
@@ -1600,7 +1600,7 @@ exports[`in typescript mode creates a show page 1`] = `
 "import PostCell from 'src/components/PostCell'
 
 type PostPageProps = {
-  id: Int
+  id: number
 }
 
 const PostPage = ({ id }: PostPageProps) => {

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -330,7 +330,6 @@ const pageFiles = async (
         templatePath: path.join('pages', page),
       }),
       {
-        idType,
         idTsType,
         name,
         pascalScaffoldPath,

--- a/packages/cli/src/commands/generate/scaffold/templates/pages/NamePage.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/pages/NamePage.tsx.template
@@ -1,7 +1,7 @@
 import ${singularPascalName}Cell from '${importComponentNameCell}'
 
 type ${pascalName}PageProps = {
-  id: ${idType}
+  id: ${idTsType}
 }
 
 const ${singularPascalName}Page = ({ id }: ${pascalName}PageProps) => {


### PR DESCRIPTION
### What does this do?

1. The snapshot tests for TS files had "undefined" snapshots.
This PR fixes that, to ensure the tests actually test something! Dangers of snapshot testing!

2. The scaffold templates weren't using the correct variable for the typescript type
i.e.
It would generate a type of `Int`. It now does
```diff
type PostPageProps = {
-   id: Int
+  id: number
}

```