### PR TITLE
Upgrade Prisma to 3.9.2

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
-    "@prisma/client": "3.8.1",
+    "@prisma/client": "3.9.2",
     "crypto-js": "4.1.1",
     "jsonwebtoken": "8.5.1",
     "jwks-rsa": "2.0.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@prisma/sdk": "3.8.1",
+    "@prisma/sdk": "3.9.2",
     "@redwoodjs/api-server": "v0.44.1",
     "@redwoodjs/internal": "v0.44.1",
     "@redwoodjs/prerender": "v0.44.1",
@@ -56,7 +56,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.5.1",
-    "prisma": "3.8.1",
+    "prisma": "3.9.2",
     "prompts": "2.4.2",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -31,7 +31,7 @@
     "@graphql-tools/merge": "8.2.2",
     "@graphql-tools/schema": "8.3.1",
     "@graphql-tools/utils": "8.6.1",
-    "@prisma/client": "3.8.1",
+    "@prisma/client": "3.9.2",
     "@redwoodjs/api": "v0.44.1",
     "core-js": "3.21.0",
     "graphql": "16.3.0",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -27,8 +27,8 @@
     ]
   },
   "dependencies": {
-    "@prisma/client": "3.8.1",
-    "@prisma/sdk": "3.8.1",
+    "@prisma/client": "3.9.2",
+    "@prisma/sdk": "3.9.2",
     "core-js": "3.21.0"
   },
   "devDependencies": {

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -30,7 +30,7 @@
     ]
   },
   "dependencies": {
-    "@prisma/sdk": "3.8.1",
+    "@prisma/sdk": "3.9.2",
     "@redwoodjs/internal": "v0.44.1",
     "@types/line-column": "1.0.0",
     "camelcase": "6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5108,27 +5108,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:3.8.1":
-  version: 3.8.1
-  resolution: "@prisma/client@npm:3.8.1"
+"@prisma/client@npm:3.9.2":
+  version: 3.9.2
+  resolution: "@prisma/client@npm:3.9.2"
   dependencies:
-    "@prisma/engines-version": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
+    "@prisma/engines-version": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
   peerDependencies:
     prisma: "*"
   peerDependenciesMeta:
     prisma:
       optional: true
-  checksum: 395a7c6ac4c6630e5b6ee4943efff99f99356c67c062c0bee3a504f665ea7b50beddd8ec6800df39b6705ef41a94bd50a16c1306c7b47699db0c596ee7f7c75f
-  languageName: node
-  linkType: hard
-
-"@prisma/debug@npm:3.7.0":
-  version: 3.7.0
-  resolution: "@prisma/debug@npm:3.7.0"
-  dependencies:
-    "@types/debug": 4.1.7
-    ms: 2.1.3
-  checksum: 975ee4a888f3678469da4e508cf7ab1405e0418bf08dff7f3a856c7b447cd24e20de62c08cb6b5368f6e60b825dfaaeb8905f8528816bf9f28e0825ed1f5c283
+  checksum: 91353b3e39bd12c74471c516198843abbb3283eef32fb5f48c152503ad2b965a13933221b1678707b6978374352dd215e1865cab6ab93235d1f56ef3110a55ae
   languageName: node
   linkType: hard
 
@@ -5143,14 +5133,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/engine-core@npm:3.8.1":
-  version: 3.8.1
-  resolution: "@prisma/engine-core@npm:3.8.1"
+"@prisma/debug@npm:3.9.2":
+  version: 3.9.2
+  resolution: "@prisma/debug@npm:3.9.2"
   dependencies:
-    "@prisma/debug": 3.8.1
-    "@prisma/engines": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-    "@prisma/generator-helper": 3.8.1
-    "@prisma/get-platform": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
+    "@types/debug": 4.1.7
+    ms: 2.1.3
+    strip-ansi: 6.0.1
+  checksum: 56a8a69162d710c3a591eda9608e652d4cfa3b5eb9ca717f837b0bb81612b08b40fa3909598164eca5cf6cf112d153b884f39e28e0eb959134299bced3aee363
+  languageName: node
+  linkType: hard
+
+"@prisma/engine-core@npm:3.9.2":
+  version: 3.9.2
+  resolution: "@prisma/engine-core@npm:3.9.2"
+  dependencies:
+    "@prisma/debug": 3.9.2
+    "@prisma/engines": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+    "@prisma/generator-helper": 3.9.2
+    "@prisma/get-platform": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
     chalk: 4.1.2
     execa: 5.1.1
     get-stream: 6.0.1
@@ -5160,30 +5161,30 @@ __metadata:
     strip-ansi: 6.0.1
     terminal-link: 2.1.1
     undici: 3.3.6
-  checksum: 773fba0f6ac9975de0d9981edd7270037b5cd600302f706aa88100144d1bcfe967f477fb893ce41bd77e88f247b70da61c4fe3a1036e01c9215870b5c46bdcdb
+  checksum: 7788af8088c1e51a45a69425be4a69199ce322502b680a821d72503a87c2e6dce202471aaf56e37a58e7cd70dbf869d611b2511219e9316bb6ba36526746d634
   languageName: node
   linkType: hard
 
-"@prisma/engines-version@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f":
-  version: 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-  resolution: "@prisma/engines-version@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
-  checksum: 47156289e54f0d9284bb18e843f67eaafc423fb6b673c3773fd1dcd08a385531ed2182e9013534862ad9721a9ea388a9961ca85e8ae7bef9211b300810500cdf
+"@prisma/engines-version@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009":
+  version: 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+  resolution: "@prisma/engines-version@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
+  checksum: 7c7032bdae4533ba07a44537d378c5ad3e926989b7646bf9ac3069bd5cdbd8e51df3c5ed36ca153358b391c39615948fd1988ed4ce7116027c09b6355d6805ae
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f":
-  version: 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-  resolution: "@prisma/engines@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
-  checksum: 4d1abcc18f9784fae6f6bff342e0cfce04d9635e7f0f0a89375d8955bc1ed8f206f05a3131cf72198af213252a376d44b428afd8c1a2e9541349c967edca6cd9
+"@prisma/engines@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009":
+  version: 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+  resolution: "@prisma/engines@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
+  checksum: ac28b60d3cc2106f800da066c240fae826d96cfd10f5ab6064fb96caf9e05fdbe6b10b32d59ff77f8da1464f1ee534bca81e5a813c08c1af8282c0269d30290a
   languageName: node
   linkType: hard
 
-"@prisma/fetch-engine@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f":
-  version: 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-  resolution: "@prisma/fetch-engine@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+"@prisma/fetch-engine@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009":
+  version: 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+  resolution: "@prisma/fetch-engine@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
   dependencies:
-    "@prisma/debug": 3.7.0
-    "@prisma/get-platform": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
+    "@prisma/debug": 3.8.1
+    "@prisma/get-platform": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
     chalk: 4.1.2
     execa: 5.1.1
     find-cache-dir: 3.3.2
@@ -5191,7 +5192,7 @@ __metadata:
     http-proxy-agent: 5.0.0
     https-proxy-agent: 5.0.0
     make-dir: 3.1.0
-    node-fetch: 2.6.6
+    node-fetch: 2.6.7
     p-filter: 2.1.0
     p-map: 4.0.0
     p-retry: 4.6.1
@@ -5199,62 +5200,62 @@ __metadata:
     rimraf: 3.0.2
     temp-dir: 2.0.0
     tempy: 1.0.1
-  checksum: 068ba3a8e29a635e4246733589ef8cfd964434e78dae735248e1b69e30df9a017b03f510778e764b0bb644c50caf9aef1abb7b2f1d9a3b45dd11b0c2815984ad
+  checksum: 924b8d7c48d9987897765f470c5b70d26abf308b36615ed14b0f171ad6ad40a631cbd37c1cbe97e36ce536ba30957f12d1f50ba0af665b76641df8cdd4a60828
   languageName: node
   linkType: hard
 
-"@prisma/generator-helper@npm:3.8.1":
-  version: 3.8.1
-  resolution: "@prisma/generator-helper@npm:3.8.1"
+"@prisma/generator-helper@npm:3.9.2":
+  version: 3.9.2
+  resolution: "@prisma/generator-helper@npm:3.9.2"
   dependencies:
-    "@prisma/debug": 3.8.1
+    "@prisma/debug": 3.9.2
     "@types/cross-spawn": 6.0.2
     chalk: 4.1.2
     cross-spawn: 7.0.3
-  checksum: bd0a8b519ed429ac870c466decf7d05bd425e41bb1a64b8d10b1f4d5ce0f47c8f926a9c4c2e4743a91cbcaa9429bba5bf57ea33b471c16133e7e60d553a335b1
+  checksum: fb3894db08be5f6aa24ae978934d822f028b2a65d5911126d00f7e1468f25e4ffe4210222e6b10a1ab25559a85efb441a4c51e3c0dcb58e84559ed94eded3a35
   languageName: node
   linkType: hard
 
-"@prisma/get-platform@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f":
-  version: 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-  resolution: "@prisma/get-platform@npm:3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
-  dependencies:
-    "@prisma/debug": 3.7.0
-  checksum: 6f4eba09f2524fdfda4704853de7e8ed8fe04d3e1d375876ba45e4ff7edfd6f9772d7e63ceb84ad8a3bb8c7e25a1ad6c76770574b0b462b1cc65545f6bd54083
-  languageName: node
-  linkType: hard
-
-"@prisma/sdk@npm:3.8.1":
-  version: 3.8.1
-  resolution: "@prisma/sdk@npm:3.8.1"
+"@prisma/get-platform@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009":
+  version: 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+  resolution: "@prisma/get-platform@npm:3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
   dependencies:
     "@prisma/debug": 3.8.1
-    "@prisma/engine-core": 3.8.1
-    "@prisma/engines": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-    "@prisma/fetch-engine": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
-    "@prisma/generator-helper": 3.8.1
-    "@prisma/get-platform": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
+  checksum: e2b8b1c4892483000a757dd1db6f2a9da74be8ca01091fb8f9d8834af8a57a7603994e70c2fedc785707e16b483d39b612e5e2248592824b3715b36466bf0fb7
+  languageName: node
+  linkType: hard
+
+"@prisma/sdk@npm:3.9.2":
+  version: 3.9.2
+  resolution: "@prisma/sdk@npm:3.9.2"
+  dependencies:
+    "@prisma/debug": 3.9.2
+    "@prisma/engine-core": 3.9.2
+    "@prisma/engines": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+    "@prisma/fetch-engine": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
+    "@prisma/generator-helper": 3.9.2
+    "@prisma/get-platform": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
     "@timsuchanek/copy": 1.4.5
     archiver: 5.3.0
     arg: 5.0.1
     chalk: 4.1.2
     checkpoint-client: 1.1.20
     cli-truncate: 2.1.0
-    dotenv: 10.0.0
+    dotenv: 15.0.0
     escape-string-regexp: 4.0.0
     execa: 5.1.1
     find-up: 5.0.0
-    fs-jetpack: 4.3.0
+    fs-jetpack: 4.3.1
     global-dirs: 3.0.0
     globby: 11.1.0
     has-yarn: 2.1.0
     is-ci: 3.0.1
     make-dir: 3.1.0
-    node-fetch: 2.6.6
+    node-fetch: 2.6.7
     p-map: 4.0.0
     read-pkg-up: 7.0.1
     replace-string: 3.1.0
-    resolve: 1.21.0
+    resolve: 1.22.0
     rimraf: 3.0.2
     shell-quote: 1.7.3
     string-width: 4.2.3
@@ -5266,7 +5267,7 @@ __metadata:
     tempy: 1.0.1
     terminal-link: 2.1.1
     tmp: 0.2.1
-  checksum: fbcdbbc9f5e382008ee4944c0b0914b42d3aa749a1af85320f8134771ae1e338e430bb1a808d82692891ae30e271aa42676fc064de6a4fb5b28caaf656819ec7
+  checksum: e3edc5d1c5c66bd5a3cb89b6d4f97444b045d5ec91f961a31d4d12525bf245e19b3a32e64a4f9cb30c770b754a2f42c24facd334cbfccb9c0d6b718439cb6d70
   languageName: node
   linkType: hard
 
@@ -5414,7 +5415,7 @@ __metadata:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
     "@babel/runtime-corejs3": 7.16.7
-    "@prisma/client": 3.8.1
+    "@prisma/client": 3.9.2
     "@redwoodjs/auth": v0.44.1
     "@types/crypto-js": 4.1.0
     "@types/jsonwebtoken": 8.5.8
@@ -5479,7 +5480,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
-    "@prisma/sdk": 3.8.1
+    "@prisma/sdk": 3.9.2
     "@redwoodjs/api-server": v0.44.1
     "@redwoodjs/internal": v0.44.1
     "@redwoodjs/prerender": v0.44.1
@@ -5510,7 +5511,7 @@ __metadata:
     pascalcase: 1.0.0
     pluralize: 8.0.0
     prettier: 2.5.1
-    prisma: 3.8.1
+    prisma: 3.9.2
     prompts: 2.4.2
     rimraf: 3.0.2
     secure-random-password: 0.2.3
@@ -5686,7 +5687,7 @@ __metadata:
     "@graphql-tools/merge": 8.2.2
     "@graphql-tools/schema": 8.3.1
     "@graphql-tools/utils": 8.6.1
-    "@prisma/client": 3.8.1
+    "@prisma/client": 3.9.2
     "@redwoodjs/api": v0.44.1
     "@redwoodjs/auth": v0.44.1
     "@types/lodash.merge": 4.6.6
@@ -5790,8 +5791,8 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
-    "@prisma/client": 3.8.1
-    "@prisma/sdk": 3.8.1
+    "@prisma/client": 3.9.2
+    "@prisma/sdk": 3.9.2
     core-js: 3.21.0
     jest: 27.5.1
   languageName: unknown
@@ -5822,7 +5823,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
-    "@prisma/sdk": 3.8.1
+    "@prisma/sdk": 3.9.2
     "@redwoodjs/internal": v0.44.1
     "@types/fs-extra": 9.0.13
     "@types/line-column": 1.0.0
@@ -13501,7 +13502,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:10.0.0, dotenv@npm:^10.0.0":
+"dotenv@npm:15.0.0":
+  version: 15.0.0
+  resolution: "dotenv@npm:15.0.0"
+  checksum: 3b4e3c6885eefaa8f1f4b98c74ef0d528b913e733fc02cbee842d9b1911835b18cb4604d7ae0abbead632256abc862be10c6c257848bc53c31ae765936b43f66
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^10.0.0":
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: 2d8d4ba64bfaff7931402aa5e8cbb8eba0acbc99fe9ae442300199af021079eafa7171ce90e150821a5cb3d74f0057721fbe7ec201a6044b68c8a7615f8c123f
@@ -15829,13 +15837,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-jetpack@npm:4.3.0":
-  version: 4.3.0
-  resolution: "fs-jetpack@npm:4.3.0"
+"fs-jetpack@npm:4.3.1":
+  version: 4.3.1
+  resolution: "fs-jetpack@npm:4.3.1"
   dependencies:
     minimatch: ^3.0.2
     rimraf: ^2.6.3
-  checksum: 2ac8bfc7301fedf603289c245e0e166dd78c95409982f00103f8f25abec0d8e91df88e14932544db5a0ad2cf8775fec5fbbcc8e023bc53fe327a7a760ed74a47
+  checksum: 5d27e829233de005505417bae2f55412ae65ff63a57b68ac6d3cd8dde29ed9f0797c2a83356d20237bf74f516db8e40636c5fc238b49b4414b3d9339e60f7914
   languageName: node
   linkType: hard
 
@@ -21550,15 +21558,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.6":
-  version: 2.6.6
-  resolution: "node-fetch@npm:2.6.6"
-  dependencies:
-    whatwg-url: ^5.0.0
-  checksum: f9b5c8789c7bcd393a2fb70d752e36d5b5e84eb52bd5bffceb4fb64ac81dce1a1f55ca023a990e51bbf8594fc502ea9bea3004037e6eab65205cd84e8af94fc9
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:2.6.7, node-fetch@npm:^2.6.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.5, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
@@ -23808,15 +23807,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"prisma@npm:3.8.1":
-  version: 3.8.1
-  resolution: "prisma@npm:3.8.1"
+"prisma@npm:3.9.2":
+  version: 3.9.2
+  resolution: "prisma@npm:3.9.2"
   dependencies:
-    "@prisma/engines": 3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f
+    "@prisma/engines": 3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009
   bin:
     prisma: build/index.js
     prisma2: build/index.js
-  checksum: dcfa60aaa1d3b161d3b09952e0b79003aec80ff21fd4ddc9a7dbc5df938ea37da1807e99e06052a269f1c463ecd0f25ef7c0555328f3fdfb584a436bbc64f13e
+  checksum: fc1fe58a89a7349e72f727714821f49cae280761cddce6a01152172bcafa0091800923129e82f7baa8c8303d962e17b87e355f468521948d341d8073fc3e62c1
   languageName: node
   linkType: hard
 
@@ -25375,7 +25374,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0":
+"resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0, resolve@npm:1.22.0":
   version: 1.22.0
   resolution: "resolve@npm:1.22.0"
   dependencies:
@@ -25398,33 +25397,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"resolve@npm:1.21.0":
-  version: 1.21.0
-  resolution: "resolve@npm:1.21.0"
-  dependencies:
-    is-core-module: ^2.8.0
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: 6447a15d9ed10c1c7e3df85307c8ecb534c4c2522ce7b86a21353069c79c70b6d9dacc09a4bed36ce1764e1faa506af368db5b17e93e7b244951aead8e3c719e
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@1.21.0#~builtin<compat/resolve>":
-  version: 1.21.0
-  resolution: "resolve@patch:resolve@npm%3A1.21.0#~builtin<compat/resolve>::version=1.21.0&hash=07638b"
-  dependencies:
-    is-core-module: ^2.8.0
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: e964f3ed5b3004eb92ff281cabe087c2e1d867369b3ef0b66bb6d10f64810b41e6d5780b57d8f11246e5f0d46c07a58742c468fb8c35afdb12242cf661afdef8
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.0
   resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
   dependencies:


### PR DESCRIPTION
We reverted Prisma because a regression in v 3.9.1. That regression has now been fix, so let's upgrade again

More info about the regression
https://github.com/redwoodjs/redwood/issues/4396
https://github.com/prisma/prisma/issues/11641

Prisma's fix
https://github.com/prisma/prisma/pull/11679

Prisma's release notes for this release
https://github.com/prisma/prisma/releases/tag/3.9.2
