### PR TITLE
i18n setup: Fix storybook preview config template

### DIFF
--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.js.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.js.template
@@ -18,7 +18,7 @@ export const globalTypes = {
   },
 }
 
-//**
+/**
  * We're following Storybook's naming convention here. See for example
  * https://github.com/storybookjs/addon-kit/blob/main/src/withGlobals.ts
  * Unfortunately that will make eslint complain, so we have to disable it when


### PR DESCRIPTION
When running `yarn rw setup i18n` it gives you a `web/config/storybook.preview.js` file. There was a minor issue with how a comment was formatted in that file. See screenshot below

![image](https://user-images.githubusercontent.com/30793/162083674-cdba089e-6ec5-4c3b-8323-b4ddcc19ca4e.png)

This PR just removes one of the extra forward slashes that shouldn't be there
