### PR TITLE
Increase test timeout

### DIFF
--- a/packages/codemods/jest.config.js
+++ b/packages/codemods/jest.config.js
@@ -8,5 +8,5 @@ module.exports = {
     'dist',
   ],
   setupFilesAfterEnv: ['./jest.setup.js'],
-  testTimeout: 15000,
+  testTimeout: 20_000,
 }

--- a/packages/testing/src/web/__tests__/MockHandlers.test.tsx
+++ b/packages/testing/src/web/__tests__/MockHandlers.test.tsx
@@ -5,6 +5,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 import { mockGraphQLQuery } from '../mockRequests'
 
+jest.setTimeout(6_000)
+
 describe('GraphQLMockHandlers', () => {
   it('should allow you to compose mock graphql handlers for more complex tests', async () => {
     const baseResult = {
@@ -81,27 +83,40 @@ describe('GraphQLMockHandlers', () => {
 
     fireEvent.click(button)
 
-    await waitFor(() =>
-      expect(JSON.parse(result.textContent)).toEqual({
-        data: onceResult,
-      })
+    await waitFor(
+      () =>
+        expect(JSON.parse(result.textContent)).toEqual({
+          data: onceResult,
+        }),
+      {
+        timeout: 2_000,
+      }
     )
 
     fireEvent.click(button)
 
-    await waitFor(() =>
-      expect(JSON.parse(result.textContent)).toEqual({
-        data: baseResult,
-      })
+    await waitFor(
+      () =>
+        expect(JSON.parse(result.textContent)).toEqual({
+          data: baseResult,
+        }),
+      {
+        timeout: 2_000,
+      }
     )
 
     fireEvent.click(button)
 
-    await waitFor(() => {
-      expect(status).toHaveTextContent('false')
-      expect(JSON.parse(result.textContent)).toEqual({
-        data: baseResult,
-      })
-    })
+    await waitFor(
+      () => {
+        expect(status).toHaveTextContent('false')
+        expect(JSON.parse(result.textContent)).toEqual({
+          data: baseResult,
+        })
+      },
+      {
+        timeout: 2_000,
+      }
+    )
   })
 })


### PR DESCRIPTION
This PR tries to close #4316 by doing the easiest thing possible first which is wait a little longer for the result in `MockHandlers.test.tsx` to update. Also see https://github.com/redwoodjs/redwood/pull/4370#issuecomment-1030757284.

Although https://github.com/redwoodjs/redwood/pull/4389 passed CI, `updateJestConfig.test.ts` is still flaky too, so we try the same strategy.
