### PR TITLE
Add graphql-scalars to graphql-server

### DIFF
--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -36,6 +36,7 @@
     "core-js": "3.22.3",
     "cross-undici-fetch": "0.3.6",
     "graphql": "16.4.0",
+    "graphql-scalars": "1.17.0",
     "graphql-tag": "2.12.6",
     "lodash.merge": "4.6.2",
     "lodash.omitby": "4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6212,6 +6212,7 @@ __metadata:
     core-js: 3.22.3
     cross-undici-fetch: 0.3.6
     graphql: 16.4.0
+    graphql-scalars: 1.17.0
     graphql-tag: 2.12.6
     jest: 27.5.1
     lodash.merge: 4.6.2
@@ -17638,6 +17639,17 @@ __metadata:
   peerDependencies:
     graphql: 14 - 16
   checksum: b5cfac5e04d4f79c30894526d6d0689ee59b8f3c5db4c8d81d6f1c7f3bb3b38bc568bc5edc56afeb2fbd6a4913c5cc94ec6f640ad7a09cad4ae9df25708f6617
+  languageName: node
+  linkType: hard
+
+"graphql-scalars@npm:1.17.0":
+  version: 1.17.0
+  resolution: "graphql-scalars@npm:1.17.0"
+  dependencies:
+    tslib: ~2.3.0
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: a0ed295b265fa235027c84a665eb5cf8cd289c5896c11f8630287837bea4aaed72bc0f1cf026b01a1f5b6c9390620fa7a51a3ff74fedd909ebc68415082576d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update: turns out I removed it in the merge commit, so entirely self inflicted: [https://github.com/redwoodjs/redwood/commit/5c891294188b95cc5beaceb32930a14ea61cdcca](https://github.com/redwoodjs/redwood/commit/5c891294188b95cc5beaceb32930a14ea61cdcca).

***

After releasing v1.2.1, [redwoodjs](https://www.github.com/redwoodjs)/graphql-server can't find graphql-scalars: [https://github.com/redwoodjs/redwood/runs/6261468443?check_suite_focus=true#step:6:86](https://github.com/redwoodjs/redwood/runs/6261468443?check_suite_focus=true#step:6:86).

It was never listed in its package.json so I'm not sure how it found it before; probably a dependency of a dependency. This lists it explicitly since resolvers are imported from it in `rootSchema.ts`:

[https://github.com/redwoodjs/redwood/blob/b8877d86aaa30daf3a5d44ee360531d12f4fa3c8/packages/graphql-server/src/rootSchema.ts#L2-L9](https://github.com/redwoodjs/redwood/blob/b8877d86aaa30daf3a5d44ee360531d12f4fa3c8/packages/graphql-server/src/rootSchema.ts#L2-L9)