### PR TITLE
Pass secret to slack message action

### DIFF
--- a/.github/actions/message_slack/action.yml
+++ b/.github/actions/message_slack/action.yml
@@ -10,6 +10,9 @@ inputs:
   version:
     description: version
     required: true
+  slack-webhook-url:
+    description: endpoint
+    required: true
 runs:
   using: composite
   steps:
@@ -23,4 +26,4 @@ runs:
             "version": "${{ inputs.version }}"
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PUBLISHING_WORKFLOWS_WEBHOOK }}
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}

--- a/.github/actions/message_slack/action.yml
+++ b/.github/actions/message_slack/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: version
     required: true
   slack-webhook-url:
-    description: endpoint
+    description: 'Slack webhook URL'
     required: true
 runs:
   using: composite

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -65,3 +65,4 @@ jobs:
           title: "🦜 Canary Packages"
           status: ${{ needs.publish-canary.result }}
           version: ${{ needs.publish-canary.outputs.version }}
+          slack-webhook-url: ${{ secrets.SLACK_PUBLISHING_WORKFLOWS_WEBHOOK }}

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -100,3 +100,4 @@ jobs:
           title: "🏎 RC Packages"
           status: ${{ needs.publish-release-candidate.result }}
           version: ${{ needs.publish-release-candidate.outputs.version }}
+          slack-webhook-url: ${{ secrets.SLACK_PUBLISHING_WORKFLOWS_WEBHOOK }}


### PR DESCRIPTION
Apparently you can't use GitHub secrets in actions (makes sense retrospectively). This PR changes it so that the secret is passed to the action.