### PR TITLE
[Renovate] Ignore pretty bytes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -44,6 +44,7 @@
     "@redwoodjs/telemetry",
     "@redwoodjs/testing",
     "@redwoodjs/web",
-    "lru-cache"
+    "lru-cache",
+    "pretty-bytes"
   ]
 }


### PR DESCRIPTION
Pretty bytes is now ESM only: https://github.com/redwoodjs/redwood/pull/4458.