### PR TITLE
Add deployment index page

### DIFF
--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -1,6 +1,10 @@
+---
+description: Have complete control by hosting your own code
+---
+
 # Introduction to Baremetal
 
-Once you've grown beyond the confines and limitations of the cloud deployment providers, it's time to get serious: hosting your own code on big iron. Prepare for performance like you've only dreamed of! Also be prepared for IT and infrastructure responsibilties like you've only had nightmares of.
+Once you've grown beyond the confines and limitations of the cloud deployment providers, it's time to get serious: hosting your own code on big iron. Prepare for performance like you've only dreamed of! Also be prepared for IT and infrastructure responsibilities like you've only had nightmares of.
 
 With Redwood's Baremetal deployment option, the source (like your dev machine) will SSH into one or more remote machines and execute commands in order to update your codebase, run any database migrations and restart services.
 
@@ -18,13 +22,13 @@ The baremetal deploy runs several commands in sequence. These can be customized,
 2. `yarn install` - installs dependencies
 3. `yarn rw prisma migrate deploy` - runs db migrations
 3. `yarn rw prisma generate` - generates latest Prisma Client libs
-4. `yarn rw dataMigrate up` - runs data migrations, igorning them if not installed
+4. `yarn rw dataMigrate up` - runs data migrations, ignoring them if not installed
 5. `yarn rw build` - builds the web and/or api sides
 6. `yarn pm2 restart [service]` - restarts the serving process(es)
 
 There is a special `--first-run` flag which can be included in your deploy command the first time you run it, which starts the PM2 services rather than restarting them.
 
-> We're working on making the commands in this stack more customizeable, for example `clone`ing your code instead of doing a `git pull` to avoid issues like not being able to pull because your `yarn.lock` file has changes that would be overwritten.
+> We're working on making the commands in this stack more customizable, for example `clone`ing your code instead of doing a `git pull` to avoid issues like not being able to pull because your `yarn.lock` file has changes that would be overwritten.
 
 ## Setup
 
@@ -41,7 +45,7 @@ This will create a couple of files and add a dependency or two to your `package.
 
 > **A Note about PM2 Licensing**
 >
-> PM2 is licensed under [AGPL v3.0](https://opensource.org/licenses/AGPL-3.0) ([here's a plain english interpretation](https://snyk.io/learn/agpl-license/)) which may have implications for your codebase. We are not laywers, but some interpretations of the license say that if you include any software that is AGPL v3.0 then your own codebase must be released under AGPL v3.0 as well. In the case of baremetal deploys, we not including any PM2 code in your app, just counting on the PM2 daemon to monitor your web/api services to be sure they continue running.
+> PM2 is licensed under [AGPL v3.0](https://opensource.org/licenses/AGPL-3.0) ([here's a plain english interpretation](https://snyk.io/learn/agpl-license/)) which may have implications for your codebase. We are not lawyers, but some interpretations of the license say that if you include any software that is AGPL v3.0 then your own codebase must be released under AGPL v3.0 as well. In the case of baremetal deploys, we not including any PM2 code in your app, just counting on the PM2 daemon to monitor your web/api services to be sure they continue running.
 
 If you see an error from `gyp` you may need to add some additional dependencies before `yarn install` will be able to complete. See the README for `node-type` for more info: https://github.com/nodejs/node-gyp#installation
 
@@ -121,7 +125,7 @@ The easiest connection method is generally to include your own public key in the
 
 #### Multiple Servers
 
-If you start horizontally scaling your application you may find it necessary to have the web and api sides served from different servers. The configuration files can accomodate this:
+If you start horizontally scaling your application you may find it necessary to have the web and api sides served from different servers. The configuration files can accommodate this:
 
 ```toml title="deploy.toml"
 [[servers]]

--- a/docs/docs/deploy/flightcontrol.md
+++ b/docs/docs/deploy/flightcontrol.md
@@ -1,3 +1,7 @@
+---
+description: Bring DX to your AWS account
+---
+
 # Deploy to Flightcontrol
 
 [Flightcontrol](https://www.flightcontrol.dev?ref=redwood) is a new platform that brings world-class deployment DX natively to your AWS account. It's easy to use but lets you pop the hood and leverage the raw power of AWS when needed. It currently supports servers, static sites, and databases which makes it a perfect fit for hosting scalable Redwood apps.

--- a/docs/docs/deploy/introduction.md
+++ b/docs/docs/deploy/introduction.md
@@ -1,3 +1,7 @@
+---
+description: Deploy to serverless or serverful providers
+---
+
 # Introduction to Deployment
 
 Redwood is designed for both serverless and traditional infrastructure deployments, offering a unique continuous deployment process in both cases:

--- a/docs/docs/deploy/netlify.md
+++ b/docs/docs/deploy/netlify.md
@@ -1,11 +1,18 @@
+---
+description: The serverless git deploy you know and love
+---
+
 # Deploy to Netlify
 
 ## Netlify tl;dr Deploy
+
 If you simply want to experience the Netlify deployment process without a database and/or adding custom code, you can do the following:
+
 1. create a new redwood project: `yarn create redwood-app ./netlify-deploy`
 2. after your "netlify-deploy" project installation is complete, init git, commit, and add it as a new repo to GitHub, BitBucket, or GitLab
 3. run the command `yarn rw setup deploy netlify` and commit and push changes
 4. use the Netlify [Quick Start](https://app.netlify.com/signup) to deploy
 
 ## Netlify Complete Deploy Walkthrough
+
 For the complete deployment process on Netlify, see the [Tutorial Deployment section](tutorial/chapter4/deployment.md).

--- a/docs/docs/deploy/render.md
+++ b/docs/docs/deploy/render.md
@@ -1,3 +1,7 @@
+---
+description: Serverful deploys via Render's unified cloud
+---
+
 # Deploy to Render
 
 Render is a unified cloud to build and run all your apps and websites with free SSL, a global CDN, private networks and auto deploys from Git — **database included**!

--- a/docs/docs/deploy/serverless.md
+++ b/docs/docs/deploy/serverless.md
@@ -1,3 +1,7 @@
+---
+description: Deploy to AWS with Serverless Framework
+---
+
 # Deploy to AWS with Serverless Framework
 
 >The following instructions assume you have read the [General Deployment Setup](#general-deployment-setup) section above.

--- a/docs/docs/deploy/vercel.md
+++ b/docs/docs/deploy/vercel.md
@@ -1,3 +1,7 @@
+---
+description: Deploy serverless in an instant with Vercel
+---
+
 # Deploy to Vercel
 
 >The following instructions assume you have read the [General Deployment Setup](#general-deployment-setup) section above.
@@ -11,7 +15,6 @@ If you simply want to experience the Vercel deployment process without a databas
 4. use the Vercel [Quick Start](https://vercel.com/#get-started) to deploy
 
 _If you choose this quick deploy experience, the following steps do not apply._
-
 
 ## Redwood Project Setup
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -83,7 +83,14 @@ module.exports = {
         'custom-web-index',
         'data-migrations',
         {
-          Deployment: [
+          type: 'category',
+          label: 'Deployment',
+          link: {
+            type: 'generated-index',
+            title: 'Deployment',
+            slug: 'deployment/index',
+          },
+          items: [
             { type: 'doc', label: 'Introduction', id: 'deploy/introduction' },
             { type: 'doc', label: 'Baremetal', id: 'deploy/baremetal' },
             { type: 'doc', label: 'Flightcontrol', id: 'deploy/flightcontrol' },


### PR DESCRIPTION
Over in https://github.com/redwoodjs/redwood/pull/4993#issuecomment-1086910496, @thedavidprice suggested every top-level category have an index page. Since the mobile UX relies on breadcrumbs, making sure they're consistently clickable is important. This PR adds an index page to the deployment subcategory.

Besides the deployment subcategory, only the Tutorial and its categories lack index pages. @thedavidprice do we want this for the tutorial as well?