### PR TITLE
Don't publish canaries on docs-only changes

### DIFF
--- a/.github/workflows/publish-npm-canary.yaml
+++ b/.github/workflows/publish-npm-canary.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     tags-ignore:
       - v** # We don't want this to run on release
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
For docs-only changes, we definitely want to skip this workflow at least. I think we've already published quite a few 1.0.1 canaries as it is 😅 