### PR TITLE
Enable vscode debugging on api server

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import { argv } from 'process'
 
 import concurrently from 'concurrently'
 import terminalLink from 'terminal-link'
@@ -11,6 +12,7 @@ import c from '../lib/colors'
 import { generatePrismaClient } from '../lib/generatePrismaClient'
 import checkForBabelConfig from '../middleware/checkForBabelConfig'
 
+const defaultApiDebugPort = 18911
 export const command = 'dev [side..]'
 export const description = 'Start development servers for api, and web'
 export const builder = (yargs) => {
@@ -36,6 +38,11 @@ export const builder = (yargs) => {
       type: 'boolean',
       description: 'Reload on changes to node_modules',
     })
+    .option('apiDebugPort', {
+      type: 'number',
+      description:
+        'Port on which to expose API server debugger. If you supply the flag with no value it defaults to 18911.',
+    })
     .middleware(checkForBabelConfig)
     .epilogue(
       `Also see the ${terminalLink(
@@ -50,6 +57,7 @@ export const handler = async ({
   forward = '',
   generate = true,
   watchNodeModules = process.env.RWJS_WATCH_NODE_MODULES === '1',
+  apiDebugPort,
 }) => {
   const rwjsPaths = getPaths()
 
@@ -93,13 +101,30 @@ export const handler = async ({
     '@redwoodjs/core/config/webpack.development.js'
   )
 
+  const getApiDebugFlag = () => {
+    // Passed in flag takes precedence
+    if (apiDebugPort) {
+      return `--debug-port ${apiDebugPort}`
+    } else if (argv.includes('--apiDebugPort')) {
+      return `--debug-port ${defaultApiDebugPort}`
+    }
+
+    const apiDebugPortInToml = getConfig().api.debugPort
+    if (apiDebugPortInToml) {
+      return `--debug-port ${apiDebugPortInToml}`
+    }
+
+    // Dont pass in debug port flag, unless configured
+    return ''
+  }
+
   const redwoodConfigPath = getConfigPath()
 
   /** @type {Record<string, import('concurrently').CommandObj>} */
   const jobs = {
     api: {
       name: 'api',
-      command: `yarn cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --watch "${redwoodConfigPath}" --exec "yarn rw-api-server-watch | rw-log-formatter"`,
+      command: `yarn cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --watch "${redwoodConfigPath}" --exec "yarn rw-api-server-watch ${getApiDebugFlag()} | rw-log-formatter"`,
       prefixColor: 'cyan',
       runWhen: () => fs.existsSync(rwjsPaths.api.src),
     },

--- a/packages/create-redwood-app/template/.vscode/launch.json
+++ b/packages/create-redwood-app/template/.vscode/launch.json
@@ -6,6 +6,20 @@
       "name": "launch development",
       "request": "launch",
       "type": "node-terminal"
+    },
+    {
+      "name": "Attach",
+      "port": 18911,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node",
+      "protocol": "inspector",
+      "stopOnEntry": false,
+      "localRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
+      "remoteRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
+      "sourceMaps": true
     }
   ]
 }

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -22,6 +22,7 @@ export interface NodeTargetConfig {
   target: TargetEnum.NODE
   schemaPath: string
   serverConfig: string
+  debugPort?: number
 }
 
 interface BrowserTargetConfig {


### PR DESCRIPTION
Original PR from @twodotsmax


Additional tasks for Danny

- [ ]  keep the debugger attached even on restart, by adding the "restart: true" property
- [ ] add some default values for this to the CLI, I don't see a reason not to launch debugger at the port by default
- [ ] I'll see if I can add a test for this
- [ ]  Regenerate the test fixture so it uses the latest template :)
