### PR TITLE
Supabase Auth: Reset URL state only if there's Session info in URL

### DIFF
--- a/packages/auth/src/authClients/supabase.ts
+++ b/packages/auth/src/authClients/supabase.ts
@@ -115,9 +115,17 @@ export const supabase = (client: Supabase): AuthClientSupabase => {
       return await client.auth.user()
     },
     restoreAuthState: async () => {
-      await client.auth.getSessionFromUrl()
+      const { data: session } = await client.auth.getSessionFromUrl()
 
-      window.history.replaceState({}, document.title, window.location.pathname)
+      // Modify URL state only if there is a session.
+      // Prevents resetting URL state (like query params) for all other cases.
+      if (session) {
+        window.history.replaceState(
+          {},
+          document.title,
+          window.location.pathname
+        )
+      }
 
       return
     },


### PR DESCRIPTION
**Problem:** Kris identified that if we use Supabase Auth, the query params get reset every time. Demo: https://s.tape.sh/WPmCfE3M

**Fix:**
This PR changes the` restoreAuthState` logic to reset only it's able to retrieve a Session from the current URL. If it's not able to get one, it's likely that the URL is not a callback from auth flow.

I tested the fix but was not able to find the case where we actually receive the params from auth callback. Mostly it opens a new browser window and resumes the flow in the original window. Can anyone point to the case with auth redirect back on the same window/tab with auth success query params.

After fix: https://s.tape.sh/ifcIyy9m

cc: @KrisCoulson 