### PR TITLE
event.requestContext can be optional for domain name

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -268,7 +268,7 @@ export const createGraphQLHandler = ({
 
     const requestUrl = new URL(
       event.path,
-      protocol + '://' + event.requestContext.domainName || 'localhost'
+      protocol + '://' + event.requestContext?.domainName || 'localhost'
     )
 
     if (event.queryStringParameters) {


### PR DESCRIPTION
Since the event.requestContext can be undefined in certain provider deploys, needs to have an optional check