### PR TITLE
Consider not running CI on changes to docs

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -3,6 +3,7 @@ name: Lint, Build & Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore: ['docs/**']
 
 jobs:
   all:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,6 +3,7 @@ name: Cypress E2E tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore: ['docs/**']
 
 jobs:
   cypress-run:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -3,6 +3,7 @@ name: Smoke test, CLI Checks and Telemetry Benchmarks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore: ['docs/**']
 
 jobs:
   smoke-test:


### PR DESCRIPTION
Requiring CI to pass for changes to docs seems a little excessive. We definitely want some CI to run, but probably just some kind of check that confirms that the docs site still deploys. Opening this up for discussion! Here's the docs on the workflow syntax I'm using: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths