### PR TITLE
Change algolia config

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,9 +23,9 @@ module.exports = {
   projectName: 'redwood', // Usually your repo name.,
   themeConfig: {
     algolia: {
-      appId: '37B3LHULK0',
-      apiKey: '1d7f2f299d9a38c157501c301425f090',
-      indexName: 'learn-redwood',
+      appId: '9YZJ9GHCKX',
+      apiKey: 'b8585f09d7fec5154602cdf8788ccb1d',
+      indexName: 'docs',
       contextualSearch: true,
       searchParameters: {},
     },


### PR DESCRIPTION
Search on the redwoodjs.com/docs page is broken; the redirects don't work because this is a single page app (at least, I think that's why), so we have to change the paths in the algolia index. I did that in another algolia app, just so we can switch back to the docs search app if/when we hear back