### PR TITLE
[Release notes] Only use list items for renovate

### DIFF
--- a/tasks/release-notes/release-notes.mjs
+++ b/tasks/release-notes/release-notes.mjs
@@ -249,17 +249,17 @@ function sortPRs(prs) {
     const labels = pr.labels.nodes.map((label) => label.name)
 
     if (labels.includes('release:feature')) {
-      features.push(`<li>${formatPR(pr)}</li>`)
+      features.push(`- ${formatPR(pr)}`)
       continue
     }
 
     if (labels.includes('release:fix')) {
-      fixed.push(`<li>${formatPR(pr)}</li>`)
+      fixed.push(`- ${formatPR(pr)}`)
       continue
     }
 
     if (labels.includes('release:chore')) {
-      chore.push(`<li>${formatPR(pr)}</li>`)
+      chore.push(`- ${formatPR(pr)}`)
       continue
     }
 


### PR DESCRIPTION
Fixing a typo from the previous PR that updated this: https://github.com/redwoodjs/redwood/pull/4212.