### PR TITLE
Netlify client getToken fix when GoTrue client refreshes JWT

### DIFF
--- a/packages/auth/src/authClients/goTrue.ts
+++ b/packages/auth/src/authClients/goTrue.ts
@@ -33,8 +33,12 @@ export const goTrue = (client: GoTrue): AuthClientGoTrue => {
     signup: async ({ email, password, remember }) =>
       client.signup(email, password, remember),
     getToken: async () => {
-      const user = await client.currentUser()
-      return user?.jwt() || null
+      try {
+        const user = await client.currentUser()
+        return user?.jwt() || null
+      } catch {
+        return null
+      }
     },
     getUserMetadata: async () => client.currentUser(),
   }

--- a/packages/auth/src/authClients/netlify.ts
+++ b/packages/auth/src/authClients/netlify.ts
@@ -41,11 +41,15 @@ export const netlify = (client: NetlifyIdentity): AuthClient => {
       })
     },
     getToken: async () => {
-      // The client refresh function only actually refreshes token
-      // when it's been expired. Don't panic
-      await client.refresh()
-      const user = await client.currentUser()
-      return user?.token?.access_token || null
+      try {
+        // The client refresh function only actually refreshes token
+        // when it's been expired. Don't panic
+        await client.refresh()
+        const user = await client.currentUser()
+        return user?.token?.access_token || null
+      } catch {
+        return null
+      }
     },
     getUserMetadata: async () => {
       return client.currentUser()


### PR DESCRIPTION
This PR fixes an issue in the Netlify authentication client where refreshing and getting a token can cause an error such as:

```
Error: null is not an object (evaluating 'u.default.gotrue.currentUser().jwt')
```

Because of a null default value set as part of the isAuthentication fix to set default values: https://github.com/redwoodjs/redwood/pull/4320/files

This PR catches any error from the Netlify client sdk and handles it.

Note that it isn't client that's null and raising the error as checking from it still causes the error.

```
      if (client) {
        // The client refresh function only actually refreshes token
        // when it's been expired. Don't panic
        await client.refresh()
        const user = await client.currentUser()
        return user?.token?.access_token || null
      } else {
        return null
      }
```

Edit: Also added some check for the GoTrue client, since it is the same underneath.