### PR TITLE
Update details CSS (docs)

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -13,12 +13,14 @@
   --yellow-darkest: hsl(38deg 72% 46%);
 
   --green: hsl(85deg 55% 54%);
-  --green-lightest: hsl(85deg 55% 70%);
+  --green-lightest: hsl(85deg 55% 90%);
   --green-lighter: hsl(85deg 55% 62%);
   --green-light: hsl(85deg 55% 59%);
   --green-dark: hsl(85deg 55% 49%);
   --green-darker: hsl(85deg 55% 46%);
   --green-darkest: hsl(85deg 55% 38%);
+
+  --forest: hsl(144deg 61% 20%);
 
   --blue: hsl(184, 49%, 76%);
   --blue-lightest: hsl(200deg 60% 99%);
@@ -229,4 +231,20 @@ blockquote {
 */
 .row .col--6 {
   padding: 0 0 0 2rem;
+}
+
+/*
+  ------------------------
+  Details
+  ------------------------
+*/
+.alert {
+  --ifm-alert-background-color: var(--green-lightest) !important;
+  --ifm-alert-border-color: transparent !important;
+  --docusaurus-details-decoration-color: var(--black) !important;
+}
+
+[data-theme="dark"] .alert {
+  --ifm-alert-background-color: hsl(210deg 3% 15%) !important;
+  --docusaurus-details-decoration-color: hsl(210deg 11% 96%) !important;
 }


### PR DESCRIPTION
The styling for the HTML details element was Docusaurus's default, a light blue. This updates it to at least look a little more consistent.

### Before (light):

<img width="776" alt="image" src="https://user-images.githubusercontent.com/32992335/161381461-8cae6d8d-5607-4610-9ef9-98397e6bc2b6.png">

### After (light):

<img width="776" alt="image" src="https://user-images.githubusercontent.com/32992335/161381509-1a8489a4-7737-48cb-ace8-952e49c02510.png">

### Before (dark):

<img width="776" alt="image" src="https://user-images.githubusercontent.com/32992335/161381478-33a62bb5-288c-4dbc-881b-7d2acef8d1b0.png">

### After (dark):

<img width="776" alt="image" src="https://user-images.githubusercontent.com/32992335/161381519-01b9fbc1-7b6d-4371-82fc-9cc8641cde56.png">
