### PR TITLE
remove Redwood extension from CRWA VS Code extension list

### DIFF
--- a/packages/create-redwood-app/template/.vscode/extensions.json
+++ b/packages/create-redwood-app/template/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "redwoodjs.redwood",
     "dbaeumer.vscode-eslint",
     "eamodio.gitlens",
     "ofhumanbondage.react-proptypes-intellisense",


### PR DESCRIPTION
This removes the Redwood VS Code extension from the list of recommended extensions in the CRWA template.

I'll create a separate issue to deprecate the package itself.

Background:
The extension is effectively not compatible with v1. It's planned for a re-implementation, which will not be started by v1 launch. Basically it's now a "use-at-your-own-risk" extension.