### PR TITLE
Updates to construct GraphQL Yoga request url

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -30,7 +30,7 @@
     "@graphql-tools/merge": "8.2.4",
     "@graphql-tools/schema": "8.3.3",
     "@graphql-tools/utils": "8.6.3",
-    "@graphql-yoga/common": "0.1.0-canary-bfd2627.0",
+    "@graphql-yoga/common": "0.1.1-canary-986b1f4.0",
     "@prisma/client": "3.11.0",
     "@redwoodjs/api": "0.49.1",
     "core-js": "3.21.1",

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -174,7 +174,7 @@ export const createGraphQLHandler = ({
     logging: logger,
     graphiql: isDevEnv
       ? {
-          title: 'Redwood GraphQL playground',
+          title: 'Redwood GraphQL Playground',
           endpoint: graphiQLEndpoint,
           defaultQuery: `query Redwood {
         redwood {
@@ -184,6 +184,8 @@ export const createGraphQLHandler = ({
           headerEditorEnabled: true,
         }
       : false,
+    healthCheckPath: 'graphql', // @todo: may default here, but need to configure per app or derive from event path?
+    readinessCheckPath: 'graphql', // but we don't have access to event yet
     cors: (request: Request) => {
       const yogaCORSOptions: CORSOptions = {}
       if (cors?.methods) {
@@ -262,8 +264,12 @@ export const createGraphQLHandler = ({
       }
     }
 
-    const requestProtocol = event.requestContext?.protocol || 'http'
-    const requestUrl = new URL(event.path, requestProtocol + '://localhost')
+    const requestProtocol = isDevEnv ? 'http' : 'https'
+    const requestDomain = event.requestContext?.domainName || 'localhost'
+    const requestUrl = new URL(
+      event.path,
+      requestProtocol + `://${requestDomain}`
+    )
     let request: Request
     if (event.httpMethod === 'GET' || event.httpMethod === 'HEAD') {
       request = new Request(requestUrl.toString(), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3607,7 +3607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-typed-document-node/core@npm:^3.0.0":
+"@graphql-typed-document-node/core@npm:^3.0.0, @graphql-typed-document-node/core@npm:^3.1.1":
   version: 3.1.1
   resolution: "@graphql-typed-document-node/core@npm:3.1.1"
   peerDependencies:
@@ -3616,9 +3616,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-yoga/common@npm:0.1.0-canary-bfd2627.0":
-  version: 0.1.0-canary-bfd2627.0
-  resolution: "@graphql-yoga/common@npm:0.1.0-canary-bfd2627.0"
+"@graphql-yoga/common@npm:0.1.1-canary-986b1f4.0":
+  version: 0.1.1-canary-986b1f4.0
+  resolution: "@graphql-yoga/common@npm:0.1.1-canary-986b1f4.0"
   dependencies:
     "@envelop/core": ^2.0.0
     "@envelop/disable-introspection": ^3.0.0
@@ -3626,6 +3626,7 @@ __metadata:
     "@envelop/validation-cache": ^4.0.0
     "@graphql-tools/schema": ^8.3.1
     "@graphql-tools/utils": ^8.6.0
+    "@graphql-typed-document-node/core": ^3.1.1
     "@graphql-yoga/render-graphiql": 0.1.0-beta.1
     "@graphql-yoga/subscription": 0.0.1-beta.1
     cross-undici-fetch: ^0.1.25
@@ -3633,7 +3634,7 @@ __metadata:
     tslib: ^2.3.1
   peerDependencies:
     graphql: ^15.2.0 || ^16.0.0
-  checksum: 2a787418f9e1e4e371b26ed7af0bd76e8e0feafec27e61ee018447e253907c77e0ee3be1a2a6ad513f3825ff8a23d6061a83ca3df5b76c5cff3a508d89823bc5
+  checksum: a5971e0c4281fb8dc0c08dae29bc54bdcf7cf8f2aafb3397265f996293606859383b7013570fa6ed1e1de250b8bac46a5e82f680218657769df3a03542caa7a6
   languageName: node
   linkType: hard
 
@@ -6061,7 +6062,7 @@ __metadata:
     "@graphql-tools/merge": 8.2.4
     "@graphql-tools/schema": 8.3.3
     "@graphql-tools/utils": 8.6.3
-    "@graphql-yoga/common": 0.1.0-canary-bfd2627.0
+    "@graphql-yoga/common": 0.1.1-canary-986b1f4.0
     "@prisma/client": 3.11.0
     "@redwoodjs/api": 0.49.1
     "@redwoodjs/auth": 0.49.1


### PR DESCRIPTION
Reworks the way the request url is constructed when passed to GraphQL Yoga.

* https vs https
* fetch domain name vs localhost
* set health check paths