### PR TITLE
Add types for react-testing library to tsconfig

### DIFF
--- a/packages/create-redwood-app/template/web/tsconfig.json
+++ b/packages/create-redwood-app/template/web/tsconfig.json
@@ -20,7 +20,7 @@
       "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]
     },
     "typeRoots": ["../node_modules/@types", "./node_modules/@types"],
-    "types": ["jest"],
+    "types": ["jest", "@testing-library/jest-dom"],
     "jsx": "preserve",
   },
   "include": [


### PR DESCRIPTION
### What does this PR do?

Looks like we were missing configuration for getting types in web-side tests.

Explanation here: https://s.tape.sh/za2n6n8j
