### PR TITLE
(render.com deployment) resolve deploy render exceeding memory on free tier

### DIFF
--- a/packages/cli/src/commands/deploy/render.js
+++ b/packages/cli/src/commands/deploy/render.js
@@ -36,6 +36,13 @@ export const builder = (yargs) => {
     )
 }
 
+// Telemetry mem usage exceeds Render free plan limit for API service
+// Because telemetryMiddleware is added to Yargs as middleware,
+// we need to set env outside handler to correctly disable Telemetry
+if (process.argv.slice(2).includes('api')) {
+  process.env.REDWOOD_DISABLE_TELEMETRY = 1
+}
+
 export const handler = async ({ side, prisma, dm: dataMigrate }) => {
   const rwjsPaths = getPaths()
 
@@ -67,6 +74,7 @@ export const handler = async ({ side, prisma, dm: dataMigrate }) => {
   }
 
   if (side === 'api') {
+    process.env.REDWOOD_DISABLE_TELEMETRY = 1
     runApiCommands()
   } else if (side === 'web') {
     console.log('\nRunning yarn install and building web...')

--- a/packages/cli/src/commands/deploy/render.js
+++ b/packages/cli/src/commands/deploy/render.js
@@ -74,7 +74,6 @@ export const handler = async ({ side, prisma, dm: dataMigrate }) => {
   }
 
   if (side === 'api') {
-    process.env.REDWOOD_DISABLE_TELEMETRY = 1
     runApiCommands()
   } else if (side === 'web') {
     console.log('\nRunning yarn install and building web...')


### PR DESCRIPTION
This PR disables the detached telemetry process from the api service deployment, which was causing `yarn rw deploy render api` to exceed the mem limit for the Render.com free tier.