### PR TITLE
Prepare release script for patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "publish:canary": "lerna publish --force-publish --canary --include-merged-tags --preid canary --dist-tag canary --yes --loglevel verbose",
     "release": "node ./tasks/release/cli.mjs",
     "test": "lerna run test --stream -- --colors --maxWorkers=4",
-    "test:release": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
+    "test:release-script": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
   },
   "resolutions": {
     "@types/react": "17.0.39",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "publish:canary": "lerna publish --force-publish --canary --include-merged-tags --preid canary --dist-tag canary --yes --loglevel verbose",
     "release": "node ./tasks/release/cli.mjs",
     "test": "lerna run test --stream -- --colors --maxWorkers=4",
-    "test-release": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
+    "test:release": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
   },
   "resolutions": {
     "@types/react": "17.0.39",

--- a/tasks/release/__tests__/release.test.mjs
+++ b/tasks/release/__tests__/release.test.mjs
@@ -8,16 +8,16 @@ describe('release', () => {
   it('uses the right queries', () => {
     expect(MERGED_PRS_NO_MILESTONE).toMatchInlineSnapshot(`
       "
-          {
-            search(query: \\"repo:redwoodjs/redwood is:pr is:merged no:milestone\\", first: 5, type: ISSUE) {
-              nodes {
-                ... on PullRequest {
-                  id
-                }
+        {
+          search(query: \\"repo:redwoodjs/redwood is:pr is:merged no:milestone\\", first: 5, type: ISSUE) {
+            nodes {
+              ... on PullRequest {
+                id
               }
             }
           }
-        "
+        }
+      "
     `)
 
     expect(MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE).toMatchInlineSnapshot(`

--- a/tasks/release/__tests__/updatePullRequestsMilestone.test.mjs
+++ b/tasks/release/__tests__/updatePullRequestsMilestone.test.mjs
@@ -3,12 +3,11 @@ import { rest, graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import prompts from 'prompts'
 
-import updateNextReleasePullRequestsMilestone, {
+import updatePRsMilestone, {
   GET_MILESTONES,
-  GET_NEXT_RELEASE_MILESTONE_ID,
-  GET_NEXT_RELEASE_PULL_REQUEST_IDS,
-  UPDATE_NEXT_RELEASE_PULL_REQUEST_MILESTONE,
-} from '../updateNextReleasePullRequestsMilestone.mjs'
+  GET_PULL_REQUEST_IDS,
+  UPDATE_PULL_REQUEST_MILESTONE,
+} from '../updatePRsMilestone.mjs'
 
 /**
  * MSW setup
@@ -18,30 +17,30 @@ const nextReleaseMilestone = {
   id: 'MI_kwDOC2M2f84Aa82f',
 }
 
+const nextReleasePatchMilestone = {
+  title: 'next-release-patch',
+  id: 'MDk6TWlsZXN0b25lNjc1Nzk0MQ==',
+}
+
 const milestonesNodes = [
-  {
-    title: 'next-release-patch',
-    id: 'MDk6TWlsZXN0b25lNjc1Nzk0MQ==',
-  },
+  nextReleaseMilestone,
+  nextReleasePatchMilestone,
   {
     title: 'next-release-priority',
     id: 'MDk6TWlsZXN0b25lNjc3MTI3MQ==',
   },
-  nextReleaseMilestone,
 ]
 
-const handleGetMilestones = graphql.query(
-  /Get(.*)MilestoneId(s?)/,
-  (_req, res, ctx) =>
-    res(
-      ctx.data({
-        repository: {
-          milestones: {
-            nodes: milestonesNodes,
-          },
+const handleGetMilestones = graphql.query('GetMilestoneIds', (_req, res, ctx) =>
+  res(
+    ctx.data({
+      repository: {
+        milestones: {
+          nodes: milestonesNodes,
         },
-      })
-    )
+      },
+    })
+  )
 )
 
 let nextVersionMilestone
@@ -83,12 +82,16 @@ const pullRequests = [
   },
 ]
 
-const handleGetNextReleasePullRequestIds = graphql.query(
-  'GetNextReleasePullRequestIds',
+const handleGetPullRequestIds = graphql.query(
+  'GetPullRequestIds',
   (req, res, ctx) => {
     const { milestoneId } = req.variables
 
-    if (milestoneId !== nextReleaseMilestone.id) {
+    if (
+      ![nextReleaseMilestone.id, nextReleasePatchMilestone.id].includes(
+        milestoneId
+      )
+    ) {
       return res(
         ctx.data({
           node: null,
@@ -114,7 +117,7 @@ const handleUpdatePullRequestMilestone = graphql.mutation(
     const { pullRequestId, milestoneId } = req.variables
 
     if (
-      milestoneId !== nextVersionMilestone.nod_id ||
+      milestoneId !== nextVersionMilestone.node_id ||
       !pullRequests.map((pullRequest) => pullRequest.id).includes(pullRequestId)
     ) {
       return res(
@@ -137,8 +140,10 @@ const handleUpdatePullRequestMilestone = graphql.mutation(
 const handleCloseMilestone = rest.post(
   'https://api.github.com/repos/:owner/:repo/milestones/:milestone_number',
   (req, res, ctx) => {
+    // eslint-disable-next-line camelcase
     const { milestone_number } = req.params
 
+    // eslint-disable-next-line camelcase
     if (+milestone_number !== nextVersionMilestone.number) {
       return res(ctx.status(404))
     }
@@ -156,7 +161,7 @@ const handleCloseMilestone = rest.post(
 const server = setupServer(
   handleGetMilestones,
   handleCreateMilestone,
-  handleGetNextReleasePullRequestIds,
+  handleGetPullRequestIds,
   handleUpdatePullRequestMilestone,
   handleCloseMilestone
 )
@@ -165,7 +170,7 @@ beforeAll(() => server.listen())
 
 afterAll(() => server.close())
 
-describe('updateNextReleasePullRequestsMilestone', () => {
+describe('updatePRsMilestone', () => {
   it('uses the right queries', () => {
     expect(GET_MILESTONES).toMatchInlineSnapshot(`
       "
@@ -187,24 +192,9 @@ describe('updateNextReleasePullRequestsMilestone', () => {
       "
     `)
 
-    expect(GET_NEXT_RELEASE_MILESTONE_ID).toMatchInlineSnapshot(`
+    expect(GET_PULL_REQUEST_IDS).toMatchInlineSnapshot(`
       "
-        query GetNextReleaseMilestoneId {
-          repository(owner: \\"redwoodjs\\", name: \\"redwood\\") {
-            milestones(query: \\"next-release\\", first: 5) {
-              nodes {
-                title
-                id
-              }
-            }
-          }
-        }
-      "
-    `)
-
-    expect(GET_NEXT_RELEASE_PULL_REQUEST_IDS).toMatchInlineSnapshot(`
-      "
-        query GetNextReleasePullRequestIds($milestoneId: ID!) {
+        query GetPullRequestIds($milestoneId: ID!) {
           node(id: $milestoneId) {
             ... on Milestone {
               pullRequests(first: 100) {
@@ -218,7 +208,7 @@ describe('updateNextReleasePullRequestsMilestone', () => {
       "
     `)
 
-    expect(UPDATE_NEXT_RELEASE_PULL_REQUEST_MILESTONE).toMatchInlineSnapshot(`
+    expect(UPDATE_PULL_REQUEST_MILESTONE).toMatchInlineSnapshot(`
       "
         mutation UpdatePullRequestMilestone($pullRequestId: ID!, $milestoneId: ID!) {
           updatePullRequest(
@@ -231,7 +221,7 @@ describe('updateNextReleasePullRequestsMilestone', () => {
     `)
   })
 
-  it('MSW unit test', async () => {
+  it('changes next-release milestones to a version milestone', async () => {
     prompts.inject([
       // createOk
       true,
@@ -241,7 +231,22 @@ describe('updateNextReleasePullRequestsMilestone', () => {
       true,
     ])
 
-    const milestone = await updateNextReleasePullRequestsMilestone('v0.42.1')
+    const milestone = await updatePRsMilestone('next-release', 'v0.42.1')
+    const { node_id: id, ...rest } = nextVersionMilestone
+    expect(milestone).toEqual({ id, ...rest })
+  })
+
+  it('changes next-release-patch milestones to a version milestone', async () => {
+    prompts.inject([
+      // createOk
+      true,
+      // updateOk
+      true,
+      // looksOk
+      true,
+    ])
+
+    const milestone = await updatePRsMilestone('next-release-patch', 'v0.42.1')
     const { node_id: id, ...rest } = nextVersionMilestone
     expect(milestone).toEqual({ id, ...rest })
   })

--- a/tasks/release/cli.mjs
+++ b/tasks/release/cli.mjs
@@ -1,15 +1,54 @@
 #!/usr/bin/env node
 /* eslint-env node, es2021 */
+import prompts from 'prompts'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
 import generateReleaseNotes from './generateReleaseNotes.mjs'
 import release from './release.mjs'
-import updateNextReleasePullRequestsMilestone from './updateNextReleasePullRequestsMilestone.mjs'
+import updatePRsMilestone from './updatePRsMilestone.mjs'
 
 yargs(hideBin(process.argv))
   .scriptName('release')
-  .command('$0', 'Release RedwoodJS', {}, release)
+  .command(
+    '$0',
+    'Release RedwoodJS',
+    (yargs) => {
+      yargs.option('semver', {
+        describe: 'Semver to release',
+        choices: ['major', 'minor', 'patch'],
+      })
+      yargs.option('update-prs-milestone', {
+        alias: 'prs',
+        describe: "Update pull requests' milestones",
+        type: 'boolean',
+      })
+      yargs.option('checkout', {
+        alias: 'b',
+        describe: 'Checkout the release branch',
+        type: 'boolean',
+      })
+      yargs.option('clean-install-update', {
+        alias: 'ciu',
+        describe: 'Clean, install, and update the package versions',
+        type: 'boolean',
+      })
+      yargs.option('commit-tag-qa', {
+        alias: 'ctq',
+        describe: 'Commit, tag, and and run through local QA',
+        type: 'boolean',
+      })
+      yargs.option('generate-release-notes', {
+        alias: 'notes',
+        describe: 'Generate release notes',
+        type: 'boolean',
+      })
+    },
+    async (argv) => {
+      prompts.override(argv)
+      await release()
+    }
+  )
   .command(
     'generate-release-notes [milestone]',
     'Generates release notes for a given milestone',
@@ -22,15 +61,21 @@ yargs(hideBin(process.argv))
     (argv) => generateReleaseNotes(argv.milestone)
   )
   .command(
-    'update-next-release-prs-milestone <milestone>',
-    "Update next-release PRs' milestone. Note that this creates the milestone if it doesn't exist",
+    'update-prs-milestone',
+    "Update PRs' milestone from something to something",
     (yargs) => {
-      yargs.positional('milestone', {
-        describe: 'The milestone to update next-release PRs to',
+      yargs.option('from', {
+        demandOption: true,
+        describe: 'The milestone to PRs from',
+        type: 'string',
+      })
+      yargs.option('to', {
+        demandOption: true,
+        describe: 'The milestone to PRs to',
         type: 'string',
       })
     },
-    (argv) => updateNextReleasePullRequestsMilestone(argv.milestone)
+    ({ from, to }) => updatePRsMilestone(from, to)
   )
   .help()
   .parse()

--- a/tasks/release/prompts.mjs
+++ b/tasks/release/prompts.mjs
@@ -36,23 +36,23 @@ export async function promptForSemver() {
 /**
  * Wrapper around confirm-type `prompts`.
  *
- * @typedef {{ exit: boolean, exitCode: string }} ConfirmOptions
+ * @typedef {{ name: string, exit: boolean, exitCode: string }} ConfirmOptions
  * @param {string} message
  * @param {ConfirmOptions} options
  * @returns {Promise<boolean>}
  */
 export async function confirm(
   message,
-  { exit, exitCode } = { exit: false, exitCode: 0 }
+  { name, exit, exitCode } = { name: 'confirmed', exit: false, exitCode: 0 }
 ) {
-  const { confirmed } = await exitOnCancelPrompts({
+  const answer = await exitOnCancelPrompts({
     type: 'confirm',
-    name: 'confirmed',
+    name,
     message,
   })
 
-  if (confirmed || !exit) {
-    return confirmed
+  if (answer[name] || !exit) {
+    return answer[name]
   }
 
   process.exit(exitCode)
@@ -113,9 +113,9 @@ export const ok = makeStringFormatter(`${HEAVY_CHECK} ${OK}`)
 export async function confirmRuns(
   message,
   runs,
-  { exit, exitCode } = { exit: false, exitCode: 0 }
+  { name, exit, exitCode } = { name: 'confirmed', exit: false, exitCode: 0 }
 ) {
-  const confirmed = await confirm(message, { exit, exitCode })
+  const confirmed = await confirm(message, { name, exit, exitCode })
 
   if (!confirmed) {
     return false

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -7,13 +7,7 @@
  * ```
  *
  * @remarks
- *
  * You'll need a GitHub token and an NPM token. (So only @thedavidprice can do this right now.)
- *
- * @remarks
- *
- * - handle the case where a branch already exists; start on the "update package versions" step
- * - at this point, consider using xstate
  */
 import c from 'ansi-colors'
 import notifier from 'node-notifier'
@@ -32,9 +26,7 @@ import {
   ok,
   rocketBoxen,
 } from './prompts.mjs'
-import updateNextReleasePullRequestsMilestone, {
-  closeMilestone,
-} from './updateNextReleasePullRequestsMilestone.mjs'
+import updatePRsMilestone, { closeMilestone } from './updatePRsMilestone.mjs'
 
 let milestone
 
@@ -45,9 +37,12 @@ export default async function release() {
   await validateGitTag(nextVersion)
   await validateMergedPRs(semver)
 
+  const fromTitle = 'next-release' + (semver === 'patch' ? '-patch' : '')
+
   milestone = await confirmRuns(
-    ask`Do you want to update next-release PRs' milestone to ${nextVersion}?`,
-    () => updateNextReleasePullRequestsMilestone(nextVersion)
+    ask`Do you want to update ${fromTitle} PRs' milestone to ${nextVersion}?`,
+    () => updatePRsMilestone(fromTitle, nextVersion),
+    { name: 'update-prs-milestone' }
   )
 
   // Do the release.
@@ -256,24 +251,25 @@ function releaseMinor(nextVersion) {
  * @param {string} nextVersion
  */
 async function releaseMajorOrMinor(semver, nextVersion) {
-  // Checkout main.
-  const currentBranchPO = await $`git branch --show-current`
-  const currentBranch = currentBranchPO.stdout.trim()
-  if (currentBranch !== 'main') {
-    await $`git checkout main`
+  const currentBranch = getCurrentBranch()
+  const releaseBranch = ['release', semver, nextVersion].join('/')
+
+  if (currentBranch !== releaseBranch) {
+    const releaseBranchExists = await branchExists(releaseBranch)
+
+    if (releaseBranchExists) {
+      await checkoutExisting(releaseBranch)
+    } else {
+      await confirmRuns(
+        ask`Ok to checkout new branch ${releaseBranch}?`,
+        [() => $`git checkout main`, () => $`git checkout -b ${releaseBranch}`],
+        { name: 'checkout', exit: true }
+      )
+    }
   }
 
-  const releaseBranch = ['release', semver, nextVersion].join('/')
-  // In the future we'll expand the control flow on whether the branch exists or not:
-  // await releaseBranchExists(releaseBranch)
-  await confirmRuns(
-    ask`Ok to checkout new branch ${releaseBranch}?`,
-    () => $`git checkout -b ${releaseBranch}`,
-    { exit: true }
-  )
-
   await confirm(
-    ask`Checked out new release branch ${releaseBranch}.\nContinue to publish or stop here to push this branch to GitHub to create an RC`,
+    ask`Continue to publish or stop here to push this branch to GitHub to create an RC`,
     { exit: true }
   )
 
@@ -291,7 +287,10 @@ async function releaseMajorOrMinor(semver, nextVersion) {
   await confirmRuns(
     ask`Everything passed local QA. Are you ready to push your branch to GitHub and publish to NPM?`,
     [
-      () => $`git push && git push --tags`,
+      () => $`git push`,
+      // This is supposedly safer than `git push --tags`.
+      // See https://git-scm.com/book/en/v2/Git-Basics-Tagging.
+      () => $`git push --follow-tags`,
       // We've had an issue with this one.
       async () => {
         try {
@@ -308,8 +307,10 @@ async function releaseMajorOrMinor(semver, nextVersion) {
     { exit: true }
   )
 
-  await confirmRuns(ask`Do you want to generate release notes?`, () =>
-    generateReleaseNotes(nextVersion)
+  await confirmRuns(
+    ask`Do you want to generate release notes?`,
+    () => generateReleaseNotes(nextVersion),
+    { name: 'generate-release-notes' }
   )
 
   if (milestone) {
@@ -320,65 +321,88 @@ async function releaseMajorOrMinor(semver, nextVersion) {
 }
 
 /**
- * Check if the release branch already exists.
- * If it does, offer to check it out. Otherwise, offer to create it.
- *
- * @param {string} releaseBranch
- */
-// async function releaseBranchExists(releaseBranch) {
-//   const gitBranchPO = await $`git branch`
-
-//   const branches = gitBranchPO.stdout
-//     .trim()
-//     .split('\n')
-//     .map((branch) => branch.trim())
-
-//   if (branches.includes(releaseBranch)) {
-//     return true
-//   }
-
-//   return false
-// }
-
-/**
- * This is a WIP.
- *
  * @param {string} nextVersion
  */
 async function releasePatch(currentVersion, nextVersion) {
-  const previousReleaseBranch = ['tag', currentVersion].join('/')
+  const currentBranch = await getCurrentBranch()
   const releaseBranch = ['release', 'patch', nextVersion].join('/')
 
-  await confirmRuns(
-    ask`Ok to checkout new branch ${releaseBranch} from ${previousReleaseBranch}?`,
-    () => $`git checkout ${previousReleaseBranch} -b ${releaseBranch}`,
-    { exit: true }
-  )
+  if (currentBranch !== releaseBranch) {
+    const releaseBranchExists = await branchExists(releaseBranch)
 
-  await pushAndDiff(releaseBranch, currentVersion)
-  await confirm('Does the diff look ok?', { exit: true })
-  await confirm(
-    ask`Cherry pick and handle the conflicts—tell me when you're done`,
-    { exit: true }
-  )
+    if (releaseBranchExists) {
+      await checkoutExisting(releaseBranch)
+    } else {
+      await confirmRuns(
+        ask`Ok to checkout new branch ${releaseBranch} from ${currentVersion} tag?`,
+        // See https://git-scm.com/book/en/v2/Git-Basics-Tagging
+        // Scroll down to "Checking out Tags".
+        () => $`git checkout -b ${releaseBranch} ${currentVersion}`,
+        { name: 'checkout', exit: true }
+      )
+    }
+  }
 
-  await pushAndDiff(releaseBranch, currentVersion, { exit: true })
-  await confirm('Does the diff look ok?', { exit: true })
+  const releaseBranchExistsOnOrigin = await branchExistsOnOrigin(releaseBranch)
+
+  if (!releaseBranchExistsOnOrigin) {
+    await pushAndDiff(releaseBranch, currentVersion)
+    await confirm('Does the diff look ok?', { exit: true })
+
+    await confirm(ask`Done cherry picking?`, { exit: true })
+
+    await pushAndDiff(releaseBranch, currentVersion)
+    await confirm('Does the diff look ok?', { exit: true })
+  }
 
   await cleanInstallUpdate(nextVersion)
   notifier.notify('done')
 
   await confirm(
-    check`The package versions have been updated. Does everything look right?`,
+    check`The package versions have been updated. Does everything look ok?`,
     { exit: true }
   )
 
   await commitTagQA(nextVersion)
   notifier.notify('done')
 
-  // Merge commit
+  // I think we need to do a merge commit:
+  //
   // await $`git checkout main`
   // await $`git branch -d release/patch/${nextVersion}`
+  //
+  // And I need to confirm if these steps are the same...
+  //
+  // await confirmRuns(
+  //   ask`Everything passed local QA. Are you ready to push your branch to GitHub and publish to NPM?`,
+  //   [
+  //     () => $`git push`,
+  //     () => $`git push --follow-tags`,
+  //     // We've had an issue with this one.
+  //     async () => {
+  //       try {
+  //         await $`yarn lerna publish from-package`
+  //         console.log(rocketBoxen(`Released ${c.green(nextVersion)}`))
+  //       } catch (e) {
+  //         console.log(
+  //           `Couldn't run ${c.green('yarn lerna publish from-package')}`
+  //         )
+  //         console.log(e)
+  //       }
+  //     },
+  //   ],
+  //   { exit: true }
+  // )
+  //
+  // await confirmRuns(ask`Do you want to generate release notes?`, () =>
+  //   generateReleaseNotes(nextVersion)
+  // )
+  //
+  // if (milestone) {
+  //   await confirmRuns(ask`Ok to close milestone ${nextVersion}?`, () =>
+  //     closeMilestone(milestone.number)
+  //   )
+  // }
 }
 
 /**
@@ -392,7 +416,7 @@ function cleanInstallUpdate(nextVersion) {
       () => $`yarn install`,
       () => $`./tasks/update-package-versions ${nextVersion}`,
     ],
-    { exit: true }
+    { name: 'clean-install-update', exit: true }
   )
 }
 
@@ -410,6 +434,7 @@ function commitTagQA(nextVersion) {
       () => $`yarn test`,
     ],
     {
+      name: 'commit-tag-qa',
       exit: true,
     }
   )
@@ -421,12 +446,58 @@ function commitTagQA(nextVersion) {
  */
 function pushAndDiff(releaseBranch, currentVersion) {
   return confirmRuns(
-    ask`Ok to push new branch ${releaseBranch} and open diff?`,
+    ask`Ok to push new branch ${releaseBranch} to GitHub and open diff?`,
     [
       () => $`git push origin ${releaseBranch}`,
       () =>
         $`open https://github.com/redwoodjs/redwood/compare/${currentVersion}..${releaseBranch}`,
     ],
     { exit: true }
+  )
+}
+
+async function getCurrentBranch() {
+  const { stdout } = await $`git branch --show-current`
+  return stdout.trim()
+}
+
+/**
+ * @param {string} branch
+ */
+// eslint-disable-next-line no-unused-vars
+async function branchExists(branch) {
+  const { stdout } = await $`git branch`
+
+  const branches = stdout
+    .trim()
+    .split('\n')
+    .map((branch) => branch.trim())
+
+  if (branches.includes(branch)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * @param {string} branch
+ */
+async function branchExistsOnOrigin(branch) {
+  const { stdout } =
+    await $`git ls-remote --heads git@github.com:redwoodjs/redwood ${branch}`
+
+  if (stdout.length) {
+    return true
+  }
+
+  return false
+}
+
+function checkoutExisting(releaseBranch) {
+  confirmRuns(
+    ask`Ok to checkout existing release branch ${releaseBranch}?`,
+    () => $`git checkout ${releaseBranch}`,
+    { name: 'checkout', exit: true }
   )
 }

--- a/tasks/release/updatePRsMilestone.mjs
+++ b/tasks/release/updatePRsMilestone.mjs
@@ -1,21 +1,17 @@
 /* eslint-env node, es2021 */
-/**
- * - is:pr is:merged no:milestone -> should empty
- * - milestone:next-release-patch -> check empty
- * - close milestone _after_ publish
- */
 import octokit from './octokit.mjs'
-import { confirm, ask, check } from './prompts.mjs'
+import { confirm, ask, check, ok } from './prompts.mjs'
 
 /**
- * @param {string} title
+ * @param {'next-release' | 'next-release-patch'} fromTitle
+ * @param {string} toTitle
  */
-export default async function updateNextReleasePullRequestsMilestone(title) {
-  let milestone = await getMilestone(title)
+export default async function updatePRsMilestone(fromTitle, toTitle) {
+  let milestone = await getMilestone(toTitle)
 
   if (!milestone) {
     const createOk = await confirm(
-      ask`Milestone ${title} doesn't exist. Ok to create it?`
+      ask`Milestone ${toTitle} doesn't exist. Ok to create it?`
     )
     if (!createOk) {
       return
@@ -23,18 +19,22 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
 
     const {
       data: { node_id: id, number },
-    } = await createMilestone(title)
+    } = await createMilestone(toTitle)
 
-    milestone = { title, id, number }
+    milestone = { title: toTitle, id, number }
   }
 
-  const nextReleaseMilestoneId = await getNextReleaseMilestoneId()
-  const pullRequestIds = await getPullRequestIdsWithMilestone(
-    nextReleaseMilestoneId
-  )
+  const fromMilestoneId = (await getMilestone(fromTitle)).id
+
+  const pullRequestIds = await getPullRequestIdsWithMilestone(fromMilestoneId)
+
+  if (!pullRequestIds.length) {
+    console.log(ok`No pull requests with milestone ${fromTitle}`)
+    return
+  }
 
   const updateOk = await confirm(
-    ask`Ok to update the milestone of ${pullRequestIds.length} PRs from next-release to ${title}?`
+    ask`Ok to update the milestone of ${pullRequestIds.length} PRs from ${fromTitle} to ${toTitle}?`
   )
   if (!updateOk) {
     return
@@ -47,7 +47,7 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
   )
 
   const looksOk = await confirm(
-    check`Updated the milestone of ${pullRequestIds.length} PRs: https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${title}\nDoes everything look ok?`
+    check`Updated the milestone of ${pullRequestIds.length} PRs: https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${toTitle}\nDoes everything look ok?`
   )
   if (looksOk) {
     return milestone
@@ -59,7 +59,7 @@ export default async function updateNextReleasePullRequestsMilestone(title) {
   if (undoPRs) {
     await Promise.all(
       pullRequestIds.map((pullRequestId) =>
-        updatePullRequestMilestone(pullRequestId, nextReleaseMilestoneId)
+        updatePullRequestMilestone(pullRequestId, fromMilestoneId)
       )
     )
   }
@@ -132,50 +132,12 @@ function createMilestone(title) {
 
 /**
  * @typedef {{
- *   repository: {
- *     milestones: {
- *       nodes: Array<{ title: string, id: string }>
- *     }
- *   }
- * }} GetNextReleaseMilestoneIdRes
- */
-async function getNextReleaseMilestoneId() {
-  const {
-    repository: {
-      milestones: { nodes: milestones },
-    },
-  } = /** @type {GetNextReleaseMilestoneIdRes} */ (
-    await octokit.graphql(GET_NEXT_RELEASE_MILESTONE_ID)
-  )
-
-  const { id } = milestones.find(
-    (milestone) => milestone.title === 'next-release'
-  )
-
-  return id
-}
-
-export const GET_NEXT_RELEASE_MILESTONE_ID = `
-  query GetNextReleaseMilestoneId {
-    repository(owner: "redwoodjs", name: "redwood") {
-      milestones(query: "next-release", first: 5) {
-        nodes {
-          title
-          id
-        }
-      }
-    }
-  }
-`
-
-/**
- * @typedef {{
  *   node: {
  *     pullRequests: {
  *       nodes: Array<{ id: string }>
  *     }
  *   }
- * }} GetNextReleasePullRequestIdsRes
+ * }} GetPullRequestIdsRes
  *
  * @param {string} milestoneId
  */
@@ -187,8 +149,8 @@ export async function getPullRequestIdsWithMilestone(milestoneId) {
     node: {
       pullRequests: { nodes: pullRequests },
     },
-  } = /** @type {GetNextReleasePullRequestIdsRes} */ (
-    await octokit.graphql(GET_NEXT_RELEASE_PULL_REQUEST_IDS, {
+  } = /** @type {GetPullRequestIdsRes} */ (
+    await octokit.graphql(GET_PULL_REQUEST_IDS, {
       milestoneId,
     })
   )
@@ -196,8 +158,8 @@ export async function getPullRequestIdsWithMilestone(milestoneId) {
   return pullRequests.map((pullRequest) => pullRequest.id)
 }
 
-export const GET_NEXT_RELEASE_PULL_REQUEST_IDS = `
-  query GetNextReleasePullRequestIds($milestoneId: ID!) {
+export const GET_PULL_REQUEST_IDS = `
+  query GetPullRequestIds($milestoneId: ID!) {
     node(id: $milestoneId) {
       ... on Milestone {
         pullRequests(first: 100) {
@@ -215,13 +177,13 @@ export const GET_NEXT_RELEASE_PULL_REQUEST_IDS = `
  * @param {string} milestoneId
  */
 function updatePullRequestMilestone(pullRequestId, milestoneId) {
-  return octokit.graphql(UPDATE_NEXT_RELEASE_PULL_REQUEST_MILESTONE, {
+  return octokit.graphql(UPDATE_PULL_REQUEST_MILESTONE, {
     pullRequestId,
     milestoneId,
   })
 }
 
-export const UPDATE_NEXT_RELEASE_PULL_REQUEST_MILESTONE = `
+export const UPDATE_PULL_REQUEST_MILESTONE = `
   mutation UpdatePullRequestMilestone($pullRequestId: ID!, $milestoneId: ID!) {
     updatePullRequest(
       input: { pullRequestId: $pullRequestId, milestoneId: $milestoneId }
@@ -234,12 +196,14 @@ export const UPDATE_NEXT_RELEASE_PULL_REQUEST_MILESTONE = `
 /**
  * @param {number} milestone_number
  */
+// eslint-disable-next-line camelcase
 export function closeMilestone(milestone_number) {
   return octokit.request(
     'POST /repos/{owner}/{repo}/milestones/{milestone_number}',
     {
       owner: 'redwoodjs',
       repo: 'redwood',
+      // eslint-disable-next-line camelcase
       milestone_number,
       state: 'closed',
     }
@@ -249,12 +213,14 @@ export function closeMilestone(milestone_number) {
 /**
  * @param {number} milestone_number
  */
+// eslint-disable-next-line camelcase
 function deleteMilestone(milestone_number) {
   return octokit.request(
     'DELETE /repos/{owner}/{repo}/milestones/{milestone_number}',
     {
       owner: 'redwoodjs',
       repo: 'redwood',
+      // eslint-disable-next-line camelcase
       milestone_number,
     }
   )


### PR DESCRIPTION
Partially closes https://github.com/redwoodjs/redwood/issues/2067. This PR prepares the release script for releasing patches.

Also, you can now pass options to answer some of the questions from the CLI and speed things up:
```
yarn release --semver minor --no-prs --checkout
```
But "check" steps will never be skipped.

@thedavidprice, a couple things:

-> I've seen two syntaxes for checking out the release branch:
```shell
# 1
git checkout -b release/patch/v0.28.1 v0.28.0
# 2
git checkout tags/v0.28.0 -b release/patch/v0.28.1
```
I'm going with the first one because that's what's in the git-tagging docs: https://git-scm.com/book/en/v2/Git-Basics-Tagging (at the end—"Checking out Tags").

-> This script now handles updating `next-release-patch` pull requests.

-> This one's probably obvious but we probably have to do a run through to get this 100% right.