### PR TITLE
fix prettier codemods and CLI failing test; revert glob v8 PR

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
@@ -19,11 +19,12 @@ describe('editable columns', () => {
       tests: true,
       nestScaffoldByModel: true,
     })
-    form = files[
-      path.normalize(
-        '/path/to/project/web/src/components/ExcludeDefault/ExcludeDefaultForm/ExcludeDefaultForm.js'
-      )
-    ]
+    form =
+      files[
+        path.normalize(
+          '/path/to/project/web/src/components/ExcludeDefault/ExcludeDefaultForm/ExcludeDefaultForm.js'
+        )
+      ]
   })
 
   test('includes String fields with a default string', async () => {

--- a/packages/cli/src/lib/__tests__/index.test.js
+++ b/packages/cli/src/lib/__tests__/index.test.js
@@ -98,5 +98,7 @@ describe('usingVSCode', () => {
     const output = index.usingVSCode()
 
     expect(output).toEqual(true)
+
+    fs.rmdirSync(path.join(BASE_PATH, '.vscode'))
   })
 })

--- a/packages/codemods/src/testUtils/index.ts
+++ b/packages/codemods/src/testUtils/index.ts
@@ -2,10 +2,14 @@ import fs from 'fs'
 import path from 'path'
 
 import { format } from 'prettier'
+import parserBabel from 'prettier/parser-babel'
 import tempy from 'tempy'
 
 export const formatCode = (code: string) => {
-  return format(code, { parser: 'babel-ts' })
+  return format(code, {
+    parser: 'babel-ts',
+    plugins: [parserBabel],
+  })
 }
 
 export const createProjectMock = () => {

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -50,7 +50,7 @@
     "fast-glob": "3.2.11",
     "findup-sync": "5.0.0",
     "fs-extra": "10.1.0",
-    "glob": "8.0.1",
+    "glob": "7.2.0",
     "graphql": "16.3.0",
     "kill-port": "1.6.1",
     "prettier": "2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,7 +6194,7 @@ __metadata:
     fast-glob: 3.2.11
     findup-sync: 5.0.0
     fs-extra: 10.1.0
-    glob: 8.0.1
+    glob: 7.2.0
     graphql: 16.3.0
     graphql-tag: 2.12.6
     jest: 27.5.1
@@ -17260,21 +17260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:8.0.1":
-  version: 8.0.1
-  resolution: "glob@npm:8.0.1"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^5.0.1
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: 5886928f2a2797c6109670c18750a67b8f99b398aa2f029f0b92dec2fb8b8cdc92c57b6410cf8998e75a18d2ffee38d918f9060a5dbc82d9cc34059b2de72f1f
-  languageName: node
-  linkType: hard
-
-"glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
+"glob@npm:7.2.0, glob@npm:^7.0.0, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:


### PR DESCRIPTION
cc @jtoar 

- reverts https://github.com/redwoodjs/redwood/pull/5181
- updated codemods test parser syntax to pass. See:
https://github.com/redwoodjs/redwood/pull/5287/commits/5cdbf8e4166c11f46a541f4d80fcf6bdfcf3fc4a#diff-1df4cc7b04164297e24519ab93a462620384a3de38e1867c824a409353394c36
- cleanup fixture in CLI test