### PR TITLE
Add extra step in netlify deploy to generate _redirects

### DIFF
--- a/packages/cli/src/commands/deploy/helpers/helpers.js
+++ b/packages/cli/src/commands/deploy/helpers/helpers.js
@@ -1,3 +1,6 @@
+import fs from 'fs'
+import path from 'path'
+
 import execa from 'execa'
 import terminalLink from 'terminal-link'
 
@@ -56,4 +59,9 @@ export const deployHandler = async ({ build, prisma, dm: dataMigrate }) => {
     extendEnv: true,
     cleanup: true,
   })
+}
+
+export const isWebIndexPrerendered = () => {
+  const basePrerenderedHtml = path.join(getPaths().web.dist, '200.html')
+  return fs.existsSync(basePrerenderedHtml)
 }

--- a/packages/cli/src/commands/deploy/netlify.js
+++ b/packages/cli/src/commands/deploy/netlify.js
@@ -1,8 +1,39 @@
-import { deployBuilder, deployHandler } from './helpers/helpers'
+import fs from 'fs'
+import path from 'path'
+
+import { getPaths } from '@redwoodjs/internal'
+
+import {
+  deployBuilder,
+  deployHandler,
+  isWebIndexPrerendered,
+} from './helpers/helpers'
 
 export const command = 'netlify [...commands]'
 export const description = 'Build command for Netlify deploy'
 
-export const builder = (yargs) => deployBuilder(yargs)
+export const builder = (yargs) => {
+  yargs.option('generate-redirects', {
+    description:
+      'Generate the _redirects file to redirect to 200.html if no prerender html file is found for your path, only has an effect if you are using prerender on the web side',
+    type: 'boolean',
+    default: true,
+  })
 
-export const handler = deployHandler
+  return deployBuilder(yargs)
+}
+
+export const handler = async (args) => {
+  // Use the standard deploy handler
+  await deployHandler(args)
+
+  if (isWebIndexPrerendered() && args.generateRedirects) {
+    const pathToRedirects = path.join(getPaths().web.dist, '_redirects')
+    console.log(`Generating prerender redirects file at ${pathToRedirects}`)
+
+    fs.writeFileSync(
+      pathToRedirects,
+      '/*                 /200.html          200'
+    )
+  }
+}


### PR DESCRIPTION
Fixes #4774

### What does this PR do?
In the `yarn rw deploy netlify` command introduces additional steps that generates a `_redirects` file (https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file), **but only if** the landing page i.e. `/` path is prerendered. 

### Things to note
**- Netlify will not apply the redirect in an html file with the path name exists, because we don't force the redirect (i.e. using `200!` with the exclamation.** 
So for example:
/pageThatExists -> renders pageThatExists.html
/pageNotExist -> renders 200.html


This is the desired behaviour, because we always want it to use the html file with the pathname if it exists 

**- The `_redirects` file takes precedence over netlify.toml**
I'm still looking into the impact of this
