### PR TITLE
[Tutorial] Add command to generate SESSION_SECRET

### DIFF
--- a/docs/docs/tutorial/intermission.md
+++ b/docs/docs/tutorial/intermission.md
@@ -38,11 +38,12 @@ If you haven't been through the first tutorial, or maybe you went through it on 
 git clone https://github.com/redwoodjs/redwood-tutorial
 cd redwood-tutorial
 yarn install
+echo "SESSION_SECRET=$(yarn --silent rw g secret --raw)" >> .env
 yarn rw prisma migrate dev
 yarn rw dev
 ```
 
-That'll check out the repo, install all the dependencies, create your local database (SQLite) and fill it with a few blog posts, and finally start up the dev server.
+That'll check out the repo, install all the dependencies, generate a `SESSION_SECRET` environment variable for you in `.env`, create your local database (SQLite) and fill it with a few blog posts, and finally start up the dev server.
 
 Your browser should open to a fresh new blog app:
 


### PR DESCRIPTION
In [chapter 4](https://redwoodjs.com/docs/tutorial/chapter4/authentication) `yarn rw setup auth dbAuth` is [executed](https://redwoodjs.com/docs/authentication#setup) and a `SESSION_SECRET` created.
But that's not the case if you start in the [intermission chapter](https://redwoodjs.com/docs/tutorial/intermission) with a fresh [example repo](https://github.com/redwoodjs/redwood-tutorial).
So you have to create the secret explicitly.
As long as the [tutorial repo](https://github.com/redwoodjs/redwood-tutorial) runs on **Yarn v1** the added command to write directly into the `.env` file should [be valid](https://redwoodjs.com/docs/cli-commands#generate-secret).