### PR TITLE
Try increasing timeout for flaky codemods test

### DIFF
--- a/packages/codemods/src/codemods/v0.44.x/updateJestConfig/__tests__/updateJestConfig.test.ts
+++ b/packages/codemods/src/codemods/v0.44.x/updateJestConfig/__tests__/updateJestConfig.test.ts
@@ -38,6 +38,8 @@ describe('Update Jest Config', () => {
   })
 
   it('Keeps custom jest config in api and web', async () => {
+    jest.setTimeout(25_000)
+
     await matchFolderTransform(updateJestConfig, 'custom', {
       removeWhitespace: true,
     })


### PR DESCRIPTION
The update jest config codemod test seems to keep failing on Windows because of a timeout. See https://github.com/redwoodjs/redwood/runs/5258703596?check_suite_focus=true#step:11:154 for an example. This PR increases the timeout by five seconds.