### PR TITLE
Send a 'ready' message to parent process if api server was spawned

### DIFF
--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -113,6 +113,9 @@ export const bothServerHandler = async ({
     console.log(`API listening on ${on}`)
     const graphqlEnd = c.magenta(`${apiRootPath}graphql`)
     console.log(`GraphQL endpoint at ${graphqlEnd}`)
+    if (typeof process.send !== 'undefined') {
+      process.send('ready')
+    }
   })
 }
 
@@ -154,6 +157,9 @@ export const webServerHandler = ({ port, socket, apiHost }: WebServerArgs) => {
     const webServer = c.green(`http://localhost:${port}`)
     console.log(`Web server started on ${webServer}`)
     console.log(`GraphQL endpoint is set to ` + c.magenta(`${graphqlEndpoint}`))
+    if (typeof process.send !== 'undefined') {
+      process.send('ready')
+    }
   })
 }
 

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -74,6 +74,9 @@ export const apiServerHandler = async ({
     console.log(`API listening on ${on}`)
     const graphqlEnd = c.magenta(`${apiRootPath}graphql`)
     console.log(`GraphQL endpoint at ${graphqlEnd}`)
+    if (typeof process.send !== 'undefined') {
+      process.send('ready')
+    }
   })
   process.on('exit', () => {
     http?.close()

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -18,6 +18,10 @@ import type { HttpServerParams } from './server'
  * Also used in index.ts for the api server
  */
 
+const sendProcessReady = () => {
+  return process.send && process.send('ready')
+}
+
 export const commonOptions = {
   port: { default: getConfig().web?.port || 8910, type: 'number', alias: 'p' },
   socket: { type: 'string' },
@@ -74,9 +78,7 @@ export const apiServerHandler = async ({
     console.log(`API listening on ${on}`)
     const graphqlEnd = c.magenta(`${apiRootPath}graphql`)
     console.log(`GraphQL endpoint at ${graphqlEnd}`)
-    if (typeof process.send !== 'undefined') {
-      process.send('ready')
-    }
+    sendProcessReady()
   })
   process.on('exit', () => {
     http?.close()
@@ -113,9 +115,7 @@ export const bothServerHandler = async ({
     console.log(`API listening on ${on}`)
     const graphqlEnd = c.magenta(`${apiRootPath}graphql`)
     console.log(`GraphQL endpoint at ${graphqlEnd}`)
-    if (typeof process.send !== 'undefined') {
-      process.send('ready')
-    }
+    sendProcessReady()
   })
 }
 
@@ -157,9 +157,7 @@ export const webServerHandler = ({ port, socket, apiHost }: WebServerArgs) => {
     const webServer = c.green(`http://localhost:${port}`)
     console.log(`Web server started on ${webServer}`)
     console.log(`GraphQL endpoint is set to ` + c.magenta(`${graphqlEndpoint}`))
-    if (typeof process.send !== 'undefined') {
-      process.send('ready')
-    }
+    sendProcessReady()
   })
 }
 


### PR DESCRIPTION
This enables zero-downtime restarts for the API server with pm2. See https://pm2.keymetrics.io/docs/usage/signals-clean-restart/#graceful-start

`process.send` will only exist if the process was spawned from a parent, so we need to check if it is defined (which it is when pm2 is in control). There is no "api server" in serverless environments so this code should have no effect there.

We'll also want to document the fact somewhere that you need to add two things to your `ecosystem.config.js` for pm2:

```diff
{
  name: 'algostake-api',
  script: 'node_modules/.bin/rw',
  args: 'serve api',
  instances: 'max',
  exec_mode: 'cluster',
+ wait_ready: true,
+ listen_timeout: 10000,
},
```

`wait_ready` tells it to actually listen for that message. The default timeout is 3 seconds which is not enough for the API server to start. Here it's increased to 10 seconds.

This was tested in Algostake and works like a charm! Previous there was 2-3 seconds of downtime each time the API server was restarted on a deploy. Now it's seamless!

I'd love to include the **BAREMETAL** deploy option by the v1.0 deadline but I've got a lot of stuff that still needs to get done before then! 😬