### PR TITLE
Add pm2 as a dev dependency for baremetal deploy

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/providers/baremetal.js
@@ -39,7 +39,7 @@ const notes = [
 export const handler = async ({ force }) => {
   const tasks = new Listr([
     addPackagesTask({
-      packages: ['node-ssh'],
+      packages: ['node-ssh', 'pm2'],
       devDependency: true,
     }),
     addFilesTask({


### PR DESCRIPTION
related to discussions in #5081 

pm2 was missing as a dependency