### PR TITLE
[Search] Try external url regex

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,11 +23,12 @@ module.exports = {
   projectName: 'redwood', // Usually your repo name.,
   themeConfig: {
     algolia: {
-      appId: '9YZJ9GHCKX',
-      apiKey: 'b8585f09d7fec5154602cdf8788ccb1d',
-      indexName: 'docs',
+      appId: '37B3LHULK0',
+      apiKey: '1d7f2f299d9a38c157501c301425f090',
+      indexName: 'learn-redwood',
       contextualSearch: true,
       searchParameters: {},
+      externalUrlRegex: 'redwoodjs.com',
     },
     navbar: {
       title: 'RedwoodJS',


### PR DESCRIPTION
Seeing as https://github.com/redwoodjs/redwood/pull/4908 didn't work, a quick follow-up using a different strategy. Maybe we can force redirects with [externalUrlRegex](https://docusaurus.io/docs/search#connecting-algolia). Apologies for the PRs. Deploy previews don't seem to be working too well for the site either.