### PR TITLE
Use `jq` to get status emoji for publish action

### DIFF
--- a/.github/actions/message_slack/action.yml
+++ b/.github/actions/message_slack/action.yml
@@ -16,17 +16,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get emoji
-      id: get-emoji
-      if: inputs.status == 'failure'
-      run: echo "::set-output name=value::🚨"
-      shell: bash
-
-    - name: Get emoji
-      id: get-emoji
-      if: inputs.status == 'success'
-      run: echo "::set-output name=value::✅"
-      shell: bash
+    - name: Get status emoji
+      id: get-status-emoji
+      uses: sergeysova/jq-action@v2.1.0
+      with:
+        cmd: echo "{ \"success\": \"✅\", \"failure\": \"🚨\" }" | jq .${{ inputs.status }} -r
 
     - name: 💬 Message Slack
       uses: slackapi/slack-github-action@v1
@@ -34,7 +28,7 @@ runs:
         payload: |
           {
             "title": "${{ inputs.title }}",
-            "status": "${{ steps.get-emoji.outputs.value }} ${{ inputs.status }}",
+            "status": "${{ steps.get-status-emoji.outputs.value }} ${{ inputs.status }}",
             "version": "${{ inputs.version }}"
           }
       env:


### PR DESCRIPTION
I forgot that GitHub actions have no real way of doing if else statements, breaking the slack message job here https://github.com/redwoodjs/redwood/runs/6147235092?check_suite_focus=true. So this PR uses [jq](https://stedolan.github.io/jq/), a JSON CLI tool, to get the emoji via the `status` (success, failure). This should hopefully be the last one for now.