### PR TITLE
Adds support for multiple environments to Baremetal deploy

### DIFF
--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -132,8 +132,8 @@ const commands = (yargs, ssh) => {
   )
   let envConfig
 
-  if (deployConfig.servers[yargs.environment]) {
-    envConfig = deployConfig.servers[yargs.environment]
+  if (deployConfig[yargs.environment]) {
+    envConfig = deployConfig[yargs.environment]
   } else if (
     yargs.environment === 'production' &&
     Array.isArray(deployConfig.servers)
@@ -149,7 +149,7 @@ const commands = (yargs, ssh) => {
   let tasks = []
 
   // loop through each server in deploy.toml
-  for (const serverConfig of envConfig) {
+  for (const serverConfig of envConfig.servers) {
     const sshOptions = {
       host: serverConfig.host,
       username: serverConfig.username,

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -13,6 +13,7 @@ import { configFilename } from '../setup/deploy/providers/baremetal'
 
 const DEFAULT_BRANCH_NAME = ['main']
 const SYMLINK_FLAGS = '-nsf'
+const CURRENT_RELEASE_SYMLINK_NAME = 'current'
 
 export const command = 'baremetal [environment]'
 export const description = 'Deploy to baremetal server(s)'
@@ -68,6 +69,12 @@ export const builder = (yargs) => {
     type: 'boolean',
   })
 
+  yargs.option('cleanup', {
+    describe: 'Remove old deploy directories',
+    default: true,
+    type: 'boolean',
+  })
+
   yargs.option('releaseDir', {
     describe:
       'Directory to create for the latest release, defaults to timestamp',
@@ -83,6 +90,12 @@ export const builder = (yargs) => {
     type: 'string',
   })
 
+  yargs.option('maintenance', {
+    describe: 'Add/remove the maintenance page',
+    choices: ['up', 'down'],
+    help: 'Put up a maintenance page by replacing the content of web/dist/index.html with the content of web/src/maintenance.html',
+  })
+
   // TODO: Allow option to pass --sides and only deploy select sides instead of all, always
 
   yargs.epilogue(
@@ -96,7 +109,13 @@ export const builder = (yargs) => {
 // Executes a single command via SSH connection, capturing the exit code of the
 // process. Displays an error and will exit(1) if code is non-zero
 const sshExec = async (ssh, sshOptions, task, path, command, args) => {
-  const result = await ssh.execCommand(`${command} ${args.join(' ')}`, {
+  let sshCommand = command
+
+  if (args) {
+    sshCommand += ` ${args.join(' ')}`
+  }
+
+  const result = await ssh.execCommand(sshCommand, {
     cwd: path,
   })
 
@@ -125,6 +144,212 @@ export const verifyServerConfig = (config) => {
   }
 }
 
+const maintenanceTasks = (status, ssh, sshOptions, serverConfig) => {
+  const deployPath = path.join(serverConfig.path, CURRENT_RELEASE_SYMLINK_NAME)
+
+  if (status === 'up') {
+    return [
+      {
+        title: `Enabling maintenance page...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, deployPath, 'cp', [
+            path.join('web', 'dist', '200.html'),
+            path.join('web', 'dist', '200.html.orig'),
+          ])
+          await sshExec(ssh, sshOptions, task, deployPath, 'ln', [
+            SYMLINK_FLAGS,
+            path.join('..', 'src', 'maintenance.html'),
+            path.join('web', 'dist', '200.html'),
+          ])
+        },
+      },
+      {
+        title: `Stopping ${serverConfig.processNames.join(', ')} processes...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'stop',
+            serverConfig.processNames.join(' '),
+          ])
+        },
+      },
+    ]
+  } else if (status === 'down') {
+    return [
+      {
+        title: `Starting ${serverConfig.processNames.join(', ')} processes...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'start',
+            serverConfig.processNames.join(' '),
+          ])
+        },
+      },
+      {
+        title: `Disabling maintenance page...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, deployPath, 'rm', [
+            path.join('web', 'dist', '200.html'),
+          ])
+          await sshExec(ssh, sshOptions, task, deployPath, 'cp', [
+            path.join('web', 'dist', '200.html.orig'),
+            path.join('web', 'dist', '200.html'),
+          ])
+        },
+      },
+    ]
+  }
+}
+
+const deployTasks = (yargs, ssh, sshOptions, serverConfig) => {
+  const deployBranch =
+    yargs.branch || serverConfig.branch || DEFAULT_BRANCH_NAME
+  const cmdPath = path.join(serverConfig.path, yargs.releaseDir)
+  const tasks = []
+
+  // TODO: Add lifecycle hooks for running custom code before/after each
+  // built-in task
+
+  tasks.push({
+    title: `Cloning \`${deployBranch}\` branch...`,
+    task: async (_ctx, task) => {
+      await sshExec(ssh, sshOptions, task, serverConfig.path, 'git', [
+        'clone',
+        `--branch=${deployBranch}`,
+        `--depth=1`,
+        serverConfig.repo,
+        yargs.releaseDir,
+      ])
+    },
+    skip: () => !yargs.update,
+  })
+
+  tasks.push({
+    title: `Symlink .env...`,
+    task: async (_ctx, task) => {
+      await sshExec(ssh, sshOptions, task, cmdPath, 'ln', [
+        SYMLINK_FLAGS,
+        '../.env',
+        '.env',
+      ])
+    },
+    skip: () => !yargs.update,
+  })
+
+  tasks.push({
+    title: `Installing dependencies...`,
+    task: async (_ctx, task) => {
+      await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', ['install'])
+    },
+    skip: () => !yargs.install,
+  })
+
+  tasks.push({
+    title: `DB Migrations...`,
+    task: async (_ctx, task) => {
+      await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
+        'rw',
+        'prisma',
+        'migrate',
+        'deploy',
+      ])
+      await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
+        'rw',
+        'prisma',
+        'generate',
+      ])
+      await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
+        'rw',
+        'dataMigrate',
+        'up',
+      ])
+    },
+    skip: () => !yargs.migrate || serverConfig?.migrate === false,
+  })
+
+  for (const side of serverConfig.sides) {
+    tasks.push({
+      title: `Building ${side}...`,
+      task: async (_ctx, task) => {
+        await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
+          'rw',
+          'build',
+          side,
+        ])
+      },
+      skip: () => !yargs.build,
+    })
+  }
+
+  tasks.push({
+    title: `Symlinking current release...`,
+    task: async (_ctx, task) => {
+      await sshExec(ssh, sshOptions, task, serverConfig.path, 'ln', [
+        SYMLINK_FLAGS,
+        yargs.releaseDir,
+        CURRENT_RELEASE_SYMLINK_NAME,
+      ])
+    },
+    skip: () => !yargs.update,
+  })
+
+  // start/restart monitoring processes
+  for (const process of serverConfig.processNames) {
+    if (yargs.firstRun) {
+      tasks.push({
+        title: `Starting ${process} process for the first time...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'start',
+            path.join(CURRENT_RELEASE_SYMLINK_NAME, 'ecosystem.config.js'),
+            '--only',
+            process,
+          ])
+        },
+        skip: () => !yargs.restart,
+      })
+      tasks.push({
+        title: `Saving ${process} state for future startup...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'save',
+          ])
+        },
+        skip: () => !yargs.restart,
+      })
+    } else {
+      tasks.push({
+        title: `Restarting ${process} process...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'restart',
+            process,
+          ])
+        },
+        skip: () => !yargs.restart,
+      })
+    }
+  }
+
+  tasks.push({
+    title: `Cleaning up old deploys...`,
+    task: async (_ctx, task) => {
+      // add 2 to skip `current` and start on the 6th release
+      const fileStartIndex = (serverConfig.keepReleases || 5) + 2
+
+      await sshExec(
+        ssh,
+        sshOptions,
+        task,
+        serverConfig.path,
+        `ls -t | tail -n +${fileStartIndex} | xargs rm -rf`
+      )
+    },
+    skip: () => !yargs.cleanup,
+  })
+
+  return tasks
+}
+
 const commands = (yargs, ssh) => {
   // parse config and get server list
   const deployConfig = toml.parse(
@@ -138,7 +363,7 @@ const commands = (yargs, ssh) => {
     yargs.environment === 'production' &&
     Array.isArray(deployConfig.servers)
   ) {
-    envConfig = deployConfig.servers
+    envConfig = deployConfig
   } else {
     throw new Error(
       `No deploy servers found for environment "${yargs.environment}"`
@@ -159,9 +384,6 @@ const commands = (yargs, ssh) => {
       agent: serverConfig.agentForward && process.env.SSH_AUTH_SOCK,
       agentForward: serverConfig.agentForward,
     }
-    const deployBranch =
-      yargs.branch || serverConfig.branch || DEFAULT_BRANCH_NAME
-    const cmdPath = path.join(serverConfig.path, yargs.releaseDir)
 
     verifyServerConfig(serverConfig)
 
@@ -170,131 +392,13 @@ const commands = (yargs, ssh) => {
       task: () => ssh.connect(sshOptions),
     })
 
-    // TODO: Add lifecycle hooks for running custom code before/after each
-    // built-in task
-
-    tasks.push({
-      title: `Cloning \`${deployBranch}\` branch...`,
-      task: async (_ctx, task) => {
-        await sshExec(ssh, sshOptions, task, serverConfig.path, 'git', [
-          'clone',
-          `--branch=${deployBranch}`,
-          `--depth=1`,
-          serverConfig.repo,
-          yargs.releaseDir,
-        ])
-      },
-      skip: () => !yargs.update,
-    })
-
-    tasks.push({
-      title: `Symlink .env...`,
-      task: async (_ctx, task) => {
-        await sshExec(ssh, sshOptions, task, cmdPath, 'ln', [
-          SYMLINK_FLAGS,
-          '../.env',
-          '.env',
-        ])
-      },
-      skip: () => !yargs.update,
-    })
-
-    tasks.push({
-      title: `Installing dependencies...`,
-      task: async (_ctx, task) => {
-        await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', ['install'])
-      },
-      skip: () => !yargs.install,
-    })
-
-    tasks.push({
-      title: `DB Migrations...`,
-      task: async (_ctx, task) => {
-        await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
-          'rw',
-          'prisma',
-          'migrate',
-          'deploy',
-        ])
-        await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
-          'rw',
-          'prisma',
-          'generate',
-        ])
-        await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
-          'rw',
-          'dataMigrate',
-          'up',
-        ])
-      },
-      skip: () => !yargs.migrate || serverConfig?.migrate === false,
-    })
-
-    for (const side of serverConfig.sides) {
-      tasks.push({
-        title: `Building ${side}...`,
-        task: async (_ctx, task) => {
-          await sshExec(ssh, sshOptions, task, cmdPath, 'yarn', [
-            'rw',
-            'build',
-            side,
-          ])
-        },
-        skip: () => !yargs.build,
-      })
+    if (yargs.maintenance) {
+      tasks = tasks.concat(
+        maintenanceTasks(yargs.maintenance, ssh, sshOptions, serverConfig)
+      )
+    } else {
+      tasks = tasks.concat(deployTasks(yargs, ssh, sshOptions, serverConfig))
     }
-
-    tasks.push({
-      title: `Symlinking current release...`,
-      task: async (_ctx, task) => {
-        await sshExec(ssh, sshOptions, task, serverConfig.path, 'ln', [
-          SYMLINK_FLAGS,
-          yargs.releaseDir,
-          'current',
-        ])
-      },
-      skip: () => !yargs.update,
-    })
-
-    // start/restart monitoring processes
-    for (const process of serverConfig.processNames) {
-      if (yargs.firstRun) {
-        tasks.push({
-          title: `Starting ${process} process for the first time...`,
-          task: async (_ctx, task) => {
-            await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
-              'start',
-              path.join('current', 'ecosystem.config.js'),
-              '--only',
-              process,
-            ])
-          },
-          skip: () => !yargs.restart,
-        })
-        tasks.push({
-          title: `Saving ${process} state for future startup...`,
-          task: async (_ctx, task) => {
-            await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
-              'save',
-            ])
-          },
-          skip: () => !yargs.restart,
-        })
-      } else {
-        tasks.push({
-          title: `Restarting ${process} process...`,
-          task: async (_ctx, task) => {
-            await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
-              'restart',
-              process,
-            ])
-          },
-          skip: () => !yargs.restart,
-        })
-      }
-    }
-
-    // TODO: Add a process for cleaning up old deploys
 
     tasks.push({
       title: 'Disconnecting...',

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -27,7 +27,7 @@ export const DEPLOY = `# This file contains config for a baremetal deployment
 #
 # See https://redwoodjs.com/docs/deploy/baremetal for more info
 
-[[servers]]
+[[servers.production]]
 host = "server.com"
 username = "user"
 agentForward = true
@@ -39,7 +39,7 @@ branch = "main"
 
 # If you have separate api and web servers:
 #
-# [[servers]]
+# [[servers.production]]
 # host = "api.server.com"
 # user = "user"
 # agentForward = true
@@ -49,7 +49,7 @@ branch = "main"
 # branch = "main"
 # processNames = ["api"]
 #
-# [[servers]]
+# [[servers.production]]
 # host = "web.server.com"
 # user = "user"
 # agentForward = true


### PR DESCRIPTION
This is built off of #5282 and assumes that will be merged first!

Closes #5300

## Release Notes

Baremetal deploy now supports deploying to multiple environments! If you've got production, and staging, and whatever else, this update is for you. If you're setting up a new deploy from scratch with `yarn rw setup deploy baremetal` you're good to go. If you have an existing `deploy.toml` file you may want to make an update:

Instead of just `[[servers]]` prefixing your server config, make it `[[servers.environment]]` where `environment` is the actual name of your environment. For example:

```
[[production.servers]]
host: 'server.com'
# remaining config...

[[staging.servers]]
host: 'staging.server.com'
# remaining config...
```

You can still have multiple servers in an environment, just repeat the `[[servers.production]]` heading multiple times, one for each block of server config:

```
[[production.servers]]
host: 'prod1.server.com'
# remaining config...

[[production.servers]]
host: 'prod2.server.com'
# remaining config...
```

This new syntax is optional: keeping your default `[[servers]]` name will act as production (and leaving off the stage name in `yarn rw deploy baremetal` will default to use these server settings).