### PR TITLE
[Renovate] Rearrange config, ignore redwoodjs packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,16 @@
 {
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "assignees": ["@jtoar"],
+  "labels": ["release:chore"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
   ],
   "ignoreDeps": [
     "boxen",
@@ -15,20 +25,24 @@
     "@types/node-fetch",
     "chalk",
     "pascalcase",
-    "node-fetch"
-  ],
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true
-    }
-  ],
-  "postUpdateOptions": ["yarnDedupeHighest"],
-  "assignees": [
-    "@jtoar"
-  ],
-  "labels": ["release:chore"]
+    "node-fetch",
+    "@redwoodjs/api",
+    "@redwoodjs/api-server",
+    "@redwoodjs/auth",
+    "@redwoodjs/cli",
+    "@redwoodjs/codemods",
+    "@redwoodjs/core",
+    "@redwoodjs/create-redwood-app",
+    "@redwoodjs/eslint-config",
+    "@redwoodjs/forms",
+    "@redwoodjs/graphql-server",
+    "@redwoodjs/internal",
+    "@redwoodjs/prerender",
+    "@redwoodjs/record",
+    "@redwoodjs/router",
+    "@redwoodjs/structure",
+    "@redwoodjs/telemetry",
+    "@redwoodjs/testing",
+    "@redwoodjs/web"
+  ]
 }


### PR DESCRIPTION
After we release, renovate tries to rollback the versions of the redwoodjs packages (see https://github.com/redwoodjs/redwood/pull/4214). This change just tells it not to bother with doing that.