### PR TITLE
g secret: raw output

### DIFF
--- a/packages/cli/src/commands/generate/secret/__tests__/secret.test.js
+++ b/packages/cli/src/commands/generate/secret/__tests__/secret.test.js
@@ -1,4 +1,6 @@
-import { generateSecret, handler } from './../secret.js'
+import yargs from 'yargs'
+
+import { generateSecret, handler, builder } from './../secret.js'
 
 describe('generateSecret', () => {
   it('contains only uppercase letters, lowercase letters, and digits', () => {
@@ -13,26 +15,26 @@ describe('generateSecret', () => {
     expect(secret.length).toEqual(16)
   })
 
-  it('only prints the secret when stdout is not a tty', () => {
+  it('prints nothing but the secret when setting the --raw flag', () => {
     const realLog = console.log
     const realInfo = console.info
     const realWrite = process.stdout.write
-    const realIsTty = process.stdout.isTTY
 
     let output = ''
 
     console.log = (...args) => (output += args.join(' ') + '\n')
     console.info = (...args) => (output += args.join(' ') + '\n')
     process.stdout.write = (str) => (output += str)
-    process.stdout.isTTY = false
 
-    handler({})
-
-    expect(output).toMatch(/^[A-Za-z0-9]{64}$/)
+    const { raw, length } = yargs
+      .command('secret', false, builder, handler)
+      .parse('secret --raw')
 
     console.log = realLog
     console.info = realInfo
     process.stdout.write = realWrite
-    process.stdout.isTTY = realIsTty
+
+    expect(raw).toBeTruthy()
+    expect(output).toMatch(new RegExp(`^[A-Za-z0-9]{${length}}$`))
   })
 })

--- a/packages/cli/src/commands/generate/secret/__tests__/secret.test.js
+++ b/packages/cli/src/commands/generate/secret/__tests__/secret.test.js
@@ -1,4 +1,4 @@
-import { generateSecret } from './../secret.js'
+import { generateSecret, handler } from './../secret.js'
 
 describe('generateSecret', () => {
   it('contains only uppercase letters, lowercase letters, and digits', () => {
@@ -11,5 +11,28 @@ describe('generateSecret', () => {
     const secret = generateSecret(16)
 
     expect(secret.length).toEqual(16)
+  })
+
+  it('only prints the secret when stdout is not a tty', () => {
+    const realLog = console.log
+    const realInfo = console.info
+    const realWrite = process.stdout.write
+    const realIsTty = process.stdout.isTTY
+
+    let output = ''
+
+    console.log = (...args) => (output += args.join(' ') + '\n')
+    console.info = (...args) => (output += args.join(' ') + '\n')
+    process.stdout.write = (str) => (output += str)
+    process.stdout.isTTY = false
+
+    handler({})
+
+    expect(output).toMatch(/^[A-Za-z0-9]{64}$/)
+
+    console.log = realLog
+    console.info = realInfo
+    process.stdout.write = realWrite
+    process.stdout.isTTY = realIsTty
   })
 })

--- a/packages/cli/src/commands/generate/secret/__tests__/secret.test.js
+++ b/packages/cli/src/commands/generate/secret/__tests__/secret.test.js
@@ -35,6 +35,6 @@ describe('generateSecret', () => {
     process.stdout.write = realWrite
 
     expect(raw).toBeTruthy()
-    expect(output).toMatch(new RegExp(`^[A-Za-z0-9]{${length}}$`))
+    expect(output).toMatch(new RegExp(`^[A-Za-z0-9]{${length}}\n$`))
   })
 })

--- a/packages/cli/src/commands/generate/secret/secret.js
+++ b/packages/cli/src/commands/generate/secret/secret.js
@@ -22,6 +22,14 @@ export const builder = (yargs) =>
   })
 
 export const handler = ({ length }) => {
+  if (!process.stdout.isTTY) {
+    // If the output is being piped we only print the secret, no
+    // information messages. This makes it easier to programmatically use the
+    // output
+    console.log(generateSecret(length))
+    return
+  }
+
   console.info('')
   console.info(`  ${generateSecret(length)}`)
   console.info('')

--- a/packages/cli/src/commands/generate/secret/secret.js
+++ b/packages/cli/src/commands/generate/secret/secret.js
@@ -25,8 +25,10 @@ export const handler = ({ length }) => {
   if (!process.stdout.isTTY) {
     // If the output is being piped we only print the secret, no
     // information messages. This makes it easier to programmatically use the
-    // output
-    console.log(generateSecret(length))
+    // output.
+    // Using stdout.write here to not get the newline that console.log always
+    // adds
+    process.stdout.write(generateSecret(length))
     return
   }
 

--- a/packages/cli/src/commands/generate/secret/secret.js
+++ b/packages/cli/src/commands/generate/secret/secret.js
@@ -30,9 +30,7 @@ export const builder = (yargs) =>
 
 export const handler = ({ length, raw }) => {
   if (raw) {
-    // Using stdout.write here to not get the newline that console.log always
-    // adds
-    process.stdout.write(generateSecret(length))
+    console.log(generateSecret(length))
     return
   }
 

--- a/packages/cli/src/commands/generate/secret/secret.js
+++ b/packages/cli/src/commands/generate/secret/secret.js
@@ -14,18 +14,22 @@ export const description =
   'Generates a secret key using a cryptographically-secure source of entropy'
 
 export const builder = (yargs) =>
-  yargs.option('length', {
-    description: 'Length of the generated secret',
-    type: 'integer',
-    required: false,
-    default: DEFAULT_LENGTH,
-  })
+  yargs
+    .option('length', {
+      description: 'Length of the generated secret',
+      type: 'integer',
+      required: false,
+      default: DEFAULT_LENGTH,
+    })
+    .option('raw', {
+      description: 'Prints just the raw secret',
+      type: 'boolean',
+      required: false,
+      default: false,
+    })
 
-export const handler = ({ length }) => {
-  if (!process.stdout.isTTY) {
-    // If the output is being piped we only print the secret, no
-    // information messages. This makes it easier to programmatically use the
-    // output.
+export const handler = ({ length, raw }) => {
+  if (raw) {
     // Using stdout.write here to not get the newline that console.log always
     // adds
     process.stdout.write(generateSecret(length))


### PR DESCRIPTION
This PR makes the `yarn redwood generate secret` command output just the secret, no extra information messaging, when used in a pipeline. 

It allows you to do things like `yarn --silent rw g secret > myfile` to print just the secret to a file.
Or more relevant for dbAuth:
```
echo "SESSION_SECRET=$(yarn --silent rw g secret --raw)" >> .env
```
To append the needed environment variable to the user's .env file

(Updated to add `--silent`)