### PR TITLE
Let CI run for docs

### DIFF
--- a/.github/workflows/build-eslint-jest.yaml
+++ b/.github/workflows/build-eslint-jest.yaml
@@ -3,7 +3,6 @@ name: Lint, Build & Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore: ['docs/**']
 
 jobs:
   all:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,7 +3,6 @@ name: Cypress E2E tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore: ['docs/**']
 
 jobs:
   cypress-run:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -3,7 +3,6 @@ name: Smoke test, CLI Checks and Telemetry Benchmarks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore: ['docs/**']
 
 jobs:
   smoke-test:


### PR DESCRIPTION
While we think about https://github.com/redwoodjs/redwood/pull/4848, we should just let CI run (and pass) on docs in the meantime instead of not running at all