### PR TITLE
(fixture chore) move tailwind devDeps into root package.json

### DIFF
--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -8,7 +8,11 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "0.47.1"
+    "@redwoodjs/core": "0.47.1",
+    "autoprefixer": "10.4.2",
+    "postcss": "8.4.6",
+    "postcss-loader": "6.2.1",
+    "tailwindcss": "3.0.23"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -20,11 +20,5 @@
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"
-  },
-  "devDependencies": {
-    "autoprefixer": "9.8.8",
-    "postcss": "8.4.6",
-    "postcss-loader": "6.2.1",
-    "tailwindcss": "3.0.23"
   }
 }


### PR DESCRIPTION
Our old friend, the webpack-can't-find-postcss-error, is back and throwing CI Smoke-test. See:
- https://github.com/redwoodjs/redwood/actions/workflows/smoke-test.yaml
- example: https://github.com/redwoodjs/redwood/runs/5383843167?check_suite_focus=true#step:9:99

Confirming this is also failing GitPod builds:
- https://gitpod.io/#https://github.com/redwoodjs/redwood/pull/4613

I'm attempting to resolve by reverting autoprefixer pinned to 9.8.8, which is what worked last time around.

## ToDo
- [x] fix CI
- [x] update fixture
- [x] confirm GitPod is building successfully