### PR TITLE
Specify `unknown` Type For Relational Field Resolvers In Generated Services

### DIFF
--- a/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
+++ b/packages/cli/src/commands/generate/service/__tests__/__snapshots__/service.test.js.snap
@@ -473,7 +473,7 @@ export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
 }
 
 export const User = {
-  identity: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
+  identity: (_obj: unknown, { root }: ResolverArgs<ReturnType<typeof user>>) =>
     db.user.findUnique({ where: { id: root.id } }).identity(),
 }
 "
@@ -496,8 +496,10 @@ export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
 }
 
 export const User = {
-  userProfiles: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
-    db.user.findUnique({ where: { id: root.id } }).userProfiles(),
+  userProfiles: (
+    _obj: unknown,
+    { root }: ResolverArgs<ReturnType<typeof user>>
+  ) => db.user.findUnique({ where: { id: root.id } }).userProfiles(),
 }
 "
 `;
@@ -519,9 +521,11 @@ export const user = ({ id }: Prisma.UserWhereUniqueInput) => {
 }
 
 export const User = {
-  userProfiles: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
-    db.user.findUnique({ where: { id: root.id } }).userProfiles(),
-  identity: (_obj, { root }: ResolverArgs<ReturnType<typeof user>>) =>
+  userProfiles: (
+    _obj: unknown,
+    { root }: ResolverArgs<ReturnType<typeof user>>
+  ) => db.user.findUnique({ where: { id: root.id } }).userProfiles(),
+  identity: (_obj: unknown, { root }: ResolverArgs<ReturnType<typeof user>>) =>
     db.user.findUnique({ where: { id: root.id } }).identity(),
 }
 "

--- a/packages/cli/src/commands/generate/service/templates/service.ts.template
+++ b/packages/cli/src/commands/generate/service/templates/service.ts.template
@@ -41,5 +41,5 @@ export const delete${singularPascalName} = ({ id }: Prisma.${singularPascalName}
 }<% } %><% if (relations.length) { %>
 
 export const ${singularPascalName} = {<% relations.forEach(relation => { %>
-  ${relation}: (_obj, { root }: ResolverArgs<ReturnType<typeof ${singularCamelName}>>) => db.${singularCamelName}.findUnique({ where: { id: root.id } }).${relation}(),<% }) %>
+  ${relation}: (_obj: unknown, { root }: ResolverArgs<ReturnType<typeof ${singularCamelName}>>) => db.${singularCamelName}.findUnique({ where: { id: root.id } }).${relation}(),<% }) %>
 }<% } %>


### PR DESCRIPTION
When services are generated for models that have relations, Redwood generates field resolvers for those relations. This is very helpful, but defaults to showing alerts in a developer's editor for those lines of code on a TypeScript project. These alerts can be avoided by marking the type as `unknown`, since at the moment that's what it is, and allow users to add type definitions to the arguments if any arguments are added to the field in GraphQL.