### PR TITLE
revert dotenv ignorestub

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -172,7 +172,7 @@ const getSharedPlugins = (isEnvProduction) => {
     new Dotenv({
       path: path.resolve(redwoodPaths.base, '.env'),
       silent: true,
-      ignoreStub: true, // FIXME: this might not be necessary once the storybook webpack 4/5 stuff is ironed out. See also: https://github.com/mrsteele/dotenv-webpack#processenv-stubbing--replacing
+      // ignoreStub: true, // FIXME: this might not be necessary once the storybook webpack 4/5 stuff is ironed out. See also: https://github.com/mrsteele/dotenv-webpack#processenv-stubbing--replacing
     }),
   ].filter(Boolean)
 }


### PR DESCRIPTION
As a workaround to publish v0.44, this temporarily reverts a Webpack DotEnv config that was added to support running Storybook in CI. The config change caused an error for some cases where env vars were defined but empty until deployed to production — those env vars were no longer included in the production build.

Long term solution is #4344 