### PR TITLE
Envelop: Don't use useImmediateIntrospection as it causes auth bug

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -3,7 +3,6 @@ import {
   envelop,
   EnvelopError,
   FormatErrorHandler,
-  useImmediateIntrospection,
   useMaskedErrors,
   useSchema,
 } from '@envelop/core'
@@ -168,8 +167,6 @@ export const createGraphQLHandler = ({
 
   if (!isDevEnv) {
     plugins.push(useDisableIntrospection())
-  } else {
-    plugins.push(useImmediateIntrospection())
   }
 
   // Simple LRU for caching parse results.


### PR DESCRIPTION
Envelop recently added a new plugin:

> Add new plugin `useImmediateIntrospection` for speeding up introspection only operations by skipping context building.

We added that in https://github.com/redwoodjs/redwood/commit/faede7f5dbcf7291fe4a5813c10175b056b9abbb, but it seems it caused some auth bugs. See https://github.com/redwoodjs/redwood/issues/4520

So this PR reverts that change.

It was only enabled in dev as a performance optimization. So should be safe to go without.

Fixes: https://github.com/redwoodjs/redwood/issues/4520

