### PR TITLE
Fix URL of all tutorial path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TOML (an obvious, minimal configuration language used by many projects).
 > phase and intend to release a final v1.0.0 in March of 2022.
 
 > **TUTORIAL:** The best way to get to know Redwood is by going through the
-> extensive [Redwood Tutorial](https://redwoodjs.com/tutorial). Have fun!
+> extensive [Redwood Tutorial](https://redwoodjs.com/docs/tutorial). Have fun!
 
 > **QUICK START:** You can install and run a full-stack Redwood application on
 > your machine with only a couple commands. Check out the [Quick

--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -20,7 +20,7 @@ The options and their structure are based on Redwood's notion of sides and targe
 
 The idea is that, in the future, changes here will have cascading, "app-level" effects. Using generators as an example, based on your side and target, the generators will behave differently, but appropriately different.
 
-> For the difference between a side and a target, see [Redwood File Structure](https://redwoodjs.com/tutorial/redwood-file-structure).
+> For the difference between a side and a target, see [Redwood File Structure](https://redwoodjs.com/docs/tutorial/redwood-file-structure).
 
 You can think of `redwood.toml` as a convenience layer over Redwood's webpack configuration files. That is, for certain settings, instead of having to deal with webpack directly, we give you quick access via `redwood.toml`. Some of these settings are for development, some are for production, and some are for both. You can actually see this reflected in which webpack file each configuration option is referenced in&mdash;[webpack.development.js](https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.development.js), [webpack.production.js](https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.production.js), and [webpack.common.js](https://github.com/redwoodjs/redwood/blob/main/packages/core/config/webpack.common.js).
 

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -261,7 +261,7 @@ yarn add @redwoodjs/auth netlify-identity-widget
 
 #### Setup
 
-You will need to enable Identity on your Netlify site. See [Netlify Identity Setup](https://redwoodjs.com/tutorial/authentication#netlify-identity-setup).
+You will need to enable Identity on your Netlify site. See [Netlify Identity Setup](https://redwoodjs.com/docs/tutorial/authentication#netlify-identity-setup).
 
 ```js
 // web/src/App.js
@@ -318,7 +318,7 @@ yarn add @redwoodjs/auth gotrue-js
 
 #### Setup
 
-You will need to enable Identity on your Netlify site. See [Netlify Identity Setup](https://redwoodjs.com/tutorial/authentication#netlify-identity-setup).
+You will need to enable Identity on your Netlify site. See [Netlify Identity Setup](https://redwoodjs.com/docs/tutorial/authentication#netlify-identity-setup).
 
 Add the GoTrue-JS package to the web side:
 

--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -47,7 +47,7 @@ yarn rw generate cell equipment --list
 
 We'll go over each of these files in detail. But know that the file appended with just `.js` (in the example above, `UserCell.js`) contains all your Cell's logic.
 
-Off the bat, this file exports five constants: `QUERY`, `Loading` , `Empty` , `Failure`  and `Success`. The root query in `QUERY` is the same as `<name>` so that, if you're generating a cell based on a model in your `schema.prisma`, you can get something out of the database right away. But there's a good chance you won't generate your Cell this way, so if you need to, make sure to change the root query. See the [Cells](https://redwoodjs.com/tutorial/cells#our-first-cell) section of the Tutorial for a great example of this.
+Off the bat, this file exports five constants: `QUERY`, `Loading` , `Empty` , `Failure`  and `Success`. The root query in `QUERY` is the same as `<name>` so that, if you're generating a cell based on a model in your `schema.prisma`, you can get something out of the database right away. But there's a good chance you won't generate your Cell this way, so if you need to, make sure to change the root query. See the [Cells](https://redwoodjs.com/docs/tutorial/cells#our-first-cell) section of the Tutorial for a great example of this.
 
 ## Usage
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -416,7 +416,7 @@ Cells are signature to Redwood. We think they provide a simpler and more declara
 
 The cell generator supports both single items and lists. See the [Single Item Cell vs List Cell](https://redwoodjs.com/docs/cells.html#single-item-cell-vs-list-cell) section of the Cell documentation.
 
-See the [Cells](https://redwoodjs.com/tutorial/cells) section of the Tutorial for usage examples.
+See the [Cells](https://redwoodjs.com/docs/tutorial/cells) section of the Tutorial for usage examples.
 
 **Destroying**
 
@@ -659,7 +659,7 @@ Layouts wrap pages and help you stay DRY.
 
 **Usage**
 
-See the [Layouts](https://redwoodjs.com/tutorial/layouts) section of the tutorial.
+See the [Layouts](https://redwoodjs.com/docs/tutorial/layouts) section of the tutorial.
 
 **Destroying**
 
@@ -886,7 +886,7 @@ The content of the generated components is different from what you'd get by runn
 
 **Usage**
 
-See [Creating a Post Editor](https://redwoodjs.com/tutorial/getting-dynamic#creating-a-post-editor).
+See [Creating a Post Editor](https://redwoodjs.com/docs/tutorial/getting-dynamic#creating-a-post-editor).
 
 **Nesting of Components and Pages**
 
@@ -1198,7 +1198,7 @@ Generate a service component.
 yarn redwood generate service <name>
 ```
 
-Services are where Redwood puts its business logic. They can be used by your GraphQL API or any other place in your backend code. See [How Redwood Works with Data](https://redwoodjs.com/tutorial/side-quest-how-redwood-works-with-data).
+Services are where Redwood puts its business logic. They can be used by your GraphQL API or any other place in your backend code. See [How Redwood Works with Data](https://redwoodjs.com/docs/tutorial/side-quest-how-redwood-works-with-data).
 
 | Arguments & Options  | Description                                                                          |
 | -------------------- | ------------------------------------------------------------------------------------ |

--- a/docs/docs/contributing-walkthrough.md
+++ b/docs/docs/contributing-walkthrough.md
@@ -30,8 +30,8 @@ These are the foundations for contributing, which you should be familiar with be
 
 **The Redwood Tutorial**
 The best (and most fun) way to learn Redwood and the underlying tools and technologies:
-- [Tutorial Part 1](https://redwoodjs.com/tutorial)
-- [Tutorial Part 2](https://redwoodjs.com/tutorial2/welcome-to-redwood-part-ii-redwood-s-revenge)
+- [Tutorial Part 1](https://redwoodjs.com/docs/tutorial)
+- [Tutorial Part 2](https://redwoodjs.com/docs/tutorial2/welcome-to-redwood-part-ii-redwood-s-revenge)
 
 **Docs and Cookbook**
 - Start with the [Introduction](https://redwoodjs.com/docs/introduction) Doc

--- a/docs/docs/cookbook/file-uploads.md
+++ b/docs/docs/cookbook/file-uploads.md
@@ -1,6 +1,6 @@
 # File Uploads
 
-As you've probably heard, Redwood thinks the future is serverless. This concept introduces some interesting problems you might not have had to worry about in the past. For example, where do files go when you upload them? There's no server! Like many tasks you may have done [yourself](https://redwoodjs.com/tutorial/authentication) in the past, this is another job that we can farm out to a third-party service.
+As you've probably heard, Redwood thinks the future is serverless. This concept introduces some interesting problems you might not have had to worry about in the past. For example, where do files go when you upload them? There's no server! Like many tasks you may have done [yourself](https://redwoodjs.com/docs/tutorial/authentication) in the past, this is another job that we can farm out to a third-party service.
 
 ## The Service
 
@@ -390,13 +390,13 @@ const thumbnail = (url) => {
 }
 ```
 
-What this does is turn a URL like 
+What this does is turn a URL like
 
 ```
 https://cdn.filestackcontent.com/81m7qIrURxSp7WHcft9a
-``` 
+```
 
-into 
+into
 
 ```
 https://cdn.filestackcontent.com/resize=width:100/81m7qIrURxSp7WHcft9a
@@ -468,7 +468,7 @@ We're borrowing the styles from the submit button and making sure that the image
 
 ## The Wrap-up
 
-Files uploaded! 
+Files uploaded!
 
 There's plenty of ways to integrate a file picker. This is just one, but we think it's simple, yet flexible. We use the same technique on the [example-blog](https://github.com/redwoodjs/example-blog).
 

--- a/docs/docs/cookbook/gotrue-auth.md
+++ b/docs/docs/cookbook/gotrue-auth.md
@@ -19,9 +19,9 @@ But first, some housekeeping...
 
 Before getting started, there are a few steps you should have completed:
 
-- [Create a Redwood app](https://redwoodjs.com/tutorial/installation-starting-development)
+- [Create a Redwood app](https://redwoodjs.com/docs/tutorial/installation-starting-development)
 - [Create a Netlify account](https://www.netlify.com/)
-- [Deploy your Netlify site](https://redwoodjs.com/tutorial/deployment)
+- [Deploy your Netlify site](https://redwoodjs.com/docs/tutorial/deployment)
 - [Enable Netlify Identity](#enable-netlify-identity)
 - Fire up a dev server: `yarn redwood dev`
 

--- a/docs/docs/cookbook/pagination.md
+++ b/docs/docs/cookbook/pagination.md
@@ -1,6 +1,6 @@
 # Pagination
 
-This tutorial will show you one way to implement pagination in an app built using RedwoodJS. It builds on top of [the tutorial](https://redwoodjs.com/tutorial) and I'll assume you have a folder with the code from the tutorial that you can continue working on. (If you don't, you can clone this repo: https://github.com/thedavidprice/redwood-tutorial-test)
+This tutorial will show you one way to implement pagination in an app built using RedwoodJS. It builds on top of [the tutorial](https://redwoodjs.com/docs/tutorial) and I'll assume you have a folder with the code from the tutorial that you can continue working on. (If you don't, you can clone this repo: https://github.com/thedavidprice/redwood-tutorial-test)
 
 ![redwoodjs-pagination](https://user-images.githubusercontent.com/30793/94778130-ec6d6e00-03c4-11eb-9fd0-97cbcdf68ec2.png)
 

--- a/docs/docs/cookbook/role-based-access-control.md
+++ b/docs/docs/cookbook/role-based-access-control.md
@@ -89,7 +89,7 @@ In order to integrate RBAC in a RedwoodJS app, you will have to:
 - Enforce Access
 - Secure Web and Api sides
 
-Helps to be familiar with [Blog Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood) as well as pages, cells, services, authentication, and routes.
+Helps to be familiar with [Blog Tutorial](https://redwoodjs.com/docs/tutorial/welcome-to-redwood) as well as pages, cells, services, authentication, and routes.
 
 ## Identity as a Service
 

--- a/docs/docs/cookbook/supabase-auth.md
+++ b/docs/docs/cookbook/supabase-auth.md
@@ -20,7 +20,7 @@ But first, some housekeeping...
 
 Before getting started, there are a few steps you should complete:
 
-- [Create a Redwood app](https://redwoodjs.com/tutorial/installation-starting-development)
+- [Create a Redwood app](https://redwoodjs.com/docs/tutorial/installation-starting-development)
 - [Create a Supabase account](https://www.supabase.io/)
 - [Go through the Supabase React Quick Start](https://supabase.io/docs/guides/with-react)
 - [Go through the Supabase Redwood Quick Start](https://supabase.io/docs/guides/with-redwoodjs)

--- a/docs/docs/deploy.md
+++ b/docs/docs/deploy.md
@@ -93,7 +93,7 @@ If you simply want to experience the Netlify deployment process without a databa
 4. use the Netlify [Quick Start](https://app.netlify.com/signup) to deploy
 
 ### Netlify Complete Deploy Walkthrough
-For the complete deployment process on Netlify, see the [Tutorial Deployment section](https://redwoodjs.com/tutorial/deployment).
+For the complete deployment process on Netlify, see the [Tutorial Deployment section](https://redwoodjs.com/docs/tutorial/deployment).
 
 ## Render Deploy
 Render is a unified cloud to build and run all your apps and websites with free SSL, a global CDN, private networks and auto deploys from Git — **database included**!
@@ -120,7 +120,7 @@ _If you choose this quick deploy experience, the following steps do not apply._
 ### Redwood Project Setup
 If you already have a Redwood project, proceed to the next step.
 
-Otherwise, we recommend experiencing the full Redwood DX via the [Redwood Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood). Simply return to these instructions when you reach the "Deployment" section.
+Otherwise, we recommend experiencing the full Redwood DX via the [Redwood Tutorial](https://redwoodjs.com/docs/tutorial/welcome-to-redwood). Simply return to these instructions when you reach the "Deployment" section.
 
 ### Redwood Deploy Configuration
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -75,7 +75,7 @@ We have some other [generators](https://redwoodjs.com/docs/cli-commands#generate
 
 ## Next Steps
 
-Need more? The best way to get to know Redwood is by going through the extensive [Redwood Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood).
+Need more? The best way to get to know Redwood is by going through the extensive [Redwood Tutorial](https://redwoodjs.com/docs/tutorial/welcome-to-redwood).
 
 - Join our [Discord Server](https://discord.gg/redwoodjs)
 - Join our [Discourse Community](https://community.redwoodjs.com)

--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -158,7 +158,7 @@ Here's the same example again, but now using `<Private>`
 </Router>
 ```
 
-Redwood uses the `useAuth` hook under the hood to determine if the user is authenticated. Read more about authentication in Redwood [here](https://redwoodjs.com/tutorial/authentication).
+Redwood uses the `useAuth` hook under the hood to determine if the user is authenticated. Read more about authentication in Redwood [here](https://redwoodjs.com/docs/tutorial/authentication).
 
 ## Link and named route functions
 

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -2,7 +2,7 @@
 
 <!-- prettier-ignore-start -->
 <p align="center">
-  <a aria-label="Start the Tutorial" href="https://redwoodjs.com/tutorial">
+  <a aria-label="Start the Tutorial" href="https://redwoodjs.com/docs/tutorial">
     <img alt="" src="https://img.shields.io/badge/Start%20the%20Tutorial-%23BF4722?style=for-the-badge&labelColor=000000&logoWidth=20&logo=RedwoodJS">
   </a>
   <a aria-label="Join the Forums" href="https://community.redwoodjs.com">
@@ -35,7 +35,7 @@ yarn redwood dev
 
 <h3>Resources</h3>
 
-- The [Redwood Tutorial](https://redwoodjs.com/tutorial): The best way to learn Redwood
+- The [Redwood Tutorial](https://redwoodjs.com/docs/tutorial): The best way to learn Redwood
 - The [Redwood CLI](https://redwoodjs.com/docs/cli-commands): code generators, DB helpers, setup commands, and more
 - [Documentation](https://redwoodjs.com/docs) and [Cookbooks](https://redwoodjs.com/cookbook/custom-function)
 - Join the Community [Forums](https://community.redwoodjs.com) and [Chat](https://discord.gg/redwoodjs)

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -311,7 +311,7 @@ new Listr(
       '',
       `${style.redwood(
         ' ❖ Get started with the Tutorial'
-      )}: https://redwoodjs.com/tutorial`,
+      )}: https://redwoodjs.com/docs/tutorial`,
       `${style.redwood(
         ' ❖ Read the Documentation'
       )}: https://redwoodjs.com/docs`,

--- a/packages/create-redwood-app/template/README.md
+++ b/packages/create-redwood-app/template/README.md
@@ -6,7 +6,7 @@
 > to release a truly production-ready 1.0 in early 2022.
 
 ## Getting Started
-- [Tutorial](https://redwoodjs.com/tutorial/welcome-to-redwood): getting started and complete overview guide.
+- [Tutorial](https://redwoodjs.com/docs/tutorial/welcome-to-redwood): getting started and complete overview guide.
 - [Docs](https://redwoodjs.com/docs/introduction): using the Redwood Router, handling assets and files, list of command-line tools, and more.
 - [Redwood Community](https://community.redwoodjs.com): get help, share tips and tricks, and collaborate on everything about RedwoodJS.
 

--- a/packages/structure/src/outline/outline.ts
+++ b/packages/structure/src/outline/outline.ts
@@ -103,7 +103,7 @@ function _pages(project: RWProject): TreeItem2 {
     menu: {
       kind: 'group',
       add: Command_cli('rw generate page ...'),
-      doc: Command_open('https://redwoodjs.com/tutorial/our-first-page'),
+      doc: Command_open('https://redwoodjs.com/docs/tutorial/our-first-page'),
     },
   }
 }
@@ -146,7 +146,7 @@ function _layouts(project: RWProject): TreeItem2 {
     menu: {
       kind: 'group',
       add: Command_cli('rw generate layout ...'),
-      doc: Command_open('https://redwoodjs.com/tutorial/layouts'),
+      doc: Command_open('https://redwoodjs.com/docs/tutorial/layouts'),
     },
   }
 }
@@ -159,7 +159,7 @@ function _cells(project: RWProject): TreeItem2 {
     menu: {
       kind: 'group',
       add: Command_cli('rw generate cell ...'),
-      doc: Command_open('https://redwoodjs.com/tutorial/cells'),
+      doc: Command_open('https://redwoodjs.com/docs/tutorial/cells'),
     },
   }
 }

--- a/tasks/e2e/cypress/integration/01-tutorial/sharedTests.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/sharedTests.js
@@ -70,7 +70,7 @@ export const test_first_page = () =>
 
 export const test_pages = () =>
   it('2. A Second Page and a Link', () => {
-    // https://redwoodjs.com/tutorial/a-second-page-and-a-link
+    // https://redwoodjs.com/docs/tutorial/a-second-page-and-a-link
     cy.exec(`cd ${BASE_DIR}; yarn redwood generate page about --force`)
     cy.writeFile(
       path.join(BASE_DIR, 'web/src/pages/HomePage/HomePage.js'),
@@ -114,7 +114,7 @@ export const test_layouts = () =>
 
 export const test_dynamic = () =>
   it('4. Getting Dynamic', () => {
-    // https://redwoodjs.com/tutorial/getting-dynamic
+    // https://redwoodjs.com/docs/tutorial/getting-dynamic
     cy.writeFile(path.join(BASE_DIR, 'api/db/schema.prisma'), Step4_1_DbSchema)
     cy.exec(`rm ${BASE_DIR}/api/db/dev.db`, { failOnNonZeroExit: false })
     // need to also handle case where Prisma Client be out of sync
@@ -208,7 +208,7 @@ export const test_cells = () =>
 
 export const test_routing_params = () =>
   it('6. Routing Params', () => {
-    // https://redwoodjs.com/tutorial/routing-params
+    // https://redwoodjs.com/docs/tutorial/routing-params
     cy.exec(`cd ${BASE_DIR}; yarn rw g page BlogPost --force`)
     cy.exec(`cd ${BASE_DIR}; yarn rw g cell BlogPost --force`)
     cy.exec(`cd ${BASE_DIR}; yarn rw g component BlogPost --force`)
@@ -273,7 +273,7 @@ export const test_routing_params = () =>
 
 export const test_forms = () =>
   it("7. Everyone's Favorite Thing to Build: Forms", () => {
-    // https://redwoodjs.com/tutorial/everyone-s-favorite-thing-to-build-forms
+    // https://redwoodjs.com/docs/tutorial/everyone-s-favorite-thing-to-build-forms
     cy.exec(`cd ${BASE_DIR}; yarn rw g page contact --force`)
     cy.writeFile(
       path.join(BASE_DIR, 'web/src/layouts/BlogLayout/BlogLayout.js'),

--- a/tasks/e2e/cypress/integration/01-tutorial/tutorial.spec.js
+++ b/tasks/e2e/cypress/integration/01-tutorial/tutorial.spec.js
@@ -25,8 +25,8 @@ import Step9_3_DisableAuth from './codemods/Step9_3_DisableAuth'
 const BASE_DIR = Cypress.env('RW_PATH')
 
 describe('The Redwood Tutorial - Golden path edition', () => {
-  // TODO: https://redwoodjs.com/tutorial/saving-data
-  // TODO: https://redwoodjs.com/tutorial/administration
+  // TODO: https://redwoodjs.com/docs/tutorial/saving-data
+  // TODO: https://redwoodjs.com/docs/tutorial/administration
   after(() => {
     cy.exec(
       `cd ${BASE_DIR}; git add . && git commit -a --message=01-tutorial`,
@@ -51,7 +51,7 @@ describe('The Redwood Tutorial - Golden path edition', () => {
     //   Step0_2_GraphQL
     // )
 
-    // https://redwoodjs.com/tutorial/installation-starting-development
+    // https://redwoodjs.com/docs/tutorial/installation-starting-development
 
     waitForApiSide()
 


### PR DESCRIPTION
This replace 
https://redwoodjs.com/tutorial
to 
https://redwoodjs.com/docs/tutorial

for the new path URL of the tutorial