### PR TITLE
Skip v44.x updateJestConfig codemod test

### DIFF
--- a/packages/codemods/src/codemods/v0.44.x/updateJestConfig/__tests__/updateJestConfig.test.ts
+++ b/packages/codemods/src/codemods/v0.44.x/updateJestConfig/__tests__/updateJestConfig.test.ts
@@ -32,7 +32,9 @@ jest.mock('../../../../lib/fetchFileFromTemplate', () =>
 
 jest.setTimeout(25_000)
 
-describe('Update Jest Config', () => {
+// Skip these tests as these are old codemods
+// and the tests seem flakey
+describe.skip('Update Jest Config', () => {
   it('Adds missing files', async () => {
     await matchFolderTransform(updateJestConfig, 'missing', {
       removeWhitespace: true,


### PR DESCRIPTION
Disabled the old flakey jest codemod test.

Not a big issue since the codemod is quite a few versions behind.