### PR TITLE
Fix favicon for docs site (continued)

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -142,8 +142,3 @@
   from = "/docs/tutorial2/wrapping-up"
   to = "/docs/tutorial/afterword"
   status = 301
-
-[[redirects]]
-  from = "/img/*"
-  to = "https://redwoodjs-docs.netlify.app/img/:splat"
-  status = 200


### PR DESCRIPTION
~Continued from https://github.com/redwoodjs/redwood/pull/4874. Forgot to include the `*` and a change the status code.~ My mistake; this should actually be in the redwood/redwoodjs.com repo.