### PR TITLE
Set default value for RC release notes

### DIFF
--- a/tasks/release/generateReleaseNotes.mjs
+++ b/tasks/release/generateReleaseNotes.mjs
@@ -19,7 +19,7 @@ import octokit from './octokit.mjs'
  */
 export default async function generateReleaseNotes(
   milestone,
-  { releaseCandidate }
+  { releaseCandidate = false }
 ) {
   // Get the milestone's title, id, and PRs.
   const { title, id } = await getMilestoneId(milestone)


### PR DESCRIPTION
Minor fix to the release process; yargs handles this when invoked directly, but it's failing when invoked by the release script.