### PR TITLE
Fixing type for BrowserOnly children

### DIFF
--- a/packages/prerender/src/browserUtils/index.ts
+++ b/packages/prerender/src/browserUtils/index.ts
@@ -15,12 +15,8 @@ export const useIsBrowser = () => {
   }, [])
 }
 
-export const BrowserOnly = ({
-  children,
-}: {
-  children: ReactElement
-}) => {
+export const BrowserOnly = ({ children }: { children: ReactElement }) => {
   const isBrowser = useIsBrowser()
 
-  return isBrowser && children
+  return isBrowser ? children : null
 }

--- a/packages/prerender/src/browserUtils/index.ts
+++ b/packages/prerender/src/browserUtils/index.ts
@@ -18,7 +18,7 @@ export const useIsBrowser = () => {
 export const BrowserOnly = ({
   children,
 }: {
-  children: ReactElement<any, any>
+  children: ReactElement
 }) => {
   const isBrowser = useIsBrowser()
 

--- a/packages/prerender/src/browserUtils/index.ts
+++ b/packages/prerender/src/browserUtils/index.ts
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react'
 import { useMemo } from 'react'
 
 /* Web side prerender utils, to be used on the browser */
@@ -14,7 +15,11 @@ export const useIsBrowser = () => {
   }, [])
 }
 
-export const BrowserOnly = ({ children }: { children: React.ReactNode }) => {
+export const BrowserOnly = ({
+  children,
+}: {
+  children: ReactElement<any, any>
+}) => {
   const isBrowser = useIsBrowser()
 
   return isBrowser && children


### PR DESCRIPTION
Changed children type to ReactElement<any, any> in BrowserOnly from BrowserUtils.
During implementation of prerender in my app, i tried to use BrowserOnly to test prerender, unfortunatly children type was set to React.Node and it doesn't worked for me.
I changed it by ReactElement<any, any>.
- Build ok
- tests ok for my modification
- lint ok