### PR TITLE
WIP: Update params if navigated to different route with same page

### DIFF
--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1259,3 +1259,30 @@ describe('trailing slashes', () => {
     await waitFor(() => screen.getByText(/Contact Page/i))
   })
 })
+
+test('params should be updated if navigated to different route with same page', async () => {
+  const UserPage = ({ id }: { id?: number }) => {
+    const { id: idFromContext } = useParams()
+    return (
+      <>
+        <p>param {id ? id : 'no-id'}</p>
+        <p>hookparams {idFromContext ? idFromContext : 'no-param-id'} </p>
+      </>
+    )
+  }
+  const TestRouter = () => (
+    <Router>
+      <Route path="/user" page={UserPage} name="allUsers" />
+      <Route path="/user/{id:Int}" page={UserPage} name="user" />
+    </Router>
+  )
+
+  const screen = render(<TestRouter />)
+  act(() => navigate('/user'))
+  act(() => navigate('/user/99'))
+
+  await waitFor(() => {
+    expect(screen.queryByText('param 99')).toBeInTheDocument()
+    expect(screen.queryByText('hookparams 99')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This work in progress. Added a failing test.

**Problem:**
When we have routes like below - same page with different route params. The params should be updated when navigated from one route to another.

```jsx
<Router>
  <Route path="/user" page={UserPage} name="allUsers" />
  <Route path="/user/{id:Int}" page={UserPage} name="user" />
</Router>
```

@Tobbe I think you have a better idea about this. I've pinpointed it to the following block of code, specifically it's trying to find `page` with updated `path` and it's not there, so `ArNullPage`. Plus, probably need to update `renderedPath` and `renderedChildren`. I'm working on a fix that doesn't cause unnecessary renders, I thought to let you know if you have suggestions in mind. :)

https://github.com/redwoodjs/redwood/blob/3b567099a377b85da2e8100bbd2429925a7f552e/packages/router/src/active-route-loader.tsx#L136-L143