### PR TITLE
Fix typo (`valiation` -> `validation`) in Docs

### DIFF
--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -817,7 +817,7 @@ export const createCar = ({ input }) => {
 }
 ```
 
-You can still include your own custom valiation logic and have the errors handled in the same manner as the built-in validations:
+You can still include your own custom validation logic and have the errors handled in the same manner as the built-in validations:
 
 ```js
 validateWith(() => {


### PR DESCRIPTION
Present in Tutorial -> chapter3