### PR TITLE
Generate RC release notes

### DIFF
--- a/tasks/release/__tests__/generateReleaseNotes.test.mjs
+++ b/tasks/release/__tests__/generateReleaseNotes.test.mjs
@@ -1,6 +1,7 @@
+import fs from 'node:fs'
+
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
-import fs from 'node:fs'
 
 import generateReleaseNotes, {
   GET_MILESTONE_IDS,

--- a/tasks/release/cli.mjs
+++ b/tasks/release/cli.mjs
@@ -50,18 +50,28 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
-    'generate-release-notes [milestone]',
+    ['generate-release-notes [milestone]', 'notes'],
     'Generates release notes for a given milestone',
     (yargs) => {
       yargs.positional('milestone', {
         describe: 'The milestone to generate release notes for',
         type: 'string',
       })
+
+      yargs.option('release-candidate', {
+        alias: 'rc',
+        default: false,
+        describe: 'Generate release notes for a release candidate',
+        type: 'boolean',
+      })
     },
-    (argv) => generateReleaseNotes(argv.milestone)
+    (argv) =>
+      generateReleaseNotes(argv.milestone, {
+        releaseCandidate: argv.releaseCandidate,
+      })
   )
   .command(
-    'update-prs-milestone',
+    ['update-prs-milestone', 'prs'],
     "Update PRs' milestone from something to something",
     (yargs) => {
       yargs.option('from', {

--- a/tasks/release/generateReleaseNotes.mjs
+++ b/tasks/release/generateReleaseNotes.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import url from 'node:url'
 
 import template from 'lodash.template'
+import { $ } from 'zx'
 
 import octokit from './octokit.mjs'
 
@@ -14,10 +15,20 @@ import octokit from './octokit.mjs'
  * If no milestone's given, just fetch the latest version milestone (e.g. `v0.42.0`).
  *
  * @param {string} [milestone]
+ * @param {{ releaseCandidate: boolean }} [options]
  */
-export default async function generateReleaseNotes(milestone) {
+export default async function generateReleaseNotes(
+  milestone,
+  { releaseCandidate }
+) {
   // Get the milestone's title, id, and PRs.
   const { title, id } = await getMilestoneId(milestone)
+
+  if (releaseCandidate) {
+    await generateReleaseCandidateReleaseNotes(title)
+    return
+  }
+
   const prs = await getPRsWithMilestone({ milestoneId: id })
 
   const filename = new URL(`${title}ReleaseNotes.md`, import.meta.url)
@@ -28,6 +39,41 @@ export default async function generateReleaseNotes(milestone) {
   })
   fs.writeFileSync(filename, filedata)
   console.log(`Written to ${url.fileURLToPath(filename)}`)
+}
+
+async function generateReleaseCandidateReleaseNotes(milestone) {
+  let { stdout: latestVersion } =
+    await $`yarn npm info @redwoodjs/core@latest --fields version --json`
+
+  latestVersion = 'v' + JSON.parse(latestVersion.trim()).version
+
+  const {
+    repository: {
+      refs: { nodes },
+    },
+  } = await octokit.graphql(
+    `
+        query GetReleaseBranch($milestone: String!) {
+          repository(owner: "redwoodjs", name: "redwood") {
+            refs(first: 1, refPrefix:"refs/heads/", query: $milestone) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      `,
+    {
+      milestone,
+    }
+  )
+
+  const [{ name: releaseBranch }] = nodes
+
+  console.log({
+    compare: `https://github.com/redwoodjs/redwood/compare/${latestVersion}...${releaseBranch}`,
+    mergedPrs: `https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${milestone}`,
+  })
 }
 
 // Helpers


### PR DESCRIPTION
Closes the last item in https://github.com/redwoodjs/redwood/issues/5229. This PR adds a `--release-candidate` (alias, `--rc`) flag to `yarn release generate-release-notes` (alias, `notes`). When using this flag, the command logs the two links necessary for the RC's release notes. Example output

```bash
# "notes" is an alias for "generate-release-notes"
yarn release notes --rc
No milestone was provided; using the latest: v1.2.0
$ yarn npm info @redwoodjs/core@latest --fields version --json
{"name":"@redwoodjs/core","version":"1.1.1"}
{
  compare: 'https://github.com/redwoodjs/redwood/compare/v1.1.1...release/minor/v1.2.0',
  mergedPrs: 'https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3Av1.2.0'
}
```