### PR TITLE
[Tutorial] Chapter 2: Wrap rendered `<article>` in React fragments

### DIFF
--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -270,17 +270,21 @@ The page should now show a dump of all the data you created for any blog posts y
 
 Now we're in the realm of good ol' React components, so just build out the `Success` component to display the blog post in a nicer format:
 
-```jsx {2-10} title="web/src/components/ArticlesCell/ArticlesCell.js"
+```jsx {3-13} title="web/src/components/ArticlesCell/ArticlesCell.js"
 export const Success = ({ articles }) => {
-  return articles.map((article) => (
-    <article key={article.id}>
-      <header>
-        <h2>{article.title}</h2>
-      </header>
-      <p>{article.body}</p>
-      <div>Posted at: {article.createdAt}</div>
-    </article>
-  ))
+  return (
+    <>
+      {articles.map((article) => (
+        <article key={article.id}>
+          <header>
+            <h2>{article.title}</h2>
+          </header>
+          <p>{article.body}</p>
+          <div>Posted at: {article.createdAt}</div>
+        </article>
+      ))}
+    </>
+  )
 }
 ```
 

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -15,18 +15,22 @@ import { Link, routes } from '@redwoodjs/router'
 // QUERY, Loading, Empty and Failure definitions...
 
 export const Success = ({ articles }) => {
-  return articles.map((article) => (
-    <article key={article.id}>
-      <header>
-        <h2>
-          // highlight-next-line
-          <Link to={routes.article()}>{article.title}</Link>
-        </h2>
-      </header>
-      <p>{article.body}</p>
-      <div>Posted at: {article.createdAt}</div>
-    </article>
-  ))
+  return (
+    <>
+      {articles.map((article) => (
+        <article key={article.id}>
+          <header>
+            <h2>
+              // highlight-next-line
+              <Link to={routes.article()}>{article.title}</Link>
+            </h2>
+          </header>
+          <p>{article.body}</p>
+          <div>Posted at: {article.createdAt}</div>
+        </article>
+      ))}
+    </>
+  )
 }
 ```
 
@@ -306,10 +310,14 @@ export const Failure = ({ error }) => (
 )
 
 export const Success = ({ articles }) => {
-  return articles.map((article) => (
-    // highlight-next-line
-    <Article key={article.id} article={article} />
-  ))
+  return (
+    <>
+      {articles.map((article) => (
+        // highlight-next-line
+        <Article key={article.id} article={article} />
+      ))}
+    </>
+  )
 }
 ```
 


### PR DESCRIPTION
This avoids warning `'ArticlesCell' cannot be used as a JSX component.
Its return type 'Element[]' is not a valid JSX element.`.

Closes #5008
