### PR TITLE
Bump node target

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,9 +2,10 @@ const path = require('path')
 
 const packageJSON = require(path.join(__dirname, 'package.json'))
 
-// RedwoodJS targets Node.js 12.x because this is the default version
-// for Netlify's functions.
-const TARGETS_NODE = '14.18.3'
+// RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
+// - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
+// - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
+const TARGETS_NODE = '^14.18.3'
 
 // Run `npx browserslist "defaults, not IE 11, not IE_Mob 11"` to see a list
 // of target browsers.

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ const packageJSON = require(path.join(__dirname, 'package.json'))
 // RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
 // - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
 // - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
-const TARGETS_NODE = '14.18'
+const TARGETS_NODE = '14.19'
 
 // Run `npx browserslist "defaults, not IE 11, not IE_Mob 11"` to see a list
 // of target browsers.

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ const packageJSON = require(path.join(__dirname, 'package.json'))
 // RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
 // - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
 // - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
-const TARGETS_NODE = '^14.18.3'
+const TARGETS_NODE = '14.18'
 
 // Run `npx browserslist "defaults, not IE 11, not IE_Mob 11"` to see a list
 // of target browsers.

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ const packageJSON = require(path.join(__dirname, 'package.json'))
 // RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
 // - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
 // - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
-const TARGETS_NODE = '14.19'
+const TARGETS_NODE = '14.20'
 
 // Run `npx browserslist "defaults, not IE 11, not IE_Mob 11"` to see a list
 // of target browsers.

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ const packageJSON = require(path.join(__dirname, 'package.json'))
 
 // RedwoodJS targets Node.js 12.x because this is the default version
 // for Netlify's functions.
-const TARGETS_NODE = '12.16'
+const TARGETS_NODE = '14.18.3'
 
 // Run `npx browserslist "defaults, not IE 11, not IE_Mob 11"` to see a list
 // of target browsers.

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -64,7 +64,7 @@ export const transpileApi = (files: string[], options = {}) => {
     absWorkingDir: rwjsPaths.api.base,
     entryPoints: files,
     platform: 'node',
-    target: 'node12', // Netlify defaults NodeJS 12: https://answers.netlify.com/t/aws-lambda-now-supports-node-js-14/31789/3
+    target: 'node14', // Netlify defaults NodeJS 14: https://answers.netlify.com/t/aws-lambda-now-supports-node-js-14/31789/3
     format: 'cjs',
     bundle: false,
     outdir: rwjsPaths.api.dist,

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -14,7 +14,10 @@ import {
   getCommonPlugins,
 } from './common'
 
-const TARGETS_NODE = '12.16'
+// RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
+// - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
+// - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
+const TARGETS_NODE = '^14.18.3'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -17,7 +17,7 @@ import {
 // RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
 // - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
 // - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
-const TARGETS_NODE = '14.19'
+const TARGETS_NODE = '14.20'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -17,7 +17,7 @@ import {
 // RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
 // - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
 // - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
-const TARGETS_NODE = '^14.18.3'
+const TARGETS_NODE = '14.18'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -17,7 +17,7 @@ import {
 // RedwoodJS targets Node.js 14.x because it's the default version for Netlify and Vercel's functions:
 // - https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
 // - https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version
-const TARGETS_NODE = '14.18'
+const TARGETS_NODE = '14.19'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env


### PR DESCRIPTION
Both Netlify and Vercel's default Node.js version is `v14.x.x`.[^netlify][^vercel] Currently, `v14.19.0` is the latest v14.x release.

To bump the Node.js version we target, this PR changes two parameters: `TARGETS_NODE`, which is passed to Babel's `preset-env`, and ESBuild's `target` parameter for its build API.

`TARGETS_NODE` mainly affects how the packages in the Redwood framework are built, which indirectly affects the Redwood projects that use them. I.e., `TARGETS_NODE` doesn't really affect how redwood projects are built (when users run `yarn rw build`). Instead, the `target` param for ESBuild matters.

But `TARGETS_NODE` does directly affect CLI Commands that use `registerApiSideBabelHook`:

- `yarn rw console`
- `yarn rw exec`
- `yarn rw data-migrate up`

[^netlify]: https://docs.netlify.com/functions/build-with-javascript/#runtime-settings
[^vercel]: https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version