### PR TITLE
fix(telemetry): Safely lookup shell for windows

### DIFF
--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -67,9 +67,10 @@ const getInfo = async (presets = {}) => {
   )
 
   // get shell name instead of path
-  if (info.System?.Shell?.path?.match('/')) {
+  const shell = info.System?.Shell // Windows doesn't always provide shell info, I guess
+  if (shell?.path?.match('/')) {
     info.System.Shell.name = info.System.Shell.path.split('/').pop()
-  } else if (info.System.Shell.path.match('\\')) {
+  } else if (shell?.path.match('\\')) {
     info.System.Shell.name = info.System.Shell.path.split('\\').pop()
   }
 

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -67,7 +67,7 @@ const getInfo = async (presets = {}) => {
   )
 
   // get shell name instead of path
-  if (info.System.Shell.path.match('/')) {
+  if (info.System?.Shell?.path?.match('/')) {
     info.System.Shell.name = info.System.Shell.path.split('/').pop()
   } else if (info.System.Shell.path.match('\\')) {
     info.System.Shell.name = info.System.Shell.path.split('\\').pop()

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -80,7 +80,7 @@ const getInfo = async (presets = {}) => {
   return {
     os: info.System.OS.split(' ')[0],
     osVersion: info.System.OS.split(' ')[1],
-    shell: info.System.Shell.name,
+    shell: info.System.Shell?.name,
     nodeVersion: info.Binaries?.Node?.version,
     yarnVersion: info.Binaries?.Node?.version,
     npmVersion: info.Binaries?.Node?.version,

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -78,9 +78,9 @@ const getInfo = async (presets = {}) => {
   const mem = await system.mem()
 
   return {
-    os: info.System.OS.split(' ')[0],
-    osVersion: info.System.OS.split(' ')[1],
-    shell: info.System.Shell?.name,
+    os: info.System?.OS?.split(' ')[0],
+    osVersion: info.System?.OS?.split(' ')[1],
+    shell: info.System?.Shell?.name,
     nodeVersion: info.Binaries?.Node?.version,
     yarnVersion: info.Binaries?.Node?.version,
     npmVersion: info.Binaries?.Node?.version,


### PR DESCRIPTION
Fixes the non-critical errors we're receiving from the CLI running on Windows. I'm not 100% certain if it always happens, because @cannikin had some code to detect the shell for windows, but on my Windows dev box, I never see the shell property.

Walkthrough: https://s.tape.sh/xGJk8Iu0