### PR TITLE
feat(exec): Allow listing of scripts with rw exec to improve dx

### DIFF
--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -28,7 +28,7 @@ const runScript = async (scriptPath, scriptArgs) => {
   return
 }
 
-export const command = 'exec <name>'
+export const command = 'exec [name]'
 export const description = 'Run scripts generated with yarn generate script'
 export const builder = (yargs) => {
   yargs
@@ -41,6 +41,12 @@ export const builder = (yargs) => {
       default: true,
       description: 'Generate the Prisma client',
     })
+    .option('list', {
+      alias: 'ls',
+      type: 'boolean',
+      default: false,
+      description: 'List available scripts',
+    })
     .strict(false)
     .epilogue(
       `Also see the ${terminalLink(
@@ -50,8 +56,22 @@ export const builder = (yargs) => {
     )
 }
 
+const printAvailableScriptsToConsole = () => {
+  console.log('Available scripts:')
+  findScripts().forEach((scriptPath) => {
+    const { name } = path.parse(scriptPath)
+    console.log(c.info(`- ${name}`))
+  })
+  console.log()
+}
+
 export const handler = async (args) => {
-  const { name, prisma, ...scriptArgs } = args
+  const { name, prisma, list, ...scriptArgs } = args
+  if (list || !name) {
+    printAvailableScriptsToConsole()
+    return
+  }
+
   const scriptPath = path.join(getPaths().scripts, name)
 
   const {
@@ -120,12 +140,7 @@ export const handler = async (args) => {
       c.error(`\nNo script called ${c.underline(name)} in ./scripts folder.\n`)
     )
 
-    console.log('Available scripts:')
-    findScripts().forEach((scriptPath) => {
-      const { name } = path.parse(scriptPath)
-      console.log(c.info(`- ${name}`))
-    })
-    console.log()
+    printAvailableScriptsToConsole()
     process.exit(1)
   }
 

--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -42,7 +42,7 @@ export const builder = (yargs) => {
       description: 'Generate the Prisma client',
     })
     .option('list', {
-      alias: 'ls',
+      alias: 'l',
       type: 'boolean',
       default: false,
       description: 'List available scripts',


### PR DESCRIPTION
### List available scripts with rw exec
This PR makes the script name optional, and provides a bit more guidance, because its easy to forget script names.

Explanation: https://s.tape.sh/G92eIWlR

To list scripts you can run
Just: `yarn rw exec`
or `yarn rw exec --list`


