### PR TITLE
Allows API resolvers to be callable

### DIFF
--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -152,6 +152,8 @@ function getPluginConfig() {
     // prevent type names being PetQueryQuery, RW generators already append
     // Query/Mutation/etc
     omitOperationSuffix: true,
+    // Allows you to call resolvers internally, or write tests which call them
+    makeResolverTypeCallable: true,
 
     customResolverFn: `(
       args: TArgs,


### PR DESCRIPTION
Doesn't do all of https://github.com/redwoodjs/redwood/issues/5370 - but gets one of the key components out of the way