### PR TITLE
Revert "chore: test-project workaround for tailwind PostCSS error"

### DIFF
--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -180,7 +180,7 @@ async function webTasks(outputPath, { link, verbose }) {
         // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
         task: () =>
           execa(
-            'yarn workspace web add postcss postcss-loader tailwindcss autoprefixer@^9.8.8',
+            'yarn workspace web add postcss postcss-loader tailwindcss autoprefixer',
             [],
             getExecaOptions(outputPath)
           ),


### PR DESCRIPTION
Reverts redwoodjs/redwood#4143
Fixes #4144

I can no longer reproduce the original issue with Webpack and PostCSS (locally built project from framework, upgraded to canary, and ran yarn rw setup ui tailwindcss then rw dev; success). Reverting this workaround to confirm. Will check locally as well as GitPod.