### PR TITLE
Add a CI workflow file to create-redwood-app template

### DIFF
--- a/packages/create-redwood-app/template/.github/workflows/ci.yml
+++ b/packages/create-redwood-app/template/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  redwood-project-ci:
+    name: 🌲 Redwood Project CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Redwood Project CI
+        uses: redwoodjs/project-ci-action@v0.1.1


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/2559. Also see discussion in https://github.com/redwoodjs/redwood/pull/2615. We have an action over in https://github.com/redwoodjs/project-ci-action. Let's ship it with redwood apps.