### PR TITLE
Fix failing codemod test for RedwoodDevFatalErrorPage

### DIFF
--- a/packages/codemods/src/codemods/v47.x/updateDevFatalErrorPage/__testfixtures__/default/output/web/src/pages/FatalErrorPage/FatalErrorPage.js
+++ b/packages/codemods/src/codemods/v47.x/updateDevFatalErrorPage/__testfixtures__/default/output/web/src/pages/FatalErrorPage/FatalErrorPage.js
@@ -10,7 +10,8 @@
 // Ensures that production builds do not include the error page
 let RedwoodDevFatalErrorPage = undefined
 if (process.env.NODE_ENV === 'development') {
-  RedwoodDevFatalErrorPage = require('@redwoodjs/web').DevFatalErrorPage
+  RedwoodDevFatalErrorPage =
+    require('@redwoodjs/web/dist/components/DevFatalErrorPage').DevFatalErrorPage
 }
 
 export default RedwoodDevFatalErrorPage ||


### PR DESCRIPTION
The codemod test to update the development fatal error page was failing (not sure why didn't see in PR but ... this fixes the issue):

![image](https://user-images.githubusercontent.com/1051633/157958732-5547070c-0fa3-41a3-be01-21d70dd2e5bc.png)

And with this PR change:

```bash
 PASS  src/codemods/v0.37.x/updateForms/__tests__/updateForms.test.ts
 PASS  src/codemods/v47.x/updateDevFatalErrorPage/__tests__/updateDevFatalErrorPage.test.ts
 PASS  src/codemods/v0.39.x/updateRouterParamTypes/__tests__/updateRouterParamTypes.ts

...

Test Suites: 10 passed, 10 total
Tests:       20 passed, 20 total
Snapshots:   0 total
Time:        4.405 s, estimated 8 s
Ran all test suites matching /src/i.
```