### PR TITLE
Remove more than X old releases in Baremetal deploy

### DIFF
--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -152,7 +152,8 @@ This lists a single server, in the `production` environment, providing the hostn
 * `migrate` - [optional] Whether or not to run migration processes on this server, defaults to `true`
 * `processNames` - An array of service names from `ecosystem.config.js` which will be (re)started on a successful deploy
 * `repo` - The path to the git repo to clone
-* `branch` - The branch to deploy (defaults to `main` if not set)
+* `branch` - [optional] The branch to deploy (defaults to `main`)
+* `keepReleases` - [optional] The number of previous releases to keep on the server, including the one currently being served (defaults to 5)
 
 The easiest connection method is generally to include your own public key in the server's `~/.ssh/authorized_keys` file, [enable agent forwarding](https://docs.github.com/en/developers/overview/using-ssh-agent-forwarding), and then set `agentForward = true` in `deploy.toml`. This will allow you to use your own credentials when pulling code from GitHub (required for private repos). Otherwise you can create a [deploy key](https://docs.github.com/en/developers/overview/managing-deploy-keys) and keep it on the server.
 

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -357,8 +357,8 @@ const commands = (yargs, ssh) => {
   )
   let envConfig
 
-  if (deployConfig.servers[yargs.environment]) {
-    envConfig = deployConfig.servers[yargs.environment]
+  if (deployConfig[yargs.environment]) {
+    envConfig = deployConfig[yargs.environment]
   } else if (
     yargs.environment === 'production' &&
     Array.isArray(deployConfig.servers)
@@ -374,7 +374,7 @@ const commands = (yargs, ssh) => {
   let tasks = []
 
   // loop through each server in deploy.toml
-  for (const serverConfig of envConfig) {
+  for (const serverConfig of envConfig.servers) {
     const sshOptions = {
       host: serverConfig.host,
       username: serverConfig.username,

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -357,8 +357,8 @@ const commands = (yargs, ssh) => {
   )
   let envConfig
 
-  if (deployConfig[yargs.environment]) {
-    envConfig = deployConfig[yargs.environment]
+  if (deployConfig.servers[yargs.environment]) {
+    envConfig = deployConfig.servers[yargs.environment]
   } else if (
     yargs.environment === 'production' &&
     Array.isArray(deployConfig.servers)
@@ -374,7 +374,7 @@ const commands = (yargs, ssh) => {
   let tasks = []
 
   // loop through each server in deploy.toml
-  for (const serverConfig of envConfig.servers) {
+  for (const serverConfig of envConfig) {
     const sshOptions = {
       host: serverConfig.host,
       username: serverConfig.username,

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -36,6 +36,7 @@ path = "/var/www/app"
 processNames = ["serve"]
 repo = "git@github.com:myorg/myapp.git"
 branch = "main"
+keepReleases = 5
 
 # If you have separate api and web servers:
 #


### PR DESCRIPTION
This adds a step at the end of a Baremetal deploy that will remove a number of old releases, keeping a configurable number still on the server (for rollbacks).

This code is branched from #5349 and assumes it will be merged first!

Closes #5298

## Release Notes

Baremetal will now cleanup old deploy codebase directories at the end of a deployment! It defaults to keep the last 5 deployments, but this can be configured in `deploy.toml` with the `keepReleases` option:

```diff
[[servers.production]]
host = "server.com"
username = "ubuntu"
agentForward = true
sides = ["api", "web"]
path = "/var/www/myapp"
processNames = ["api"]
repo = "git@github.com:myorg/myrepo.git"
branch = "main"
+ keepReleases = 5
```

Why keep around old deploys? In case something goes horribly wrong and you need to rollback!

This config setting is optional and will default to keeping the last 5 deploys if not set.