### PR TITLE
Don't merge: Remove global mocks in web's jest setup to improve memory usage

### DIFF
--- a/packages/testing/config/jest/web/jest.setup.js
+++ b/packages/testing/config/jest/web/jest.setup.js
@@ -3,7 +3,6 @@
 require('@testing-library/jest-dom')
 require('whatwg-fetch')
 
-const { getProject } = require('@redwoodjs/structure')
 const {
   startMSW,
   setupRequestHandlers,
@@ -16,13 +15,7 @@ global.mockGraphQLQuery = mockGraphQLQuery
 global.mockGraphQLMutation = mockGraphQLMutation
 global.mockCurrentUser = mockCurrentUser
 
-const project = getProject()
-
 beforeEach(async () => {
-  // Import the global mocks.
-  for (const m of project.mocks) {
-    require(m)
-  }
   await startMSW('node')
   setupRequestHandlers() // reset the handlers in each test.
 })


### PR DESCRIPTION
## Don't merge
Yet to discuss the impact of change.
____
On Node 16.10, and`--maxWorkers=1` to simulate single CPU machine (like CI), where the leak seems to impact more.

Before: 
```
$ yarn redwood test web --no-watch --logHeapUsage --maxWorkers=1 &| grep "heap size"
PASS web web/src/components/MenCell/MenCell.test.tsx (431 MB heap size)
PASS web web/src/components/WomanCell/WomanCell.test.tsx (488 MB heap size)
PASS web web/src/components/ManCell/ManCell.test.tsx (626 MB heap size)
PASS web web/src/components/GirlCell/GirlCell.test.tsx (765 MB heap size)
PASS web web/src/components/BoysCell/BoysCell.test.tsx (903 MB heap size)
PASS web web/src/components/WomnCell/WomnCell.test.tsx (1041 MB heap size)
PASS web web/src/components/DogCell/DogCell.test.tsx (1180 MB heap size)
PASS web web/src/components/CatsCell/CatsCell.test.tsx (1319 MB heap size)
PASS web web/src/components/CatCell/CatCell.test.tsx (1457 MB heap size)
PASS web web/src/components/DogsCell/DogsCell.test.tsx (1595 MB heap size)
PASS web web/src/components/GirlsCell/GirlsCell.test.tsx (1734 MB heap size)
PASS web web/src/components/BoyCell/BoyCell.test.tsx (811 MB heap size)
```
With these changes:
```
$ yarn redwood test web --no-watch --logHeapUsage --maxWorkers=1 &| grep "heap size"
PASS web web/src/components/MenCell/MenCell.test.tsx (259 MB heap size)
PASS web web/src/components/BoyCell/BoyCell.test.tsx (286 MB heap size)
PASS web web/src/components/WomanCell/WomanCell.test.tsx (318 MB heap size)
PASS web web/src/components/BoysCell/BoysCell.test.tsx (342 MB heap size)
PASS web web/src/components/CatCell/CatCell.test.tsx (365 MB heap size)
PASS web web/src/components/GirlsCell/GirlsCell.test.tsx (392 MB heap size)
PASS web web/src/components/DogsCell/DogsCell.test.tsx (274 MB heap size)
PASS web web/src/components/CatsCell/CatsCell.test.tsx (300 MB heap size)
PASS web web/src/components/WomnCell/WomnCell.test.tsx (326 MB heap size)
PASS web web/src/components/DogCell/DogCell.test.tsx (349 MB heap size)
PASS web web/src/components/GirlCell/GirlCell.test.tsx (374 MB heap size)
PASS web web/src/components/ManCell/ManCell.test.tsx (407 MB heap size)
```

Test setup - Run bunch of cell generation:
```
yarn redwood generate cell --force man
yarn redwood generate cell --force woman
yarn redwood generate cell --force boy
yarn redwood generate cell --force girl
yarn redwood generate cell --force dog
yarn redwood generate cell --force cat
yarn redwood generate cell --force men
yarn redwood generate cell --force women
yarn redwood generate cell --force boys
yarn redwood generate cell --force girls
yarn redwood generate cell --force dogs
yarn redwood generate cell --force cats
```