### PR TITLE
fix: declare `@babel/runtime-corejs3` and `core-js` as dependencies

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -18,11 +18,15 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, TargetDependencyRange, De
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, CurrentDependencyRange, DependencyType),
   atom_concat('^', TargetDependencyRange, CurrentDependencyRange).
 
-% Enforce that all workspaces building with Babel depend on '@babel/runtime-corejs3'
-gen_enforced_dependency(WorkspaceCwd, '@babel/runtime-corejs3', DependencyRange, 'dependencies') :-
+% Enforce that all workspaces building with Babel depend on '@babel/runtime-corejs3' and 'core-js'.
+gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, 'dependencies') :-
+  member(DependencyIdent, [
+    '@babel/runtime-corejs3',
+    'core-js'
+  ]),
   % Exclude the root workspace
   WorkspaceCwd \= '.',
   % Only target workspaces with a build:js script
   workspace_field(WorkspaceCwd, 'scripts.build:js', _),
   % Get the range from the root workspace
-  workspace_has_dependency('.', '@babel/runtime-corejs3', DependencyRange, _).
+  workspace_has_dependency('.', DependencyIdent, DependencyRange, _).

--- a/constraints.pro
+++ b/constraints.pro
@@ -17,3 +17,12 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange2, Depende
 gen_enforced_dependency(WorkspaceCwd, DependencyIdent, TargetDependencyRange, DependencyType) :-
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, CurrentDependencyRange, DependencyType),
   atom_concat('^', TargetDependencyRange, CurrentDependencyRange).
+
+% Enforce that all workspaces building with Babel depend on '@babel/runtime-corejs3'
+gen_enforced_dependency(WorkspaceCwd, '@babel/runtime-corejs3', DependencyRange, 'dependencies') :-
+  % Exclude the root workspace
+  WorkspaceCwd \= '.',
+  % Only target workspaces with a build:js script
+  workspace_field(WorkspaceCwd, 'scripts.build:js', _),
+  % Get the range from the root workspace
+  workspace_has_dependency('.', '@babel/runtime-corejs3', DependencyRange, _).

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -35,6 +35,7 @@
     "ansi-colors": "4.1.1",
     "chalk": "4.1.2",
     "chokidar": "3.5.3",
+    "core-js": "3.22.4",
     "fast-json-parse": "1.0.3",
     "fastify": "3.29.0",
     "fastify-raw-body": "3.2.0",

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-runtime": "7.16.7",
+    "@babel/runtime-corejs3": "7.16.7",
     "@fastify/http-proxy": "7.1.0",
     "@fastify/static": "5.0.2",
     "@fastify/url-data": "4.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
     "@prisma/client": "3.13.0",
+    "core-js": "3.22.4",
     "cross-undici-fetch": "0.1.27",
     "crypto-js": "4.1.1",
     "humanize-string": "2.1.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -21,6 +21,10 @@
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
+  "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
+    "core-js": "3.22.4"
+  },
   "devDependencies": {
     "@auth0/auth0-spa-js": "1.21.0",
     "@azure/msal-browser": "2.24.0",
@@ -44,9 +48,5 @@
     "supertokens-auth-react": "0.20.4",
     "typescript": "4.6.4"
   },
-  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
-  "dependencies": {
-    "@babel/runtime-corejs3": "7.16.7",
-    "core-js": "3.22.4"
-  }
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,6 +46,7 @@
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
   "dependencies": {
-    "@babel/runtime-corejs3": "7.16.7"
+    "@babel/runtime-corejs3": "7.16.7",
+    "core-js": "3.22.4"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -44,5 +44,8 @@
     "supertokens-auth-react": "0.20.4",
     "typescript": "4.6.4"
   },
-  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
+  "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@prisma/sdk": "3.13.0",
     "@redwoodjs/api-server": "1.3.1",
     "@redwoodjs/internal": "1.3.1",

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -28,6 +28,7 @@
     "@redwoodjs/telemetry": "1.3.1",
     "chalk": "4.1.2",
     "check-node-version": "4.2.1",
+    "core-js": "3.22.4",
     "execa": "5.1.1",
     "fs-extra": "10.1.0",
     "listr": "0.14.3",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
+    "core-js": "3.22.4",
     "pascalcase": "1.0.0",
     "react-hook-form": "7.30.0"
   },

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -22,6 +22,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@envelop/depth-limit": "1.5.1",
     "@envelop/disable-introspection": "3.3.1",
     "@envelop/filter-operation-type": "3.3.1",

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -32,6 +32,7 @@
     "@redwoodjs/web": "1.3.1",
     "babel-plugin-ignore-html-and-css-imports": "0.1.0",
     "cheerio": "1.0.0-rc.10",
+    "core-js": "3.22.4",
     "cross-undici-fetch": "0.1.27",
     "mime-types": "2.1.35"
   },

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -24,6 +24,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@redwoodjs/auth": "1.3.1",
     "@redwoodjs/internal": "1.3.1",
     "@redwoodjs/router": "1.3.1",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -27,6 +27,7 @@
     ]
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@prisma/client": "3.13.0",
     "core-js": "3.22.4"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -22,6 +22,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@reach/skip-nav": "0.16.0",
     "@redwoodjs/auth": "1.3.1",
     "core-js": "3.22.4",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -30,6 +30,7 @@
     ]
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@prisma/sdk": "3.13.0",
     "@redwoodjs/internal": "1.3.1",
     "@types/line-column": "1.0.0",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -35,6 +35,7 @@
     "@redwoodjs/internal": "1.3.1",
     "@types/line-column": "1.0.0",
     "camelcase": "6.3.0",
+    "core-js": "3.22.4",
     "deepmerge": "4.2.2",
     "dotenv-defaults": "5.0.0",
     "enquirer": "2.3.6",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -30,6 +30,7 @@
     "@redwoodjs/internal": "1.3.1",
     "@redwoodjs/structure": "1.3.1",
     "ci-info": "3.3.0",
+    "core-js": "3.22.4",
     "cross-undici-fetch": "0.1.27",
     "envinfo": "7.8.1",
     "systeminformation": "5.11.14",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -26,6 +26,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "7.16.7",
     "@redwoodjs/auth": "1.3.1",
     "@redwoodjs/graphql-server": "1.3.1",
     "@redwoodjs/internal": "1.3.1",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -49,6 +49,7 @@
     "@types/webpack": "5.28.0",
     "babel-jest": "27.5.1",
     "babel-plugin-inline-react-svg": "2.0.1",
+    "core-js": "3.22.4",
     "jest": "27.5.1",
     "jest-watch-typeahead": "1.1.0",
     "msw": "0.39.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,6 +39,7 @@
     "@apollo/client": "3.6.2",
     "@babel/runtime-corejs3": "7.16.7",
     "@redwoodjs/auth": "1.3.1",
+    "core-js": "3.22.4",
     "graphql": "16.4.0",
     "graphql-tag": "2.12.6",
     "react-helmet-async": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5985,6 +5985,7 @@ __metadata:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
     "@babel/plugin-transform-runtime": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@fastify/http-proxy": 7.1.0
     "@fastify/static": 5.0.2
     "@fastify/url-data": 4.0.0
@@ -6073,6 +6074,7 @@ __metadata:
     "@azure/msal-browser": 2.24.0
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@clerk/clerk-js": 3.10.1
     "@clerk/clerk-sdk-node": 3.4.0
     "@clerk/types": 2.10.0
@@ -6099,6 +6101,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@prisma/sdk": 3.13.0
     "@redwoodjs/api-server": 1.3.1
     "@redwoodjs/internal": 1.3.1
@@ -6315,6 +6318,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@envelop/depth-limit": 1.5.1
     "@envelop/disable-introspection": 3.3.1
     "@envelop/filter-operation-type": 3.3.1
@@ -6402,6 +6406,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@redwoodjs/auth": 1.3.1
     "@redwoodjs/internal": 1.3.1
     "@redwoodjs/router": 1.3.1
@@ -6427,6 +6432,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@prisma/client": 3.13.0
     "@prisma/sdk": 3.13.0
     core-js: 3.22.4
@@ -6441,6 +6447,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@reach/skip-nav": 0.16.0
     "@redwoodjs/auth": 1.3.1
     "@types/lodash.isequal": 4.5.6
@@ -6462,6 +6469,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@prisma/sdk": 3.13.0
     "@redwoodjs/internal": 1.3.1
     "@types/fs-extra": 9.0.13
@@ -6521,6 +6529,7 @@ __metadata:
   dependencies:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
+    "@babel/runtime-corejs3": 7.16.7
     "@redwoodjs/auth": 1.3.1
     "@redwoodjs/graphql-server": 1.3.1
     "@redwoodjs/internal": 1.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5998,6 +5998,7 @@ __metadata:
     aws-lambda: 1.0.7
     chalk: 4.1.2
     chokidar: 3.5.3
+    core-js: 3.22.4
     fast-json-parse: 1.0.3
     fastify: 3.29.0
     fastify-raw-body: 3.2.0
@@ -6034,6 +6035,7 @@ __metadata:
     "@types/split2": 3.2.1
     "@types/uuid": 8.3.4
     aws-lambda: 1.0.7
+    core-js: 3.22.4
     cross-undici-fetch: 0.1.27
     crypto-js: 4.1.1
     humanize-string: 2.1.0
@@ -6083,6 +6085,7 @@ __metadata:
     "@supabase/supabase-js": 1.35.2
     "@types/netlify-identity-widget": 1.9.3
     "@types/react": 17.0.45
+    core-js: 3.22.4
     firebase: 9.8.0
     firebase-admin: 10.2.0
     gotrue-js: 0.9.29
@@ -6298,6 +6301,7 @@ __metadata:
     "@types/react": 17.0.45
     "@types/react-dom": 17.0.16
     "@types/testing-library__jest-dom": 5.14.3
+    core-js: 3.22.4
     graphql: 16.4.0
     jest: 27.5.1
     nodemon: 2.0.16
@@ -6416,6 +6420,7 @@ __metadata:
     babel-plugin-ignore-html-and-css-imports: 0.1.0
     babel-plugin-tester: 10.1.0
     cheerio: 1.0.0-rc.10
+    core-js: 3.22.4
     cross-undici-fetch: 0.1.27
     jest: 27.5.1
     mime-types: 2.1.35
@@ -6479,6 +6484,7 @@ __metadata:
     "@types/node": 16.11.33
     "@types/vscode": 1.67.0
     camelcase: 6.3.0
+    core-js: 3.22.4
     deepmerge: 4.2.2
     dotenv-defaults: 5.0.0
     enquirer: 2.3.6
@@ -6514,6 +6520,7 @@ __metadata:
     "@types/uuid": 8.3.4
     "@types/yargs": 17.0.10
     ci-info: 3.3.0
+    core-js: 3.22.4
     cross-undici-fetch: 0.1.27
     envinfo: 7.8.1
     jest: 27.5.1
@@ -6552,6 +6559,7 @@ __metadata:
     "@types/webpack": 5.28.0
     babel-jest: 27.5.1
     babel-plugin-inline-react-svg: 2.0.1
+    core-js: 3.22.4
     jest: 27.5.1
     jest-watch-typeahead: 1.1.0
     msw: 0.39.2
@@ -6576,6 +6584,7 @@ __metadata:
     "@types/react": 17.0.45
     "@types/react-dom": 17.0.16
     "@types/testing-library__jest-dom": 5.14.3
+    core-js: 3.22.4
     graphql: 16.4.0
     graphql-tag: 2.12.6
     jest: 27.5.1
@@ -13389,6 +13398,7 @@ __metadata:
     "@redwoodjs/telemetry": 1.3.1
     chalk: 4.1.2
     check-node-version: 4.2.1
+    core-js: 3.22.4
     execa: 5.1.1
     fs-extra: 10.1.0
     jest: 27.5.1


### PR DESCRIPTION
**What's the problem this PR addresses?**

Not all workspaces that build using the Babel config declares `@babel/runtime-corejs3` and `core-js` as dependencies even though they all might end up importing from them.

Follow-up to https://github.com/redwoodjs/redwood/pull/5457

**How did you fix it?**

Wrote a constraint to enforce that all workspaces with a `build:js` script depends on `@babel/runtime-corejs3` and `core-js`.