### PR TITLE
create-redwood-app: Correct --overwrite description

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -69,7 +69,7 @@ const {
   .option('overwrite', {
     default: false,
     type: 'boolean',
-    describe: 'Create even if target directory is empty',
+    describe: "Create even if target directory isn't empty",
   })
   .option('telemetry', {
     default: true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30793/154926796-68890a64-7305-4577-a2c8-e74629627cc0.png)

I think the logic in the description was reversed