### PR TITLE
Patch all-contributors-cli

### DIFF
--- a/.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch
+++ b/.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/repo/github.js b/dist/repo/github.js
+index c9ac17f256c6b3529f386bc4c727ae4521256c76..1dde5dd36db340cbfbf029539c73874aaf9b9eeb 100644
+--- a/dist/repo/github.js
++++ b/dist/repo/github.js
+@@ -58,7 +58,7 @@ function getNextLink(link) {
+     return null;
+   }
+ 
+-  return nextLink.split(';')[0].slice(1, -1);
++  return nextLink.split(';')[0].trim().slice(1, -1);
+ }
+ 
+ function getContributorsPage(githubUrl, optionalPrivateToken) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-protocol": "3.15.3",
     "vscode-languageserver-textdocument": "1.0.4",
-    "vscode-languageserver-types": "3.16.0"
+    "vscode-languageserver-types": "3.16.0",
+    "all-contributors-cli@6.20.0": "patch:all-contributors-cli@npm:6.20.0#.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch"
   },
   "devDependencies": {
     "@actions/core": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "resolutions": {
     "@types/react": "17.0.44",
+    "all-contributors-cli@6.20.0": "patch:all-contributors-cli@npm:6.20.0#.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -36,8 +37,7 @@
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-protocol": "3.15.3",
     "vscode-languageserver-textdocument": "1.0.4",
-    "vscode-languageserver-types": "3.16.0",
-    "all-contributors-cli@6.20.0": "patch:all-contributors-cli@npm:6.20.0#.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch"
+    "vscode-languageserver-types": "3.16.0"
   },
   "devDependencies": {
     "@actions/core": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9930,6 +9930,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"all-contributors-cli@patch:all-contributors-cli@npm:6.20.0#.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 6.20.0
+  resolution: "all-contributors-cli@patch:all-contributors-cli@npm%3A6.20.0#.yarn/patches/all-contributors-cli-npm-6.20.0-ba332c4a3e.patch::version=6.20.0&hash=6b460a&locator=root-workspace-0b6124%40workspace%3A."
+  dependencies:
+    "@babel/runtime": ^7.7.6
+    async: ^3.0.1
+    chalk: ^4.0.0
+    didyoumean: ^1.2.1
+    inquirer: ^7.0.4
+    json-fixer: ^1.5.1
+    lodash: ^4.11.2
+    node-fetch: ^2.6.0
+    pify: ^5.0.0
+    yargs: ^15.0.1
+  bin:
+    all-contributors: dist/cli.js
+  checksum: e52c5355836a35ed65a1c9a7699922e2d6afea9053d17304bad5f3b35bd2f8f67e3e93091f46b05e2e723e848f2ae9995f8aed3f4ba3f9f427c29c7c71323498
+  languageName: node
+  linkType: hard
+
 "ansi-align@npm:^3.0.0":
   version: 3.0.1
   resolution: "ansi-align@npm:3.0.1"


### PR DESCRIPTION
If you run all contributors on the redwoodjs/redwood repo, you'll the following error: 

```
$ yarn all-contributors check --config .all-contributorsrc
Only absolute URLs are supported
```

I stepped through the code and narrowed it down; it's just that a string isn't being sliced properly. I opened a PR for the fix in the all-contributors-cli repo: https://github.com/all-contributors/cli/pull/309. But I'm not sure when it'll get merged so I applied a patch for it here. I'll handle updating the package when it gets fixed.

Now when you run the command:

```
$ yarn all-contributors check --config .all-contributorsrc
Missing contributors in .all-contributorsrc:
    peterp, thedavidprice, renovate[bot], jtoar, cannikin, dac09, Tobbe, dependabot[bot], dthyresson, mojombo, RobertBroersma, kimadeline, callingmedic911, aldonline, forresthayes, simoncrypta, KrisCoulson, realStandal, virtuoushub, m3t, alicelovescake, flybayer, dependabot-preview[bot], mattmurph9, jessicard, petemccarthy, Philzen, vikotar, ajcwebdev, Plazide, chenliu9, MJ1992, zpeters, agiannelli, benmandr, COCL2022, exu3, EricKit, carusog, ianwalter, jjbowman2, elitan, zygopleural, leothorp, mnapoli, nikfp, Olyno, robertwt7, apecollector, ccnklc, codesee-maps[bot], cremno, dkmooers, hbellahc, zzyyxxww, llmaboi
Unknown contributors found in .all-contributorsrc:
vikash-eatgeek, pepibumur, shahbaz17, redstab, AlejandroFrias
```
