### PR TITLE
[Canary publishing] add back git describe

### DIFF
--- a/.github/actions/message_slack/action.yml
+++ b/.github/actions/message_slack/action.yml
@@ -32,7 +32,7 @@ runs:
         payload: |
           {
             "title": "${{ inputs.title }}",
-            "status": "${{ steps.get-emoji.outputs.value }} ${{ inputs.status == }}",
+            "status": "${{ steps.get-emoji.outputs.value }} ${{ inputs.status }}",
             "version": "${{ inputs.version }}"
           }
       env:

--- a/.github/actions/message_slack/action.yml
+++ b/.github/actions/message_slack/action.yml
@@ -16,13 +16,23 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Get emoji
+      id: get-emoji
+      if: inputs.status == 'failure'
+      run: echo "::set-output name=value::🚨"
+
+    - name: Get emoji
+      id: get-emoji
+      if: inputs.status == 'success'
+      run: echo "::set-output name=value::✅"
+
     - name: 💬 Message Slack
       uses: slackapi/slack-github-action@v1
       with:
         payload: |
           {
             "title": "${{ inputs.title }}",
-            "status": "${{ inputs.status }}",
+            "status": "${{ steps.get-emoji.outputs.value }} ${{ inputs.status == }}",
             "version": "${{ inputs.version }}"
           }
       env:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: 🚢 Publish
         run: |
+          git describe
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
           yarn publish:canary
         env:


### PR DESCRIPTION
Got the slack message working in https://github.com/redwoodjs/redwood/commit/6f0093393f53b064d94ab930605ca3ec6d401e53 but the actual publish step is failing. I removed a seemingly innocuous line, `git describe`, that I'm adding back now to see if it makes a difference.