### PR TITLE
Fix type gen on `yarn rw g directive`

### DIFF
--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -155,7 +155,6 @@ export const handler = async (args) => {
           return execa('yarn rw-gen', [], {
             stdio: 'pipe',
             shell: true,
-            cwd: getPaths().web.base,
           })
         },
       },


### PR DESCRIPTION
Was in the process of reviewing https://github.com/redwoodjs/redwood/pull/5205 and realized that `yarn rw g directive` breaks at generating types:

```
$ yarn rw g directive uppercase
✔ What type of directive would you like to generate? › Validator
  ✔ Generating directive file ...
    ✔ Successfully wrote file `./api/src/directives/uppercase/uppercase.test.js`
    ✔ Successfully wrote file `./api/src/directives/uppercase/uppercase.js`
  ✖ Generating TypeScript definitions and GraphQL schemas ...
    → $ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] <scriptName> ...
    Next steps...
Command failed with exit code 1: yarn rw-gen
Usage Error: Couldn't find a script named "rw-gen".

$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] <scriptName> ...
```

The reason is that `yarn rw-gen` is run in the web directory:

https://github.com/redwoodjs/redwood/blob/60e7c6c778aa43bf0cfbccf252d7fa579c59875a/packages/cli/src/commands/generate/directive/directive.js#L155-L159

Running it in the base directory fixes.