### PR TITLE
(docs) update intro section links for Auth and Deploy Docs

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -8,20 +8,20 @@ description: Set up an authentication provider
 
 We currently support the following third-party authentication providers:
 
-- [Netlify Identity Widget](https://github.com/netlify/netlify-identity-widget)
-- [Auth0](https://github.com/auth0/auth0-spa-js)
-- [Azure Active Directory](https://github.com/AzureAD/microsoft-authentication-library-for-js)
-- [Clerk](https://clerk.dev)
-- [Netlify GoTrue-JS](https://github.com/netlify/gotrue-js)
-- [Magic Links - Magic.js](https://github.com/MagicHQ/magic-js)
-- [Firebase](https://firebase.google.com/docs/auth)
-- [Ethereum](https://github.com/oneclickdapp/ethereum-auth)
-- [Supabase](https://supabase.io/docs/guides/auth)
-- [Nhost](https://docs.nhost.io/platform/authentication)
+- Netlify Identity _([Repo on GitHub](https://github.com/netlify/netlify-identity-widget))_
+- Netlify GoTrue-JS _([Repo on GitHub](https://github.com/netlify/gotrue-js))_
+- Auth0 _([Repo on GitHub](https://github.com/auth0/auth0-spa-js))_
+- Clerk _([Website](https://clerk.dev))_
+- Azure Active Directory _([Repo on GitHub](https://github.com/AzureAD/microsoft-authentication-library-for-js))_
+- Magic Links - Magic.js _([Repo on GitHub](https://github.com/MagicHQ/magic-js))_
+- Firebase _([Documentation Website](https://firebase.google.com/docs/auth))_
+- Supabase _([Documentation Website](https://supabase.io/docs/guides/auth))_
+- Ethereum _([Repo on GitHub](https://github.com/oneclickdapp/ethereum-auth))_
+- Nhost _([Documentation Website](https://docs.nhost.io/platform/authentication))_
 - Custom
 - [Contribute one](https://github.com/redwoodjs/redwood/tree/main/packages/auth), it's SuperEasy™!
 
-Check out the [Auth Playground](https://github.com/redwoodjs/playground-auth).
+> 👉 Check out the [Auth Playground](https://github.com/redwoodjs/playground-auth).
 
 ## Self-hosted Auth Installation and Setup
 

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -8,12 +8,12 @@ Redwood is designed for both serverless and traditional infrastructure deploymen
 4. the hosting provider deploys the built Web static assets to a CDN and the API code to a serverless backend (e.g. AWS Lambdas)
 
 Currently, these are the officially supported deploy targets:
-- [Flightcontrol](https://www.flightcontrol.dev?ref=redwood)
-- [Layer0](https://layer0.co)
-- [Netlify](https://www.netlify.com/)
-- [Render](https://render.com)
+- [Flightcontrol.dev](https://www.flightcontrol.dev?ref=redwood)
+- [Layer0.co](https://layer0.co)
+- [Netlify.com](https://www.netlify.com/)
+- [Render.com](https://render.com)
 - [Serverless.com](https://serverless.com)
-- [Vercel](https://vercel.com)
+- [Vercel.com](https://vercel.com)
 - Baremetal (physical server that you have SSH access to)
 
 


### PR DESCRIPTION
Tweaking the intros for Auth and Deploy docs in attempt to clarify that the links are to external URLs and _not_ sections within the doc itself.