### PR TITLE
chore(story📗): extract MSW logic into a loader

### DIFF
--- a/packages/testing/config/storybook/preview.js
+++ b/packages/testing/config/storybook/preview.js
@@ -6,6 +6,7 @@ const { merge } = require('webpack-merge')
 // booting up the mock server workers, and mocking the router.
 const {
   StorybookProvider,
+  MockingLoader,
 } = require('@redwoodjs/testing/dist/web/StorybookProvider')
 
 // Import the user's default CSS file
@@ -18,6 +19,7 @@ const baseConfig = {
     (storyFn, { id }) =>
       React.createElement(StorybookProvider, { storyFn, id }),
   ],
+  loaders: [MockingLoader],
 }
 
 const userConfig = require('~__REDWOOD__USER_STORYBOOK_PREVIEW_CONFIG')

--- a/packages/testing/src/web/StorybookProvider.tsx
+++ b/packages/testing/src/web/StorybookProvider.tsx
@@ -4,35 +4,24 @@ import * as React from 'react'
 import { MockProviders } from './MockProviders'
 import { setupRequestHandlers, startMSW, mockCurrentUser } from './mockRequests'
 
+export const MockingLoader = async () => {
+  const reqs = require.context(
+    '~__REDWOOD__USER_WEB_SRC',
+    true,
+    /.+(mock).(js|ts)$/
+  )
+  reqs.keys().forEach(reqs)
+
+  await startMSW('browsers')
+  setupRequestHandlers()
+
+  return {}
+}
+
 export const StorybookProvider: React.FunctionComponent<{
   storyFn: () => ReactNode | ReactPortal
   id: string
-}> = ({ storyFn, id }) => {
-  const [loading, setLoading] = React.useState(true)
-
-  React.useEffect(() => {
-    const init = async () => {
-      // Import all the `*.mock.*` files.
-      const reqs = require.context(
-        '~__REDWOOD__USER_WEB_SRC',
-        true,
-        /.+(mock).(js|ts)$/
-      )
-      reqs.keys().forEach((r) => {
-        reqs(r)
-      })
-
-      await startMSW('browsers')
-      setupRequestHandlers()
-      setLoading(false)
-    }
-    init()
-  }, [id])
-
-  if (loading) {
-    return null
-  }
-
+}> = ({ storyFn }) => {
   // default to a non-existent user at the beginning of each story
   mockCurrentUser(null)
 


### PR DESCRIPTION
the loaders are async and execute before the story is rendered.

- https://storybook.js.org/docs/react/writing-stories/loaders
- https://mswjs.io/

---

Why this matters:

**_interaction testing_**

- https://storybook.js.org/blog/interaction-testing-with-storybook/
- https://storybook.js.org/docs/react/writing-tests/interaction-testing

Because using a loader happens before a story is rendered, we do not have to worry about the mock data being unavailable to a component. With the previous approach, we possibly had to wait for a couple render cycles in order to guarantee the mock data was available to the component.