### PR TITLE
createCell: Give cell results priority over cell props

### DIFF
--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -248,11 +248,6 @@ export function createCell<CellProps = any>({
       options
     )
 
-    const commonProps = {
-      updating: loading,
-      ...queryRest,
-    }
-
     if (error) {
       if (Failure) {
         return (
@@ -260,7 +255,8 @@ export function createCell<CellProps = any>({
             error={error}
             errorCode={error.graphQLErrors?.[0]?.extensions?.['code'] as string}
             {...props}
-            {...commonProps}
+            updating={loading}
+            {...queryRest}
           />
         )
       } else {
@@ -270,9 +266,23 @@ export function createCell<CellProps = any>({
       const afterQueryData = afterQuery(data)
 
       if (isEmpty(data, { isDataEmpty }) && Empty) {
-        return <Empty {...{ ...props, ...afterQueryData, ...commonProps }} />
+        return (
+          <Empty
+            {...props}
+            {...afterQueryData}
+            updating={loading}
+            {...queryRest}
+          />
+        )
       } else {
-        return <Success {...{ ...props, ...afterQueryData, ...commonProps }} />
+        return (
+          <Success
+            {...props}
+            {...afterQueryData}
+            updating={loading}
+            {...queryRest}
+          />
+        )
       }
     } else if (loading) {
       return <Loading {...{ ...queryRest, ...props }} />

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -241,6 +241,8 @@ export function createCell<CellProps = any>({
 
     const options = beforeQuery(variables)
 
+    // queryRest includes `variables: { ... }`, with any variables returned
+    // from beforeQuery
     const { error, loading, data, ...queryRest } = useQuery(
       typeof QUERY === 'function' ? QUERY(options) : QUERY,
       options
@@ -249,7 +251,6 @@ export function createCell<CellProps = any>({
     const commonProps = {
       updating: loading,
       ...queryRest,
-      ...props,
     }
 
     if (error) {
@@ -258,6 +259,7 @@ export function createCell<CellProps = any>({
           <Failure
             error={error}
             errorCode={error.graphQLErrors?.[0]?.extensions?.['code'] as string}
+            {...props}
             {...commonProps}
           />
         )
@@ -268,9 +270,9 @@ export function createCell<CellProps = any>({
       const afterQueryData = afterQuery(data)
 
       if (isEmpty(data, { isDataEmpty }) && Empty) {
-        return <Empty {...{ ...afterQueryData, ...commonProps }} />
+        return <Empty {...{ ...props, ...afterQueryData, ...commonProps }} />
       } else {
-        return <Success {...{ ...afterQueryData, ...commonProps }} />
+        return <Success {...{ ...props, ...afterQueryData, ...commonProps }} />
       }
     } else if (loading) {
       return <Loading {...{ ...queryRest, ...props }} />


### PR DESCRIPTION
This PR resolves https://github.com/redwoodjs/redwood/issues/2962

It's not the solution we decided on, but it's the solution I want 😁

So, this is the setup

```jsx
<JoinCell inviteCode={inviteCode} />
```

and a cell query like this

```jsx
export const QUERY = gql`
  query JoinTeamQuery($inviteCode: String!) {
    inviteCode(code: $inviteCode) {
      code
      expiry
    }
  }
`
```

And finally a Success component like this

```jsx
export const Success = ({ inviteCode }) => {
  return <pre>{JSON.stringify(inviteCode, null, 2)}</pre>
}
```

With my new implementation you'd see this:

```
{
  "__typename": "InviteCode",
  "code": "1NBVWN",
  "expiry": "2022-01-31T16:04:00.000Z"
}
```

With the old implementation all you'd get was this:

```
"1NBVWN"
```

And, finally, if you want to get at the actual props that have been over-ridden by the query result you can find them in `variables`:

```jsx
export const Success = ({ inviteCode, variables }) => {
  return <pre>{JSON.stringify({ inviteCode, variables }, null, 2)}</pre>
}
```

```
{
  "inviteCode": {
    "__typename": "InviteCode",
    "code": "1NBVWN",
    "expiry": "2022-01-31T16:04:00.000Z"
  },
  "variables": {
    "inviteCode": "1NBVWN"
  }
}
```