### PR TITLE
Update release script

### DIFF
--- a/tasks/release/__tests__/release.test.mjs
+++ b/tasks/release/__tests__/release.test.mjs
@@ -1,0 +1,37 @@
+/* eslint-env jest, es2021 */
+import {
+  MERGED_PRS_NO_MILESTONE,
+  MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE,
+} from '../release.mjs'
+
+describe('release', () => {
+  it('uses the right queries', () => {
+    expect(MERGED_PRS_NO_MILESTONE).toMatchInlineSnapshot(`
+      "
+          {
+            search(query: \\"repo:redwoodjs/redwood is:pr is:merged no:milestone\\", first: 5, type: ISSUE) {
+              nodes {
+                ... on PullRequest {
+                  id
+                }
+              }
+            }
+          }
+        "
+    `)
+
+    expect(MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE).toMatchInlineSnapshot(`
+      "
+        {
+          search(query: \\"repo:redwoodjs/redwood is:pr is:merged milestone:next-release-patch\\", first: 5, type: ISSUE) {
+            nodes {
+              ... on PullRequest {
+                id
+              }
+            }
+          }
+        }
+      "
+    `)
+  })
+})

--- a/tasks/release/prompts.mjs
+++ b/tasks/release/prompts.mjs
@@ -3,14 +3,6 @@ import c from 'ansi-colors'
 import boxen from 'boxen'
 import prompts from 'prompts'
 
-export const ASK = c.bgBlue(c.black('  ASK  '))
-export const CHECK = c.bgYellow(c.black(' CHECK '))
-export const FIX = c.bgRed(c.black('  FIX  '))
-export const OK = c.bgGreen(c.black('  O K  '))
-// https://stackoverflow.com/questions/38760554/how-to-print-cross-mark-or-check-mark-in-tcl
-export const HEAVY_X = c.red('\u2716')
-export const HEAVY_CHECK = c.green('\u2714')
-
 /**
  * Wrapper around `prompts` to exit on crtl c.
  *
@@ -58,3 +50,32 @@ export function rocketBoxen(message) {
     },
   })
 }
+
+/**
+ * @param {string} prefix
+ * @returns (string, ...values) => string
+ */
+function makeStringFormatter(prefix) {
+  return function formatter(strings, ...values) {
+    const message = strings.reduce(
+      (string, nextString, i) =>
+        (string += nextString + c.green(values[i] ?? '')),
+      ''
+    )
+
+    return `${prefix} ${message}`
+  }
+}
+
+export const ASK = c.bgBlue(c.black('  ASK  '))
+export const CHECK = c.bgYellow(c.black(' CHECK '))
+export const FIX = c.bgRed(c.black('  FIX  '))
+export const OK = c.bgGreen(c.black('  O K  '))
+// https://stackoverflow.com/questions/38760554/how-to-print-cross-mark-or-check-mark-in-tcl
+export const HEAVY_X = c.red('\u2716')
+export const HEAVY_CHECK = c.green('\u2714')
+
+export const ask = makeStringFormatter(ASK)
+export const check = makeStringFormatter(CHECK)
+export const fix = makeStringFormatter(`${HEAVY_X} ${FIX}`)
+export const ok = makeStringFormatter(`${HEAVY_CHECK} ${OK}`)

--- a/tasks/release/prompts.mjs
+++ b/tasks/release/prompts.mjs
@@ -36,17 +36,26 @@ export async function promptForSemver() {
 /**
  * Wrapper around confirm-type `prompts`.
  *
+ * @typedef {{ exit: boolean, exitCode: string }} ConfirmOptions
  * @param {string} message
+ * @param {ConfirmOptions} options
  * @returns {Promise<boolean>}
  */
-export async function confirm(message) {
+export async function confirm(
+  message,
+  { exit, exitCode } = { exit: false, exitCode: 0 }
+) {
   const { confirmed } = await exitOnCancelPrompts({
     type: 'confirm',
     name: 'confirmed',
     message,
   })
 
-  return confirmed
+  if (!exit) {
+    return confirmed
+  }
+
+  process.exit(exitCode)
 }
 
 /**
@@ -99,9 +108,14 @@ export const ok = makeStringFormatter(`${HEAVY_CHECK} ${OK}`)
 /**
  * @param {string} message
  * @param {Array<() => Promise<any>>} runs
+ * @param {{ exit: boolean, exitCode: string }} options
  */
-export async function confirmRuns(message, runs) {
-  const confirmed = await confirm(message)
+export async function confirmRuns(
+  message,
+  runs,
+  { exit, exitCode } = { exit: false, exitCode: 0 }
+) {
+  const confirmed = await confirm(message, { exit, exitCode })
 
   if (!confirmed) {
     return false

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -85,17 +85,7 @@ export default async function release() {
   // Check that there's no merged PRs without a milestone
   const {
     search: { nodes: pullRequests },
-  } = await octokit.graphql(`
-    {
-      search(query: "repo:redwoodjs/redwood is:pr is:merged no:milestone", first: 5, type: ISSUE) {
-        nodes {
-          ... on PullRequest {
-            id
-          }
-        }
-      }
-    }
-  `)
+  } = await octokit.graphql(MERGED_PRS_NO_MILESTONE)
   if (pullRequests.length) {
     console.log(
       c.bold(
@@ -109,17 +99,7 @@ export default async function release() {
   if (semver !== 'patch') {
     const {
       search: { nodes: nextReleasePatchPullRequests },
-    } = await octokit.graphql(`
-      {
-        search(query: "repo:redwoodjs/redwood is:pr is:merged milestone:next-release-patch", first: 5, type: ISSUE) {
-          nodes {
-            ... on PullRequest {
-              id
-            }
-          }
-        }
-      }
-    `)
+    } = await octokit.graphql(MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE)
     if (nextReleasePatchPullRequests.length) {
       console.log(
         c.bold(
@@ -200,6 +180,30 @@ function getNextVersion(semver, previousVersion) {
     }
   }
 }
+
+export const MERGED_PRS_NO_MILESTONE = `
+    {
+      search(query: "repo:redwoodjs/redwood is:pr is:merged no:milestone", first: 5, type: ISSUE) {
+        nodes {
+          ... on PullRequest {
+            id
+          }
+        }
+      }
+    }
+  `
+
+export const MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE = `
+  {
+    search(query: "repo:redwoodjs/redwood is:pr is:merged milestone:next-release-patch", first: 5, type: ISSUE) {
+      nodes {
+        ... on PullRequest {
+          id
+        }
+      }
+    }
+  }
+`
 
 /**
  * Right now releasing a major is the same as releasing a minor.

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -1,8 +1,19 @@
 /* eslint-env node, es2021 */
 /**
- * Notes
- * - branch already exists? start on the "update package versions" step
- * - consider using xstate
+ * Use this script to release a version of RedwoodJS:
+ *
+ * ```
+ * yarn release
+ * ```
+ *
+ * @remarks
+ *
+ * You'll need a GitHub token and an NPM token. (So only @thedavidprice can do this right now.)
+ *
+ * @remarks
+ *
+ * - handle the case where a branch already exists; start on the "update package versions" step
+ * - at this point, consider using xstate
  */
 import c from 'ansi-colors'
 import notifier from 'node-notifier'
@@ -42,7 +53,8 @@ export default async function release() {
   const previousVersion = gitDescribePO.stdout.trim()
   let nextVersion = getNextVersion(semver, previousVersion)
 
-  // Confirm that we got the next version right; give the user a chance to correct it if we didn't.
+  // Confirm that we got the next version right.
+  // Give the user a chance to correct it if we didn't.
   const nextVersionConfirmed = await confirm(
     `${CHECK} The next release is ${c.green(nextVersion)}`
   )
@@ -122,6 +134,7 @@ export default async function release() {
     )
   }
 
+  // Update next-release PRs' milestone.
   const shouldUpdateNextReleasePRsMilestone = await confirm(
     `${ASK} Do you want to update next-release PRs' milestone to ${c.green(
       nextVersion
@@ -138,6 +151,7 @@ export default async function release() {
     }
   }
 
+  // Do the release.
   switch (semver) {
     case 'major':
       console.log(c.bold(`${HEAVY_X} ${FIX} Wait till after v1`))

--- a/tasks/release/updateNextReleasePullRequestsMilestone.mjs
+++ b/tasks/release/updateNextReleasePullRequestsMilestone.mjs
@@ -4,8 +4,6 @@
  * - milestone:next-release-patch -> check empty
  * - close milestone _after_ publish
  */
-import c from 'ansi-colors'
-
 import octokit from './octokit.mjs'
 import { confirm, ask, check } from './prompts.mjs'
 
@@ -51,31 +49,27 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
   const looksOk = await confirm(
     check`Updated the milestone of ${pullRequestIds.length} PRs: https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${title}\nDoes everything look ok?`
   )
-
-  if (!looksOk) {
-    const undoPRs = await confirm(
-      ask`Do you want to undo the changes to the PRs?`
-    )
-
-    if (undoPRs) {
-      await Promise.all(
-        pullRequestIds.map((pullRequestId) =>
-          updatePullRequestMilestone(pullRequestId, nextReleaseMilestoneId)
-        )
-      )
-    }
-
-    const undoMilestone = await confirm(
-      ask`Do you want to delete the milestone`
-    )
-    if (undoMilestone) {
-      await deleteMilestone(milestone.number)
-    }
-
-    return
+  if (looksOk) {
+    return milestone
   }
 
-  return milestone
+  const undoPRs = await confirm(
+    ask`Do you want to undo the changes to the PRs?`
+  )
+  if (undoPRs) {
+    await Promise.all(
+      pullRequestIds.map((pullRequestId) =>
+        updatePullRequestMilestone(pullRequestId, nextReleaseMilestoneId)
+      )
+    )
+  }
+
+  const undoMilestone = await confirm(ask`Do you want to delete the milestone`)
+  if (undoMilestone) {
+    await deleteMilestone(milestone.number)
+  }
+
+  return
 }
 
 // Helpers

--- a/tasks/release/updateNextReleasePullRequestsMilestone.mjs
+++ b/tasks/release/updateNextReleasePullRequestsMilestone.mjs
@@ -7,7 +7,7 @@
 import c from 'ansi-colors'
 
 import octokit from './octokit.mjs'
-import { confirm, ASK, CHECK } from './prompts.mjs'
+import { confirm, ask, check } from './prompts.mjs'
 
 /**
  * @param {string} title
@@ -16,11 +16,10 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
   let milestone = await getMilestone(title)
 
   if (!milestone) {
-    const okToCreate = await confirm(
-      `${ASK} Milestone ${c.green(title)} doesn't exist. Ok to create it?`
+    const createOk = await confirm(
+      ask`Milestone ${title} doesn't exist. Ok to create it?`
     )
-
-    if (!okToCreate) {
+    if (!createOk) {
       return
     }
 
@@ -29,23 +28,17 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
     } = await createMilestone(title)
 
     milestone = { title, id, number }
-
-    console.log(`Created milestone ${c.green(title)}`)
   }
 
   const nextReleaseMilestoneId = await getNextReleaseMilestoneId()
-
   const pullRequestIds = await getPullRequestIdsWithMilestone(
     nextReleaseMilestoneId
   )
 
-  const okToUpdate = await confirm(
-    `${ASK} Ok to update the milestone of ${
-      pullRequestIds.length
-    } PRs from ${c.green('next-release')} to ${c.green(title)}?`
+  const updateOk = await confirm(
+    ask`Ok to update the milestone of ${pullRequestIds.length} PRs from next-release to ${title}?`
   )
-
-  if (!okToUpdate) {
+  if (!updateOk) {
     return
   }
 
@@ -55,14 +48,13 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
     )
   )
 
-  const looksRight = await confirm(
-    `${CHECK} Updated the milestone of ${pullRequestIds.length} PRs:
-    https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${title}\nDoes everything look right?`
+  const looksOk = await confirm(
+    check`Updated the milestone of ${pullRequestIds.length} PRs: https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${title}\nDoes everything look ok?`
   )
 
-  if (!looksRight) {
+  if (!looksOk) {
     const undoPRs = await confirm(
-      `${ASK} Do you want to undo the changes to the PRs?`
+      ask`Do you want to undo the changes to the PRs?`
     )
 
     if (undoPRs) {
@@ -74,9 +66,8 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
     }
 
     const undoMilestone = await confirm(
-      `${ASK} Do you want to delete the milestone`
+      ask`Do you want to delete the milestone`
     )
-
     if (undoMilestone) {
       await deleteMilestone(milestone.number)
     }


### PR DESCRIPTION
This PR gets the patch release process ready for action. While it doesn't change the minor release process, it does 1) improve some of the tests and 2) improve the code organization significantly:
- add basic test for release script (check that the queries are right)
- add a legit MSW unit test for updating next release pull requests 
- add better primitives
  - `ask`, `check`, `fix`, `ok` tagged template literals
  - add an option to exit the process to `confirm` prompts
  - add a new `confirmRuns` function to consolidate running tasks after asking 
