### PR TITLE
Apollo: isAuthenticated might not be up-to-date

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -47,18 +47,28 @@ export interface AuthContextInterface {
    * A reference to the client that you passed into the `AuthProvider`,
    * which is useful if we do not support some specific functionality.
    */
-  client: SupportedAuthClients
-  type: SupportedAuthTypes
+  client?: SupportedAuthClients
+  type?: SupportedAuthTypes
   hasError: boolean
   error?: Error
 }
 
-// @ts-expect-error - We do not supply default values for the functions.
 export const AuthContext = React.createContext<AuthContextInterface>({
   loading: true,
   isAuthenticated: false,
   userMetadata: null,
   currentUser: null,
+  logIn: () => Promise.resolve(),
+  logOut: () => Promise.resolve(),
+  signUp: () => Promise.resolve(),
+  getToken: () => Promise.resolve(null),
+  getCurrentUser: () => Promise.resolve(null),
+  hasRole: () => true,
+  reauthenticate: () => Promise.resolve(),
+  forgotPassword: () => Promise.resolve(),
+  resetPassword: () => Promise.resolve(),
+  validateResetToken: () => Promise.resolve(),
+  hasError: false,
 })
 
 type AuthProviderProps =

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -112,16 +112,12 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
    *
    * @see {@link https://www.apollographql.com/docs/react/api/link/introduction/}
    */
-  const { isAuthenticated, getToken, type: authProviderType } = useAuth()
+  const { getToken, type: authProviderType } = useAuth()
 
   const withToken = setContext(async () => {
-    if (isAuthenticated && getToken) {
-      const token = await getToken()
+    const token = await getToken()
 
-      return { token }
-    }
-
-    return { token: null }
+    return { token }
   })
 
   const { headers, uri } = useFetchConfig()

--- a/packages/web/src/components/FetchConfigProvider.tsx
+++ b/packages/web/src/components/FetchConfigProvider.tsx
@@ -6,7 +6,7 @@ export const getApiGraphQLUrl = () => {
 
 export interface FetchConfig {
   uri: string
-  headers?: { 'auth-provider': SupportedAuthTypes; authorization?: string }
+  headers?: { 'auth-provider'?: SupportedAuthTypes; authorization?: string }
 }
 
 export const FetchConfigContext = React.createContext<FetchConfig>({


### PR DESCRIPTION
# Problem

When a user signs in with an auth provider a call to `setState` is made to set `isAuthenticated: true`. `setState` is async, so will happen some time in the future. When in does happen it'll update the auth React Context.

RW's gql client (apollo) is a consumer of the auth context. Previously the client would look at `isAuthenticated` to decide whether to send auth tokens or not.

The problem is if the RW app has (psuedo-)code like this
```
const { logIn } = useAuth();

logIn({ username, password })
  .then((user) => {
    getUserProfile({ variables: { id: user.sub } })
  })
```

In the above case the `getUserProfile` gql query might fire off before the `isAuthenticated: true` state update has propagated down to the gql client.

# Solution

Use `getToken` to ask the auth provider client for a token. The provider client will always know if the user is signed in or not. And if the user isn't `getToken` will return `null`. If the user is signed in, it will return a token.