### PR TITLE
fix storybook DX by removing default type check config

### DIFF
--- a/packages/testing/config/storybook/main.js
+++ b/packages/testing/config/storybook/main.js
@@ -9,7 +9,6 @@ const {
   getConfig,
   getPaths,
 } = require('@redwoodjs/internal')
-const { getProject } = require('@redwoodjs/structure')
 
 const config = getConfig()
 
@@ -136,15 +135,6 @@ const baseConfig = {
   // only set staticDirs when running Storybook process; will fail if set for SB --build
   ...(process.env.NODE_ENV !== 'production' && {
     staticDirs: [`${staticAssetsFolder}`],
-  }),
-  // only set up type checking for typescript projects
-  ...(getProject().isTypeScriptProject && {
-    // https://storybook.js.org/docs/react/configure/typescript#mainjs-configuration
-    typescript: {
-      check: true,
-      // By default, the checker runs asynchronously in dev mode. Force it to run synchronously.
-      checkOptions: { async: false },
-    },
   }),
 }
 


### PR DESCRIPTION
Part one of two resolving #4676 by removing TS config added here 
- https://github.com/redwoodjs/redwood/pull/3515/files#diff-f2b8508ea44e00ef06fe0b2cd1197025d60d22cbcb4c32767b238f5c2bb57c63

This is a change to fix a DX problem with new Redwood TS projects and/or cases where Cells design in Storybook is broken because query types do not exist.

As a next step, we'll update the RW Storybook doc to explain how to enable type check. We'll also need to cover the caveat about Cells, which needs discussion.