### PR TITLE
Adds maintenance page control to Baremetal

### DIFF
--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -393,6 +393,24 @@ yarn rw deploy baremetal --no-migrate
 
 Run `yarn rw deploy baremetal --help` for the full list of flags. You can set them as `--migrate=false` or use the `--no-migrate` variant.
 
+## Maintenance Page
+
+If you find that you have a particular complex deploy, one that may involve incompatible database changes with the current codebase, or want to make sure that database changes don't occur while in the middle of a deploy, you can put up a maintenance page:
+
+```bash
+yarn rw deploy baremetal --maintenance up
+```
+
+It does this by replacing `web/dist/200.html` with `web/src/maintenance.html`. This means any new web requests, at any URL, will show the maintenance page. This process also stops any services listed in the `processNames` option of `deploy.toml`—this is important for the api server as it will otherwise keep serving requests to users currently running the app, even though no *new* users can get the Javascript packages required to start a new session in their browser.
+
+You can remove the maintenance page with:
+
+```bash
+yarn rw deploy baremetal --maintenance down
+```
+
+Note that the maintenance page will automatically come down as the result of a new deploy as it checks out a new copy of the codebase (with a brand new copy of `web/dist/200.html` and will automatically restart services (bring them all back online).
+
 ## Monitoring
 
 PM2 has a nice terminal-based dashboard for monitoring your services:

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -140,7 +140,7 @@ const maintenanceTasks = (status, ssh, sshOptions, serverConfig) => {
       {
         title: `Enabling maintenance page...`,
         task: async (_ctx, task) => {
-          await sshExec(ssh, sshOptions, task, deployPath, 'mv', [
+          await sshExec(ssh, sshOptions, task, deployPath, 'cp', [
             path.join('web', 'dist', '200.html'),
             path.join('web', 'dist', '200.html.orig'),
           ])
@@ -151,13 +151,34 @@ const maintenanceTasks = (status, ssh, sshOptions, serverConfig) => {
           ])
         },
       },
+      {
+        title: `Stopping ${serverConfig.processNames.join(', ')} processes...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'stop',
+            serverConfig.processNames.join(' '),
+          ])
+        },
+      },
     ]
   } else if (status === 'down') {
     return [
       {
+        title: `Starting ${serverConfig.processNames.join(', ')} processes...`,
+        task: async (_ctx, task) => {
+          await sshExec(ssh, sshOptions, task, serverConfig.path, 'pm2', [
+            'start',
+            serverConfig.processNames.join(' '),
+          ])
+        },
+      },
+      {
         title: `Disabling maintenance page...`,
         task: async (_ctx, task) => {
-          await sshExec(ssh, sshOptions, task, deployPath, 'mv', [
+          await sshExec(ssh, sshOptions, task, deployPath, 'rm', [
+            path.join('web', 'dist', '200.html'),
+          ])
+          await sshExec(ssh, sshOptions, task, deployPath, 'cp', [
             path.join('web', 'dist', '200.html.orig'),
             path.join('web', 'dist', '200.html'),
           ])

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -141,13 +141,13 @@ const maintenanceTasks = (status, ssh, sshOptions, serverConfig) => {
         title: `Enabling maintenance page...`,
         task: async (_ctx, task) => {
           await sshExec(ssh, sshOptions, task, deployPath, 'mv', [
-            path.join('web', 'dist', 'index.html'),
-            path.join('web', 'dist', 'index.html.orig'),
+            path.join('web', 'dist', '200.html'),
+            path.join('web', 'dist', '200.html.orig'),
           ])
           await sshExec(ssh, sshOptions, task, deployPath, 'ln', [
             SYMLINK_FLAGS,
             path.join('..', 'src', 'maintenance.html'),
-            path.join('web', 'dist', 'index.html'),
+            path.join('web', 'dist', '200.html'),
           ])
         },
       },
@@ -157,12 +157,9 @@ const maintenanceTasks = (status, ssh, sshOptions, serverConfig) => {
       {
         title: `Disabling maintenance page...`,
         task: async (_ctx, task) => {
-          await sshExec(ssh, sshOptions, task, deployPath, 'rm', [
-            path.join('web', 'dist', 'index.html'),
-          ])
           await sshExec(ssh, sshOptions, task, deployPath, 'mv', [
-            path.join('web', 'dist', 'index.html.orig'),
-            path.join('web', 'dist', 'index.html'),
+            path.join('web', 'dist', '200.html.orig'),
+            path.join('web', 'dist', '200.html'),
           ])
         },
       },

--- a/packages/cli/src/commands/setup/deploy/providers/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/providers/baremetal.js
@@ -8,7 +8,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 import { getPaths } from '../../../../lib'
 import c from '../../../../lib/colors'
 import { addFilesTask, addPackagesTask, printSetupNotes } from '../helpers'
-import { DEPLOY, ECOSYSTEM } from '../templates/baremetal'
+import { DEPLOY, ECOSYSTEM, MAINTENANCE } from '../templates/baremetal'
 
 export const command = 'baremetal'
 export const description = 'Setup Baremetal deploy'
@@ -24,8 +24,8 @@ const files = [
     content: ECOSYSTEM,
   },
   {
-    path: path.join(getPaths().web.base, 'serve', '.keep'),
-    content: '',
+    path: path.join(getPaths().web.src, 'maintenance.html'),
+    content: MAINTENANCE,
   },
 ]
 

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -62,7 +62,6 @@ branch = "main"
 `
 
 export const MAINTENANCE = `<!--
-<!--
 Put up this maintenance page on your deployed service with:
 
   yarn rw baremetal deploy --maintenance up

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -60,3 +60,62 @@ branch = "main"
 # migrate = false # only one server in a cluster needs to migrate
 # processNames = ["web"]
 `
+
+export const MAINTENANCE = `<!--
+<!--
+Put up this maintenance page on your deployed service with:
+
+  yarn rw baremetal deploy --maintenance up
+
+And take it back down with:
+
+  yarn rw baremetal deploy --maintenance down
+-->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Maintenance</title>
+    <style>
+      html, body {
+        margin: 0;
+      }
+      html * {
+        box-sizing: border-box;
+      }
+      main {
+        display: flex;
+        align-items: center;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+        text-align: center;
+        background-color: #E2E8F0;
+        height: 100vh;
+      }
+      section {
+        background-color: white;
+        border-radius: 0.25rem;
+        width: 36rem;
+        padding: 1rem;
+        margin: 0 auto;
+        box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+      }
+      h1 {
+        font-size: 2rem;
+        margin: 0;
+        font-weight: 500;
+        line-height: 1;
+        color: #2D3748;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section>
+        <h1>
+          <span>Maintenance Mode: Be Back Soon</span>
+        </h1>
+      </section>
+    </main>
+  </body>
+</html>
+`


### PR DESCRIPTION
This PR builds on #5334 and assumes it has merged first!

Closes #5347

## Release Notes

You can now enable/disable a maintenance page with the Baremetal deploy! Simply create `web/src/maintenance.html` containing your maintenance message. (For now this page must just be plain HTML, but if the need is there it should be possible to add the page to the webpack/babel pipeline and make it a full React app. If this is something you'd like to work on, get in touch!)

When you're ready to enable your maintenance page on the site:

```bash
yarn rw deploy baremetal --maintenance up
```

And to take it back down:

```bash
yarn rw deploy baremetal --maintenance down
```

This command respects the environment argument so you can put it up on just your `staging` environment, for example:

```bash
yarn rw deploy baremetal staging --maintenance up
```

That's it! This feature works by turning `web/dist/index.html` into a symlink pointing to `web/src/maintenance.html`. As long as your server is configured to check for the existence of `200.html` for the web side and serve that for any URL request that isn't the API, users should see the maintenance page the time time your site loads. Note that if a user already has your site loaded, they will most likely be able to keep clicking through your pages since everything is already cached in the browser. We're thinking about adding a "ping" feature that, on each page request, would check with the server to see if the maintenance page should be displayed, and if so interrupt their browsing session to show it. If this is something you'd like to work on, let us know by opening an issue or PR!