### PR TITLE
added Jest mocking for react-i18next

### DIFF
--- a/packages/cli/src/commands/setup/i18n/i18n.js
+++ b/packages/cli/src/commands/setup/i18n/i18n.js
@@ -43,6 +43,9 @@ const i18nConfigExists = () => {
 const localesExists = (lng) => {
   return fs.existsSync(path.join(getPaths().web.src, 'locales', lng + '.json'))
 }
+const mocksExists = () => {
+  return fs.existsSync(path.join(getPaths().web, '__mocks__/react-i18next.js'))
+}
 
 export const handler = async ({ force }) => {
   const tasks = new Listr([
@@ -168,6 +171,26 @@ export const handler = async ({ force }) => {
           fs.writeFileSync(APP_JS_PATH, addI18nImport(appJS))
         }
       },
+    },
+    {
+      title: 'Adding mock for "react-i18next"',
+      task: (_ctx, task) => {
+        if (!force && mocksExists()) {
+          throw new Error(
+            '__mocks__/react-i18next.js already exists.\nUse --force to override existing mocks.'
+          )
+        } else {
+          return writeFile(
+            path.join(getPaths().web, '__mocks__/react-i18next.js'),
+            fs
+              .readFileSync(
+                path.resolve(__dirname, 'templates', 'mock.js.template')
+              )
+              .toString(),
+            { overwriteExisting: force }
+          )
+        }
+      }
     },
     {
       title: 'One more thing...',

--- a/packages/cli/src/commands/setup/i18n/templates/mock.js.template
+++ b/packages/cli/src/commands/setup/i18n/templates/mock.js.template
@@ -1,0 +1,57 @@
+const React = require('react')
+const reactI18next = require('react-i18next')
+
+const hasChildren = (node) =>
+  node && (node.children || (node.props && node.props.children))
+
+const getChildren = (node) =>
+  node && node.children ? node.children : node.props && node.props.children
+
+const renderNodes = (reactNodes) => {
+  if (typeof reactNodes === 'string') {
+    return reactNodes
+  }
+
+  return Object.keys(reactNodes).map((key, i) => {
+    const child = reactNodes[key]
+    const isElement = React.isValidElement(child)
+
+    if (typeof child === 'string') {
+      return child
+    }
+    if (hasChildren(child)) {
+      const inner = renderNodes(getChildren(child))
+      return React.cloneElement(child, { ...child.props, key: i }, inner)
+    }
+    if (typeof child === 'object' && !isElement) {
+      return Object.keys(child).reduce(
+        (str, childKey) => `${str}${child[childKey]}`,
+        ''
+      )
+    }
+
+    return child
+  })
+}
+
+const useMock = [(k) => k, {}]
+useMock.t = (k) => k
+useMock.i18n = {}
+
+module.exports = {
+  // this mock makes sure any components using the translate HoC receive the t function as a prop
+  withTranslation: () => (Component) => (props) =>
+    <Component t={(k) => k} {...props} />,
+  Trans: ({ children }) =>
+    Array.isArray(children) ? renderNodes(children) : renderNodes([children]),
+  Translation: ({ children }) => children((k) => k, { i18n: {} }),
+  useTranslation: () => useMock,
+
+  // mock if needed
+  I18nextProvider: reactI18next.I18nextProvider,
+  initReactI18next: reactI18next.initReactI18next,
+  setDefaults: reactI18next.setDefaults,
+  getDefaults: reactI18next.getDefaults,
+  setI18n: reactI18next.setI18n,
+  getI18n: reactI18next.getI18n,
+}


### PR DESCRIPTION
### Context

When running my web-side's tests and having `rw setup i18n`, my tests failed - wanting me to have initialized `react-i18next`. I consulted the [`react-i18next` documentation on testing](https://react.i18next.com/misc/testing), where the recommendation was to: test against a component _without_ translations or mock the hooks and components provided by the library.

### What this PR does

This PR does the second part of that recommendation, adding mocks for the hooks and components provided by `react-i18next`.

It adds the code from the [jest sample](https://github.com/i18next/react-i18next/tree/master/example/test-jest) repository (namely [`__mocks__/react-i18next.js`](https://github.com/i18next/react-i18next/blob/master/example/test-jest/src/__mocks__/react-i18next.js)) to the `yarn rw setup i18n` command.

This will provide developers the ability to adjust the mock in whatever way their application may need, with enough of a foundation to get tests to a passing state.