### PR TITLE
Fix release script

### DIFF
--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -291,8 +291,7 @@ async function releaseMajorOrMinor(semver, nextVersion) {
         $`${['git push', !releaseBranchExists && `-u origin ${releaseBranch}`]
           .filter(Boolean)
           .join(' ')}`,
-      // This is supposedly safer than `git push --tags`. See https://git-scm.com/book/en/v2/Git-Basics-Tagging.
-      () => $`git push --follow-tags`,
+      () => $`git push --tags`,
       // We've had an issue with this one.
       async () => {
         try {
@@ -395,8 +394,7 @@ async function releasePatch(currentVersion, nextVersion) {
     ask`Everything passed local QA. Are you ready to push your branch and tag to GitHub and publish to NPM?`,
     [
       () => $`git push`,
-      // This is supposedly safer than `git push --tags`. See https://git-scm.com/book/en/v2/Git-Basics-Tagging.
-      () => $`git push --follow-tags`,
+      () => $`git push --tags`,
       // We've had an issue with this one.
       async () => {
         try {

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -287,7 +287,10 @@ async function releaseMajorOrMinor(semver, nextVersion) {
   await confirmRuns(
     ask`Everything passed local QA. Are you ready to push your branch and tag to GitHub and publish to NPM?`,
     [
-      () => $`git push ${[!releaseBranchExists && `-u origin ${releaseBranch}`].filter(Boolean)}`,
+      () =>
+        $`git push ${[
+          !releaseBranchExists && `-u origin ${releaseBranch}`,
+        ].filter(Boolean)}`,
       () => $`git push --tags`,
       // We've had an issue with this one.
       async () => {

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -287,10 +287,7 @@ async function releaseMajorOrMinor(semver, nextVersion) {
   await confirmRuns(
     ask`Everything passed local QA. Are you ready to push your branch and tag to GitHub and publish to NPM?`,
     [
-      () =>
-        $`${['git push', !releaseBranchExists && `-u origin ${releaseBranch}`]
-          .filter(Boolean)
-          .join(' ')}`,
+      () => $`git push ${[!releaseBranchExists && `-u origin ${releaseBranch}`].filter(Boolean)}`,
       () => $`git push --tags`,
       // We've had an issue with this one.
       async () => {

--- a/tasks/release/updatePRsMilestone.mjs
+++ b/tasks/release/updatePRsMilestone.mjs
@@ -48,10 +48,10 @@ export default async function updatePRsMilestone(fromTitle, toTitle) {
     )
   )
 
-  const looksOk = await confirmRuns(
-    check`Updated the milestone of ${pullRequestIds.length} PRs\nDoes everything look ok?`,
-    () =>
-      $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3A${toTitle}`
+  await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3A${toTitle}`
+
+  const looksOk = await confirm(
+    check`Updated the milestone of ${pullRequestIds.length} PRs\nDoes everything look ok?`
   )
   if (looksOk) {
     return milestone


### PR DESCRIPTION
- opens the link to the updated PRs before asking for confirmation
- fixes `git push` (I wasn't handling arrays properly https://github.com/google/zx/blob/main/docs/quotes.md#array-of-arguments)
- reverts to `git push --tags`