### PR TITLE
Use `nmMode: hardlinks-global` to reduce disk space consumption

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,7 +2,7 @@ compressionLevel: 0
 
 enableGlobalCache: true
 
-nmMode: hardlinks-local
+nmMode: hardlinks-global
 
 nodeLinker: node-modules
 


### PR DESCRIPTION
This could alleviate some of the perceived pain of pnpm-fanfolks (like me) when starting their RedwoodJS journey.

It saves ~0.8 GB of disk space for any additional fresh `yarn install` of a redwood project and also, (at least in theory) is faster as those packages will be linked rather than copied into the project folder.

I've used this setting in an existing project for a couple of weeks now and could not observe any negative side-effects. However, leaving this off to the RedwoodJS dev team to review and decide whether you'd like to merge this enhancement.