### PR TITLE
jwtVerifier: Remove unreachable code

### DIFF
--- a/packages/api/src/auth/verifiers/jwtVerifier.ts
+++ b/packages/api/src/auth/verifiers/jwtVerifier.ts
@@ -67,9 +67,7 @@ export const verifySignature = ({
     }
 
     return true
-
-    throw new WebhookVerificationError()
-  } catch (error) {
+  } catch {
     throw new WebhookVerificationError()
   }
 }


### PR DESCRIPTION
Found some code that was unreachable. Because of the `return` the `throw` statement will never be executed.
And because we're not using the `error` in the `catch` I removed that too.