### PR TITLE
Fix/ts resolvers type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,11 +238,6 @@ jobs:
           yarn rw test web --no-watch
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
-      - name: Run "rw type-check"
-        run: |
-          yarn rw type-check
-        working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
-
       - name: Run "rw check"
         run: |
           yarn rw check
@@ -289,6 +284,16 @@ jobs:
       - name: Run "g page"
         run: |
           yarn rw g page ciTest
+        working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
+
+      - name: Run "g sdl"
+        run: |
+          yarn rw g sdl userExample
+        working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
+
+      - name: Run "rw type-check"
+        run: |
+          yarn rw type-check
         working-directory: ${{ steps.setup_test_project.outputs.test_project_path }}
 
       - name: Throw Error | Run `rw g sdl <model>`

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -137,6 +137,7 @@ function getPluginConfig() {
 
   const pluginConfig: CodegenTypes.PluginConfig &
     typescriptResolvers.TypeScriptResolversPluginConfig = {
+    makeResolverTypeCallable: true,
     namingConvention: 'keep', // to allow camelCased query names
     scalars: {
       // We need these, otherwise these scalars are mapped to any
@@ -155,7 +156,7 @@ function getPluginConfig() {
 
     customResolverFn: `(
       args: TArgs,
-      obj: { root: TParent; context: TContext; info: GraphQLResolveInfo }
+      obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
     ) => Promise<Partial<TResult>> | Partial<TResult>;`,
     mappers: prismaModels,
     contextType: `@redwoodjs/graphql-server/dist/functions/types#RedwoodGraphQLContext`,


### PR DESCRIPTION
Closes #5370

### What does this PR do?

1. Adds the   `makeResolverTypeCallable: true` to graphql-codgen config
2. Makes the `obj` optional, because we don't use it in testing. 
This is a little dubious, because obj is always included when actually using the resolving, but it just feels like a lot of extra code when testing services to pass an empty object.
3. Adds g sdl to CI, and moves typecheck to the end so we check all the generated code (so this sort of regression doesn't happen again)
