### PR TITLE
Update seed.ts to reflect correct input type

### DIFF
--- a/packages/create-redwood-app/template/scripts/seed.ts
+++ b/packages/create-redwood-app/template/scripts/seed.ts
@@ -9,7 +9,7 @@ export default async () => {
     //
     // Update "const data = []" to match your data model and seeding needs
     //
-    const data: Prisma.UserExampleCreateInput['data'][] = [
+    const data: Prisma.UserExampleCreateArgs['data'][] = [
       // To try this example data with the UserExample model in schema.prisma,
       // uncomment the lines below and run 'yarn rw prisma migrate dev'
       //
@@ -28,7 +28,7 @@ export default async () => {
       //
       // Change to match your data model and seeding needs
       //
-      data.map(async (data: Prisma.UserExampleCreateInput['data']) => {
+      data.map(async (data: Prisma.UserExampleCreateArgs['data']) => {
         const record = await db.userExample.create({ data })
         console.log(record)
       })


### PR DESCRIPTION
In #3874 this type was narrowed down to make it more accurate. I think a slight error happened here and the correct type should be `UserExampleCreateArgs` and not `UserExampleCreateInput`.