### PR TITLE
[dbAuth] Deprecates existing internal cookie config, adds config to auth function

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.function.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.function.ts.template
@@ -140,6 +140,21 @@ export const handler = async (event, context) => {
       resetTokenExpiresAt: 'resetTokenExpiresAt',
     },
 
+    // Specifies attributes on the cookie that dbAuth sets in order to remember
+    // who is logged in. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#restrict_access_to_cookies
+    cookie: {
+      HttpOnly: true,
+      Path: '/',
+      SameSite: 'Strict',
+      Secure: process.env.NODE_ENV !== 'development',
+
+      // If your web and api sides are deployed to different hosts you'll need
+      // to set the Domain. For example, setting it to "example.com" would allow
+      // the cookie to be sent to both www.example.com and api.example.com
+
+      // Domain: 'example.com',
+    },
+
     forgotPassword: forgotPasswordOptions,
     login: loginOptions,
     resetPassword: resetPasswordOptions,


### PR DESCRIPTION
As discussed in https://github.com/redwoodjs/redwood/pull/4150 this moves cookie config for dbAuth beside the other auth configuration in `api/src/functions/auth.js` instead of a mix of internal config and cookies.

## Release Notes

If you are using dbAuth, we've moved the configuration for the dbAuth cookie alongside the rest of the configuration in `api/src/functions/auth.js`. The original configuration, which was internal to Redwood itself, is now deprecated. If you do not add this cookie config to auth.js your app will continue to work for now, but will show a deprecation notice in your api logs. The old behavior will be removed in a future version of Redwood.

To preserve the existing cookie settings, add the `cookie` property to the options sent into `new DbAuthHandler()`:

```diff
const authHandler = new DbAuthHandler(event, context, {
  db: db,
  authModelAccessor: 'user',
  authFields: {
    id: 'id',
    username: 'email',
    hashedPassword: 'hashedPassword',
    salt: 'salt',
    resetToken: 'resetToken',
    resetTokenExpiresAt: 'resetTokenExpiresAt',
  },
  forgotPassword: forgotPasswordOptions,
  login: loginOptions,
  resetPassword: resetPasswordOptions,
  signup: signupOptions,

+ cookie: {
+  HttpOnly: true,
+  Path: '/',
+  SameSite: 'Strict',
+  Secure: process.env.NODE_ENV !== 'development',
+  // Domain: 'example.com',
+  },

})
```

The cookie `Domain` is now set here instead of in an ENV var.