### PR TITLE
Add path param array to `rw lint [path]`

### DIFF
--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -6,10 +6,14 @@ import terminalLink from 'terminal-link'
 import { getPaths } from '../lib'
 import c from '../lib/colors'
 
-export const command = 'lint'
+export const command = 'lint [path]'
 export const description = 'Lint your files'
 export const builder = (yargs) => {
   yargs
+    .positional('path', {
+      description: 'Specify file or directory to lint relative to project root',
+      type: 'string',
+    })
     .option('fix', {
       default: false,
       description: 'Try to fix errors',
@@ -23,14 +27,15 @@ export const builder = (yargs) => {
     )
 }
 
-export const handler = async ({ fix }) => {
+export const handler = async ({ path, fix }) => {
   try {
     const result = await execa(
       'yarn eslint',
       [
         fix && '--fix',
-        fs.existsSync(getPaths().web.src) && 'web/src',
-        fs.existsSync(getPaths().api.src) && 'api/src',
+        !path && fs.existsSync(getPaths().web.src) && 'web/src',
+        !path && fs.existsSync(getPaths().api.src) && 'api/src',
+        path,
       ].filter(Boolean),
       {
         cwd: getPaths().base,

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -6,13 +6,14 @@ import terminalLink from 'terminal-link'
 import { getPaths } from '../lib'
 import c from '../lib/colors'
 
-export const command = 'lint [path]'
+export const command = 'lint [path..]'
 export const description = 'Lint your files'
 export const builder = (yargs) => {
   yargs
     .positional('path', {
-      description: 'Specify file or directory to lint relative to project root',
-      type: 'string',
+      description:
+        'Specify file(s) or directory(ies) to lint relative to project root',
+      type: 'array',
     })
     .option('fix', {
       default: false,
@@ -29,13 +30,14 @@ export const builder = (yargs) => {
 
 export const handler = async ({ path, fix }) => {
   try {
+    const pathString = path?.join(' ')
     const result = await execa(
       'yarn eslint',
       [
         fix && '--fix',
-        !path && fs.existsSync(getPaths().web.src) && 'web/src',
-        !path && fs.existsSync(getPaths().api.src) && 'api/src',
-        path,
+        !pathString && fs.existsSync(getPaths().web.src) && 'web/src',
+        !pathString && fs.existsSync(getPaths().api.src) && 'api/src',
+        pathString,
       ].filter(Boolean),
       {
         cwd: getPaths().base,


### PR DESCRIPTION
The command `rw lint` is hardcoded to run eslint on the web and api directories. However, eslint accepts paths to files or directories. 

This PR updates `yarn rw lint [path]` to accept an array of file(s) or directory(ies), overriding the default behavior. This will make it possible to test `yarn rw lint` during CI (current test projects always have some lint errors, which are challenging to resolve during test project generation).