### PR TITLE
(chore) upgrade node-fetch 2.6.7 (security)

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -19,7 +19,7 @@
     "findup-sync": "5.0.0",
     "jest": "27.4.7",
     "jscodeshift": "0.13.0",
-    "node-fetch": "2.6.6",
+    "node-fetch": "2.6.7",
     "prettier": "2.5.1",
     "tasuku": "1.0.2",
     "toml": "3.0.0",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -27,7 +27,7 @@
     "graphql-tag": "2.12.6",
     "lodash.merge": "4.6.2",
     "lodash.omitby": "4.6.0",
-    "node-fetch": "2.6.6",
+    "node-fetch": "2.6.7",
     "uuid": "8.3.2"
   },
   "repository": {

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -22,7 +22,7 @@
     "babel-plugin-ignore-html-and-css-imports": "0.1.0",
     "cheerio": "1.0.0-rc.10",
     "mime-types": "2.1.34",
-    "node-fetch": "2.6.6"
+    "node-fetch": "2.6.7"
   },
   "repository": {
     "type": "git",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -13,7 +13,7 @@
     "@redwoodjs/structure": "0.42.1",
     "ci-info": "^3.3.0",
     "envinfo": "7.8.1",
-    "node-fetch": "2.6.6",
+    "node-fetch": "2.6.7",
     "systeminformation": "5.11.0",
     "uuid": "8.3.2",
     "yargs": "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5495,7 +5495,7 @@ __metadata:
     fs-extra: 10.0.0
     jest: 27.4.7
     jscodeshift: 0.13.0
-    node-fetch: 2.6.6
+    node-fetch: 2.6.7
     prettier: 2.5.1
     tasuku: 1.0.2
     tempy: 1.0.1
@@ -5640,7 +5640,7 @@ __metadata:
     jest: 27.4.7
     lodash.merge: 4.6.2
     lodash.omitby: 4.6.0
-    node-fetch: 2.6.6
+    node-fetch: 2.6.7
     typescript: 4.5.5
     uuid: 8.3.2
   languageName: unknown
@@ -5714,7 +5714,7 @@ __metadata:
     cheerio: 1.0.0-rc.10
     jest: 27.4.7
     mime-types: 2.1.34
-    node-fetch: 2.6.6
+    node-fetch: 2.6.7
     typescript: 4.5.5
   peerDependencies:
     react: 17.0.2
@@ -5807,7 +5807,7 @@ __metadata:
     ci-info: ^3.3.0
     envinfo: 7.8.1
     jest: 27.4.7
-    node-fetch: 2.6.6
+    node-fetch: 2.6.7
     systeminformation: 5.11.0
     uuid: 8.3.2
     yargs: 16.2.0
@@ -21465,7 +21465,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5, node-fetch@npm:^2.6.7":
+"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
Recommended security upgrade:
- https://nvd.nist.gov/vuln/detail/CVE-2022-0235
