### PR TITLE
Remove `git reset` in canary workflow

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -40,7 +40,14 @@ jobs:
       - name: 🚢 Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
-          yarn lerna publish --force-publish --canary --include-merged-tags --preid canary --dist-tag canary --yes --loglevel verbose --no-git-reset
+          yarn lerna publish --include-merged-tags \
+                             --canary \
+                             --preid canary \
+                             --dist-tag canary \
+                             --force-publish \
+                             --loglevel verbose \
+                             --no-git-reset \
+                             --yes
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 🚢 Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
-          yarn publish:canary
+          yarn lerna publish --force-publish --canary --include-merged-tags --preid canary --dist-tag canary --yes --loglevel verbose --no-git-reset
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -76,7 +76,13 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
           SEMVER=$(basename $(dirname ${{ github.ref_name }}))
-          yarn lerna publish pre$SEMVER --include-merged-tags --canary --preid rc --dist-tag rc --force-publish --loglevel verbose --yes
+          yarn lerna publish pre$SEMVER --include-merged-tags \
+                                        --canary \
+                                        --preid rc \
+                                        --dist-tag rc \
+                                        --force-publish \
+                                        --loglevel verbose \
+                                        --yes
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -82,6 +82,7 @@ jobs:
                                         --dist-tag rc \
                                         --force-publish \
                                         --loglevel verbose \
+                                        --no-git-reset \                                        
                                         --yes
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "project:copy": "node ./tasks/framework-tools/frameworkFilesToProject.mjs",
     "project:deps": "node ./tasks/framework-tools/frameworkDepsToProject.mjs",
     "project:sync": "node ./tasks/framework-tools/frameworkSyncToProject.mjs",
-    "publish:canary": "lerna publish --force-publish --canary --include-merged-tags --preid canary --dist-tag canary --yes --loglevel verbose",
     "release": "node ./tasks/release/cli.mjs",
     "smoke-test": "cd ./tasks/smoke-test && npx playwright install && npx playwright test",
     "test": "lerna run test --stream -- --colors --maxWorkers=4",


### PR DESCRIPTION
This PR adds the [`--no-git-reset` lerna flag](https://github.com/lerna/lerna/tree/main/commands/publish#--no-git-reset) to the `publish:canary` command. This is so that we can use the version later in another job. This PR also moves the `publish:canary` command to the workflow, removing it from the package.json. @thedavidprice let me know if you'd like to undo this last change.

Using this PR as a summary of some of the changes I've made to the canary and release candidate workflows:

- https://github.com/redwoodjs/redwood/commit/e00d42146fd3fda8f918ca6ac151d34b3da90700 - the "main" PR, refactors the workflows
- https://github.com/redwoodjs/redwood/commit/15751daa3f12668965e55ac6ce74950b710f8733 - debugging (forgot to checkout the repo)
- https://github.com/redwoodjs/redwood/commit/6f0093393f53b064d94ab930605ca3ec6d401e53 - debugging (you can't use secrets in composite actions)
- https://github.com/redwoodjs/redwood/commit/d6bc21898f13f2650453cdb7c08d62fe4728428e - debugging (mistakenly thought `git describe` was needed)
- https://github.com/redwoodjs/redwood/commit/682acb493a60028042008924f3e69b94187bcd6f debugging (finally realized I was checking out the repo twice)
- https://github.com/redwoodjs/redwood/commit/64c18ef9b52a96afb93e9875bf93b256bc719a8e - add emoji to status 
- https://github.com/redwoodjs/redwood/commit/c1b3a46e24cd8fda8664f79708dac378983705d0 - debugging (missing quotes)

Note that when I make changes to CI, I usually test them out on my fork, but it's pretty difficult to test if a release workflow works on a fork. So that's why I've had to do a bit of trial and error here. 