### PR TITLE
Adds type generation for the resolvers in the GraphQL API

### DIFF
--- a/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
+++ b/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
@@ -223,8 +223,9 @@ describe('users', () => {
 
 exports[`in typescript mode creates a multi word service file 1`] = `
 "import { db } from 'src/lib/db'
+import type { Queries } from 'types/resolvers'
 
-export const userProfiles = () => {
+export const userProfiles: Queries['userProfiles'] = () => {
   return db.userProfile.findMany()
 }
 "
@@ -314,50 +315,42 @@ describe('transactions', () => {
 
 exports[`in typescript mode creates a single word service file 1`] = `
 "import { db } from 'src/lib/db'
+import type { Queries } from 'types/resolvers'
 
-export const users = () => {
+export const users: Queries['users'] = () => {
   return db.user.findMany()
 }
 "
 `;
 
 exports[`in typescript mode creates a single word service file with CRUD actions 1`] = `
-"import type { Prisma } from '@prisma/client'
+"import { db } from 'src/lib/db'
+import type { Queries, Mutations } from 'types/resolvers'
 
-import { db } from 'src/lib/db'
-
-export const posts = () => {
+export const posts: Queries['posts'] = () => {
   return db.post.findMany()
 }
 
-export const post = ({ id }: Prisma.PostWhereUniqueInput) => {
+export const post: Queries['post'] = ({ id }) => {
   return db.post.findUnique({
     where: { id },
   })
 }
 
-interface CreatePostArgs {
-  input: Prisma.PostCreateInput
-}
-
-export const createPost = ({ input }: CreatePostArgs) => {
+export const createPost: Mutations['createPost'] = ({ input }) => {
   return db.post.create({
     data: input,
   })
 }
 
-interface UpdatePostArgs extends Prisma.PostWhereUniqueInput {
-  input: Prisma.PostUpdateInput
-}
-
-export const updatePost = ({ id, input }: UpdatePostArgs) => {
+export const updatePost: Mutations['createPost'] = ({ id, input }) => {
   return db.post.update({
     data: input,
     where: { id },
   })
 }
 
-export const deletePost = ({ id }: Prisma.PostWhereUniqueInput) => {
+export const deletePost: Mutations['deletePost'] = ({ id }) => {
   return db.post.delete({
     where: { id },
   })
@@ -366,71 +359,65 @@ export const deletePost = ({ id }: Prisma.PostWhereUniqueInput) => {
 `;
 
 exports[`in typescript mode creates a single word service file with a belongsTo relation 1`] = `
-"import type { Prisma } from '@prisma/client'
-import type { ResolverArgs } from '@redwoodjs/graphql-server'
+"import { db } from 'src/lib/db'
+import type { Queries, userQueries } from 'types/resolvers'
 
-import { db } from 'src/lib/db'
-
-export const users = () => {
+export const users: Queries['users'] = () => {
   return db.user.findMany()
 }
 
-export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
+export const user: Queries['user'] = ({ id }) => {
   return db.user.findUnique({
     where: { id },
   })
 }
 
-export const User = {
-  identity: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
+export const User: userQueries = {
+  identity: (_obj, { root }) =>
     db.user.findUnique({ where: { id: root.id } }).identity(),
 }
 "
 `;
 
 exports[`in typescript mode creates a single word service file with a hasMany relation 1`] = `
-"import type { Prisma } from '@prisma/client'
-import type { ResolverArgs } from '@redwoodjs/graphql-server'
+"import { db } from 'src/lib/db'
+import type { Queries, userQueries } from 'types/resolvers'
 
-import { db } from 'src/lib/db'
-
-export const users = () => {
+export const users: Queries['users'] = () => {
   return db.user.findMany()
 }
 
-export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
+export const user: Queries['user'] = ({ id }) => {
   return db.user.findUnique({
     where: { id },
   })
 }
 
-export const User = {
-  userProfiles: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
+export const User: userQueries = {
+  userProfiles: (_obj, { root }) =>
     db.user.findUnique({ where: { id: root.id } }).userProfiles(),
 }
 "
 `;
 
 exports[`in typescript mode creates a single word service file with multiple relations 1`] = `
-"import type { Prisma } from '@prisma/client'
-import type { ResolverArgs } from '@redwoodjs/graphql-server'
+"import { db } from 'src/lib/db'
+import type { Queries, userQueries } from 'types/resolvers'
 
-import { db } from 'src/lib/db'
-
-export const users = () => {
+export const users: Queries['users'] = () => {
   return db.user.findMany()
 }
 
-export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
+export const user: Queries['user'] = ({ id }) => {
   return db.user.findUnique({
     where: { id },
   })
 }
 
-export const User = {
-  userProfiles: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
+export const User: userQueries = {
+  userProfiles: (_obj, { root }) =>
     db.user.findUnique({ where: { id: root.id } }).userProfiles(),
-  identity: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
+  identity: (_obj, { root }) =>
     db.user.findUnique({ where: { id: root.id } }).identity(),
 }
 "

--- a/packages/cli/src/commands/generate/service/templates/service.ts.template
+++ b/packages/cli/src/commands/generate/service/templates/service.ts.template
@@ -1,45 +1,35 @@
-<% if (crud || relations.length > 0) { %>import type { Prisma } from '@prisma/client'<% } %>
-<% if (relations.length) { %>import type { ResolverArgs } from '@redwoodjs/graphql-server'<% } %>
-
 import { db } from 'src/lib/db'
+import type { Queries<% if (crud) { %>, Mutations<% } %><% if (relations.length) { %>, ${singularCamelName}Queries<% } %> } from 'types/resolvers'
 
-export const ${pluralCamelName} = () => {
+export const ${pluralCamelName}: Queries['${pluralCamelName}'] = () => {
   return db.${singularCamelName}.findMany()
 }<% if (crud || relations.length) { %>
 
-export const ${singularCamelName} = ({ id }: Prisma.${singularPascalName}WhereUniqueInput) => {
+export const ${singularCamelName}: Queries['${singularCamelName}'] = ({ id }) => {
   return db.${singularCamelName}.findUnique({
     where: { id },
   })
 }<% } %><% if (crud) { %>
 
-interface Create${singularPascalName}Args {
-  input: Prisma.${singularPascalName}CreateInput
-}
-
-export const create${singularPascalName} = ({ input }: Create${singularPascalName}Args) => {
+export const create${singularPascalName}: Mutations['create${singularPascalName}'] = ({ input }) => {
   return db.${singularCamelName}.create({
     data: input,
   })
 }
 
-interface Update${singularPascalName}Args extends Prisma.${singularPascalName}WhereUniqueInput {
-  input: Prisma.${singularPascalName}UpdateInput
-}
-
-export const update${singularPascalName} = ({ id, input }: Update${singularPascalName}Args) => {
+export const update${singularPascalName}: Mutations['create${singularPascalName}'] = ({ id, input }) => {
   return db.${singularCamelName}.update({
     data: input,
     where: { id },
   })
 }
 
-export const delete${singularPascalName} = ({ id }: Prisma.${singularPascalName}WhereUniqueInput) => {
+export const delete${singularPascalName}: Mutations['delete${singularPascalName}'] = ({ id }) => {
   return db.${singularCamelName}.delete({
     where: { id },
   })
 }<% } %><% if (relations.length) { %>
 
-export const ${singularPascalName} = {<% relations.forEach(relation => { %>
-  ${relation}: (_obj, { root }: ResolverArgs<ReturnType<typeof ${singularCamelName}>>) => db.${singularCamelName}.findUnique({ where: { id: root.id } }).${relation}(),<% }) %>
+export const ${singularPascalName}: ${singularCamelName}Queries  = {<% relations.forEach(relation => { %>
+  ${relation}: (_obj, { root }) => db.${singularCamelName}.findUnique({ where: { id: root.id } }).${relation}(),<% }) %>
 }<% } %>

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -342,6 +342,7 @@ export const User: UserQueries = {
 `
 
   const typeExports = typesWithFields
+    // Skip the hardcoded ones
     .filter((t) => !(t.name === 'Query') && !(t.name === 'Mutation'))
     .map(
       (t) =>


### PR DESCRIPTION
One of the tensions I felt with my resolvers was a lack of cohesion between the generated templates and the type system represented in the schema. For example the default template recommends using something like:

```ts
import type { Prisma } from '@prisma/client'

export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
  return db.user.findUnique({
    where: { id },
  })
}

interface CreateUserArgs {
  input: Prisma.UserCreateInput
}

export const createUser = ({ input }: CreateUserArgs) => {
  return db.user.create({
    data: input,
  })
}
```

Where the input comes from Prisma's type system, and not graphqls - this is kinda right, _most of the time_ but also not right enough that I started to lose time to warrant figuring out a better answer. This PR is my answer, I mentioned it in redwoodjs/redwood#4802 (I still think `root` should be called `obj` FWIW)

My solution is to make a new file in the types directory `types/resolvers` whose job is to take the SDL and generate types which match the Redwood resolver shape. The above code would now be:

```ts
import type { Queries, Mutations } from 'types/resolvers'

export const user: Queries['user'] = ({ id }) => {
  return db.user.findUnique({
    where: { id },
  })
}

export const createUser: Mutations['createUser'] = ({ input }) => {
  return db.user.create({
    data: input,
  })
}
```

Which is less code, and I think a bit clearer in the intent.

<details>
  <summary>The JS output can also be improved...</summary>
  <p>I didn't do it, but for JS users you could use JSDocs to make the tooling work:</p>

```ts
/** @type {import("types/resolvers").Queries["user"] */
export const user = ({ id }) => {
  return db.user.findUnique({
    where: { id },
  })
}

/** @type {import("types/resolvers"). Mutations["createUser"] */
export const createUser = ({ input }) => {
  return db.user.create({
    data: input,
  })
}
```

I'll leave that for someone else to figure out.

</details>