### PR TITLE
Fix netlify ignore build script

### DIFF
--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -7,43 +7,51 @@ const { execSync } = require('child_process')
 console.log('------------------------')
 console.log("Running 'docs/ignore_build.js'")
 
-console.log(process.env)
-
-const remoteExists = execSync('git remote -v').toString().includes('origin')
-
-if (remoteExists) {
-  console.log('Remote exists')
-} else {
-  console.log('Adding remote')
-  execSync('git remote add origin https://github.com/redwoodjs/redwood.git')
-}
-
-console.log('Fetching main')
-execSync('git fetch origin main')
-
-console.log('Diffing changed files against main (name only)')
-const changedFiles = execSync('git diff origin/main --name-only')
-  .toString()
-  .trim()
-  .split('\n')
-  .filter(Boolean)
 console.log({
-  changedFiles,
+  branch: process.env.BRANCH,
 })
 
-const shouldBuild = changedFiles.some((changedFile) =>
-  changedFile.startsWith('docs')
-)
-console.log({
-  shouldBuild,
-})
-
-// We've done all the logic based on whether we should build the site,
-// but since this is an ignore script, we have to flip the logic here.
-if (shouldBuild) {
-  console.log(`PR '${process.env.HEAD}' has doc changes. Proceeding`)
+if (process.env.BRANCH === 'main') {
+  console.log(`Branch is main. Proceeding`)
   process.exitCode = 1
+  console.log('------------------------')
 } else {
-  console.log(`PR '${process.env.HEAD}' doesn't have doc changes. Ignoring`)
+  const remoteExists = execSync('git remote -v').toString().includes('origin')
+
+  if (remoteExists) {
+    console.log('Remote exists')
+  } else {
+    console.log('Adding remote')
+    execSync('git remote add origin https://github.com/redwoodjs/redwood.git')
+  }
+
+  console.log('Fetching main')
+  execSync('git fetch origin main')
+
+  console.log('Diffing changed files against main (name only)')
+  const changedFiles = execSync('git diff origin/main --name-only')
+    .toString()
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+  console.log({
+    changedFiles,
+  })
+
+  const shouldBuild = changedFiles.some((changedFile) =>
+    changedFile.startsWith('docs')
+  )
+  console.log({
+    shouldBuild,
+  })
+
+  // We've done all the logic based on whether we should build the site,
+  // but since this is an ignore script, we have to flip the logic here.
+  if (shouldBuild) {
+    console.log(`PR '${process.env.HEAD}' has doc changes. Proceeding`)
+    process.exitCode = 1
+  } else {
+    console.log(`PR '${process.env.HEAD}' doesn't have doc changes. Ignoring`)
+  }
+  console.log('------------------------')
 }
-console.log('------------------------')

--- a/docs/ignore_build.js
+++ b/docs/ignore_build.js
@@ -7,6 +7,8 @@ const { execSync } = require('child_process')
 console.log('------------------------')
 console.log("Running 'docs/ignore_build.js'")
 
+console.log(process.env)
+
 const remoteExists = execSync('git remote -v').toString().includes('origin')
 
 if (remoteExists) {


### PR DESCRIPTION
Once PRs with doc-related changes are merged to main, they should deploy no matter what.

The diff makes it look like there's a lot of changes, but I really just added an if else statement that checks if `process.env.BRANCH` is main.

I'm not sure what the value of `process.env.BRANCH` will actually be if the branch is main (I assume just `'main'`), so I'll have to merge to find out. I'll follow up with a fix if necessary.