### PR TITLE
Fix to show original error in dev log when masking errors in GraphQL Server

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -60,7 +60,15 @@ export const formatError: FormatErrorHandler = (err: any, message: string) => {
       (allowedError) => err.originalError instanceof allowedError
     )
   ) {
-    return new GraphQLError(message)
+    return new GraphQLError(
+      message,
+      err.nodes,
+      err.source,
+      err.positions,
+      err.path,
+      err,
+      undefined
+    )
   }
 
   return err

--- a/packages/graphql-server/src/plugins/useRedwoodLogger.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodLogger.ts
@@ -145,9 +145,11 @@ const logResult =
         } else {
           envelopLogger.error(
             {
-              error,
+              error: error.originalError,
             },
-            error.message || `Error in GraphQL execution: ${operationName}`
+            error?.originalError?.message ||
+              error.message ||
+              `Error in GraphQL execution: ${operationName}`
           )
         }
       })


### PR DESCRIPTION
The constructor of the GraphQL error changed a bit (I think) such that the original error was not getting populated so that the `useRedwoodLogger` could log the info details and stack.

This PR restores the expected masking but logging the full error behavior.

<img width="472" alt="image" src="https://user-images.githubusercontent.com/1051633/159831373-6f2b6792-3a09-4aff-b390-a5197bb24baf.png">

But the error is still masked in the response and UI

<img width="573" alt="image" src="https://user-images.githubusercontent.com/1051633/159831597-ffd9a5e5-ec1c-41d7-9b93-ae7d2552aebe.png">


```
{
    "errors": [
        {
            "message": "Something went wrong.",
            "locations": [
                {
                    "line": 2,
                    "column": 3
                }
            ],
            "path": [
                "posts"
            ]
        }
    ],
    "data": null
}
```