### PR TITLE
fix(generators): Generate types after gen-ing files

### DIFF
--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -175,7 +175,7 @@ export const { command, description, builder, handler } =
       return [
         {
           title: `Generating types ...`,
-          task: () => generateTypes,
+          task: generateTypes,
         },
       ]
     },

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -224,7 +224,7 @@ export const handler = async ({
       },
       {
         title: `Generating types...`,
-        task: () => generateTypes,
+        task: generateTypes,
       },
       {
         title: 'One more thing...',

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -678,7 +678,7 @@ export const tasks = ({
       },
       {
         title: `Generating types ...`,
-        task: () => generateTypes,
+        task: generateTypes,
       },
     ],
     { collapse: false, exitOnError: true }

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -233,7 +233,7 @@ export const handler = async ({ model, crud, force, tests, typescript }) => {
         },
         {
           title: `Generating types ...`,
-          task: () => generateTypes,
+          task: generateTypes,
         },
       ].filter(Boolean),
       { collapse: false, exitOnError: true }


### PR DESCRIPTION
Related to #4303

This PR fixes a bug where types weren't being generated after runnign `yarn rw g` on Cells, Pages, Scaffold or SDLs