### PR TITLE
Netlify: ignore PRs without changes in the docs directory

### DIFF
--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -5,10 +5,18 @@
 const { execSync } = require('child_process')
 
 console.group('Ignore script')
-console.log('Adding remote and fetching origin/main')
-execSync(
-  'git remote add origin https://github.com/redwoodjs/redwood.git && git fetch origin main'
-)
+
+try {
+  console.log('Adding remote')
+  execSync('git remote add origin https://github.com/redwoodjs/redwood.git')
+} catch (e) {
+  if (e.error !== 'remote origin already exists') {
+    throw e
+  }
+  console.log('Remote already exists')
+}
+
+execSync('git fetch origin main')
 
 console.log('Diffing changed files against main (name only)')
 const changedFiles = execSync('git diff origin/main --name-only')

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -1,0 +1,21 @@
+// We only want Netlify to build the site if a PR changes files in this `docs` directory.
+// See https://docs.netlify.com/configure-builds/ignore-builds.
+// Note: Netilfy runs this via Node.js 12.
+
+const { execSync } = require('child_process')
+
+execSync('git fetch origin main')
+
+const changedFiles = execSync('git diff origin/main --name-only')
+  .toString()
+  .trim()
+  .split('\n')
+  .filter(Boolean)
+
+const shouldBuild = changedFiles.some((changedFile) =>
+  changedFile.startsWith('docs')
+)
+
+if (!shouldBuild) {
+  process.exitCode = 1
+}

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -16,6 +16,8 @@ const shouldBuild = changedFiles.some((changedFile) =>
   changedFile.startsWith('docs')
 )
 
-if (!shouldBuild) {
+// We've done all the logic based on whether we should build the site,
+// but since this is an ignore script, we have to flip the logic here.
+if (shouldBuild) {
   process.exitCode = 1
 }

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -6,10 +6,17 @@ const { execSync } = require('child_process')
 
 console.group('Ignore script')
 
+const remoteExists = execSync('git remote -v').toString().includes('origin')
+
+console.log('Remote exists:', remoteExists)
+
 try {
   console.log('Adding remote')
   execSync('git remote add origin https://github.com/redwoodjs/redwood.git')
 } catch (e) {
+  console.log(e.error)
+  console.log(e.error !== 'remote origin already exists')
+
   if (e.error !== 'remote origin already exists') {
     throw e
   }

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -4,25 +4,18 @@
 
 const { execSync } = require('child_process')
 
-console.group('Ignore script')
+console.group('Ignore build')
 
 const remoteExists = execSync('git remote -v').toString().includes('origin')
 
-console.log('Remote exists:', remoteExists)
-
-try {
+if (remoteExists) {
+  console.log('Remote exists')
+} else {
   console.log('Adding remote')
   execSync('git remote add origin https://github.com/redwoodjs/redwood.git')
-} catch (e) {
-  console.log(e.error)
-  console.log(e.error !== 'remote origin already exists')
-
-  if (e.error !== 'remote origin already exists') {
-    throw e
-  }
-  console.log('Remote already exists')
 }
 
+console.log('Fetching main')
 execSync('git fetch origin main')
 
 console.log('Diffing changed files against main (name only)')

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -4,12 +4,10 @@
 
 const { execSync } = require('child_process')
 
-console.log(process.env)
+execSync(
+  'git remote add origin https://github.com/redwoodjs/redwood.git && git fetch origin main'
+)
 
-console.log('fetching origin main')
-execSync('git fetch origin main')
-
-console.log('dffing origin main')
 const changedFiles = execSync('git diff origin/main --name-only')
   .toString()
   .trim()

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -4,22 +4,34 @@
 
 const { execSync } = require('child_process')
 
+console.group('Ignore script')
+console.log('Adding remote and fetching origin/main')
 execSync(
   'git remote add origin https://github.com/redwoodjs/redwood.git && git fetch origin main'
 )
 
+console.log('Diffing changed files against main (name only)')
 const changedFiles = execSync('git diff origin/main --name-only')
   .toString()
   .trim()
   .split('\n')
   .filter(Boolean)
+console.log({
+  changedFiles,
+})
 
 const shouldBuild = changedFiles.some((changedFile) =>
   changedFile.startsWith('docs')
 )
+console.log({
+  shouldBuild,
+})
 
 // We've done all the logic based on whether we should build the site,
 // but since this is an ignore script, we have to flip the logic here.
 if (shouldBuild) {
+  console.log(`${process.env.HEAD} doesn't have doc changes. Ignoring`)
   process.exitCode = 1
 }
+console.log(`${process.env.HEAD} has doc changes. Proceeding`)
+console.groupEnd()

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -4,7 +4,8 @@
 
 const { execSync } = require('child_process')
 
-console.group('Ignore build')
+console.log('------------------------')
+console.log('Ignore build script')
 
 const remoteExists = execSync('git remote -v').toString().includes('origin')
 
@@ -38,8 +39,9 @@ console.log({
 // We've done all the logic based on whether we should build the site,
 // but since this is an ignore script, we have to flip the logic here.
 if (shouldBuild) {
-  console.log(`${process.env.HEAD} doesn't have doc changes. Ignoring`)
+  console.log(`${process.env.HEAD} has doc changes. Proceeding`)
   process.exitCode = 1
+} else {
+  console.log(`${process.env.HEAD} doesn't have doc changes. Ignoring`)
 }
-console.log(`${process.env.HEAD} has doc changes. Proceeding`)
-console.groupEnd()
+console.log('------------------------')

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -4,8 +4,12 @@
 
 const { execSync } = require('child_process')
 
+console.log(process.env)
+
+console.log('fetching origin main')
 execSync('git fetch origin main')
 
+console.log('dffing origin main')
 const changedFiles = execSync('git diff origin/main --name-only')
   .toString()
   .trim()

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -5,7 +5,7 @@
 const { execSync } = require('child_process')
 
 console.log('------------------------')
-console.log('Ignore build script')
+console.log("Running 'docs/ignore_build.js'")
 
 const remoteExists = execSync('git remote -v').toString().includes('origin')
 
@@ -39,9 +39,9 @@ console.log({
 // We've done all the logic based on whether we should build the site,
 // but since this is an ignore script, we have to flip the logic here.
 if (shouldBuild) {
-  console.log(`${process.env.HEAD} has doc changes. Proceeding`)
+  console.log(`PR '${process.env.HEAD}' has doc changes. Proceeding`)
   process.exitCode = 1
 } else {
-  console.log(`${process.env.HEAD} doesn't have doc changes. Ignoring`)
+  console.log(`PR '${process.env.HEAD}' doesn't have doc changes. Ignoring`)
 }
 console.log('------------------------')

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -2,7 +2,8 @@
   base = "docs"
   publish = "build"
   command = "yarn build"
-  
+  ignore = "node ignore_build.js"
+
 [[redirects]]
   from = "/docs"
   to = "/docs/introduction"


### PR DESCRIPTION
Right now Netlify builds Redwood's docs site on every PR, whether it includes docs changes or not. This PR adds an ignore script that Netlify runs to check if it should build the docs site: https://docs.netlify.com/configure-builds/ignore-builds/.

The script is basically the inverse of the [only_doc_changes](https://github.com/redwoodjs/redwood/blob/main/.github/actions/only_doc_changes/only_doc_changes.mjs) action, except that this one excepts to run on Node.js 12 while the other expects to be able to use the GitHub actions toolkit. It may be worth trying to merge both into one in the future, but right now I just want to see if this works at all.