### PR TITLE
add rw-server bin to core bins

### DIFF
--- a/packages/core/src/bins/rw-server.ts
+++ b/packages/core/src/bins/rw-server.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { createRequire } from 'module'
+
+const requireFromApiServer = createRequire(
+  require.resolve('@redwoodjs/api-server/package.json')
+)
+
+const bins = requireFromApiServer('./package.json')['bin']
+
+requireFromApiServer(bins['rw-server'])


### PR DESCRIPTION
We were missing `rw-server` from the bins in core required for Yarn 3.

Does this look correct @jtoar?