### PR TITLE
fix(test-project): Ignore exit code from rimraf if dist not present

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "yarn build:js && yarn build:types",
-    "build:clean": "yarn clean:prisma && rimraf packages/**/dist",
+    "build:clean": "yarn clean:prisma && (rimraf packages/**/dist || true)",
     "build:js": "lerna run build:js",
     "build:link": "node ./tasks/build-and-copy",
     "build:test-project": "node ./tasks/test-project/test-project",


### PR DESCRIPTION
Gitpod is currently failing, because rimraf (or yarn) has started exiting the `build:clean` command with the exit code `127`. 

This results in the test project not being generated annoyingly, which means Gitpod also doesn't spin up correctly.

This PR ignores the exit code from rimraf, in the `build:clean` script