### PR TITLE
Use learn instead of redwoodjs.com for external url regex

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -28,7 +28,7 @@ module.exports = {
       indexName: 'learn-redwood',
       contextualSearch: true,
       searchParameters: {},
-      externalUrlRegex: 'redwoodjs.com',
+      externalUrlRegex: 'https://learn-redwood.netlify.app',
     },
     navbar: {
       title: 'RedwoodJS',


### PR DESCRIPTION
After swizzling the docs search bar and trying things out locally, this seems to be redirecting the tutorial search results from the learn URLs to the new ones consistently. 