### PR TITLE
gql typegen messaging updates

### DIFF
--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -207,9 +207,9 @@ export const generateTypeDefGraphQLApi = async () => {
     })
     return f
   } catch (e) {
-    console.error()
-    console.error('Error: Could not generate GraphQL type definitions (api)')
-    console.error()
+    console.log()
+    console.log('No GraphQL type definitions generated (api)')
+    console.log()
     return []
   }
 }
@@ -232,9 +232,9 @@ export const generateTypeDefGraphQLWeb = async () => {
     })
     return f
   } catch (e) {
-    console.error()
-    console.error('Error: Could not generate GraphQL type definitions (web)')
-    console.error()
+    console.log()
+    console.log('No GraphQL type definitions generated (web)')
+    console.log()
     return []
   }
 }


### PR DESCRIPTION
Fixes #4393 

To recap, this is the error we're printing

```
gen | Generating TypeScript definitions and GraphQL schemas...
gen |
gen |       Unable to find any GraphQL type definitions for the following pointers:
gen |
gen |           - ./web/src/**/!(*.d).{ts,tsx,js,jsx}
gen |
gen |
gen |       Unable to find any GraphQL type definitions for the following pointers:
gen |
gen |           - ./web/src/**/!(*.d).{ts,tsx,js,jsx}
gen |
gen |
gen | Error: Could not generate GraphQL type definitions (web)
gen |
gen | 14 files generated
```

The "Unable to find..." error message comes from here: https://github.com/ardatan/graphql-tools/blob/2207fbcdacf708ee9836ee72d0c0f92dba0d0942/packages/load/src/load-typedefs.ts#L120

The "Error: Could not generate..." message is our own.


With `errorsOnly: false` we get a better idea of what's going on:

```
gen | Generating TypeScript definitions and GraphQL schemas...
gen | gene /Users/tobbe/tmp/typegen/web/types/graphql.d.ts
gen | [01:38:48] Parse configuration [started]
gen | [01:38:48] Parse configuration [completed]
gen | [01:38:48] Generate outputs [started]
gen | [01:38:48] Generate /Users/tobbe/tmp/typegen/web/types/graphql.d.ts [started]
gen | [01:38:48] Load GraphQL schemas [started]
gen | [01:38:48] Load GraphQL schemas [completed]
gen | [01:38:48] Load GraphQL documents [started]
gen | [01:38:48] Load GraphQL documents [failed]
gen | [01:38:48] →
gen |       Unable to find any GraphQL type definitions for the following pointers:
gen |
gen |           - ./web/src/**/!(*.d).{ts,tsx,js,jsx}
gen |
gen | [01:38:48] Generate /Users/tobbe/tmp/typegen/web/types/graphql.d.ts [failed]
gen | [01:38:48] →
gen |       Unable to find any GraphQL type definitions for the following pointers:
gen |
gen |           - ./web/src/**/!(*.d).{ts,tsx,js,jsx}
gen |
gen | [01:38:48] Generate outputs [failed]
gen |
gen | Error: Could not generate GraphQL type definitions (web)
gen |
gen | 14 files generated
``` 

`@graphql-codegen` is using Listr, and as you can see there are two tasks that fail with the same error message, that's why we get duplicated output. We get it for both "Load GraphQL documents" and "Generate /Users/tobbe/tmp/typegen/web/types/graphql.d.ts". 

The first of those two is here: https://github.com/dotansimha/graphql-code-generator/blob/1e3d37a349a1d6748f235465a8bb78c66e0d1edf/packages/graphql-codegen-cli/src/codegen.ts#L261  and the other one is right after. And because they have `exitOnError: true` configured, as soon as the first of those two fails, so does the other one. And apparently the error carries over. If I switch it to `exitOnError: false` I only get one error output:

```
gen | Generating TypeScript definitions and GraphQL schemas...
gen | gene /Users/tobbe/tmp/typegen/web/types/graphql.d.ts
gen | [01:45:41] Parse configuration [started]
gen | [01:45:41] Parse configuration [completed]
gen | [01:45:41] Generate outputs [started]
gen | [01:45:41] Generate /Users/tobbe/tmp/typegen/web/types/graphql.d.ts [started]
gen | [01:45:41] Load GraphQL schemas [started]
gen | [01:45:41] Load GraphQL schemas [completed]
gen | [01:45:41] Load GraphQL documents [started]
gen | [01:45:41] Load GraphQL documents [failed]
gen | [01:45:41] →
gen |       Unable to find any GraphQL type definitions for the following pointers:
gen |
gen |           - ./web/src/**/!(*.d).{ts,tsx,js,jsx}
gen |
gen | [01:45:41] Generate [started]
gen | [01:45:41] Generate [completed]
gen | [01:45:41] Generate /Users/tobbe/tmp/typegen/web/types/graphql.d.ts [failed]
gen | [01:45:41] Generate outputs [failed]
gen |
gen | Error: Could not generate GraphQL type definitions (web)
gen |
gen | 14 files generated
```

But that's not something I can control, so we'll have to live with duplicated output from `@graphql-codegen`