### PR TITLE
GraphQL Yoga / Rework multi and non-multi query string param handling when building request

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -271,15 +271,6 @@ export const createGraphQLHandler = ({
       protocol + '://' + event.requestContext?.domainName || 'localhost'
     )
 
-    if (event.queryStringParameters) {
-      for (const queryStringParam in event.queryStringParameters) {
-        const queryStringValue = event.queryStringParameters[queryStringParam]
-        if (queryStringValue) {
-          requestUrl.searchParams.append(queryStringParam, queryStringValue)
-        }
-      }
-    }
-
     if (event.multiValueQueryStringParameters) {
       for (const queryStringParam in event.multiValueQueryStringParameters) {
         const queryStringValues =

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -207,13 +207,13 @@ export const createGraphQLHandler = ({
     logging: logger,
     graphiql: isDevEnv
       ? {
-          title: 'Redwood GraphQL playground',
+          title: 'Redwood GraphQL Playground',
           endpoint: graphiQLEndpoint,
           defaultQuery: `query Redwood {
-        redwood {
-          version
-        }
-      }`,
+  redwood {
+    version
+  }
+}`,
           headerEditorEnabled: true,
         }
       : false,

--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -284,10 +284,17 @@ export const createGraphQLHandler = ({
       for (const queryStringParam in event.multiValueQueryStringParameters) {
         const queryStringValues =
           event.multiValueQueryStringParameters[queryStringParam]
-        if (queryStringValues) {
+        if (queryStringValues && Array.isArray(queryStringValues)) {
           for (const queryStringValue of queryStringValues) {
             requestUrl.searchParams.append(queryStringParam, queryStringValue)
           }
+        }
+      }
+    } else if (event.queryStringParameters) {
+      for (const queryStringParam in event.queryStringParameters) {
+        const queryStringValue = event.queryStringParameters[queryStringParam]
+        if (queryStringValue) {
+          requestUrl.searchParams.append(queryStringParam, queryStringValue)
         }
       }
     }


### PR DESCRIPTION
Seeing 

```
invalid json response body at https://undefined/api/graphql?query=%7Bpost%28id%3A1%29%7Btitle%7D%7D&query=%7Bpost%28id%3A1%29%7Btitle%7D%7D&query=%7B&query=p&query=o&query=s&query=t&query=%28&query=i&query=d&query=%3A&query=1&query=%29&query=%7B&query=t&query=i&query=t&query=l&query=e&query=%7D&query=%7D reason: Unexpected token e in JSON at position 0
```

Notice the many `query` per character.

This PR reworks the way the `multiValueQueryStringParameters` and gives that precedence of the queryString to avoid duplicates.