### PR TITLE
Remove stray @types/react resolution from @redwoodjs/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,9 +31,6 @@
     "build:js": "babel src -d dist --extensions \".js,.ts,.tsx\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "resolutions": {
-    "@types/react": "17.0.44"
-  },
   "dependencies": {
     "@babel/cli": "7.16.7",
     "@babel/core": "7.16.7",


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/5192. In that PR, we removed resolutions in `@redwoodjs/forms`, `@redwoodjs/testing` and `@redwoodjs/web`, but left it in `@redwoodjs/core`. @thedavidprice was there a reason the one in `@redwoodjs/core` was left in? Yarn seems to totally ignore it (this output is from `yarn install`):

```
➤ YN0000: ┌ Project validation
➤ YN0057: │ @redwoodjs/core: Resolutions field will be ignored
➤ YN0000: └ Completed
```