### PR TITLE
Scaffold: Add support for optional relations with string IDs

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -489,6 +489,69 @@ test('intForeignKeysForModel does not include foreign keys of other datatypes', 
   expect(helpers.intForeignKeysForModel(model)).toEqual([])
 })
 
+test('optionalStringForeignKeysForModel returns names of optional foreign keys that are String datatypes', () => {
+  const model = {
+    name: 'User',
+    dbName: null,
+    fields: [
+      {
+        name: 'id',
+        kind: 'scalar',
+        isList: false,
+        isRequired: true,
+        isUnique: false,
+        isId: true,
+        isReadOnly: false,
+        type: 'Int',
+        hasDefaultValue: true,
+        default: {
+          name: 'autoincrement',
+          args: [],
+        },
+        isGenerated: false,
+        isUpdatedAt: false,
+      },
+      {
+        name: 'addressId',
+        kind: 'scalar',
+        isList: false,
+        isRequired: false,
+        isUnique: false,
+        isId: false,
+        isReadOnly: true,
+        type: 'String',
+        hasDefaultValue: false,
+        isGenerated: false,
+        isUpdatedAt: false,
+      },
+      {
+        name: 'address',
+        kind: 'object',
+        isList: false,
+        isRequired: false,
+        isUnique: false,
+        isId: false,
+        isReadOnly: false,
+        type: 'Address',
+        hasDefaultValue: false,
+        relationName: 'AddressToUser',
+        relationFromFields: ['addressId'],
+        relationToFields: ['id'],
+        isGenerated: false,
+        isUpdatedAt: false,
+      },
+    ],
+    isGenerated: false,
+    primaryKey: null,
+    uniqueFields: [],
+    uniqueIndexes: [],
+  }
+
+  expect(helpers.optionalStringForeignKeysForModel(model)).toEqual([
+    'addressId',
+  ])
+})
+
 describe('mapRouteParamTypeToTsType', () => {
   it('maps scalar type String to TS type string', () => {
     expect(helpers.mapRouteParamTypeToTsType('String')).toBe('string')

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -221,6 +221,12 @@ export const intForeignKeysForModel = (model) => {
     .map((f) => f.name)
 }
 
+export const optionalStringForeignKeysForModel = (model) => {
+  return model.fields
+    .filter((f) => f.name.match(/Id$/) && f.type === 'String' && !f.isRequired)
+    .map((f) => f.name)
+}
+
 /**
  * Adds "List" to the end of words we can't pluralize
  */

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -1,5 +1,117 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`in javascript (default) mode creates a UserForm with empty optional string foreign keys transformed to null 1`] = `
+"import {
+  Form,
+  FormError,
+  FieldError,
+  Label,
+  TextField,
+  CheckboxField,
+  Submit,
+} from '@redwoodjs/forms'
+
+const formatDatetime = (value) => {
+  if (value) {
+    return value.replace(/:\\\\d{2}\\\\.\\\\d{3}\\\\w/, '')
+  }
+}
+
+const UserForm = (props) => {
+  const onSubmit = (data) => {
+    props.onSave(data, props?.user?.id)
+  }
+
+  return (
+    <div className=\\"rw-form-wrapper\\">
+      <Form onSubmit={onSubmit} error={props.error}>
+        <FormError
+          error={props.error}
+          wrapperClassName=\\"rw-form-error-wrapper\\"
+          titleClassName=\\"rw-form-error-title\\"
+          listClassName=\\"rw-form-error-list\\"
+        />
+
+        <Label
+          name=\\"name\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Name
+        </Label>
+        <TextField
+          name=\\"name\\"
+          defaultValue={props.user?.name}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+        />
+
+        <FieldError name=\\"name\\" className=\\"rw-field-error\\" />
+
+        <Label
+          name=\\"email\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Email
+        </Label>
+        <TextField
+          name=\\"email\\"
+          defaultValue={props.user?.email}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+          validation={{ required: true }}
+        />
+
+        <FieldError name=\\"email\\" className=\\"rw-field-error\\" />
+
+        <Label
+          name=\\"isAdmin\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Is admin
+        </Label>
+        <CheckboxField
+          name=\\"isAdmin\\"
+          defaultChecked={props.user?.isAdmin}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+        />
+
+        <FieldError name=\\"isAdmin\\" className=\\"rw-field-error\\" />
+
+        <Label
+          name=\\"addressId\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Address id
+        </Label>
+        <TextField
+          name=\\"addressId\\"
+          defaultValue={props.user?.addressId}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+          validation={{ setValueAs: (val) => val || null }}
+        />
+
+        <FieldError name=\\"addressId\\" className=\\"rw-field-error\\" />
+
+        <div className=\\"rw-button-group\\">
+          <Submit disabled={props.loading} className=\\"rw-button rw-button-blue\\">
+            Save
+          </Submit>
+        </div>
+      </Form>
+    </div>
+  )
+}
+
+export default UserForm
+"
+`;
+
 exports[`in javascript (default) mode creates a edit page 1`] = `
 "import EditPostCell from 'src/components/Post/EditPostCell'
 
@@ -1203,6 +1315,117 @@ const PostsList = ({ posts }) => {
 }
 
 export default PostsList
+"
+`;
+
+exports[`in typescript mode creates a UserForm with empty optional string foreign keys transformed to null 1`] = `
+"import {
+  Form,
+  FormError,
+  FieldError,
+  Label,
+  TextField,
+  CheckboxField,
+  Submit,
+} from '@redwoodjs/forms'
+
+const formatDatetime = (value) => {
+  if (value) {
+    return value.replace(/:\\\\d{2}\\\\.\\\\d{3}\\\\w/, '')
+  }
+}
+
+const UserForm = (props) => {
+  const onSubmit = (data) => {
+    props.onSave(data, props?.user?.id)
+  }
+
+  return (
+    <div className=\\"rw-form-wrapper\\">
+      <Form onSubmit={onSubmit} error={props.error}>
+        <FormError
+          error={props.error}
+          wrapperClassName=\\"rw-form-error-wrapper\\"
+          titleClassName=\\"rw-form-error-title\\"
+          listClassName=\\"rw-form-error-list\\"
+        />
+
+        <Label
+          name=\\"name\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Name
+        </Label>
+        <TextField
+          name=\\"name\\"
+          defaultValue={props.user?.name}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+        />
+        <FieldError name=\\"name\\" className=\\"rw-field-error\\" />
+
+        <Label
+          name=\\"email\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Email
+        </Label>
+        <TextField
+          name=\\"email\\"
+          defaultValue={props.user?.email}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+          validation={{ required: true }}
+        />
+        <FieldError name=\\"email\\" className=\\"rw-field-error\\" />
+
+        <Label
+          name=\\"isAdmin\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Is admin
+        </Label>
+        <CheckboxField
+          name=\\"isAdmin\\"
+          defaultChecked={props.user?.isAdmin}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+        />
+        <FieldError name=\\"isAdmin\\" className=\\"rw-field-error\\" />
+
+        <Label
+          name=\\"addressId\\"
+          className=\\"rw-label\\"
+          errorClassName=\\"rw-label rw-label-error\\"
+        >
+          Address id
+        </Label>
+        <TextField
+          name=\\"addressId\\"
+          defaultValue={props.user?.addressId}
+          className=\\"rw-input\\"
+          errorClassName=\\"rw-input rw-input-error\\"
+          validation={{ setValueAs: (val: string) => val || null }}
+        />
+        <FieldError name=\\"addressId\\" className=\\"rw-field-error\\" />
+
+        <div className=\\"rw-button-group\\">
+          <Submit
+            disabled={props.loading}
+            className=\\"rw-button rw-button-blue\\"
+          >
+            Save
+          </Submit>
+        </div>
+      </Form>
+    </div>
+  )
+}
+
+export default UserForm
 "
 `;
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/fixtures/schema.prisma
@@ -27,12 +27,25 @@ model Post {
   favorites  Favorite[]
 }
 
+model Address {
+  id           String  @id @default(uuid())
+  country      String
+  state        String?
+  zip          String
+  town         String
+  street       String
+  streetNumber String // Can be 12C for example
+  users        User[]
+}
+
 model User {
-  id       Int           @id @default(autoincrement())
-  name     String?
-  email    String        @unique
-  isAdmin  Boolean       @default(false)
-  profiles UserProfile[]
+  id        Int           @id @default(autoincrement())
+  name      String?
+  email     String        @unique
+  isAdmin   Boolean       @default(false)
+  profiles  UserProfile[]
+  addressId String?
+  address   Address?      @relation(fields: [addressId], references: [id])
 }
 
 model UserProfile {

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -392,6 +392,22 @@ describe('in javascript (default) mode', () => {
       ]
     ).toMatchSnapshot()
   })
+
+  test('creates a UserForm with empty optional string foreign keys transformed to null', async () => {
+    const foreignKeyFiles = await scaffold.files({
+      model: 'User',
+      tests: false,
+      nestScaffoldByModel: true,
+    })
+
+    expect(
+      foreignKeyFiles[
+        path.normalize(
+          '/path/to/project/web/src/components/User/UserForm/UserForm.js'
+        )
+      ]
+    ).toMatchSnapshot()
+  })
 })
 
 describe('in typescript mode', () => {
@@ -676,6 +692,23 @@ describe('in typescript mode', () => {
       foreignKeyFiles[
         path.normalize(
           '/path/to/project/web/src/components/UserProfile/EditUserProfileCell/EditUserProfileCell.tsx'
+        )
+      ]
+    ).toMatchSnapshot()
+  })
+
+  test('creates a UserForm with empty optional string foreign keys transformed to null', async () => {
+    const foreignKeyFiles = await scaffold.files({
+      model: 'User',
+      typescript: true,
+      tests: false,
+      nestScaffoldByModel: true,
+    })
+
+    expect(
+      foreignKeyFiles[
+        path.normalize(
+          '/path/to/project/web/src/components/User/UserForm/UserForm.tsx'
         )
       ]
     ).toMatchSnapshot()

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -31,6 +31,7 @@ import {
   relationsForModel,
   intForeignKeysForModel,
   mapPrismaScalarToPagePropTsType,
+  optionalStringForeignKeysForModel,
 } from '../helpers'
 import { files as sdlFiles, builder as sdlBuilder } from '../sdl/sdl'
 import {
@@ -357,6 +358,7 @@ const componentFiles = async (
   const model = await getSchema(singularName)
   const idType = getIdType(model)
   const intForeignKeys = intForeignKeysForModel(model)
+  const optionalStringForeignKeys = optionalStringForeignKeysForModel(model)
   let fileList = {}
   const componentMetadata = {
     Boolean: {
@@ -406,7 +408,9 @@ const componentFiles = async (
     .map((column) => {
       let validation
 
-      if (componentMetadata[column.type]?.validation) {
+      if (optionalStringForeignKeys.includes(column.name)) {
+        validation = '{{ setValueAs: (val: string) => val || null }}'
+      } else if (componentMetadata[column.type]?.validation) {
         validation = componentMetadata[column.type]?.validation(
           column?.isRequired
         )


### PR DESCRIPTION
Adds support for optional relations with string IDs to the scaffold generator. Does this by converting `''` to `null`

Fixes https://github.com/redwoodjs/redwood/issues/4297