### PR TITLE
fix(docs): add WindiCSS in setup ui list

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1781,7 +1781,7 @@ yarn redwood setup tsconfig
 
 ### setup ui
 
-Set up a UI design or style library. Right now the choices are [Chakra UI](https://chakra-ui.com/) and [TailwindCSS](https://tailwindcss.com/).
+Set up a UI design or style library. Right now the choices are [Chakra UI](https://chakra-ui.com/), [TailwindCSS](https://tailwindcss.com/) and [WindiCSS](https://windicss.org/).
 
 ```
 yarn rw setup ui <library>


### PR DESCRIPTION
# Description

This pull request fixes the docs by adding [WindiCSS](https://windicss.org/) to the list of all ``setup ui`` available. The setup command for Windi has been added some days ago, but the updated documentation is missing. Here is the fix.