### PR TITLE
fix(scenario): Accidentally comitted debugging change

### DIFF
--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -12,7 +12,10 @@ const { defineScenario } = require('@redwoodjs/testing/dist/api')
 // fails on DELETE
 const FOREIGN_KEY_ERRORS = [1451, 1811, 23503]
 const DEFAULT_SCENARIO = 'standard'
-const TEARDOWN_CACHE_PATH = path.join(process.cwd(), 'scenarioTeardown.json')
+const TEARDOWN_CACHE_PATH = path.join(
+  getPaths().generated.base,
+  'scenarioTeardown.json'
+)
 let teardownOrder = []
 let originalTeardownOrder = []
 


### PR DESCRIPTION
When running `yarn rw test api`, it generate scenarioTeardown.json at the root of the project now. This was done by accident! 

This PR restores the behaviour to put it into the `.redwood` folder