### PR TITLE
Uncomment role checks in dbAuth's auth.js template

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
@@ -54,14 +54,13 @@ export const hasRole = ({ roles }: { roles: AllowedRoles }): boolean => {
     return false
   }
 
-  // If your User model includes roles, uncomment the role checks on currentUser
   if (roles) {
     if (Array.isArray(roles)) {
-      // return context.currentUser.roles?.some((r) => roles.includes(r))
+      return context.currentUser.roles?.some((r) => roles.includes(r))
     }
 
     if (typeof roles === 'string') {
-      // return context.currentUser.roles?.includes(roles)
+      return context.currentUser.roles?.includes(roles)
     }
 
     // roles not found


### PR DESCRIPTION
Not sure why I would have commented these out, I thought I just copied the standard `auth.js` template and make a couple of changes for `getCurrentUser()` unique to dbAuth.