### PR TITLE
[for discussion] Adding Auth functional tests to Playwright Smoke-test

### DIFF
--- a/tasks/smoke-test/tests/common.ts
+++ b/tasks/smoke-test/tests/common.ts
@@ -24,4 +24,30 @@ export const smokeTest = async ({ page, webServerPort }) => {
   // Click text=Admin
   await page.click('text=Admin')
   expect(page.url()).toBe(`http://localhost:${webServerPort}/posts`)
+
+  // Auth
+  await page.goto(`http://localhost:${webServerPort}/posts/1/edit`)
+
+  // unAuthenticated
+  await page.click('text=SAVE')
+  expect(page).toHaveTextContent("You don't have permission to do that.")
+
+  // create user and Save post
+  await page.goto(`http://localhost:${webServerPort}/signup`)
+
+  await page.fill('#username', 'thedavid')
+  await page.fill('#password', 'isthebest')
+  await page.click('text=SIGN UP')
+  expect(page).toHaveTextContent('Log Out')
+
+  await page.goto(`http://localhost:${webServerPort}/posts/1/edit`)
+
+  // Authenticated
+  await page.click('text=SAVE')
+  expect(page).toHaveTextContent('Welcome to the blog!')
+
+  // Log Out
+  await page.goto(`http://localhost:${webServerPort}/about`)
+  await page.click('text=Log Out')
+  expect(page).toHaveTextContent('Log In')
 }


### PR DESCRIPTION
For discussion re: https://github.com/redwoodjs/redwood/issues/4486

@dac09 I started playing around with how to use Playwright + Test-project with dbAuth to do some basic Auth functional testing.

> This is for discussion only. Let's close once path is determined.

Playwright looks like it will make this super simple:
- should it be a separate test or add-on tests to either or both `rw dev` and `rw serve`; long-term I prefer standalone but game to do what needs to be done right now
- I think this will better serve us as a stand-alone GH workflow; if easy, let's do that now. But I want something up asap so if using Smoke-test workflow for now, I'm all for it
- I suggest we use the Test-project until proven otherwise. I can see why, in the future, we'll want a separate fixture. But for the tests we need now this feels like the foundation we need

Reactions and suggestions?