### PR TITLE
Update docs node version requirement to reflect current redwood reqs

### DIFF
--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19.0 <17.0.0"
+- node: ">=14.19 <=16.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.17 <=16.x"
+- node: ">=14.19.0 <17.0.0"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:


### PR DESCRIPTION
Wasn't sure whether to keep `<= 16.x` format from current docs, or switch to `< 17.0.0` from current redwood CLI error message, but opted for the latter