### PR TITLE
Print metadata

### DIFF
--- a/packages/api-server/src/__tests__/__snapshots__/logFormatter.test.ts.snap
+++ b/packages/api-server/src/__tests__/__snapshots__/logFormatter.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LogFormatter text input Should format api server request logs 1`] = `
+"[90m20:32:06[39m 🌲 [32mincoming request[39m [37m[39m
+[37m🗒  Metadata[39m
+[37m{[39m
+[37m  \\"name\\": \\"api-server\\",[39m
+[37m  \\"reqId\\": \\"req-5\\",[39m
+[37m  \\"req\\": {[39m
+[37m    \\"method\\": \\"POST\\",[39m
+[37m    \\"url\\": \\"/graphql\\",[39m
+[37m    \\"hostname\\": \\"localhost:8910\\",[39m
+[37m    \\"remoteAddress\\": \\"::1\\",[39m
+[37m    \\"remotePort\\": 64671[39m
+[37m  }[39m
+[37m}[39m
+"
+`;
+
+exports[`LogFormatter text input Should format api server response logs 1`] = `
+"[90m20:32:06[39m 🌲 [32mrequest completed[39m [37m[39m
+[37m🗒  Metadata[39m
+[37m{[39m
+[37m  \\"name\\": \\"api-server\\",[39m
+[37m  \\"reqId\\": \\"req-4\\",[39m
+[37m  \\"res\\": {[39m
+[37m    \\"statusCode\\": 200[39m
+[37m  },[39m
+[37m  \\"responseTime\\": 48.36454105377197[39m
+[37m}[39m
+"
+`;
+
+exports[`LogFormatter text input Should format basic graphql logs 1`] = `
+"[90m20:32:06[39m 🐛 [34mrw-graphql-server[39m [33mGraphQL execution completed: BlogPostsQuery[39m
+"
+`;
+
+exports[`LogFormatter text input Should format regular user logs that has metadata 1`] = `
+"[90m20:51:49[39m 🐛 [33mupdatePost input[39m [37m[39m
+[37m🗒  Metadata[39m
+[37m{[39m
+[37m  \\"input\\": {[39m
+[37m    \\"title\\": \\"A little more about me\\",[39m
+[37m    \\"body\\": \\"Raclette shoreditch before they sold out lyft.\\"[39m
+[37m  }[39m
+[37m}[39m
+"
+`;

--- a/packages/api-server/src/__tests__/logFormatter.test.ts
+++ b/packages/api-server/src/__tests__/logFormatter.test.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk'
+
 import { LogFormatter } from '../logFormatter/index'
 
 const logFormatter = LogFormatter()
@@ -53,10 +55,6 @@ describe('LogFormatter', () => {
       expect(logFormatter(logData)).toMatch('POST')
       expect(logFormatter(logData)).toMatch('200')
     })
-
-    test('Should not format Status Code without a Method', () => {
-      expect(logFormatter({ level: 10, statusCode: 200 })).not.toMatch('200')
-    })
   })
 
   describe('Formats GraphQL injected log data from useRedwoodLogger plugin', () => {
@@ -98,17 +96,6 @@ describe('LogFormatter', () => {
     })
   })
 
-  describe('Unknown log data', () => {
-    test('Should not include an unknown log data attribute', () => {
-      expect(
-        logFormatter({
-          level: 10,
-          unknown: 'I should not see this',
-        })
-      ).not.toMatch('I should not see this')
-    })
-  })
-
   describe('Custom log data', () => {
     test('Should include the custom log attribute text', () => {
       expect(
@@ -119,13 +106,13 @@ describe('LogFormatter', () => {
       ).toMatch('I should see this')
     })
 
-    test('Should include the custom log attribute info a custom emoji and label', () => {
+    test('Should include the custom log attribute info with a special emoji and label', () => {
       expect(
         logFormatter({
           level: 10,
           custom: 'I should see this custom emoji and label',
         })
-      ).toMatch('🗒 Custom')
+      ).toMatch('🗒  Metadata')
     })
 
     test('Should include the custom log attribute info with nested text message', () => {
@@ -174,5 +161,160 @@ describe('LogFormatter', () => {
         },
       })
     ).toMatch('"foo": "bar"')
+  })
+
+  describe('text input', () => {
+    it('Should format graphql logs with data, requestId, userAgent and operationName enabled, plus response cache configured', () => {
+      expect(
+        logFormatter(
+          '{"level":20,"time":1652375352844,"pid":41826,"hostname":"Tobbes-MacBook-Pro.local","name":"rw-graphql-server","operationName":"BlogPostsQuery","query":{},"requestId":"req-4","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.147 Safari/537.36","data":{"blogPosts":[{"id":1,"title":"A little more about me","body":"Raclette shoreditch before they sold out lyft. Ethical bicycle rights meh prism twee. Tote bag ennui vice, slow-carb taiyaki crucifix whatever you probably haven\'t heard of them jianbing raw denim DIY hot chicken. Chillwave blog succulents freegan synth af ramps poutine wayfarers yr seitan roof party squid. Jianbing flexitarian gentrify hexagon portland single-origin coffee raclette gluten-free. Coloring book cloud bread street art kitsch lumbersexual af distillery ethical ugh thundercats roof party poke chillwave.","createdAt":"2022-05-07T07:41:21.150Z","__typename":"Post"},{"id":2,"title":"What is the meaning of life?","body":"Meh waistcoat succulents umami asymmetrical, hoodie post-ironic paleo chillwave tote bag. Trust fund kitsch waistcoat vape, cray offal gochujang food truck cloud bread enamel pin forage. Roof party chambray ugh occupy fam stumptown. Dreamcatcher tousled snackwave, typewriter lyft unicorn pabst portland blue bottle locavore squid PBR&B tattooed.","createdAt":"2022-05-07T07:41:21.150Z","__typename":"Post"},{"id":3,"title":"Welcome to the blog!","body":"I\'m baby single- origin coffee kickstarter lo - fi paleo skateboard.Tumblr hashtag austin whatever DIY plaid knausgaard fanny pack messenger bag blog next level woke.Ethical bitters fixie freegan,helvetica pitchfork 90\'s tbh chillwave mustache godard subway tile ramps art party. Hammock sustainable twee yr bushwick disrupt unicorn, before they sold out direct trade chicharrones etsy polaroid hoodie. Gentrify offal hoodie fingerstache.","createdAt":"2022-05-07T07:41:21.150Z","__typename":"Post"}]},"responseCache":{"hit":false,"didCache":true,"ttl":null},"msg":"GraphQL execution completed: BlogPostsQuery"}'
+        )
+      ).toEqual(
+        [
+          `${chalk.gray('19:09:12')} 🐛 ${chalk.blue(
+            'rw-graphql-server'
+          )} ${chalk.cyan('req-4')} ${chalk.yellow(
+            'GraphQL execution completed: BlogPostsQuery'
+          )} `,
+          chalk.white('\n🏷  BlogPostsQuery') + ' ',
+          chalk.white(
+            [
+              '\n📦 Result Data',
+              '{',
+              '  "blogPosts": [',
+              '    {',
+              '      "id": 1,',
+              '      "title": "A little more about me",',
+              '      "body": "Raclette shoreditch before they sold out lyft. Ethical bicycle rights meh prism twee. Tote bag ennui vice, slow-carb taiyaki crucifix whatever you probably haven\'t heard of them jianbing raw denim DIY hot chicken. Chillwave blog succulents freegan synth af ramps poutine wayfarers yr seitan roof party squid. Jianbing flexitarian gentrify hexagon portland single-origin coffee raclette gluten-free. Coloring book cloud bread street art kitsch lumbersexual af distillery ethical ugh thundercats roof party poke chillwave.",',
+              '      "createdAt": "2022-05-07T07:41:21.150Z",',
+              '      "__typename": "Post"',
+              '    },',
+              '    {',
+              '      "id": 2,',
+              '      "title": "What is the meaning of life?",',
+              '      "body": "Meh waistcoat succulents umami asymmetrical, hoodie post-ironic paleo chillwave tote bag. Trust fund kitsch waistcoat vape, cray offal gochujang food truck cloud bread enamel pin forage. Roof party chambray ugh occupy fam stumptown. Dreamcatcher tousled snackwave, typewriter lyft unicorn pabst portland blue bottle locavore squid PBR&B tattooed.",',
+              '      "createdAt": "2022-05-07T07:41:21.150Z",',
+              '      "__typename": "Post"',
+              '    },',
+              '    {',
+              '      "id": 3,',
+              '      "title": "Welcome to the blog!",',
+              '      "body": "I\'m baby single- origin coffee kickstarter lo - fi paleo skateboard.Tumblr hashtag austin whatever DIY plaid knausgaard fanny pack messenger bag blog next level woke.Ethical bitters fixie freegan,helvetica pitchfork 90\'s tbh chillwave mustache godard subway tile ramps art party. Hammock sustainable twee yr bushwick disrupt unicorn, before they sold out direct trade chicharrones etsy polaroid hoodie. Gentrify offal hoodie fingerstache.",',
+              '      "createdAt": "2022-05-07T07:41:21.150Z",',
+              '      "__typename": "Post"',
+              '    }',
+              '  ]',
+              '}',
+            ].join('\n')
+          ) + ' ',
+          chalk.white(
+            [
+              '\n💾 Response Cache',
+              '{',
+              '  "hit": false,',
+              '  "didCache": true,',
+              '  "ttl": null',
+              '}',
+            ].join('\n')
+          ) + ' ',
+          chalk.gray(
+            '\n🕵️‍♀️ Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.147 Safari/537.36'
+          ),
+          '\n',
+        ].join('')
+      )
+    })
+
+    it('Should format basic graphql logs', () => {
+      expect(
+        logFormatter(
+          '{"level":20,"time":1652380326869,"pid":46072,"hostname":"Tobbes-MacBook-Pro.local","name":"rw-graphql-server","msg":"GraphQL execution completed: BlogPostsQuery"}'
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('Should format api server request logs', () => {
+      expect(
+        logFormatter(
+          '{"level":30,"time":1652380326855,"pid":46072,"hostname":"Tobbes-MacBook-Pro.local","name":"api-server","reqId":"req-5","req":{"method":"POST","url":"/graphql","hostname":"localhost:8910","remoteAddress":"::1","remotePort":64671},"msg":"incoming request"}'
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('Should format api server response logs', () => {
+      expect(
+        logFormatter(
+          '{"level":30,"time":1652380326869,"pid":46072,"hostname":"Tobbes-MacBook-Pro.local","name":"api-server","reqId":"req-4","res":{"statusCode":200},"responseTime":48.36454105377197,"msg":"request completed"}'
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('Should format regular user logs that has metadata', () => {
+      // This is the result of a Redwood app calling
+      // logger.debug({ input }, 'updatePost input')
+      expect(
+        logFormatter(
+          '{"level":20,"time":1652381509868,"pid":46484,"hostname":"Tobbes-MacBook-Pro.local","input":{"title":"A little more about me","body":"Raclette shoreditch before they sold out lyft."},"msg":"updatePost input"}'
+        )
+      ).toMatchSnapshot()
+    })
+
+    it('Should print only metadata, if only metadata is logged', () => {
+      expect(
+        logFormatter(
+          '{"level":20,"time":1652387012644,"pid":49648,"hostname":"Tobbes-MacBook-Pro.local","input":{"title":"A little more about me","body":"Metadata only"}}'
+        )
+      ).toEqual(
+        [
+          `${chalk.gray('22:23:32')} 🐛` + ' ',
+          chalk.white(
+            [
+              '\n🗒  Metadata',
+              '{',
+              '  "input": {',
+              '    "title": "A little more about me",',
+              '    "body": "Metadata only"',
+              '  }',
+              '}',
+            ].join('\n')
+          ),
+          '\n',
+        ].join('')
+      )
+    })
+
+    it('Should print the full details of error objects', () => {
+      expect(
+        logFormatter(
+          '{"level":50,"time":1652385852132,"pid":48711,"hostname":"Tobbes-MacBook-Pro.local","err":{"code":3,"message":"Error number three"},"msg":"We got an error"}'
+        )
+      ).toEqual(
+        [
+          `${chalk.gray('22:04:12')} 🚨 ${chalk.red('We got an error')}` + ' ',
+          chalk.white(
+            [
+              '\n🗒  Metadata',
+              '{',
+              '  "err": {',
+              '    "code": 3,',
+              '    "message": "Error number three"',
+              '  }',
+              '}',
+            ].join('\n')
+          ),
+          '\n',
+        ].join('')
+      )
+    })
+
+    it('Should not crash on malformed json', () => {
+      expect(
+        logFormatter(
+          '{"level":50,"time":1652385852132,"msg":"missing ending quote and curly brace'
+        )
+      ).toEqual(
+        '{"level":50,"time":1652385852132,"msg":"missing ending quote and curly brace\n'
+      )
+    })
   })
 })

--- a/packages/api-server/src/app.ts
+++ b/packages/api-server/src/app.ts
@@ -8,7 +8,7 @@ export type ServerOptionsWithPino = Omit<
   'logger'
 > & { logger?: boolean | pino.LoggerOptions }
 
-export const DEFAULT_API_SERVER_LOGGER_NAME = 'api-server'
+export const DEFAULT_API_SERVER_LOGGER_NAME = 'rw-api-server'
 
 const DEFAULT_OPTIONS: ServerOptionsWithPino = {
   logger: {

--- a/packages/api-server/src/app.ts
+++ b/packages/api-server/src/app.ts
@@ -1,15 +1,37 @@
-import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
+import http from 'http'
 
-const DEFAULT_OPTIONS = {
+import Fastify, { FastifyInstance, FastifyServerOptions } from 'fastify'
+import pino from 'pino'
+
+export type ServerOptionsWithPino = Omit<
+  FastifyServerOptions<http.Server, pino.Logger>,
+  'logger'
+> & { logger?: boolean | pino.LoggerOptions }
+
+export const DEFAULT_API_SERVER_LOGGER_NAME = 'api-server'
+
+const DEFAULT_OPTIONS: ServerOptionsWithPino = {
   logger: {
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
+    name: DEFAULT_API_SERVER_LOGGER_NAME,
   },
 }
 
-export const createApp = (options?: FastifyServerOptions): FastifyInstance => {
-  const app = Fastify(options || DEFAULT_OPTIONS)
+export const createApp = (options?: ServerOptionsWithPino): FastifyInstance => {
+  const fastifyOptions: ServerOptionsWithPino = options || DEFAULT_OPTIONS
 
-  return app
+  // Merge in a default logger name unless the user has already specified a
+  // logger name on their own
+  if (fastifyOptions.logger === true) {
+    fastifyOptions.logger = { name: DEFAULT_API_SERVER_LOGGER_NAME }
+  } else if (fastifyOptions.logger) {
+    fastifyOptions.logger = {
+      name: DEFAULT_API_SERVER_LOGGER_NAME,
+      ...fastifyOptions.logger,
+    }
+  }
+
+  return Fastify(fastifyOptions)
 }
 
 export default createApp

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -2,11 +2,10 @@ import fs from 'fs'
 import path from 'path'
 
 import c from 'ansi-colors'
-import { FastifyServerOptions } from 'fastify'
 
 import { getConfig, getPaths } from '@redwoodjs/internal'
 
-import createApp from './app'
+import createApp, { ServerOptionsWithPino } from './app'
 import withApiProxy from './plugins/withApiProxy'
 import withFunctions from './plugins/withFunctions'
 import withWebServer from './plugins/withWebServer'
@@ -183,5 +182,5 @@ function loadServerConfig() {
 
   console.log(`Loading server config from ${serverConfigPath} \n`)
 
-  return require(serverConfigPath) as FastifyServerOptions
+  return require(serverConfigPath) as ServerOptionsWithPino
 }

--- a/packages/api-server/src/logFormatter/formatters.ts
+++ b/packages/api-server/src/logFormatter/formatters.ts
@@ -1,0 +1,168 @@
+import chalk from 'chalk'
+import prettyBytes from 'pretty-bytes'
+import prettyMs from 'pretty-ms'
+
+const newline = '\n'
+
+const emojiLog: Record<string, string> = {
+  warn: '🚦',
+  info: '🌲',
+  error: '🚨',
+  debug: '🐛',
+  fatal: '💀',
+  trace: '🧵',
+}
+
+const isObjectWithData = (object?: Record<string, unknown>) => {
+  return object && Object.keys(object).length > 0
+}
+
+const isWideEmoji = (character: string) => {
+  return character !== '🚦'
+}
+
+export const formatBundleSize = (bundleSize: string) => {
+  const bytes = parseInt(bundleSize, 10)
+  const size = prettyBytes(bytes).replace(/ /, '')
+  return chalk.gray(size)
+}
+
+export const formatMetadata = (metadata?: Record<string, unknown>) => {
+  return isObjectWithData(metadata)
+    ? chalk.white(
+        newline + '🗒  Metadata' + newline + JSON.stringify(metadata, null, 2)
+      )
+    : undefined
+}
+
+export const formatData = (data?: Record<string, unknown>) => {
+  return isObjectWithData(data)
+    ? chalk.white(
+        newline + '📦 Result Data' + newline + JSON.stringify(data, null, 2)
+      )
+    : undefined
+}
+
+export const formatDate = (instant: number) => {
+  const date = new Date(instant)
+  const hours = date.getHours().toString().padStart(2, '0')
+  const minutes = date.getMinutes().toString().padStart(2, '0')
+  const seconds = date.getSeconds().toString().padStart(2, '0')
+  const prettyDate = hours + ':' + minutes + ':' + seconds
+  return chalk.gray(prettyDate)
+}
+
+export const formatLevel = (level: string) => {
+  const emoji = emojiLog[level]
+  const padding = isWideEmoji(emoji) ? '' : ' '
+  return emoji + padding
+}
+
+export const formatLoadTime = (elapsedTime?: string) => {
+  if (!elapsedTime) {
+    return
+  }
+
+  const elapsed = Math.round(parseFloat(elapsedTime))
+  const time = prettyMs(elapsed)
+
+  return chalk.gray(time)
+}
+
+export const formatMessage = (logData: { msg?: string; level: string }) => {
+  if (!logData.msg) {
+    return
+  }
+
+  const msg = formatMessageName(logData.msg)
+
+  switch (logData.level) {
+    case 'error':
+      return chalk.red(msg)
+    case 'trace':
+      return chalk.white(msg)
+    case 'warn':
+      return chalk.magenta(msg)
+    case 'debug':
+      return chalk.yellow(msg)
+    case 'info':
+    case 'customLevel':
+      return chalk.green(msg)
+    case 'fatal':
+      return chalk.white.bgRed(msg)
+  }
+
+  return msg
+}
+
+export const formatMethod = (method: string) => {
+  return chalk.white(method)
+}
+
+export const formatRequestId = (requestId?: string) => {
+  return requestId && chalk.cyan(requestId)
+}
+
+export const formatNs = (name?: string) => {
+  return name && chalk.cyan(name || '')
+}
+
+export const formatName = (name: string) => {
+  return chalk.blue(name)
+}
+
+export const formatMessageName = (msg: string) => {
+  if (msg === 'request') {
+    return '<--'
+  } else if (msg === 'response') {
+    return '-->'
+  }
+
+  return msg
+}
+
+export const formatOperationName = (operationName?: string) => {
+  return operationName && chalk.white(newline + '🏷  ' + operationName)
+}
+
+export const formatQuery = (query?: Record<string, unknown>) => {
+  return isObjectWithData(query)
+    ? chalk.white(
+        newline + '🔭 Query' + newline + JSON.stringify(query, null, 2)
+      )
+    : undefined
+}
+
+export const formatResponseCache = (
+  responseCache?: Record<string, unknown>
+) => {
+  return isObjectWithData(responseCache)
+    ? chalk.white(
+        newline +
+          '💾 Response Cache' +
+          newline +
+          JSON.stringify(responseCache, null, 2)
+      )
+    : undefined
+}
+
+export const formatStatusCode = (statusCode?: string) => {
+  statusCode = statusCode || 'xxx'
+  return chalk.white(statusCode)
+}
+
+export const formatTracing = (data?: Record<string, unknown>) => {
+  return isObjectWithData(data)
+    ? chalk.white(
+        newline + '⏰ Timing' + newline + JSON.stringify(data, null, 2)
+      )
+    : undefined
+}
+
+export const formatUrl = (url?: string) => {
+  return url && chalk.white(url)
+}
+
+export const formatUserAgent = (userAgent?: string) => {
+  return userAgent && chalk.grey(newline + '🕵️‍♀️ ' + userAgent)
+}

--- a/packages/api-server/src/logFormatter/index.ts
+++ b/packages/api-server/src/logFormatter/index.ts
@@ -31,6 +31,24 @@ const isWideEmoji = (character: any) => {
 }
 
 export const LogFormatter = () => {
+  /**
+   * Example inputData:
+   *   {
+   *     "level": 20,
+   *     "time": 1650298442951,
+   *     "pid": 80980,
+   *     "hostname": "Tobbes-MacBook-Pro.local",
+   *     "foo": "foo",
+   *     "nested": {
+   *       "arr": [
+   *         "one",
+   *         "two",
+   *         "three"
+   *       ]
+   *     },
+   *     "msg": "Example debug log"
+   *   }
+   */
   const parse = (inputData: any) => {
     let logData
     if (typeof inputData === 'string') {
@@ -83,6 +101,16 @@ export const LogFormatter = () => {
 
   const output = (logData: any) => {
     const output = []
+    const {
+      level: _level,
+      time: _time,
+      pid: _pid,
+      hostname: _hostname,
+      msg: _msg,
+      name: _name,
+      ns: _ns,
+      ...metadata
+    } = logData
 
     if (!logData.level) {
       logData.level = 'customlevel'
@@ -101,7 +129,7 @@ export const LogFormatter = () => {
     output.push(formatNs(logData.ns))
     output.push(formatName(logData.name))
     output.push(formatRequestId(logData.requestId))
-    output.push(formatMessage(logData))
+    output.push(formatMessage(logData, metadata))
 
     const req = logData.req
     const res = logData.res
@@ -238,8 +266,12 @@ export const LogFormatter = () => {
     return chalk.gray(time)
   }
 
-  const formatMessage = (logData: any) => {
-    const msg = formatMessageName(logData.message)
+  const formatMessage = (logData: any, metadata: Record<string, unknown>) => {
+    const msg =
+      formatMessageName(logData.message) +
+      '\n' +
+      JSON.stringify(metadata, null, 2)
+
     let pretty
     if (logData.level === 'error') {
       pretty = chalk.red(msg)

--- a/packages/api-server/src/logFormatter/index.ts
+++ b/packages/api-server/src/logFormatter/index.ts
@@ -100,7 +100,7 @@ export const LogFormatter = () => {
     if (typeof inputData === 'string') {
       const parsedData = jsonParse(inputData)
 
-      // TODO: Write testcase that tries to run logger.debug({ err: 'my error' }, 'Uh-ohh')
+      // TODO: Write test case that tries to run logger.debug({ err: 'my error' }, 'Uh-ohh')
       if (!parsedData.value || parsedData.err || !isPinoLog(parsedData.value)) {
         return inputData + newline
       }
@@ -311,7 +311,7 @@ export const LogFormatter = () => {
     let output: (string | undefined)[] = []
 
     if (!logData.level) {
-      logData.level = 'customlevel'
+      logData.level = 'customLevel'
     }
 
     output.push(formatDate(logData.time || Date.now()))

--- a/packages/api-server/src/logFormatter/index.ts
+++ b/packages/api-server/src/logFormatter/index.ts
@@ -267,10 +267,7 @@ export const LogFormatter = () => {
   }
 
   const formatMessage = (logData: any, metadata: Record<string, unknown>) => {
-    const msg =
-      formatMessageName(logData.message) +
-      '\n' +
-      JSON.stringify(metadata, null, 2)
+    const msg = formatMessageName(logData.message)
 
     let pretty
     if (logData.level === 'error') {
@@ -291,7 +288,7 @@ export const LogFormatter = () => {
     if (logData.level === 'fatal') {
       pretty = chalk.white.bgRed(msg)
     }
-    return pretty
+    return pretty + '\n' + JSON.stringify(metadata, null, 2)
   }
 
   const formatMethod = (method: any) => {

--- a/packages/create-redwood-app/template/api/server.config.js
+++ b/packages/create-redwood-app/template/api/server.config.js
@@ -17,6 +17,7 @@ const config = {
   requestTimeout: 15_000,
   logger: {
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
+    name: 'rw-api-server',
   },
 }
 

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodLogger.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodLogger.test.ts
@@ -137,7 +137,8 @@ describe('Populates context', () => {
     expect(lastStatement).toHaveProperty('level')
     expect(lastStatement).toHaveProperty('time')
     expect(lastStatement).toHaveProperty('msg')
-    expect(lastStatement.name).toEqual('graphql-server')
+    // rw-log-formatter depends on this value being exactly 'rw-graphql-server'
+    expect(lastStatement.name).toEqual('rw-graphql-server')
 
     expect(lastStatement.msg).toEqual(
       'Cannot query field "unknown_field" on type "User".'

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodLogger.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodLogger.test.ts
@@ -97,7 +97,7 @@ describe('Populates context', () => {
     expect(executionStarted).toHaveProperty('msg')
     expect(executionStarted).toHaveProperty('query')
 
-    expect(executionStarted.name).toEqual('graphql-server')
+    expect(executionStarted.name).toEqual('rw-graphql-server')
     expect(executionStarted.level).toEqual(20)
     expect(executionStarted.msg).toEqual('GraphQL execution started: meQuery')
 
@@ -164,7 +164,7 @@ describe('Populates context', () => {
     expect(lastStatement.level).toEqual(50)
 
     expect(lastStatement).toHaveProperty('level')
-    expect(lastStatement.name).toEqual('graphql-server')
+    expect(lastStatement.name).toEqual('rw-graphql-server')
     expect(lastStatement).toHaveProperty('time')
 
     expect(lastStatement).toHaveProperty('msg')
@@ -201,7 +201,7 @@ describe('Populates context', () => {
     expect(errorLogStatement).toHaveProperty('msg')
     expect(errorLogStatement).toHaveProperty('error')
 
-    expect(errorLogStatement.name).toEqual('graphql-server')
+    expect(errorLogStatement.name).toEqual('rw-graphql-server')
     expect(errorLogStatement.level).toEqual(50)
     expect(errorLogStatement.msg).toEqual('You are forbidden')
   })

--- a/packages/graphql-server/src/plugins/useRedwoodLogger.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodLogger.ts
@@ -196,7 +196,7 @@ export const useRedwoodLogger = (
   const level = loggerConfig.options?.level || logger.level || 'warn'
 
   const childLogger = logger.child({
-    name: 'graphql-server',
+    name: 'rw-graphql-server',
   })
 
   childLogger.level = level


### PR DESCRIPTION
Fixes #5228 and rewrites the full logger with proper TS types

**Breaking change**
All metadata sent to the logger will now be printed.
Previously if you did `logger.debug({ user }, 'my user')` only "my user" would be printed. Now the full `user` object will be included in the output