### PR TITLE
Don't remove `node_modules` in `@redwoodjs` packages on `yarn rwfw project:copy`

### DIFF
--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -1,8 +1,10 @@
 /* eslint-env node */
 
-import execa from 'execa'
 import fs from 'node:fs'
 import path from 'node:path'
+
+import execa from 'execa'
+import fg from 'fast-glob'
 import ora from 'ora'
 import rimraf from 'rimraf'
 import terminalLink from 'terminal-link'
@@ -106,7 +108,17 @@ export function copyFrameworkFilesToProject(
       files.length,
       'files'
     )
-    rimraf.sync(`${packageDstPath}/**/!node_modules`)
+
+    const entries = fg.sync('*', {
+      absolute: true,
+      cwd: packageDstPath,
+      ignore: ['node_modules'],
+      onlyFiles: false,
+    })
+
+    for (const entry of entries) {
+      rimraf.sync(entry)
+    }
 
     for (const file of files) {
       const src = path.join(

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -120,6 +120,16 @@ export function copyFrameworkFilesToProject(
       rimraf.sync(entry)
     }
 
+    const nestedRwfwNodeModulesPath = path.join(
+      packageDstPath,
+      'node_modules',
+      '@redwoodjs'
+    )
+
+    if (fs.existsSync(nestedRwfwNodeModulesPath)) {
+      rimraf.sync(nestedRwfwNodeModulesPath)
+    }
+
     for (const file of files) {
       const src = path.join(
         REDWOOD_PACKAGES_PATH,

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -106,7 +106,7 @@ export function copyFrameworkFilesToProject(
       files.length,
       'files'
     )
-    rimraf.sync(packageDstPath)
+    rimraf.sync(`${packageDstPath}/**/!node_modules`)
 
     for (const file of files) {
       const src = path.join(


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/4937.

TL;DR yarn does a lot of work to make `node_modules` exactly the way it should be, so we shouldn't change it. 

When we run `yarn rwfw project:copy`, we `rimraf` all the `@redwoodjs` packages in a Redwood project's `node_modules`: (line 109) 

https://github.com/redwoodjs/redwood/blob/3dc54a6dc113b8b38c619366d584e98174d9c420/tasks/framework-tools/lib/project.mjs#L103-L109

To make this more concrete, for `@redwoodjs/testing`, `packageDistPath` ends up being `"/Users/dom/prjcts/rwfw/rwfw/node_modules/@redwoodjs/testing"` (I named my Redwood project "rwfw"). Here's what the directory structure of that filepath looks like:

```
/Users/dom/prjcts/rwfw/rwfw/node_modules/@redwoodjs/testing/
├── node_modules/
│  ├── mime/
│  ├── // so, many, more...
│  └── acorn-jsx/
├── web/
│  ├── package.json
│  └── index.js
├── api/
│  ├── package.json
│  └── index.js
├── dist/
│  ├── web/
│  ├── api/
│  └── tsconfig.tsbuildinfo
├── config/
│  ├── storybook/
│  └── jest/
├── README.md
├── package.json
└── LICENSE
```

`yarn rwfw project:copy` wants to replace everything in this directory with files built from your local copy of the framework. This is what it ends up looking like after it does so:

```
/Users/dom/prjcts/rwfw/rwfw/node_modules/@redwoodjs/testing/
├── web/
│  ├── package.json
│  └── index.js
├── api/
│  ├── package.json
│  └── index.js
├── dist/
│  ├── web/
│  ├── api/
│  └── tsconfig.tsbuildinfo
├── config/
│  ├── storybook/
│  └── jest/
├── README.md
└── package.json
```

Notice that `node_modules` is gone (and LICENSE too, but that doesn't matter). This may seem innocuous, but it causes problems if you run `yarn install` again because yarn doesn't expect the contents of `node_modules` to have changed from under it. Especially the contents of a package's `node_modules` in `node_modules`.

Instead, when running `yarn rwfw project:copy`, let's just leave `node_modules` in `@redwoodjs` packages the way they are.