### PR TITLE
fix(dotenv-loading): Fixes dotenv loading regression

### DIFF
--- a/packages/core/config/__tests__/webpack.common.test.js
+++ b/packages/core/config/__tests__/webpack.common.test.js
@@ -1,11 +1,14 @@
-import { getEnvVars } from '../webpack.common'
+// @NOTE
+// No babel in the package, so use standard node syntax
+
+const { getEnvVars } = require('../webpack.common')
 
 jest.mock('@redwoodjs/internal', () => {
   return {
     getConfigPath: () => '/path/to/project/redwood.toml',
     getConfig: () => ({
       web: {
-        includeEnvironmentVariables: ['API_KEY', 'API_SECRET'],
+        includeEnvironmentVariables: ['API_KEY', 'API_SECRET', 'IM_NOT_THERE'],
       },
     }),
     getPaths: () => ({
@@ -33,6 +36,7 @@ describe('getEnvVars', () => {
     expect(getEnvVars()).toEqual({
       'process.env.API_KEY': '"dog"',
       'process.env.API_SECRET': '"cat"',
+      'process.env.IM_NOT_THERE': undefined, // even if value isn't there, the key is defined, so that webpack 5 doesn't throw "process.env undefined" error
     })
   })
 })

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/*.test.[jt]s?(x)'],
+  testPathIgnorePatterns: ['fixtures', 'dist'],
+  testTimeout: 15000,
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,10 @@
   "files": [
     "config"
   ],
+  "scripts": {
+    "test": "jest",
+    "test:watch": "yarn test --watch"
+  },
   "dependencies": {
     "@babel/cli": "7.16.7",
     "@babel/core": "7.16.7",
@@ -40,7 +44,6 @@
     "core-js": "3.21.0",
     "css-loader": "6.5.1",
     "css-minimizer-webpack-plugin": "3.4.1",
-    "dotenv-webpack": "7.1.0",
     "esbuild": "0.14.16",
     "esbuild-loader": "2.18.0",
     "fast-glob": "3.2.11",
@@ -64,6 +67,9 @@
     "webpack-manifest-plugin": "4.1.1",
     "webpack-merge": "5.8.0",
     "webpack-retry-chunk-load-plugin": "3.0.0"
+  },
+  "devDependencies": {
+    "jest": "27.4.7"
   },
   "gitHead": "8be6a35c2dfd5aaeb12d55be4f0c77eefceb7762"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5573,7 +5573,6 @@ __metadata:
     core-js: 3.21.0
     css-loader: 6.5.1
     css-minimizer-webpack-plugin: 3.4.1
-    dotenv-webpack: 7.1.0
     esbuild: 0.14.16
     esbuild-loader: 2.18.0
     fast-glob: 3.2.11
@@ -5581,6 +5580,7 @@ __metadata:
     graphql: 16.3.0
     graphql-tag: 2.12.6
     html-webpack-plugin: 5.5.0
+    jest: 27.4.7
     lodash.escaperegexp: 4.1.2
     mini-css-extract-plugin: 2.5.3
     nodemon: 2.0.15
@@ -13452,30 +13452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv-defaults@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "dotenv-defaults@npm:2.0.2"
-  dependencies:
-    dotenv: ^8.2.0
-  checksum: 14b7b8f6c21a30404106384398728746e63405bfeabe47ef7aadd0e81de49986d5896a612e5b1acddf655af6472a24947b7b113aa3ef3270a2877afa9c5bd287
-  languageName: node
-  linkType: hard
-
 "dotenv-expand@npm:^5.1.0":
   version: 5.1.0
   resolution: "dotenv-expand@npm:5.1.0"
   checksum: 24ac633de853ef474d0421cc639328b7134109c8dc2baaa5e3afb7495af5e9237136d7e6971e55668e4dce915487eb140967cdd2b3e99aa439e0f6bf8b56faeb
-  languageName: node
-  linkType: hard
-
-"dotenv-webpack@npm:7.1.0":
-  version: 7.1.0
-  resolution: "dotenv-webpack@npm:7.1.0"
-  dependencies:
-    dotenv-defaults: ^2.0.2
-  peerDependencies:
-    webpack: ^4 || ^5
-  checksum: 780bb44aaa400ccad12c47afdab5e2e4c1cba26c92d5092bacbf5233d2d81a578489b5533af9f2dc12dd311b027649ec9ba78317d445650111bdadcd66bd0d23
   languageName: node
   linkType: hard
 
@@ -13500,7 +13480,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^8.0.0, dotenv@npm:^8.2.0":
+"dotenv@npm:^8.0.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 6750431dea8efbd54b9f2d9681b04e1ccc7989486461dcf058bb708d9e3d63b04115fcdf8840e38ad1e24a4a2e1e7c1560626c5e3ac7bc09371b127c49e2d45f


### PR DESCRIPTION
This PR does the following

### 1. Removes the `dotenv-webpack` plugin.
I'm not sure why this was here, probably legacy reasons, but having this plugin here meant we weren't handling env vars on the web side, the way our documentation said we did. 

Example: Accessing "unsafe" variables
```diff
# redwood.toml
+includeEnvironmentVariables = ['BAZINGA']
```
And somewhere in the web code we do the following:
```js
console.log(process.env.BAZINGA) // prints values of BAZINGA ✅ comes through, great

console.log(process.env.DATABASE_URL) // prints value of DATABASE_URL ❌ this is not expected behaviour
```

---

### 2. Prevents erroring out on the website with `process.env is undefined` errors, by instantiting all the values defined in `includeEnvironmentVariables`

**This was the regression in v0.43**

Example: 
```toml
# redwood.toml
+includeEnvironmentVariables = ['ENV_1', 'ENV_2']
```
```diff
#.env
-ENV_1=value
-ENV_2=value
```

And somewhere in the web code we do:

```
console.log('env1', process.env.ENV_1)
console.log('env2', process.env.ENV_2)
```
- **in v0.42:** it would print:
```
env1 MISSING_ENV_VAR // ❌ unexpected, but acceptable, behaviour
env2 MISSING_ENV_VAR
```
- **in v0.43** it would error with`process.env is undefined`
❌ unexpected behaviour 

- After this fix:
```
env1 undefined // ✅ expected behaviour
env2 undefined
```

---

### 3. Adds jest config for rwjs/core
We had a test in the `@redwoodjs/core` but no jest config, and no script to actually run it. :S Adds jest stuff back so the test actually runs (also updated the test)
