### PR TITLE
Service Validations: Returns error message as an array in faked extensions

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,6 +33,7 @@
     "@babel/runtime-corejs3": "7.16.7",
     "@prisma/client": "3.11.0",
     "crypto-js": "4.1.1",
+    "humanize-string": "2.1.0",
     "jsonwebtoken": "8.5.1",
     "jwks-rsa": "2.0.5",
     "md5": "2.3.0",

--- a/packages/api/src/validations/errors.ts
+++ b/packages/api/src/validations/errors.ts
@@ -24,7 +24,7 @@ export class ServiceValidationError extends RedwoodError {
         code: 'BAD_USER_INPUT',
         properties: {
           messages: {
-            [String(value)]: errorMessage,
+            [String(value)]: [errorMessage],
           },
         },
       }

--- a/packages/forms/src/FormError.tsx
+++ b/packages/forms/src/FormError.tsx
@@ -58,7 +58,12 @@ const FormError = ({
     !!error.networkError && Object.keys(error.networkError).length > 0
 
   if (hasGraphQLError) {
-    rootMessage = 'Errors prevented this form from being saved:'
+    rootMessage = error.graphQLErrors[0].message ?? 'Something went wrong'
+
+    // override top-level message for ServiceValidation errorrs
+    if (error.graphQLErrors[0]?.extensions?.code === 'BAD_USER_INPUT') {
+      rootMessage = 'Errors prevented this form from being saved'
+    }
 
     const properties = error.graphQLErrors[0].extensions?.[
       'properties'

--- a/packages/forms/src/FormError.tsx
+++ b/packages/forms/src/FormError.tsx
@@ -58,7 +58,7 @@ const FormError = ({
     !!error.networkError && Object.keys(error.networkError).length > 0
 
   if (hasGraphQLError) {
-    rootMessage = error.graphQLErrors[0].message ?? 'Something went wrong.'
+    rootMessage = 'Errors prevented this form from being saved:'
 
     const properties = error.graphQLErrors[0].extensions?.[
       'properties'
@@ -69,7 +69,7 @@ const FormError = ({
     if (propertyMessages) {
       for (const e in propertyMessages) {
         propertyMessages[e].forEach((fieldError: any) => {
-          messages.push(`${e} ${fieldError}`)
+          messages.push(fieldError)
         })
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5741,6 +5741,7 @@ __metadata:
     "@types/split2": 3.2.1
     aws-lambda: 1.0.7
     crypto-js: 4.1.1
+    humanize-string: 2.1.0
     jest: 27.5.1
     jsonwebtoken: 8.5.1
     jwks-rsa: 2.0.5


### PR DESCRIPTION
The new Service Validation update #4756 almost works, just a couple of tweaks:

* the error message needs to be in the form of an array instead of a string
* the field name is now included in the error message so no need to prefix on output
* Update the title of the `<FormError>` box

Before this PR:

![image](https://user-images.githubusercontent.com/300/158866175-796fcfb0-f501-423d-a92e-1dfec95d38d6.png)

After this PR:

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/300/158867966-82dbc037-40f2-4474-adda-bf97e758e5db.png">

