### PR TITLE
Remove nested function post processing during build

### DIFF
--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -65,65 +65,6 @@ test('api files are prebuilt', () => {
   )
 })
 
-describe("Should create a 'proxy' function for nested functions", () => {
-  it('Handles functions nested with the same name', () => {
-    const [buildPath, reExportPath] = generateProxyFilesForNestedFunction(
-      fullPath('.redwood/prebuild/api/src/functions/nested/nested.js')
-    )
-
-    // Hidden path in the _nestedFunctions folder
-    expect(cleanPaths(buildPath)).toBe(
-      '.redwood/prebuild/api/src/_nestedFunctions/nested/nested.js'
-    )
-
-    // Proxy/reExport function placed in the function directory
-    expect(cleanPaths(reExportPath)).toBe(
-      '.redwood/prebuild/api/src/functions/nested.js'
-    )
-
-    const reExportContent = fs.readFileSync(reExportPath, 'utf-8')
-    expect(reExportContent).toMatchInlineSnapshot(
-      `"export * from '../_nestedFunctions/nested/nested';"`
-    )
-  })
-
-  it('Handles folders with an index file', () => {
-    const [buildPath, reExportPath] = generateProxyFilesForNestedFunction(
-      fullPath('.redwood/prebuild/api/src/functions/x/index.js')
-    )
-
-    // Hidden path in the _build folder
-    expect(cleanPaths(buildPath)).toBe(
-      '.redwood/prebuild/api/src/_nestedFunctions/x/index.js'
-    )
-
-    // Proxy/reExport function placed in the function directory
-    expect(cleanPaths(reExportPath)).toBe(
-      '.redwood/prebuild/api/src/functions/x.js'
-    )
-
-    const reExportContent = fs.readFileSync(reExportPath, 'utf-8')
-
-    expect(reExportContent).toMatchInlineSnapshot(
-      `"export * from '../_nestedFunctions/x';"`
-    )
-  })
-
-  it('Should not put files that dont match the folder name in dist/functions', () => {
-    const [buildPath, reExportPath] = generateProxyFilesForNestedFunction(
-      fullPath('.redwood/prebuild/api/src/functions/invalid/x.js')
-    )
-
-    // File is transpiled to the _nestedFunctions folder
-    expect(cleanPaths(buildPath)).toEqual(
-      '.redwood/prebuild/api/src/_nestedFunctions/invalid/x.js'
-    )
-
-    // But not exposed as a serverless function
-    expect(reExportPath).toBe(undefined)
-  })
-})
-
 test('api prebuild finds babel.config.js', () => {
   let p = getApiSideBabelConfigPath()
   p = cleanPaths(p)

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -2,10 +2,10 @@ import fs from 'fs'
 import path from 'path'
 
 import * as esbuild from 'esbuild'
-import { moveSync, removeSync } from 'fs-extra'
+import { removeSync } from 'fs-extra'
 
 import { findApiFiles } from '../files'
-import { ensurePosixPath, getPaths } from '../paths'
+import { getPaths } from '../paths'
 
 import { getApiSideBabelPlugins, prebuildApiFile } from './babel/api'
 
@@ -16,9 +16,9 @@ export const buildApi = () => {
 
   const srcFiles = findApiFiles()
 
-  const prebuiltFiles = prebuildApiFiles(srcFiles)
-    .filter((path): path is string => path !== undefined)
-    .flatMap(generateProxyFilesForNestedFunction)
+  const prebuiltFiles = prebuildApiFiles(srcFiles).filter(
+    (path): path is string => path !== undefined
+  )
 
   return transpileApi(prebuiltFiles)
 }
@@ -27,77 +27,6 @@ export const cleanApiBuild = () => {
   const rwjsPaths = getPaths()
   removeSync(rwjsPaths.api.dist)
   removeSync(path.join(rwjsPaths.generated.prebuild, 'api'))
-}
-
-/**
- * Takes prebuilt api files, and will generate proxy functions where required
- *  If the function is nested in a folder, put it into the special _build directory
- *  at the same level as functions, then re-export it.
- *
- * This allows for support for nested functions across all our supported providers,
- * (Netlify, Vercel, Render, Self-hosted) - and they behave consistently
- *
- * Note that this function takes prebuilt files in the .redwood/prebuild directory
- *
- */
-export const generateProxyFilesForNestedFunction = (prebuiltFile: string) => {
-  const rwjsPaths = getPaths()
-
-  const relativePathFromFunctions = path.relative(
-    path.join(rwjsPaths.generated.prebuild, 'api/src/functions'),
-    prebuiltFile
-  )
-  const folderName = path.dirname(relativePathFromFunctions)
-
-  const isNestedFunction =
-    ensurePosixPath(prebuiltFile).includes('api/src/functions') &&
-    folderName !== '.'
-
-  if (isNestedFunction) {
-    const { name: fileName } = path.parse(relativePathFromFunctions)
-    const isIndexFile = fileName === 'index'
-
-    // .redwood/prebuilds/api/src/_build/{folder}/{fileName}
-    const nestedFunctionOutputPath = path
-      .join(
-        rwjsPaths.generated.prebuild,
-        'api/src/_nestedFunctions',
-        relativePathFromFunctions
-      )
-      .replace(/\.(ts)$/, '.js')
-
-    // move existing file into the new nestedOutputPath
-    // @Note: use fs-extra.moveSync for compatibility under docker and linux
-    moveSync(prebuiltFile, nestedFunctionOutputPath)
-
-    // Only generate proxy files for the function
-    if (fileName === folderName || isIndexFile) {
-      // .redwood/prebuild/api/src/functions/{folderName}.js
-      const reExportPath =
-        path.join(
-          rwjsPaths.generated.prebuild,
-          'api/src/functions',
-          folderName
-        ) + '.js'
-
-      const importString = isIndexFile
-        ? `../_nestedFunctions/${folderName}`
-        : `../_nestedFunctions/${folderName}/${folderName}`
-
-      const reExportContent = `export * from '${importString}';`
-
-      fs.writeFileSync(reExportPath, reExportContent)
-
-      return [nestedFunctionOutputPath, reExportPath]
-    } else {
-      // other files in the folder e.g. functions/helloWorld/otherFile.js
-
-      return [nestedFunctionOutputPath]
-    }
-  }
-
-  // If no post-processing required
-  return [prebuiltFile]
 }
 
 /**

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -88,8 +88,9 @@ export const findApiServerFunctions = (
 }
 
 export const findApiDistFunctions = (cwd: string = getPaths().api.base) => {
-  return fg.sync('dist/functions/*.{ts,js}', {
+  return fg.sync('dist/functions/**/*.{ts,js}', {
     cwd,
+    deep: 2, // We don't support deeply nested api functions, to maximise compatibility with deployment providers
     absolute: true,
   })
 }


### PR DESCRIPTION
## WIP

This removes the post processing we do to handle nested functions. This was specifically for vercel, and I'm now updating their builder to add support for nested functions so we don't need to do extra steps.

**Side effects:**
- faster builds, faster dev (esp. windows)
- less complicated