### PR TITLE
useRequireAuth: Refactor to make it easier to read

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -57,7 +57,7 @@ export const getAuthenticationContext = async ({
 }): Promise<undefined | AuthContextPayload> => {
   const type = getAuthProviderHeader(event)
   // No `auth-provider` header means that the user is logged out,
-  // and none of this is auth malarky is required.
+  // and none of this auth malarky is required.
   if (!type) {
     return undefined
   }

--- a/packages/graphql-server/src/functions/useRequireAuth.ts
+++ b/packages/graphql-server/src/functions/useRequireAuth.ts
@@ -10,30 +10,24 @@ import {
 
 import type { GetCurrentUser } from './types'
 
-export const useRequireAuth = ({
-  handlerFn,
-  getCurrentUser,
-}: {
+interface Args {
   handlerFn: (
     event: APIGatewayEvent,
     context: LambdaContext,
     ...others: any
   ) => any
   getCurrentUser: GetCurrentUser
-}) => {
+}
+
+export const useRequireAuth = ({ handlerFn, getCurrentUser }: Args) => {
   return async (
     event: APIGatewayEvent,
     context: LambdaContext,
     ...rest: any
-  ): Promise<any> => {
+  ) => {
     const authEnrichedFunction = async () => {
       try {
-        let authContext = undefined
-
-        authContext = await getAuthenticationContext({
-          event: event,
-          context: context,
-        })
+        const authContext = await getAuthenticationContext({ event, context })
 
         if (authContext) {
           const currentUser = getCurrentUser


### PR DESCRIPTION
I was reading this code to try to figure out how `useRequireAuth` works. While reading it I made some changes that, imho, made it easier to read the code.