### PR TITLE
Add missing deps to @redwoodjs/forms package.json

### DIFF
--- a/packages/forms/jest.config.js
+++ b/packages/forms/jest.config.js
@@ -1,12 +1,4 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  moduleNameMapper: {
-    /**
-     * Not entirely sure what's changed in Jest that, or react-hook-form,
-     * that now requires this.
-     */
-    'react-hook-form':
-      '<rootDir>/../../node_modules/react-hook-form/dist/index.cjs',
-  },
   testEnvironment: 'jest-environment-jsdom',
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,36 +1,50 @@
 {
   "name": "@redwoodjs/forms",
   "version": "0.43.0",
-  "files": [
-    "dist"
-  ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "license": "MIT",
-  "dependencies": {
-    "@types/pascalcase": "1.0.1",
-    "core-js": "3.20.3",
-    "pascalcase": "1.0.0",
-    "react-hook-form": "7.25.3"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/redwoodjs/redwood.git",
     "directory": "packages/forms"
   },
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "yarn build:js",
-    "prepublishOnly": "NODE_ENV=production yarn build",
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
+    "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
-  "gitHead": "8be6a35c2dfd5aaeb12d55be4f0c77eefceb7762",
+  "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
+    "pascalcase": "1.0.0",
+    "react-hook-form": "7.25.3"
+  },
   "devDependencies": {
     "@babel/cli": "7.16.7",
     "@babel/core": "7.16.7",
+    "@testing-library/dom": "^8.11.3",
+    "@testing-library/jest-dom": "5.16.1",
+    "@testing-library/react": "12.1.2",
+    "@testing-library/user-event": "13.5.0",
+    "@types/pascalcase": "^1.0.1",
+    "@types/react": "17.0.38",
+    "@types/react-dom": "^17",
+    "@types/testing-library__jest-dom": "^5",
     "jest": "27.4.7",
+    "nodemon": "2.0.15",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "typescript": "4.5.5"
-  }
+  },
+  "peerDependencies": {
+    "graphql": "16.3.0",
+    "react": "17.0.2"
+  },
+  "gitHead": "8be6a35c2dfd5aaeb12d55be4f0c77eefceb7762"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5598,12 +5598,25 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
-    "@types/pascalcase": 1.0.1
-    core-js: 3.20.3
+    "@babel/runtime-corejs3": 7.16.7
+    "@testing-library/dom": ^8.11.3
+    "@testing-library/jest-dom": 5.16.1
+    "@testing-library/react": 12.1.2
+    "@testing-library/user-event": 13.5.0
+    "@types/pascalcase": ^1.0.1
+    "@types/react": 17.0.38
+    "@types/react-dom": ^17
+    "@types/testing-library__jest-dom": ^5
     jest: 27.4.7
+    nodemon: 2.0.15
     pascalcase: 1.0.0
+    react: 17.0.2
+    react-dom: 17.0.2
     react-hook-form: 7.25.3
     typescript: 4.5.5
+  peerDependencies:
+    graphql: 16.3.0
+    react: 17.0.2
   languageName: unknown
   linkType: soft
 
@@ -6896,6 +6909,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^8.11.3":
+  version: 8.11.3
+  resolution: "@testing-library/dom@npm:8.11.3"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^4.2.0
+    aria-query: ^5.0.0
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.4.4
+    pretty-format: ^27.0.2
+  checksum: 2a27ace6e6172c26be6e7dd689ead87d874b34fa887017dcf1e20d1e0f6160f26236c53364217af005c14d87ad76680579e51b18ed2a8738e1b72c5ea908f6b2
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:5.16.1":
   version: 5.16.1
   resolution: "@testing-library/jest-dom@npm:5.16.1"
@@ -7749,7 +7778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pascalcase@npm:1.0.1":
+"@types/pascalcase@npm:^1.0.1":
   version: 1.0.1
   resolution: "@types/pascalcase@npm:1.0.1"
   checksum: beb5e1568f9dc2335c20c1f7df1332b0a357c6492e3ba04e14e0b908ff2e10509c94a991d1f90a384a0dae7c862d8c1107141dacab80532738fadd085cdbb26e
@@ -7807,7 +7836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:17.0.11":
+"@types/react-dom@npm:17.0.11, @types/react-dom@npm:^17":
   version: 17.0.11
   resolution: "@types/react-dom@npm:17.0.11"
   dependencies:
@@ -7968,7 +7997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/testing-library__jest-dom@npm:^5.9.1":
+"@types/testing-library__jest-dom@npm:^5, @types/testing-library__jest-dom@npm:^5.9.1":
   version: 5.14.2
   resolution: "@types/testing-library__jest-dom@npm:5.14.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6893,23 +6893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.0.0, @testing-library/dom@npm:^8.11.1":
-  version: 8.11.1
-  resolution: "@testing-library/dom@npm:8.11.1"
-  dependencies:
-    "@babel/code-frame": ^7.10.4
-    "@babel/runtime": ^7.12.5
-    "@types/aria-query": ^4.2.0
-    aria-query: ^5.0.0
-    chalk: ^4.1.0
-    dom-accessibility-api: ^0.5.9
-    lz-string: ^1.4.4
-    pretty-format: ^27.0.2
-  checksum: 5216c07dabdf7e32ce8ef6c3a13b068f0f4c3e1dec047ee4b6383a99e66d2aba8f98be8830f093459a17bc189e529ce74b46e47948b4d79447956461b839bc0b
-  languageName: node
-  linkType: hard
-
-"@testing-library/dom@npm:^8.11.3":
+"@testing-library/dom@npm:^8.0.0, @testing-library/dom@npm:^8.11.1, @testing-library/dom@npm:^8.11.3":
   version: 8.11.3
   resolution: "@testing-library/dom@npm:8.11.3"
   dependencies:


### PR DESCRIPTION
While I was reviewing #4302, I ran `yarn dlx @yarnpkg/doctor` to see if anything was missing. There were a few things missing and a few things there that we don't need.

I also sorted the `package.json` file and removed some jest config because it wasn't necessary anymore; moreover, `yarn dlx @yarnpkg/doctor` doesn't like seeing `node_modules` in strings.

The output from `yarn dlx @yarnpkg/doctor`:

```
dom@evaM1 ~/p/r/r/p/forms (ds-update-forms-package.json)> yarn dlx @yarnpkg/doctor
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 1s 827ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ util-deprecate@npm:1.0.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ which@npm:2.0.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ wrappy@npm:1.0.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yallist@npm:4.0.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yup@npm:0.32.11 can't be found in the cache and will be fetched from the remote registry
➤ YN0000: └ Completed in 0s 653ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 0s 672ms
➤ YN0000: Done in 3s 173ms

➤ YN0000: Found 1 package(s) to process
➤ YN0000: For a grand total of 8 file(s) to validate

➤ YN0000: ┌ /Users/dom/prjcts/rw/redwood/packages/forms/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublishOnly") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: └ Completed in 4s 193ms
➤ YN0000: ⠸ --------------------------------------------------------------------------------

➤ YN0000: Done with warnings in 4s 195ms
```

I'd like to fix the warning too in the future.