### PR TITLE
package.json: Quote path to rimraf to let rimraf do globbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "build": "yarn build:js && yarn build:types",
-    "build:clean": "yarn clean:prisma && (rimraf packages/**/dist || true)",
+    "build:clean": "yarn clean:prisma && rimraf \"packages/**/dist\"",
     "build:js": "lerna run build:js",
     "build:link": "node ./tasks/build-and-copy",
     "build:test-project": "node ./tasks/test-project/test-project",


### PR DESCRIPTION
Windows doesn't do any path expansion when passing arguments to CLI executables.

So if you're in a directory with two files: `a.txt` and `b.txt` and run `rimraf *.txt` this is what happens:

Windows: `rimraf "*.txt"`
Linux: `rimraf a.txt b.txt`

What this also means is if the glob-path doesn't exist, on Windows the CLI executable has to deal with it itself, on Linux the shell with throw an error before even trying to run the cli.

So, to make this work the same on both platform what you need to do is to quote the path: `rimraf "*.txt"`. On Windows this is already what happens, so no change, and rimraf will deal with it. On *nix this bypasses the shell path expansion and rimraf will deal with it instead.

Related: https://github.com/redwoodjs/redwood/pull/4462