### PR TITLE
Consider not running CI on changes to docs (continued)

### DIFF
--- a/.github/actions/only_changed_docs/action.yaml
+++ b/.github/actions/only_changed_docs/action.yaml
@@ -1,0 +1,8 @@
+name: Only changed docs
+description: Determines if a PR only changed docs
+outputs:
+  only_changed_docs:
+    description: If the PR only changed docs or not
+runs:
+  using: 'node16'
+  main: 'only_changed_docs.mjs'

--- a/.github/actions/only_changed_docs/only_changed_docs.mjs
+++ b/.github/actions/only_changed_docs/only_changed_docs.mjs
@@ -1,0 +1,33 @@
+import { exec, getExecOutput } from '@actions/exec'
+import core from '@actions/core'
+
+await exec('git fetch origin main')
+
+const { stdout } = await getExecOutput('git diff origin/main --name-only')
+
+const changedFiles = stdout.toString().trim().split('\n').filter(Boolean)
+
+for (const changedFile of changedFiles) {
+  if (changedFile.startsWith('docs')) {
+    continue
+  }
+
+  for (const fileToIgnore of [
+    'CHANGELOG.md',
+    'CODE_OF_CONDUCT.md',
+    'CONTRIBUTING.md',
+    'CONTRIBUTORS.md',
+    'LICENSE',
+    'README.md',
+    'SECURITY.md',
+  ]) {
+    if (changedFile === fileToIgnore) {
+      continue
+    }
+  }
+
+  core.setOutput('only_changed_docs', false)
+  process.exit(0)
+}
+
+core.setOutput('only_changed_docs', true)

--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -42,14 +42,22 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Determine if the PR only changed docs
+        id: only_changed_docs
+        uses: ./.github/actions/only_changed_docs
+
       - name: Check constraints, dependencies, and package.json's
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         uses: ./tasks/check
 
       - name: Build
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn build
 
       - name: Run ESLint
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn lint
 
       - name: Run tests
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,7 +44,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Determine if the PR only changed docs
+        id: only_changed_docs
+        uses: ./.github/actions/only_changed_docs
+
       - name: Create a temporary directory
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         id: createpath
         run: |
           project_path=$(mktemp -d -t redwood.XXXXXX)
@@ -53,11 +58,13 @@ jobs:
           echo "::set-output name=framework_path::$framework_path"
 
       - name: Create a RedwoodJS app
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: ./tasks/run-e2e ${{ steps.createpath.outputs.project_path }} --no-start
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Init Git for RedwoodJS app directory
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
@@ -66,10 +73,12 @@ jobs:
         working-directory: ${{ steps.createpath.outputs.project_path }}
 
       - name: Start server in background
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn rw dev --no-generate --fwd="--no-open" &
         working-directory: ${{ steps.createpath.outputs.project_path }}
 
       - name: Cypress run
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         uses: cypress-io/github-action@v2
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/publish-npm-canary.yaml
+++ b/.github/workflows/publish-npm-canary.yaml
@@ -40,7 +40,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Determine if the PR only changed docs
+        id: only_changed_docs
+        uses: ./.github/actions/only_changed_docs
+
       - name: 'Check Yarn constraints (fix w/ "yarn constraints --fix")'
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn constraints
 
       - name: 'Check for duplicate dependencies (fix w/ "yarn dedupe")'
@@ -48,19 +53,23 @@ jobs:
         run: yarn dedupe --check
 
       - name: Build
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn build
 
       - name: Run ESLint
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn lint
         env:
           CI: true
 
       - name: Run tests
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn test
         env:
           CI: true
 
       - name: Publish to npm
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           git describe
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -45,7 +45,12 @@ jobs:
         run: |
           yarn install --immutable
 
+      - name: Determine if the PR only changed docs
+        id: only_changed_docs
+        uses: ./.github/actions/only_changed_docs
+
       - name: Setup test project
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         id: setup_test_project
         uses: ./.github/actions/setup_test_project
         env:
@@ -53,19 +58,23 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Install Playwright deps
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: npx playwright install --with-deps chromium
 
       - name: Run `rw build` without prerender
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw build --no-prerender
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run `rw prerender`
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw prerender --verbose
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run smoke tests on 'rw dev' and 'rw serve'
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         working-directory: ./tasks/smoke-test
         run: npx playwright test
         env:
@@ -73,80 +82,95 @@ jobs:
           REDWOOD_DISABLE_TELEMETRY: 1
 
       - name: Run `rw info`
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw info
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
-
       - name: Run `rw lint`
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw lint ./api/src --fix
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw test api"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw test api --no-watch
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw test web"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw test web --no-watch
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw type-check"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw type-check
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw check"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw check
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw storybook"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw sb --smoke-test
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw exec"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw g script testScript && yarn rw exec testScript
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "prisma generate"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw prisma generate
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "rw data-migrate"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw dataMigrate up
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "data-migrate install"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw data-migrate install
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "prisma migrate"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw prisma migrate dev --name ci-test
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run `rw deploy --help`
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn rw setup deploy --help && yarn rw deploy --help
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run `rw setup ui --help`
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: yarn rw setup --help && yarn rw setup ui --help
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Run "g page"
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw g page ciTest
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Throw Error | Run `rw g sdl <model>`
+        if: fromJSON(steps.only_changed_docs.outputs.only_changed_docs) == false
         run: |
           yarn rw g sdl DoesNotExist
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}


### PR DESCRIPTION
Continuation of https://github.com/redwoodjs/redwood/pull/4816. 

There's unfortunately not a great way to to do this. See this discussion: https://github.com/github/feedback/discussions/13690.

I've looked at a few other repos for inspiration, but it doesn't seem like they use protected branches, so they can merge changes to docs without having to "pass" required checks.

Only Next.js does something similar to this (see https://github.com/vercel/next.js/blob/canary/.github/workflows/build_test_deploy.yml; almost every step has `if: ${{needs.build.outputs.docsChange != 'docs only change'}}`); it's tedious, but I'm not sure that there's a better way yet.