### PR TITLE
Reverse logic in smoke test for setting yarn 1

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -34,7 +34,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-1234-${{ hashFiles('yarn.lock') }} #change yarn-{randomString} to bust the cache
+          key: yarn-1235-${{ hashFiles('yarn.lock') }} # Change `yarn-{randomString}` to bust the cache
           restore-keys: |
             yarn-1234
 

--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -235,7 +235,7 @@ const globalTasks = () =>
             JSON.stringify(packageJson, undefined, 2)
           )
         },
-        skip: () => !(copyFromFixture && !rebuildFixture),
+        skip: () => !copyFromFixture && rebuildFixture,
       },
       {
         title: 'Installing node_modules',

--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -235,7 +235,7 @@ const globalTasks = () =>
             JSON.stringify(packageJson, undefined, 2)
           )
         },
-        skip: () => copyFromFixture && !rebuildFixture, // already configured in fixture, but copyFromFixture is default
+        skip: () => !(copyFromFixture && !rebuildFixture),
       },
       {
         title: 'Installing node_modules',


### PR DESCRIPTION
The smoke test is failing at the setup project step because the "setting yarn to v1" task is being skipped. As of https://github.com/redwoodjs/redwood/commit/097aa4e4cdb04259e7db5b24bcc9e9cd478c4624, yarn 1 is no longer included in the fixture, so we shouldn't skip that task by default.

I'm not exactly sure what the correct logic is here for skipping it.