### PR TITLE
Dynamically import nft-pack, to prevent install sls pack deps in rw/cli

### DIFF
--- a/packages/cli/src/commands/deploy/serverless.js
+++ b/packages/cli/src/commands/deploy/serverless.js
@@ -13,8 +13,6 @@ import terminalLink from 'terminal-link'
 import { getPaths } from '../../lib'
 import c from '../../lib/colors'
 
-import ntfPack from './packing/nft'
-
 export const command = 'serverless'
 export const aliases = ['aws serverless', 'sls']
 export const description = 'Deploy to AWS via the serverless framework'
@@ -82,7 +80,13 @@ export const buildCommands = ({ sides }) => {
     {
       title: 'Packing Functions...',
       enabled: () => sides.includes('api'),
-      task: ntfPack,
+      task: async () => {
+        // Dynamically import this function
+        // becuase its dependencies are only installed when `rw setup deploy serverless` is run
+        const { default: nftPack } = await import('./packing/nft')
+
+        await nftPack()
+      },
     },
   ]
 }


### PR DESCRIPTION
Brief Explanation: https://s.tape.sh/3FGxmULE

When running `yarn rw deploy serverless` we use a helper function in `packages/cli/src/commands/deploy/packing/nft.js`. This function has the following imports which are not explicit cli dependencies:

```js
import { nodeFileTrace } from '@vercel/nft'
import archiver from 'archiver'
import fse from 'fs-extra'
```

Causing `yarn rw deploy` to implode, unless your project is setup with `yarn rw setup deploy serverless` which installs these dependencies. 

This PR imports the pack function dynamically, preventing the need for these extra deps within rwjs/cli