### PR TITLE
[Renovate] Ignore @types/lru-cache

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,7 @@
     "@redwoodjs/testing",
     "@redwoodjs/web",
     "lru-cache",
+    "@types/lru-cache",
     "pretty-bytes",
     "is-port-reachable"
   ]


### PR DESCRIPTION
We ignored `lru-cache` in https://github.com/redwoodjs/redwood/pull/4442; just ignoring the the types too.