### PR TITLE
Fix: Don't swallow typegen errors

### DIFF
--- a/packages/internal/src/__tests__/graphqlCodeGen.test.ts
+++ b/packages/internal/src/__tests__/graphqlCodeGen.test.ts
@@ -146,10 +146,11 @@ describe("Doesn't swallow legit errors", () => {
     const oldConsoleError = console.error
     console.error = jest.fn()
 
-    await generateTypeDefGraphQLWeb({ logErrors: true })
+    await generateTypeDefGraphQLWeb()
 
     try {
-      expect(console.error).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenNthCalledWith(
+        3,
         expect.objectContaining({
           message: expect.stringMatching(/field.*softKitten.*Query/),
         })
@@ -169,10 +170,11 @@ describe("Doesn't swallow legit errors", () => {
     const oldConsoleError = console.error
     console.error = jest.fn()
 
-    await generateTypeDefGraphQLWeb({ logErrors: true })
+    await generateTypeDefGraphQLWeb()
 
     try {
-      expect(console.error).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenNthCalledWith(
+        3,
         expect.objectContaining({
           message: expect.stringMatching(/Unknown type.*Todo/),
         })
@@ -192,10 +194,11 @@ describe("Doesn't swallow legit errors", () => {
     const oldConsoleError = console.error
     console.error = jest.fn()
 
-    await generateTypeDefGraphQLWeb({ logErrors: true })
+    await generateTypeDefGraphQLWeb()
 
     try {
-      expect(console.error).toHaveBeenCalledWith(
+      expect(console.error).toHaveBeenNthCalledWith(
+        3,
         expect.objectContaining({
           message: expect.stringMatching(/field.*done.*Todo/),
         })

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -30,21 +30,17 @@ export const generateTypeDefGraphQLApi = async () => {
 
   try {
     return await runCodegenGraphQL([], extraPlugins, filename)
-  } catch {
+  } catch (e) {
     console.error()
     console.error('Error: Could not generate GraphQL type definitions (api)')
+    console.error(e)
     console.error()
 
     return []
   }
 }
 
-interface Args {
-  /** used for tests */
-  logErrors?: boolean | undefined
-}
-
-export const generateTypeDefGraphQLWeb = async ({ logErrors }: Args = {}) => {
+export const generateTypeDefGraphQLWeb = async () => {
   const filename = path.join(getPaths().web.types, 'graphql.d.ts')
   const options = getLoadDocumentsOptions(filename)
   const documentsGlob = './web/src/**/!(*.d).{ts,tsx,js,jsx}'
@@ -71,11 +67,8 @@ export const generateTypeDefGraphQLWeb = async ({ logErrors }: Args = {}) => {
   } catch (e) {
     console.error()
     console.error('Error: Could not generate GraphQL type definitions (web)')
+    console.error(e)
     console.error()
-
-    if (logErrors) {
-      console.error(e)
-    }
 
     return []
   }

--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -44,12 +44,14 @@ export const generateGraphQLSchema = async () => {
   } catch (e: any) {
     // `generate` outputs errors which are helpful.
     // This tries to clean up the output of those errors.
-    console.error(e)
     console.error(chalk.red('Error parsing SDLs or Schema'))
-    for (const error of e.errors ?? []) {
-      console.error(error.details)
+    if (e.errors?.length) {
+      for (const error of e.errors ?? []) {
+        console.error(error.details)
+      }
+    } else {
+      console.error(e)
     }
-
     console.warn()
   }
 


### PR DESCRIPTION
**What is currently happening?**
Demo without changes: https://s.tape.sh/gcgUm5Kw
1. If we have some issue in GraphQL files (web - query/mutations | api - sdls), that error is swallowed. Without a pointer where the error is it's extremely difficult to debug the issue. This unfairly impacts more on the web side because before the codegen step, we generate the schema from api source and probably that same error would be caught and printed in this earlier step.
2. Error is printed twice if there's something wrong with sdl, for example - invalid type.

**What this PR does?**
Demo with changes: https://s.tape.sh/a64iFBIq
1. console the errors for both api and web typegen. @Tobbe I tried to gather context from earlier PR but I didn't understand why we only log the error in test files but not in the framework?
2. Checks if we have multiple errors then only loop over and print and skip printing the whole error along with it.
