### PR TITLE
Fix for @types/react using new versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:release-script": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
   },
   "resolutions": {
+    "@types/react": "17.0.44",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:release-script": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
   },
   "resolutions": {
-    "@types/react": "17.0.40",
+    "@types/react": "17.0.44",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test:release-script": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
   },
   "resolutions": {
-    "@types/react": "17.0.44",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -32,7 +32,7 @@
     "@nhost/nhost-js": "1.0.11",
     "@supabase/supabase-js": "1.33.3",
     "@types/netlify-identity-widget": "1.9.3",
-    "@types/react": "17.0.40",
+    "@types/react": "17.0.44",
     "firebase": "9.6.11",
     "firebase-admin": "10.0.2",
     "gotrue-js": "0.9.29",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
   "resolutions": {
-    "@types/react": "17.0.40"
+    "@types/react": "17.0.44"
   },
   "dependencies": {
     "@babel/cli": "7.16.7",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -20,9 +20,6 @@
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
-  "resolutions": {
-    "@types/react": "17.0.44"
-  },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
     "pascalcase": "1.0.0",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -21,7 +21,7 @@
     "test:watch": "yarn test --watch"
   },
   "resolutions": {
-    "@types/react": "17.0.40"
+    "@types/react": "17.0.44"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
@@ -36,7 +36,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.1.0",
     "@types/pascalcase": "1.0.1",
-    "@types/react": "17.0.40",
+    "@types/react": "17.0.44",
     "@types/react-dom": "17.0.15",
     "@types/testing-library__jest-dom": "5.14.3",
     "jest": "27.5.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,7 +26,7 @@
     "test:watch": "yarn test --watch"
   },
   "resolutions": {
-    "@types/react": "17.0.40"
+    "@types/react": "17.0.44"
   },
   "dependencies": {
     "@redwoodjs/auth": "1.0.1",
@@ -46,7 +46,7 @@
     "@types/babel-core": "6.25.7",
     "@types/jest": "27.4.1",
     "@types/node": "16.11.27",
-    "@types/react": "17.0.40",
+    "@types/react": "17.0.44",
     "@types/react-dom": "17.0.15",
     "@types/webpack": "5.28.0",
     "babel-jest": "27.5.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,9 +25,6 @@
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
-  "resolutions": {
-    "@types/react": "17.0.44"
-  },
   "dependencies": {
     "@redwoodjs/auth": "1.0.1",
     "@redwoodjs/graphql-server": "1.0.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,9 +35,6 @@
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
-  "resolutions": {
-    "@types/react": "17.0.44"
-  },
   "dependencies": {
     "@apollo/client": "3.5.10",
     "@babel/runtime-corejs3": "7.16.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "test:watch": "yarn test --watch"
   },
   "resolutions": {
-    "@types/react": "17.0.40"
+    "@types/react": "17.0.44"
   },
   "dependencies": {
     "@apollo/client": "3.5.10",
@@ -54,7 +54,7 @@
     "@babel/core": "7.16.7",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/react": "12.1.5",
-    "@types/react": "17.0.40",
+    "@types/react": "17.0.44",
     "@types/react-dom": "17.0.15",
     "@types/testing-library__jest-dom": "5.14.3",
     "jest": "27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8770,18 +8770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.0.5
-  resolution: "@types/react@npm:18.0.5"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: 648fba7666c411e72cf58e13bb066760a8e872f9dc86ccde22c5e5ca711903a40a7cf6cd5c0caa7f7c90c428f6310513f4d39bb7668eb1d46d16443039bc163a
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:17.0.44, @types/react@npm:^17":
+"@types/react@npm:17.0.44":
   version: 17.0.44
   resolution: "@types/react@npm:17.0.44"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5918,7 +5918,7 @@ __metadata:
     "@nhost/nhost-js": 1.0.11
     "@supabase/supabase-js": 1.33.3
     "@types/netlify-identity-widget": 1.9.3
-    "@types/react": 17.0.40
+    "@types/react": 17.0.44
     firebase: 9.6.11
     firebase-admin: 10.0.2
     gotrue-js: 0.9.29
@@ -6125,7 +6125,7 @@ __metadata:
     "@testing-library/react": 12.1.5
     "@testing-library/user-event": 14.1.0
     "@types/pascalcase": 1.0.1
-    "@types/react": 17.0.40
+    "@types/react": 17.0.44
     "@types/react-dom": 17.0.15
     "@types/testing-library__jest-dom": 5.14.3
     jest: 27.5.1
@@ -6369,7 +6369,7 @@ __metadata:
     "@types/babel-core": 6.25.7
     "@types/jest": 27.4.1
     "@types/node": 16.11.27
-    "@types/react": 17.0.40
+    "@types/react": 17.0.44
     "@types/react-dom": 17.0.15
     "@types/webpack": 5.28.0
     babel-jest: 27.5.1
@@ -6394,7 +6394,7 @@ __metadata:
     "@redwoodjs/auth": 1.0.1
     "@testing-library/jest-dom": 5.16.4
     "@testing-library/react": 12.1.5
-    "@types/react": 17.0.40
+    "@types/react": 17.0.44
     "@types/react-dom": 17.0.15
     "@types/testing-library__jest-dom": 5.14.3
     graphql: 16.3.0
@@ -8770,14 +8770,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:17.0.40":
-  version: 17.0.40
-  resolution: "@types/react@npm:17.0.40"
+"@types/react@npm:17.0.44":
+  version: 17.0.44
+  resolution: "@types/react@npm:17.0.44"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 8b32469271f4a7cf22e5cf615a60b8f04d9f9bcf54655a7a075d599204a36bcc28fff18ccfff8c2f498f6a80488c7d5b334ebd297d9d0d3483c2911b390a8464
+  checksum: d83d6999582a17620ac208be392a1713f3d16acd6a0f0e4d5f661e43e35297eb05c89d67ea90e04fc1f1ebf92e7b6cc4353253bbee35ae1695aedf944b9af8dc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8770,7 +8770,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:17.0.44":
+"@types/react@npm:*":
+  version: 18.0.5
+  resolution: "@types/react@npm:18.0.5"
+  dependencies:
+    "@types/prop-types": "*"
+    "@types/scheduler": "*"
+    csstype: ^3.0.2
+  checksum: 648fba7666c411e72cf58e13bb066760a8e872f9dc86ccde22c5e5ca711903a40a7cf6cd5c0caa7f7c90c428f6310513f4d39bb7668eb1d46d16443039bc163a
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:17.0.44, @types/react@npm:^17":
   version: 17.0.44
   resolution: "@types/react@npm:17.0.44"
   dependencies:


### PR DESCRIPTION
Fixes #5189

`@types/react-dom` .15 fixed the semver

This upgrades `@types/react` and removes previous resolutions.

going to release as patch 1.0.2