### PR TITLE
Remove unused `SubmitHandler` in example JavaScript code

### DIFF
--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -836,6 +836,7 @@ import {
   TextField,
   TextAreaField,
   Submit,
+  SubmitHandler,
 } from '@redwoodjs/forms'
 
 import {

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -756,7 +756,6 @@ import {
   TextField,
   TextAreaField,
   Submit,
-  SubmitHandler,
 } from '@redwoodjs/forms'
 
 const CREATE_CONTACT = gql`


### PR DESCRIPTION
Hello 👋 

The `SubmitHandler` is not used in the [Creating a Contact](https://redwoodjs.com/docs/tutorial/chapter3/saving-data#creating-a-contact) section for JavaScript, but is included as an import in the code example (it looks like it belongs in the TypeScript code example instead).

This PR removes that import from the JavaScript example and adds it to the TypeScript example.