### PR TITLE
fixi(prisma): Set default cwd for runCommand task to base

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -425,12 +425,12 @@ export const removeRoutesFromRouterTask = (routes, layout) => {
 
 export const runCommandTask = async (commands, { verbose }) => {
   const tasks = new Listr(
-    commands.map(({ title, cmd, args, opts = {} }) => ({
+    commands.map(({ title, cmd, args, opts = {}, cwd = getPaths().base }) => ({
       title,
       task: async () => {
         return execa(cmd, args, {
           shell: true,
-          cwd: `${getPaths().base}/api`,
+          cwd,
           stdio: verbose ? 'inherit' : 'pipe',
           extendEnv: true,
           cleanup: true,


### PR DESCRIPTION
The `runCommandTask` which currently is only used in https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/lib/generatePrismaClient.js had the cwd set to the api side.

This PR does the following:

1. Run command tasks now take a cwd
2. Sets default cwd to the root of the project 

---

This won't 100% solve the problem we're seeing with prisma, as it seems to be a problem on their side too. Tracking issue here: https://github.com/redwoodjs/redwood/issues/4605