### PR TITLE
Adds title and description frontmatter to docs Reference section

### DIFF
--- a/docs/docs/a11y.md
+++ b/docs/docs/a11y.md
@@ -1,7 +1,5 @@
 ---
-title: Accessibility (aka a11y)
-description: Accessibility is a core feature that's built-in.
-slug: accessibility
+description: Accessibility is a core feature that's built-in
 ---
 
 # Accessibility (aka a11y)

--- a/docs/docs/a11y.md
+++ b/docs/docs/a11y.md
@@ -1,4 +1,6 @@
 ---
+title: Accessibility (aka a11y)
+description: Accessibility is a core feature that's built-in.
 slug: accessibility
 ---
 

--- a/docs/docs/a11y.md
+++ b/docs/docs/a11y.md
@@ -1,4 +1,5 @@
 ---
+slug: accessibility
 description: Accessibility is a core feature that's built-in
 ---
 

--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -1,3 +1,8 @@
+---
+title: App Configuration
+description: Configure your app with redwood.toml
+slug: app-configuration
+---
 # App Configuration: redwood.toml
 
 You can configure your Redwood app's settings in `redwood.toml`. By default, `redwood.toml` lists the following configuration options:

--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -1,8 +1,8 @@
 ---
 title: App Configuration
 description: Configure your app with redwood.toml
-slug: app-configuration
 ---
+
 # App Configuration: redwood.toml
 
 You can configure your Redwood app in `redwood.toml`. By default, `redwood.toml` lists the following configuration options:

--- a/docs/docs/assets-and-files.md
+++ b/docs/docs/assets-and-files.md
@@ -1,3 +1,8 @@
+---
+title: Assets and Files
+description: Import files, such as images, into your application.
+slug: assets-and-files
+---
 # Assets and Files
 
 > ⚠ **Work in Progress** ⚠️

--- a/docs/docs/assets-and-files.md
+++ b/docs/docs/assets-and-files.md
@@ -1,8 +1,7 @@
 ---
-title: Assets and Files
-description: Import files, such as images, into your application.
-slug: assets-and-files
+description: How to include assets—like images—in your app
 ---
+
 # Assets and Files
 
 There are two ways to add an asset to your Redwood app:

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -1,8 +1,7 @@
 ---
-title: Authentication
-description: Setup an authentication provider.
-slug: authentication
+description: Set up an authentication provider
 ---
+
 # Authentication
 
 `@redwoodjs/auth` contains both a built-in database-backed authentication system (dbAuth), as well as lightweight wrappers around popular SPA authentication libraries.

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -1,3 +1,8 @@
+---
+title: Authentication
+description: Setup an authentication provider.
+slug: authentication
+---
 # Authentication
 
 `@redwoodjs/auth` contains both a built-in database-backed authentication system (dbAuth), as well as lightweight wrappers around popular SPA authentication libraries.

--- a/docs/docs/builds.md
+++ b/docs/docs/builds.md
@@ -1,3 +1,8 @@
+---
+title: Builds
+description: Building Redwood
+slug: builds
+---
 # Builds
 
 > ⚠ **Work in Progress** ⚠️
@@ -13,7 +18,7 @@
 
 The api side of Redwood is transpiled by Babel into the `./api/dist` folder.
 
-### steps on Netlify
+### Steps on Netlify
 
 To emulate Netlify's build steps locally:
 

--- a/docs/docs/builds.md
+++ b/docs/docs/builds.md
@@ -1,7 +1,5 @@
 ---
-title: Builds
-description: Building Redwood
-slug: builds
+description: What happens when you run `yarn rw build`
 ---
 # Builds
 

--- a/docs/docs/builds.md
+++ b/docs/docs/builds.md
@@ -1,5 +1,5 @@
 ---
-description: What happens when you run `yarn rw build`
+description: What happens when you build your app
 ---
 # Builds
 

--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -1,7 +1,5 @@
 ---
-title: Cells
-description: All about Cells and data fetching in RedwoodJS.
-slug: cells
+description: Declarative data fetching with Cells
 ---
 # Cells
 

--- a/docs/docs/cells.md
+++ b/docs/docs/cells.md
@@ -1,3 +1,8 @@
+---
+title: Cells
+description: All about Cells and data fetching in RedwoodJS.
+slug: cells
+---
 # Cells
 
 Cells are a declarative approach to data fetching and one of Redwood's signature modes of abstraction.

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1,3 +1,8 @@
+---
+title: Command Line Interface
+description: A comprehensive reference of the Redwood CLI
+slug: cli
+---
 # Command Line Interface
 
 The following is a comprehensive reference of the Redwood CLI. You can get a glimpse of all the commands by scrolling the aside to the right.

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1,7 +1,6 @@
 ---
 title: Command Line Interface
 description: A comprehensive reference of the Redwood CLI
-slug: cli
 ---
 # Command Line Interface
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1,7 +1,7 @@
 ---
-title: Command Line Interface
-description: A comprehensive reference of the Redwood CLI
+description: A comprehensive reference of Redwood's CLI
 ---
+
 # Command Line Interface
 
 The following is a comprehensive reference of the Redwood CLI. You can get a glimpse of all the commands by scrolling the aside to the right.

--- a/docs/docs/connection-pooling.md
+++ b/docs/docs/connection-pooling.md
@@ -1,8 +1,7 @@
 ---
-title: Connection Pooling
-description: Enable connection pooling to scale your Serverless functions.
-slug: connection-pooling
+description: Enable connection pooling to scale your serverless functions
 ---
+
 # Connection Pooling
 
 > ⚠ **Work in Progress** ⚠️

--- a/docs/docs/connection-pooling.md
+++ b/docs/docs/connection-pooling.md
@@ -1,5 +1,5 @@
 ---
-description: Enable connection pooling to scale your serverless functions
+description: Scale your serverless functions
 ---
 
 # Connection Pooling

--- a/docs/docs/connection-pooling.md
+++ b/docs/docs/connection-pooling.md
@@ -1,3 +1,8 @@
+---
+title: Connection Pooling
+description: Enable connection pooling to scale your Serverless functions.
+slug: connection-pooling
+---
 # Connection Pooling
 
 > ⚠ **Work in Progress** ⚠️
@@ -57,8 +62,8 @@ Connection Pooling for MySQL is not yet supported.
 ## AWS
 Use [Amazon RDS Proxy](https://aws.amazon.com/rds/proxy) for MySQL or PostgreSQL.
 
-From the [AWS Docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html#rds-proxy.limitations): 
->Your RDS Proxy must be in the same VPC as the database. The proxy can't be publicly accessible. 
+From the [AWS Docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html#rds-proxy.limitations):
+>Your RDS Proxy must be in the same VPC as the database. The proxy can't be publicly accessible.
 
 Because of this limitation, with out-of-the-box configuration, you can only use RDS Proxy if you're deploying your Lambda Functions to the same AWS account. Alternatively, you can use RDS directly, but you might require larger instances to handle your production traffic and the number of concurrent connections.
 

--- a/docs/docs/contributing-overview.md
+++ b/docs/docs/contributing-overview.md
@@ -1,4 +1,6 @@
 ---
+title: Contributing Overview
+description: There are several ways you can contribute to Redwood.
 slug: contributing
 ---
 

--- a/docs/docs/contributing-overview.md
+++ b/docs/docs/contributing-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-description: There are several ways you can contribute to Redwood
+description: There's several ways to contribute to Redwood
 slug: contributing
 ---
 

--- a/docs/docs/contributing-overview.md
+++ b/docs/docs/contributing-overview.md
@@ -1,6 +1,6 @@
 ---
-title: Contributing Overview
-description: There are several ways you can contribute to Redwood.
+title: Contributing
+description: There are several ways you can contribute to Redwood
 slug: contributing
 ---
 

--- a/docs/docs/contributing-walkthrough.md
+++ b/docs/docs/contributing-walkthrough.md
@@ -1,8 +1,8 @@
 ---
 title: Contributing Walkthrough
-description: Watch a video of the complete contributing process
-slug: contributing-step-by-step
+description: Watch a video of the contributing process
 ---
+
 # Contributing: Step-by-Step Walkthrough (with Video)
 
 > ⚡️ **Quick Links**

--- a/docs/docs/contributing-walkthrough.md
+++ b/docs/docs/contributing-walkthrough.md
@@ -1,3 +1,8 @@
+---
+title: Contributing Walkthrough
+description: Watch a video of the complete contributing process
+slug: contributing-step-by-step
+---
 # Contributing: Step-by-Step Walkthrough (with Video)
 
 > ⚡️ **Quick Links**

--- a/docs/docs/cors.md
+++ b/docs/docs/cors.md
@@ -1,8 +1,8 @@
 ---
-title: Cross Origin Resource Sharing
-description: When you need to worry about CORS
-slug: cors
+title: Cross-Origin Resource Sharing
+description: For when you need to worry about CORS
 ---
+
 # CORS
 
 CORS stands for [Cross Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). In a nutshell, by default, browsers aren't allowed to access resources outside their own domain.

--- a/docs/docs/cors.md
+++ b/docs/docs/cors.md
@@ -1,3 +1,8 @@
+---
+title: Cross Origin Resource Sharing
+description: When you need to worry about CORS
+slug: cors
+---
 # CORS
 
 CORS stands for [Cross Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS). In a nutshell, by default, browsers aren't allowed to access resources outside their own domain.

--- a/docs/docs/custom-web-index.md
+++ b/docs/docs/custom-web-index.md
@@ -1,3 +1,9 @@
+---
+title: Custom Web Index
+description: Customize App mounting using a setup command
+slug: custom-web-index
+---
+
 # Custom Web Index
 
 You might've noticed that there's no call to `ReactDOM.render` anywhere in your Redwood App (`v0.26` and greater). That's because Redwood automatically mounts your `<App />` in `web/src/App.js` to the DOM. But if you need to customize how this happens, you can provide a file called `index.js` in `web/src` and Redwood will use that instead.

--- a/docs/docs/custom-web-index.md
+++ b/docs/docs/custom-web-index.md
@@ -1,7 +1,5 @@
 ---
-title: Custom Web Index
-description: Customize App mounting using a setup command
-slug: custom-web-index
+description: Customize how the App component mounts to the DOM
 ---
 
 # Custom Web Index

--- a/docs/docs/custom-web-index.md
+++ b/docs/docs/custom-web-index.md
@@ -1,5 +1,5 @@
 ---
-description: Customize how the App component mounts to the DOM
+description: Change how App mounts to the DOM
 ---
 
 # Custom Web Index

--- a/docs/docs/data-migrations.md
+++ b/docs/docs/data-migrations.md
@@ -1,3 +1,8 @@
+---
+title: Data Migrations
+description: Track changes to your database structure and content
+slug: data-migrations
+---
 # Data Migrations
 
 > Data Migrations are available as of RedwoodJS v0.15

--- a/docs/docs/data-migrations.md
+++ b/docs/docs/data-migrations.md
@@ -1,8 +1,7 @@
 ---
-title: Data Migrations
-description: Track changes to your database structure and content
-slug: data-migrations
+description: Track changes to database content
 ---
+
 # Data Migrations
 
 > Data Migrations are available as of RedwoodJS v0.15

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -1,8 +1,7 @@
 ---
-title: Directives
 description: Directives run reusable code during GraphQL execution
-slug: directives
 ---
+
 # Directives
 
 Redwood Directives are a powerful feature, supercharging your GraphQL-backed Services.

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -1,5 +1,5 @@
 ---
-description: Directives run reusable code during GraphQL execution
+description: Customize GraphQL execution
 ---
 
 # Directives

--- a/docs/docs/directives.md
+++ b/docs/docs/directives.md
@@ -1,9 +1,16 @@
+---
+title: Directives
+description: Directives run reusable code during GraphQL execution
+slug: directives
+---
 # Directives
 
 Redwood Directives are a powerful feature, supercharging your GraphQL-backed Services.
 
 You can think of directives like "middleware" that let you run reusable code during GraphQL execution to perform tasks like authentication and formatting.
+
 Redwood uses them to make it a snap to protect your API Services from unauthorized access.
+
 Here we call those types of directives **Validators**.
 
 You can also use them to transform the output of your query result to modify string values, format dates, shield sensitive data, and more!

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -1,3 +1,9 @@
+---
+title: Environment Variables
+description: Use Environment Variables both api and web side.
+slug: environment-variables
+---
+
 # Environment Variables
 
 You can provide environment variables to each side of your Redwood app in different ways, depending on each Side's target, and whether you're in development or production.

--- a/docs/docs/environment-variables.md
+++ b/docs/docs/environment-variables.md
@@ -1,7 +1,5 @@
 ---
-title: Environment Variables
-description: Use Environment Variables both api and web side.
-slug: environment-variables
+description: How to use environment variables on the api and web sides
 ---
 
 # Environment Variables

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -1,3 +1,8 @@
+---
+title: Forms
+description: Redwood makes building forms easier with helpers
+slug: forms
+---
 # Forms
 
 Redwood provides several helpers to make building forms easier.

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -1,8 +1,7 @@
 ---
-title: Forms
-description: Redwood makes building forms easier with helpers
-slug: forms
+description: Redwood makes building forms easier with helper components
 ---
+
 # Forms
 
 Redwood provides several helpers to make building forms easier.

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -1,8 +1,7 @@
 ---
-title: GraphQL
-description: All about using GraphQL in Redwood's sides
-slug: graphql
+description: GraphQL is a fundamental part of Redwood
 ---
+
 # GraphQL
 
 GraphQL is a fundamental part of Redwood. Having said that, you can get going without knowing anything about it, and can actually get quite far without ever having to read [the docs](https://graphql.org/learn/). But to master Redwood, you'll need to have more than just a vague notion of what GraphQL is. You'll have to really grok it.

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -1,3 +1,8 @@
+---
+title: GraphQL
+description: All about using GraphQL in Redwood's sides
+slug: graphql
+---
 # GraphQL
 
 GraphQL is a fundamental part of Redwood. Having said that, you can get going without knowing anything about it, and can actually get quite far without ever having to read [the docs](https://graphql.org/learn/). But to master Redwood, you'll need to have more than just a vague notion of what GraphQL is. You'll have to really grok it.
@@ -8,16 +13,16 @@ Since there's two parts to GraphQL in Redwood, the client and the server, we've 
 
 On the `web` side, Redwood uses [Apollo Client](https://www.apollographql.com/docs/react/) by default though you can swap it out for something else if you want.
 
-The `api` side offers a GraphQL server built on [GraphQL Helix](https://dev.to/danielrearden/building-a-graphql-server-with-graphql-helix-2k44) and the [Envelop plugin system](https://www.envelop.dev/docs) from [The Guild](https://the-guild.dev).
+The `api` side offers a GraphQL server built on [GraphQL Yoga]https://www.graphql-yoga.com) and the [Envelop plugin system](https://www.envelop.dev/docs) from [The Guild](https://the-guild.dev).
 
 Redwood's api side is "serverless first", meaning it's architected as functions which can be deployed on either serverless or traditional infrastructure, and Redwood's GraphQL endpoint is effectively "just another function" (with a whole lot more going on under the hood, but that part is handled for you, out of the box).
 One of the tenets of the Redwood philosophy is "Redwood believes that, as much as possible, you should be able to operate in a serverless mindset and deploy to a generic computational grid.”
 
 To be able to deploy to a “generic computation grid” means that, as a developer, you should be able to deploy using the provider or technology of your choosing. You should be able to deploy to Netlify, Vercel, Fly, Render, AWS Serverless, or elsewhere with ease and no vendor or platform lock in. You should be in control of the framework, what the response looks like, and how your clients consume it.
 
-The same should be true of your GraphQL Server. [GraphQL Helix](https://dev.to/danielrearden/building-a-graphql-server-with-graphql-helix-2k44) makes that possible.
+The same should be true of your GraphQL Server. [GraphQL Yoga](https://www.graphql-yoga.com) makes that possible.
 
-> Existing libraries like Apollo Server provide you with either a complete HTTP server or a middleware function that you can plug into your framework of choice. GraphQL Helix takes a different approach—it just provides a handful of functions that you can use to turn an HTTP request into a GraphQL execution result. In other words, GraphQL Helix leaves it up to you to decide how to send back the response.
+> Existing libraries like Apollo Server provide you with either a complete HTTP server or a middleware function that you can plug into your framework of choice. GraphQL Yoga takes a different approach—it just provides a handful of functions that you can use to turn an HTTP request into a GraphQL execution result. In other words, GraphQL Yoga leaves it up to you to decide how to send back the response.
 
 We leverage Envelop plugins to provide GraphQL [security best practices](#security) and implement custom internal plugins to help with authentication, [logging](#logging), [directive handling](#directives), and more.
 
@@ -263,7 +268,7 @@ export const handler = createGraphQLHandler({
 })
 ```
 
-> **Note:** If you use the preview GraphQL Helix/Envelop `graphql-server` package and a custom ContextFunction to modify the context in the createGraphQL handler, the function is provided **_only the context_** and **_not the event_**. However, the `event` information is available as an attribute of the context as `context.event`. Therefore, in the above example, one would fetch the ip address from the event this way: `ipAddress({ event: context.event })`.
+> **Note:** If you use the preview GraphQL Yoga/Envelop `graphql-server` package and a custom ContextFunction to modify the context in the createGraphQL handler, the function is provided **_only the context_** and **_not the event_**. However, the `event` information is available as an attribute of the context as `context.event`. Therefore, in the above example, one would fetch the ip address from the event this way: `ipAddress({ event: context.event })`.
 
 ### The Root Schema
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -1,8 +1,7 @@
 ---
-title: Introduction
-description: Redwood is the full-stack web framework designed to help you grow from side project to startup.
-slug: introduction
+description: Redwood is the full-stack web framework designed to help you grow from side project to startup
 ---
+
 # Introduction
 
 Redwood is the full-stack web framework designed to help you grow from side project to startup.

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Introduction
+description: Redwood is the full-stack web framework designed to help you grow from side project to startup.
+slug: introduction
+---
 # Introduction
 
 Redwood is the full-stack web framework designed to help you grow from side project to startup.

--- a/docs/docs/local-postgres-setup.md
+++ b/docs/docs/local-postgres-setup.md
@@ -1,8 +1,7 @@
 ---
-title: Local Postgres Setup
 description: Setup a Postgres database to develop locally
-slug: local-postgres-setup
 ---
+
 # Local Postgres Setup
 
 RedwoodJS uses a SQLite database by default. While SQLite makes local development easy, you're

--- a/docs/docs/local-postgres-setup.md
+++ b/docs/docs/local-postgres-setup.md
@@ -1,3 +1,8 @@
+---
+title: Local Postgres Setup
+description: Setup a Postgres database to develop locally
+slug: local-postgres-setup
+---
 # Local Postgres Setup
 
 RedwoodJS uses a SQLite database by default. While SQLite makes local development easy, you're

--- a/docs/docs/logger.md
+++ b/docs/docs/logger.md
@@ -1,8 +1,8 @@
 ---
 title: Logging
-description: Use the Redwood Logger to observe your application
-slug: logger
+description: Use the Logger to observe your application
 ---
+
 # Logger
 
 RedwoodJS provides an opinionated logger with sensible, practical defaults that grants you visibility into the applications while you're developing and after you have deployed.

--- a/docs/docs/logger.md
+++ b/docs/docs/logger.md
@@ -1,3 +1,8 @@
+---
+title: Logging
+description: Use the Redwood Logger to observe your application
+slug: logger
+---
 # Logger
 
 RedwoodJS provides an opinionated logger with sensible, practical defaults that grants you visibility into the applications while you're developing and after you have deployed.

--- a/docs/docs/mocking-graphql-requests.md
+++ b/docs/docs/mocking-graphql-requests.md
@@ -1,8 +1,7 @@
 ---
-title: Mocking GraphQL Requests
-description: Mock your GraphQL requests to test your components
-slug: mocking-graphql-requests
+description: Mock GraphQL requests to test your components
 ---
+
 # Mocking GraphQL Requests
 
 Testing and building components without having to rely on the API is a good best practice. Redwood makes this possible via `mockGraphQLQuery` and `mockGraphQLMutation`.

--- a/docs/docs/mocking-graphql-requests.md
+++ b/docs/docs/mocking-graphql-requests.md
@@ -1,4 +1,9 @@
-# Mocking GraphQL requests
+---
+title: Mocking GraphQL Requests
+description: Mock your GraphQL requests to test your components
+slug: mocking-graphql-requests
+---
+# Mocking GraphQL Requests
 
 Testing and building components without having to rely on the API is a good best practice. Redwood makes this possible via `mockGraphQLQuery` and `mockGraphQLMutation`.
 

--- a/docs/docs/prerender.md
+++ b/docs/docs/prerender.md
@@ -1,5 +1,5 @@
 ---
-description: Render pages ahead of time for a faster user experience
+description: Render pages ahead of time
 ---
 
 # Prerender

--- a/docs/docs/prerender.md
+++ b/docs/docs/prerender.md
@@ -1,3 +1,8 @@
+---
+title: Prerender
+description: Render pages ahead of time for a faster experience
+slug: prerender
+---
 # Prerender
 
 Some of your pages don't have dynamic content; it'd be great if you could render them ahead of time, making for a faster experience for your end users.

--- a/docs/docs/prerender.md
+++ b/docs/docs/prerender.md
@@ -1,8 +1,7 @@
 ---
-title: Prerender
-description: Render pages ahead of time for a faster experience
-slug: prerender
+description: Render pages ahead of time for a faster user experience
 ---
+
 # Prerender
 
 Some of your pages don't have dynamic content; it'd be great if you could render them ahead of time, making for a faster experience for your end users.

--- a/docs/docs/project-configuration-dev-test-build.mdx
+++ b/docs/docs/project-configuration-dev-test-build.mdx
@@ -1,6 +1,6 @@
 ---
 title: Project Configuration
-description: Configure your project for development, test, and build
+description: Advanced project configuration
 ---
 
 import ReactPlayer from 'react-player'

--- a/docs/docs/project-configuration-dev-test-build.mdx
+++ b/docs/docs/project-configuration-dev-test-build.mdx
@@ -1,7 +1,6 @@
 ---
 title: Project Configuration
-description: Configure your Project for  Development, Test, Build
-slug: project-configuration
+description: Configure your project for development, test, and build
 ---
 
 import ReactPlayer from 'react-player'

--- a/docs/docs/project-configuration-dev-test-build.mdx
+++ b/docs/docs/project-configuration-dev-test-build.mdx
@@ -1,3 +1,9 @@
+---
+title: Project Configuration
+description: Configure your Project for  Development, Test, Build
+slug: project-configuration
+---
+
 import ReactPlayer from 'react-player'
 
 # Project Configuration: Dev, Test, Build

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -1,7 +1,5 @@
 ---
-title: Quick Start
-description: RedwoodJS Quick Start
-slug: quick-start
+description: Redwood quick start
 ---
 
 # Quick Start

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -1,3 +1,9 @@
+---
+title: Quick Start
+description: RedwoodJS Quick Start
+slug: quick-start
+---
+
 # Quick Start
 
 > **Prerequisites**

--- a/docs/docs/redwoodrecord.md
+++ b/docs/docs/redwoodrecord.md
@@ -1,3 +1,8 @@
+---
+title: RedwoodRecord
+description: An ORM with a natural interface to the underlying data in your database
+slug: redwood-record
+---
 # RedwoodRecord
 
 > RedwoodRecord is currently considered to be **Experimental**. We are hoping folks will start using it and give us feedback to help shape it's development and developer experience.

--- a/docs/docs/redwoodrecord.md
+++ b/docs/docs/redwoodrecord.md
@@ -1,8 +1,7 @@
 ---
-title: RedwoodRecord
-description: An ORM with a natural interface to the underlying data in your database
-slug: redwood-record
+description: An ORM with a natural interface
 ---
+
 # RedwoodRecord
 
 > RedwoodRecord is currently considered to be **Experimental**. We are hoping folks will start using it and give us feedback to help shape it's development and developer experience.

--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -1,3 +1,8 @@
+---
+title: Router
+description: About the built-in router for Redwood apps
+slug: router
+---
 # Router
 
 This is the built-in router for Redwood apps. It takes inspiration from Ruby on Rails, React Router, and Reach Router, but is very opinionated in its own way.

--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -1,8 +1,7 @@
 ---
-title: Router
 description: About the built-in router for Redwood apps
-slug: router
 ---
+
 # Router
 
 This is the built-in router for Redwood apps. It takes inspiration from Ruby on Rails, React Router, and Reach Router, but is very opinionated in its own way.

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -1,8 +1,7 @@
 ---
-title: Prisma Relations and Generators
-description: Explains how Prisma relations work with scaffolding
-slug: schema-relations
+description: How Prisma relations work with scaffolds
 ---
+
 # Prisma Relations and Redwood's Generators
 
 These docs apply to Redwood v0.25 and greater. Previous versions of Redwood had limitations when creating scaffolds for any one-to-many or many-to-many relationships. Most of those have been resolved so you should definitely [upgrade to 0.25](https://community.redwoodjs.com/t/upgrading-to-redwoodjs-v0-25-and-prisma-v2-16-db-upgrades-and-project-code-mods/1811) if at all possible!

--- a/docs/docs/schema-relations.md
+++ b/docs/docs/schema-relations.md
@@ -1,3 +1,8 @@
+---
+title: Prisma Relations and Generators
+description: Explains how Prisma relations work with scaffolding
+slug: schema-relations
+---
 # Prisma Relations and Redwood's Generators
 
 These docs apply to Redwood v0.25 and greater. Previous versions of Redwood had limitations when creating scaffolds for any one-to-many or many-to-many relationships. Most of those have been resolved so you should definitely [upgrade to 0.25](https://community.redwoodjs.com/t/upgrading-to-redwoodjs-v0-25-and-prisma-v2-16-db-upgrades-and-project-code-mods/1811) if at all possible!

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -1,3 +1,8 @@
+---
+title: Security
+description: Build and deploy secure applications
+slug: security
+---
 # Security
 
 RedwoodJS wants you to be able build and deploy secure applications and takes the topic of security seriously.

--- a/docs/docs/security.md
+++ b/docs/docs/security.md
@@ -1,8 +1,7 @@
 ---
-title: Security
 description: Build and deploy secure applications
-slug: security
 ---
+
 # Security
 
 RedwoodJS wants you to be able build and deploy secure applications and takes the topic of security seriously.

--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -1,8 +1,7 @@
 ---
-title: SEO & Meta Tags
-description: Use <MetaTags> to set page info for SEO
-slug: seo
+description: Use meta tags to set page info for SEO
 ---
+
 # SEO & Meta tags
 
 ## Add app title

--- a/docs/docs/seo-head.md
+++ b/docs/docs/seo-head.md
@@ -1,3 +1,8 @@
+---
+title: SEO & Meta Tags
+description: Use <MetaTags> to set page info for SEO
+slug: seo
+---
 # SEO & Meta tags
 
 ## Add app title

--- a/docs/docs/serverless-functions.md
+++ b/docs/docs/serverless-functions.md
@@ -1,3 +1,8 @@
+---
+title: Serverless Functions
+description: Create, develop, and runn serverless functions
+slug: serverless-functions
+---
 # Serverless Functions
 
 <!-- `redwood.toml`&mdash;`api/src/functions` by default.  -->

--- a/docs/docs/serverless-functions.md
+++ b/docs/docs/serverless-functions.md
@@ -1,8 +1,7 @@
 ---
-title: Serverless Functions
-description: Create, develop, and runn serverless functions
-slug: serverless-functions
+description: Create, develop, and run serverless functions
 ---
+
 # Serverless Functions
 
 <!-- `redwood.toml`&mdash;`api/src/functions` by default.  -->

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -1,3 +1,8 @@
+---
+title: Services
+description: Put all of your business logic in one place
+slug: services
+---
 # Services
 
 Redwood aims to put all of your business logic in one place—Services. These can be used by your GraphQL API or any other place in your backend code. Redwood does all of the annoying stuff for you, just write your business logic!

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -1,11 +1,10 @@
 ---
-title: Services
-description: Put all of your business logic in one place
-slug: services
+description: Put all your business logic in one place
 ---
+
 # Services
 
-Redwood aims to put all of your business logic in one place—Services. These can be used by your GraphQL API or any other place in your backend code. Redwood does all of the annoying stuff for you, just write your business logic!
+Redwood aims to put all your business logic in one place—Services. These can be used by your GraphQL API or any other place in your backend code. Redwood does all the annoying stuff for you, just write your business logic!
 
 ## Overview
 
@@ -122,7 +121,7 @@ import { validate, validateWith, validateUniqueness } from '@redwoodjs/api'
 
 ### validate()
 
-This is the main function to call when you have a piece of data to validate. There are two forms of this function call, one with 2 arguments and one with 3. The first argument is always the variable to validate and the last argument is an object with all of the validations you want to run against the first argument. The (optional) second argument is the name of the field to be used in a default error message if you do not provide a custom one:
+This is the main function to call when you have a piece of data to validate. There are two forms of this function call, one with 2 arguments and one with 3. The first argument is always the variable to validate and the last argument is an object with all the validations you want to run against the first argument. The (optional) second argument is the name of the field to be used in a default error message if you do not provide a custom one:
 
 ```jsx
 // Two argument form: validate(value, validations)
@@ -654,7 +653,7 @@ yarn rw dev
 3. [Optional] An object with options.
 4. Callback to be invoked if record is found to be unique.
 
-In its most basic usage, say you want to make sure that a user's email address is unique before creating the record. `input` is an object containing all of the user fields to save to the database, including `email` which must be unique:
+In its most basic usage, say you want to make sure that a user's email address is unique before creating the record. `input` is an object containing all the user fields to save to the database, including `email` which must be unique:
 
 ```jsx
 const createUser = (input) => {

--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -1,8 +1,7 @@
 ---
-title: Storybook
 description: A frontend-first, component-driven development workflow
-slug: storybook
 ---
+
 # Storybook
 
 Storybook enables a kind of frontend-first, component-driven development workflow that we've always wanted.

--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -1,5 +1,5 @@
 ---
-description: A frontend-first, component-driven development workflow
+description: A component-driven development workflow
 ---
 
 # Storybook

--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -1,3 +1,8 @@
+---
+title: Storybook
+description: A frontend-first, component-driven development workflow
+slug: storybook
+---
 # Storybook
 
 Storybook enables a kind of frontend-first, component-driven development workflow that we've always wanted.

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,8 +1,7 @@
 ---
-title: Testing
-description: Comprehensive reference for testing your application
-slug: testing
+description: A comprehensive reference for testing your app
 ---
+
 # Testing
 
 Testing. For some it's an essential part of their development workflow. For others it's something they know they *should* do, but for whatever reason it hasn't struck their fancy yet. For others still it's something they ignore completely, hoping the whole concept will go away. But tests are here to stay, and maybe Redwood can change some opinions about testing being awesome and fun.

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,3 +1,8 @@
+---
+title: Testing
+description: Comprehensive reference for testing your application
+slug: testing
+---
 # Testing
 
 Testing. For some it's an essential part of their development workflow. For others it's something they know they *should* do, but for whatever reason it hasn't struck their fancy yet. For others still it's something they ignore completely, hoping the whole concept will go away. But tests are here to stay, and maybe Redwood can change some opinions about testing being awesome and fun.

--- a/docs/docs/toast-notifications.md
+++ b/docs/docs/toast-notifications.md
@@ -1,3 +1,8 @@
+---
+title: Toast Notifications
+description: Render toast notifications with built-in components
+slug: toast
+---
 # Toast Notifications
 
 Did you know that those little popup notifications that you sometimes see at the top of a page after you've performed an action are affectionately known as "toast" notifications?

--- a/docs/docs/toast-notifications.md
+++ b/docs/docs/toast-notifications.md
@@ -1,7 +1,6 @@
 ---
 title: Toast Notifications
 description: Render toast notifications with built-in components
-slug: toast
 ---
 # Toast Notifications
 

--- a/docs/docs/toast-notifications.md
+++ b/docs/docs/toast-notifications.md
@@ -1,7 +1,7 @@
 ---
-title: Toast Notifications
-description: Render toast notifications with built-in components
+description: Toast notifications with react-hot-toast
 ---
+
 # Toast Notifications
 
 Did you know that those little popup notifications that you sometimes see at the top of a page after you've performed an action are affectionately known as "toast" notifications?

--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -1,3 +1,8 @@
+---
+title: TypeScript
+description: Redwood comes with full TypeScript support
+slug: typescript
+---
 # TypeScript
 
 Redwood comes with full TypeScript support, and you don't have to give up any of the conveniences that Redwood offers to enjoy all the benefits of a type-safe codebase.

--- a/docs/docs/typescript.md
+++ b/docs/docs/typescript.md
@@ -1,8 +1,7 @@
 ---
-title: TypeScript
 description: Redwood comes with full TypeScript support
-slug: typescript
 ---
+
 # TypeScript
 
 Redwood comes with full TypeScript support, and you don't have to give up any of the conveniences that Redwood offers to enjoy all the benefits of a type-safe codebase.

--- a/docs/docs/webhooks.md
+++ b/docs/docs/webhooks.md
@@ -1,3 +1,8 @@
+---
+title: Webhooks
+description: Integrate third-party services with webhooks securely
+slug: webhooks
+---
 # Webhooks
 
 If you've used [Automate](https://automate.io/), [IFTTT](https://ifttt.com/maker_webhooks), [Pipedream](https://pipedream.com/docs/api/rest/webhooks/), or [Zapier](https://zapier.com/apps/webhook/integrations) then you're familiar with how webhooks can give your app the power to create complex workflows, build one-to-one automation, and sync data between apps. RedwoodJS helps you work with webhooks by giving you the tools to both receive and verify incoming webhooks and sign outgoing ones with ease.

--- a/docs/docs/webhooks.md
+++ b/docs/docs/webhooks.md
@@ -1,8 +1,7 @@
 ---
-title: Webhooks
-description: Integrate third-party services with webhooks securely
-slug: webhooks
+description: Securely integrate third-party services
 ---
+
 # Webhooks
 
 If you've used [Automate](https://automate.io/), [IFTTT](https://ifttt.com/maker_webhooks), [Pipedream](https://pipedream.com/docs/api/rest/webhooks/), or [Zapier](https://zapier.com/apps/webhook/integrations) then you're familiar with how webhooks can give your app the power to create complex workflows, build one-to-one automation, and sync data between apps. RedwoodJS helps you work with webhooks by giving you the tools to both receive and verify incoming webhooks and sign outgoing ones with ease.

--- a/docs/docs/webpack-configuration.md
+++ b/docs/docs/webpack-configuration.md
@@ -1,3 +1,8 @@
+---
+title: Webpack Configuration
+description: If you have to configure webpack, here's how.
+slug: webpack
+---
 # Webpack Configuration
 
 Redwood uses webpack. And with webpack comes configuration.

--- a/docs/docs/webpack-configuration.md
+++ b/docs/docs/webpack-configuration.md
@@ -1,8 +1,7 @@
 ---
-title: Webpack Configuration
-description: If you have to configure webpack, here's how.
-slug: webpack
+description: If you have to configure webpack, here's how
 ---
+
 # Webpack Configuration
 
 Redwood uses webpack. And with webpack comes configuration.


### PR DESCRIPTION
This PR adds title and description frontmatter to clean up the reference section docs to avoid displaying just the first line of the page content. Also, used for SEO.

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/1051633/161422062-74c429d4-47c9-425b-897d-c4251c3a2e06.png">
