### PR TITLE
Update release script to handle all contributors, versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "project:deps": "node ./tasks/framework-tools/frameworkDepsToProject.mjs",
     "project:sync": "node ./tasks/framework-tools/frameworkSyncToProject.mjs",
     "release": "node ./tasks/release/cli.mjs",
+    "release:test": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs",
     "smoke-test": "cd ./tasks/smoke-test && npx playwright install && npx playwright test",
-    "test": "lerna run test --stream -- --colors --maxWorkers=4",
-    "test:release-script": "NODE_OPTIONS=--experimental-vm-modules ./node_modules/.bin/jest --config ./tasks/release/jest.config.mjs"
+    "test": "lerna run test --stream -- --colors --maxWorkers=4"
   },
   "resolutions": {
     "@types/react": "17.0.45",

--- a/tasks/release/__tests__/__snapshots__/generateReleaseNotes.test.mjs.snap
+++ b/tasks/release/__tests__/__snapshots__/generateReleaseNotes.test.mjs.snap
@@ -7,6 +7,10 @@ Unique contributors: 3
 
 PRs merged: 3
 
+## Breaking
+
+
+
 ## Features
 
 - Added Decimal field type to Scaffold #4169 by @BBurnworth
@@ -18,6 +22,10 @@ PRs merged: 3
 ## Chore
 
 - Add storybook ci option to test that Storybook starts \\"ok\\" #3515 by @virtuoushub
+
+## Docs
+
+
 
 ### Package Dependencies
 

--- a/tasks/release/__tests__/release.test.mjs
+++ b/tasks/release/__tests__/release.test.mjs
@@ -1,4 +1,3 @@
-/* eslint-env jest, es2021 */
 import {
   MERGED_PRS_NO_MILESTONE,
   MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE,

--- a/tasks/release/cli.mjs
+++ b/tasks/release/cli.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint-env node, es2021 */
-import prompts from 'prompts'
+
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
@@ -10,45 +10,9 @@ import updatePRsMilestone from './updatePRsMilestone.mjs'
 
 yargs(hideBin(process.argv))
   .scriptName('release')
-  .command(
-    '$0',
-    'Release RedwoodJS',
-    (yargs) => {
-      yargs.option('semver', {
-        describe: 'Semver to release',
-        choices: ['major', 'minor', 'patch'],
-      })
-      yargs.option('update-prs-milestone', {
-        alias: 'prs',
-        describe: "Update pull requests' milestones",
-        type: 'boolean',
-      })
-      yargs.option('checkout', {
-        alias: 'b',
-        describe: 'Checkout the release branch',
-        type: 'boolean',
-      })
-      yargs.option('clean-install-update', {
-        alias: 'ciu',
-        describe: 'Clean, install, and update the package versions',
-        type: 'boolean',
-      })
-      yargs.option('commit-tag-qa', {
-        alias: 'ctq',
-        describe: 'Commit, tag, and and run through local QA',
-        type: 'boolean',
-      })
-      yargs.option('generate-release-notes', {
-        alias: 'notes',
-        describe: 'Generate release notes',
-        type: 'boolean',
-      })
-    },
-    async (argv) => {
-      prompts.override(argv)
-      await release()
-    }
-  )
+  .command('$0', 'Release RedwoodJS', async () => {
+    await release()
+  })
   .command(
     ['generate-release-notes [milestone]', 'notes'],
     'Generates release notes for a given milestone',

--- a/tasks/release/generateReleaseNotes.mjs
+++ b/tasks/release/generateReleaseNotes.mjs
@@ -1,9 +1,10 @@
 /* eslint-env node, es2021 */
+
+import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import url from 'node:url'
 
 import template from 'lodash.template'
-import { $ } from 'zx'
 
 import octokit from './octokit.mjs'
 
@@ -21,7 +22,6 @@ export default async function generateReleaseNotes(
   milestone,
   { releaseCandidate = false } = {}
 ) {
-  // Get the milestone's title, id, and PRs.
   const { title, id } = await getMilestoneId(milestone)
 
   if (releaseCandidate) {
@@ -41,11 +41,18 @@ export default async function generateReleaseNotes(
   console.log(`Written to ${url.fileURLToPath(filename)}`)
 }
 
+/**
+ * @param {string} milestone
+ */
 async function generateReleaseCandidateReleaseNotes(milestone) {
-  let { stdout: latestVersion } =
-    await $`yarn npm info @redwoodjs/core@latest --fields version --json`
+  const stdout = execSync(
+    'yarn npm info @redwoodjs/core@latest --fields version --json',
+    {
+      shell: true,
+    }
+  )
 
-  latestVersion = 'v' + JSON.parse(latestVersion.trim()).version
+  const latestVersion = 'v' + JSON.parse(stdout.toString().trim()).version
 
   const {
     repository: {
@@ -68,6 +75,11 @@ async function generateReleaseCandidateReleaseNotes(milestone) {
     }
   )
 
+  if (nodes.length === 0) {
+    console.log(`No release branch found for ${latestVersion}`)
+    return
+  }
+
   const [{ name: releaseBranch }] = nodes
 
   console.log({
@@ -75,8 +87,6 @@ async function generateReleaseCandidateReleaseNotes(milestone) {
     mergedPrs: `https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${milestone}`,
   })
 }
-
-// Helpers
 
 /**
  * @typedef {{
@@ -222,13 +232,12 @@ function getNoOfUniqueContributors(prs) {
 }
 
 /**
- * @remarks
- *
- * This could be a little better.
+ * @todo this could be a little better.
  *
  * @param {Array<PR>} prs
  */
 function sortPRs(prs) {
+  const breaking = []
   const features = []
   const fixed = []
   const chore = []
@@ -249,6 +258,11 @@ function sortPRs(prs) {
      * Sort the rest by label.
      */
     const labels = pr.labels.nodes.map((label) => label.name)
+
+    if (labels.includes('release:feature-breaking')) {
+      breaking.push(`- ${formatPR(pr)}`)
+      continue
+    }
 
     if (labels.includes('release:feature')) {
       features.push(`- ${formatPR(pr)}`)
@@ -277,6 +291,7 @@ function sortPRs(prs) {
   }
 
   return {
+    breaking: breaking.join('\n'),
     features: features.join('\n'),
     fixed: fixed.join('\n'),
     chore: chore.join('\n'),
@@ -305,6 +320,10 @@ const interpolate = template(
     'Unique contributors: ${uniqueContributors}',
     '',
     'PRs merged: ${prsMerged}',
+    '',
+    '## Breaking',
+    '',
+    '${breaking}',
     '',
     '## Features',
     '',

--- a/tasks/release/generateReleaseNotes.mjs
+++ b/tasks/release/generateReleaseNotes.mjs
@@ -19,7 +19,7 @@ import octokit from './octokit.mjs'
  */
 export default async function generateReleaseNotes(
   milestone,
-  { releaseCandidate = false }
+  { releaseCandidate = false } = {}
 ) {
   // Get the milestone's title, id, and PRs.
   const { title, id } = await getMilestoneId(milestone)

--- a/tasks/release/octokit.mjs
+++ b/tasks/release/octokit.mjs
@@ -1,18 +1,20 @@
 /* eslint-env node, es2021 */
+
 import { Octokit } from 'octokit'
 
 /**
  * Exit with a helpful error message if the user didn't provide a GitHub token.
  */
 if (!process.env.GITHUB_TOKEN) {
-  console.log()
-  console.error(
-    `  You have to provide a GitHub personal-access token (PAT) by setting it to an env var named "GITHUB_TOKEN"`
+  console.log(
+    [
+      '',
+      '  You have to provide a GitHub personal-access token (PAT) by setting it to an env var named "GITHUB_TOKEN"',
+      '  You can provision a PAT here: https://github.com/settings/tokens',
+      '',
+    ].join('\n')
   )
-  console.error(
-    `  You can provision a PAT here: https://github.com/settings/tokens`
-  )
-  console.log()
+
   process.exit(1)
 }
 

--- a/tasks/release/prompts.mjs
+++ b/tasks/release/prompts.mjs
@@ -1,6 +1,6 @@
 /* eslint-env node, es2021 */
+
 import c from 'ansi-colors'
-import boxen from 'boxen'
 import prompts from 'prompts'
 
 /**
@@ -18,32 +18,16 @@ export function exitOnCancelPrompts(promptsObject, promptsOptions) {
 }
 
 /**
- * @typedef {'major' | 'minor' | 'patch'} Semver
- * @returns {Promise<Semver>}
- */
-export async function promptForSemver() {
-  const { semver } = await exitOnCancelPrompts({
-    type: 'select',
-    name: 'semver',
-    message: ask`Which semver are you releasing?`,
-    choices: [{ value: 'major' }, { value: 'minor' }, { value: 'patch' }],
-    initial: 2,
-  })
-
-  return semver
-}
-
-/**
  * Wrapper around confirm-type `prompts`.
  *
- * @typedef {{ name: string, exit: boolean, exitCode: string }} ConfirmOptions
+ * @typedef {{ name: string, exitIfNo: boolean, exitCode: string }} ConfirmOptions
  * @param {string} message
  * @param {ConfirmOptions} options
  * @returns {Promise<boolean>}
  */
 export async function confirm(
   message,
-  { name, exit, exitCode } = { name: 'confirmed', exit: false, exitCode: 0 }
+  { name = 'confirmed', exitIfNo = false, exitCode = 1 } = {}
 ) {
   const answer = await exitOnCancelPrompts({
     type: 'confirm',
@@ -51,71 +35,28 @@ export async function confirm(
     message,
   })
 
-  if (answer[name] || !exit) {
-    return answer[name]
+  if (answer[name]) {
+    return true
   }
 
-  process.exit(exitCode)
-}
-
-/**
- * @param {string} message
- */
-export function rocketBoxen(message) {
-  return boxen(message, {
-    padding: 1,
-    margin: 1,
-    borderStyle: {
-      bottomLeft: '🚀',
-      bottomRight: '🚀',
-      horizontal: '—',
-      topLeft: '🚀',
-      topRight: '🚀',
-      vertical: '🚀',
-    },
-  })
-}
-
-/**
- * @param {string} prefix
- * @returns (string, ...values) => string
- */
-function makeStringFormatter(prefix) {
-  return function formatter(strings, ...values) {
-    const message = strings.reduce(
-      (string, nextString, i) =>
-        (string += nextString + c.green(values[i] ?? '')),
-      ''
-    )
-
-    return `${prefix} ${message}`
+  if (exitIfNo) {
+    process.exit(exitCode)
   }
+
+  return false
 }
-
-export const ASK = c.bgBlue(c.black('  ASK  '))
-export const CHECK = c.bgYellow(c.black(' CHECK '))
-export const FIX = c.bgRed(c.black('  FIX  '))
-export const OK = c.bgGreen(c.black('  O K  '))
-// https://stackoverflow.com/questions/38760554/how-to-print-cross-mark-or-check-mark-in-tcl
-export const HEAVY_X = c.red('\u2716')
-export const HEAVY_CHECK = c.green('\u2714')
-
-export const ask = makeStringFormatter(ASK)
-export const check = makeStringFormatter(CHECK)
-export const fix = makeStringFormatter(`${HEAVY_X} ${FIX}`)
-export const ok = makeStringFormatter(`${HEAVY_CHECK} ${OK}`)
 
 /**
  * @param {string} message
  * @param {Array<() => Promise<any>>} runs
- * @param {{ exit: boolean, exitCode: string }} options
+ * @param {{ name: string, exitIfNo: boolean, exitCode: string }} options
  */
 export async function confirmRuns(
   message,
   runs,
-  { name, exit, exitCode } = { name: 'confirmed', exit: false, exitCode: 0 }
+  { name = 'confirmed', exitIfNo = false, exitCode = 1 } = {}
 ) {
-  const confirmed = await confirm(message, { name, exit, exitCode })
+  const confirmed = await confirm(message, { name, exitIfNo, exitCode })
 
   if (!confirmed) {
     return false
@@ -134,3 +75,34 @@ export async function confirmRuns(
 
   return runResults
 }
+
+// ------------------------
+
+export const ASK = c.bgBlue(c.black('  ASK  '))
+export const CHECK = c.bgYellow(c.black(' CHECK '))
+export const FIX = c.bgRed(c.black('  FIX  '))
+export const OK = c.bgGreen(c.black('  O K  '))
+// https://stackoverflow.com/questions/38760554/how-to-print-cross-mark-or-check-mark-in-tcl
+export const HEAVY_X = c.red('\u2716')
+export const HEAVY_CHECK = c.green('\u2714')
+
+/**
+ * @param {string} prefix
+ * @returns (string, ...values) => string
+ */
+function makeStringFormatter(prefix) {
+  return function formatter(strings, ...values) {
+    const message = strings.reduce(
+      (string, nextString, i) =>
+        (string += nextString + c.green(values[i] ?? '')),
+      ''
+    )
+
+    return `${prefix} ${message}`
+  }
+}
+
+export const ask = makeStringFormatter(ASK)
+export const check = makeStringFormatter(CHECK)
+export const fix = makeStringFormatter(`${HEAVY_X} ${FIX}`)
+export const ok = makeStringFormatter(`${HEAVY_CHECK} ${OK}`)

--- a/tasks/release/prompts.mjs
+++ b/tasks/release/prompts.mjs
@@ -18,8 +18,6 @@ export function exitOnCancelPrompts(promptsObject, promptsOptions) {
 }
 
 /**
- * Wrapper around confirm-type `prompts`.
- *
  * @typedef {{ name: string, exitIfNo: boolean, exitCode: string }} ConfirmOptions
  * @param {string} message
  * @param {ConfirmOptions} options
@@ -63,7 +61,8 @@ export async function confirmRuns(
   }
 
   if (!Array.isArray(runs)) {
-    return runs()
+    const res = await runs()
+    return res ?? true
   }
 
   const runResults = []
@@ -82,13 +81,14 @@ export const ASK = c.bgBlue(c.black('  ASK  '))
 export const CHECK = c.bgYellow(c.black(' CHECK '))
 export const FIX = c.bgRed(c.black('  FIX  '))
 export const OK = c.bgGreen(c.black('  O K  '))
-// https://stackoverflow.com/questions/38760554/how-to-print-cross-mark-or-check-mark-in-tcl
+/**
+ * See {@link https://stackoverflow.com/questions/38760554/how-to-print-cross-mark-or-check-mark-in-tcl}
+ */
 export const HEAVY_X = c.red('\u2716')
 export const HEAVY_CHECK = c.green('\u2714')
 
 /**
  * @param {string} prefix
- * @returns (string, ...values) => string
  */
 function makeStringFormatter(prefix) {
   return function formatter(strings, ...values) {

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -20,9 +20,6 @@
  * - consider writing an e2e test using verdaccio
  */
 
-/**
- * @todo would be nice to have some consistency in the colors package we use
- */
 import c from 'ansi-colors'
 import boxen from 'boxen'
 import notifier from 'node-notifier'
@@ -142,11 +139,12 @@ export default async function release() {
   }
 
   /**
-   * Check that there's no merged PRs without a milestone
+   * Check that there's no merged PRs without a milestone.
    *
    * @remarks
    *
-   * If we're not releasing a patch, check that there's no merged PRs with next-release-patch
+   * If we're not releasing a patch,
+   * check that there's no merged PRs with "next-release-patch".
    */
   const {
     search: { nodes: pullRequests },
@@ -155,7 +153,7 @@ export default async function release() {
   if (pullRequests.length) {
     console.log(
       c.bold(
-        fix`There shouldn't be any merged PRs without a milestone. You must resolve this before proceeding`
+        fix`There shouldn't be any merged PRs without a milestone. You have to resolve this before proceeding`
       )
     )
     await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+no%3Amilestone`
@@ -164,7 +162,7 @@ export default async function release() {
     return
   }
 
-  console.log(c.bold(ok`No PRs without a milestone`))
+  console.log(c.bold(ok`No merged PRs without a milestone`))
 
   /**
    * If we're releasing a patch, we're done.
@@ -172,7 +170,7 @@ export default async function release() {
    */
   if (semver === 'patch') {
     await confirm(
-      check`Did you update the milestone of the PRs you plan to include in the patch to "next-release-patch"?`,
+      check`Did you update the milestone of the merged PRs you plan to include in the patch to "next-release-patch"?`,
       { exitIfNo: true }
     )
   } else {
@@ -181,14 +179,16 @@ export default async function release() {
     } = await octokit.graphql(MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE)
 
     if (!nextReleasePatchPullRequests.length) {
-      console.log(c.bold(ok`No PRs with the ${'next-release-patch'} milestone`))
+      console.log(
+        c.bold(ok`No merged PRs with the ${'next-release-patch'} milestone`)
+      )
     } else {
       console.log(
         c.bold(
-          fix`If you're not releasing a patch, there shouldn't be any merged PRs with the next-release-patch milestone. You must resolve this before proceeding`
+          fix`If you're not releasing a patch, there shouldn't be any merged PRs with the "next-release-patch" milestone. You have to resolve this before proceeding`
         )
       )
-      await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3Anext-release-patch`
+      await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3Anext-release-patch+`
 
       process.exitCode = 1
       return
@@ -222,7 +222,7 @@ export default async function release() {
  * Take the output from `git describe --abbrev=0` (which is something like `'v0.42.1'`),
  * and return an array of numbers ([0, 42, 1]).
  *
- * @param {string} version the version string (obtain by running `git describe --abbrev=0`)
+ * @param {string} version
  * @returns [string, string, string]
  */
 function parseGitTag(version) {
@@ -257,18 +257,8 @@ export const MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE = `
   }
 `
 
-// ------------------------
-
-/**
- * @param {string} nextVersion
- */
 const releaseMajor = (nextVersion) => releaseMajorOrMinor('major', nextVersion)
-
-/**
- * @param {string} nextVersion
- */
 const releaseMinor = (nextVersion) => releaseMajorOrMinor('minor', nextVersion)
-
 /**
  * Right now releasing a major is the same as releasing a minor.
  *
@@ -387,7 +377,7 @@ async function releasePatch(currentVersion, nextVersion) {
   notifier.notify('done')
 
   await confirmRuns(
-    ask`Everything passed local QA. Are you ready to push your branch and tag to GitHub and publish to NPM?`,
+    ask`Everything passed local QA. Ok to push your branch and tag to GitHub and publish to NPM?`,
     [
       () => $`git push`,
       () => $`git push --tags`,
@@ -443,7 +433,7 @@ function cleanInstallUpdate(nextVersion) {
 
 function confirmPackageVersions() {
   return confirm(
-    check`The package versions have been updated. Does everything look ok?`,
+    check`The package versions have been updated. Everything look ok?`,
     { exitIfNo: true }
   )
 }

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -1,4 +1,5 @@
 /* eslint-env node, es2021 */
+
 /**
  * Use this script to release a version of RedwoodJS:
  *
@@ -7,112 +8,105 @@
  * ```
  *
  * @remarks
- * You'll need a GitHub token and an NPM token. (So only @thedavidprice can do this right now.)
+ *
+ * You'll need...
+ *
+ * 1. a GitHub token in your environment (GITHUB_TOKEN)
+ * 2. to be logged into NPM
+ * 3. the appropriate permissions on your NPM account (contact @thedavidprice)
+ *
+ * @todo
+ *
+ * - consider writing an e2e test using verdaccio
+ */
+
+/**
+ * @todo would be nice to have some consistency in the colors package we use
  */
 import c from 'ansi-colors'
+import boxen from 'boxen'
 import notifier from 'node-notifier'
-import { $ } from 'zx'
+/**
+ * See {@link https://github.com/google/zx}
+ */
+import { $, cd } from 'zx'
 
 import generateReleaseNotes from './generateReleaseNotes.mjs'
 import octokit from './octokit.mjs'
 import {
-  promptForSemver,
+  exitOnCancelPrompts,
   confirm,
   confirmRuns,
-  exitOnCancelPrompts,
   ask,
   check,
   fix,
   ok,
-  rocketBoxen,
 } from './prompts.mjs'
 import updatePRsMilestone, { closeMilestone } from './updatePRsMilestone.mjs'
 
 let milestone
 
 export default async function release() {
-  const semver = await promptForSemver()
-  let [currentVersion, nextVersion] = await getCurrentAndNextVersions(semver)
+  /**
+   * Make sure that we're on main.
+   */
+  const gitBranchPO = await $`git branch --show-current`
 
-  await validateGitTag(nextVersion)
-  await validateMergedPRs(semver)
-
-  const fromTitle = 'next-release' + (semver === 'patch' ? '-patch' : '')
-
-  milestone = await confirmRuns(
-    ask`Do you want to update ${fromTitle} PRs' milestone to ${nextVersion}?`,
-    () => updatePRsMilestone(fromTitle, nextVersion),
-    { name: 'update-prs-milestone' }
-  )
-
-  // Do the release.
-  switch (semver) {
-    case 'major':
-      console.log(c.bold(fix`Wait till after v1`))
-      break
-    case 'minor':
-      await releaseMinor(nextVersion)
-      break
-    case 'patch':
-      await releasePatch(currentVersion, nextVersion)
-      break
-  }
-}
-
-// Helpers
-
-/**
- * Take the output from `git describe --abbrev=0` (which is something like `'v0.42.1'`),
- * and return an array of numbers ([0, 42, 1]).
- *
- * @param {string} version the version string (obtain by running `git describe --abbrev=0`)
- * @returns [string, string, string]
- */
-function parseGitTag(version) {
-  if (version.startsWith('v')) {
-    version = version.substring(1)
+  if (gitBranchPO.stdout.trim() !== 'main') {
+    console.log(fix`Start from main`)
+    process.exitCode = 1
+    return
   }
 
-  return version.split('.').map(Number)
-}
+  console.log(ok`On main`)
 
-/**
- * Bump the version according to the semver we're releasing.
- *
- * @typedef {'major' | 'minor' | 'patch'} Semver
- * @param {Semver} semver
- * @param {string} currentVersion
- */
-function getNextVersion(semver, currentVersion) {
+  /**
+   * - ask for the desired semver
+   * - get the current and next versions
+   * - do a few basic validations so that we can fail early
+   */
+  const { semver } = await exitOnCancelPrompts({
+    type: 'select',
+    name: 'semver',
+    message: ask`Which semver are you releasing?`,
+    choices: [{ value: 'major' }, { value: 'minor' }, { value: 'patch' }],
+    initial: 2,
+  })
+
+  /**
+   * Get the most-recent tag and get the next version from it.
+   * `git describe --abbrev=0` should output something like like `v0.42.1`.
+   */
+  const gitDescribePO = await $`git describe --abbrev=0`
+  const currentVersion = gitDescribePO.stdout.trim()
+
+  let nextVersion
+
+  /**
+   * Bump the version according to the semver we're releasing.
+   */
   switch (semver) {
     case 'major': {
       const [major] = parseGitTag(currentVersion)
-      return `v${[major + 1, 0, 0].join('.')}`
+      nextVersion = `v${[major + 1, 0, 0].join('.')}`
+      break
     }
     case 'minor': {
       const [major, minor] = parseGitTag(currentVersion)
-      return `v${[major, minor + 1, 0].join('.')}`
+      nextVersion = `v${[major, minor + 1, 0].join('.')}`
+      break
     }
     case 'patch': {
       const [major, minor, patch] = parseGitTag(currentVersion)
-      return `v${[major, minor, patch + 1].join('.')}`
+      nextVersion = `v${[major, minor, patch + 1].join('.')}`
+      break
     }
   }
-}
 
-/**
- * @param {Semver} semver
- * @returns {[string, string]}
- */
-async function getCurrentAndNextVersions(semver) {
-  // Get the most-recent tag and get the next version from it.
-  // `git describe --abbrev=0` should output something like like `v0.42.1`.
-  const gitDescribePO = await $`git describe --abbrev=0`
-  const currentVersion = gitDescribePO.stdout.trim()
-  let nextVersion = getNextVersion(semver, currentVersion)
-
-  // Confirm that we got the next version right.
-  // Give the user a chance to correct it if we didn't.
+  /**
+   * Confirm that we got the next version right.
+   * Give the user a chance to correct it if we didn't.
+   */
   const nextVersionConfirmed = await confirm(
     check`The next release is ${nextVersion}`
   )
@@ -131,42 +125,29 @@ async function getCurrentAndNextVersions(semver) {
     nextVersion = answer.nextVersion
   }
 
-  return [currentVersion, nextVersion]
-}
-
-// Validation
-
-/**
- * Check that the git tag doesn't already exist.
- *
- * @param {string} nextVersion
- */
-async function validateGitTag(nextVersion) {
+  /**
+   * Check that the git tag doesn't already exist.
+   */
   const gitTagPO = await $`git tag -l ${nextVersion}`
 
-  if (!gitTagPO.stdout.trim()) {
+  if (gitTagPO.stdout.trim()) {
+    console.log(
+      c.bold(
+        fix`Git tag ${nextVersion} already exists locally. You must resolve this before proceeding`
+      )
+    )
+
+    process.exitCode = 1
     return
   }
 
-  console.log(
-    c.bold(
-      fix`Git tag ${nextVersion} already exists locally. You must resolve this before proceeding`
-    )
-  )
-
-  process.exit(1)
-}
-
-/**
- * Check that there's no merged PRs without a milestone
- *
- * @remarks
- *
- * If we're not releasing a patch, check that there's no merged PRs with next-release-patch
- *
- * @param {Semver} semver
- */
-async function validateMergedPRs(semver) {
+  /**
+   * Check that there's no merged PRs without a milestone
+   *
+   * @remarks
+   *
+   * If we're not releasing a patch, check that there's no merged PRs with next-release-patch
+   */
   const {
     search: { nodes: pullRequests },
   } = await octokit.graphql(MERGED_PRS_NO_MILESTONE)
@@ -178,33 +159,78 @@ async function validateMergedPRs(semver) {
       )
     )
     await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+no%3Amilestone`
-    process.exit(1)
+
+    process.exitCode = 1
+    return
   }
 
   console.log(c.bold(ok`No PRs without a milestone`))
 
-  // If we're releasing a patch, we're done.
-  // But if we're not, check that there's no PRs with the next-release-patch milestone.
+  /**
+   * If we're releasing a patch, we're done.
+   * But if we're not, check that there's no PRs with the "next-release-patch" milestone.
+   */
   if (semver === 'patch') {
-    return
-  }
-
-  const {
-    search: { nodes: nextReleasePatchPullRequests },
-  } = await octokit.graphql(MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE)
-
-  if (!nextReleasePatchPullRequests.length) {
-    console.log(c.bold(ok`No PRs with the ${'next-release-patch'} milestone`))
-    return
-  }
-
-  console.log(
-    c.bold(
-      fix`If you're not releasing a patch, there shouldn't be any merged PRs with the next-release-patch milestone. You must resolve this before proceeding`
+    await confirm(
+      check`Did you update the milestone of the PRs you plan to include in the patch to "next-release-patch"?`,
+      { exitIfNo: true }
     )
+  } else {
+    const {
+      search: { nodes: nextReleasePatchPullRequests },
+    } = await octokit.graphql(MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE)
+
+    if (!nextReleasePatchPullRequests.length) {
+      console.log(c.bold(ok`No PRs with the ${'next-release-patch'} milestone`))
+    } else {
+      console.log(
+        c.bold(
+          fix`If you're not releasing a patch, there shouldn't be any merged PRs with the next-release-patch milestone. You must resolve this before proceeding`
+        )
+      )
+      await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3Anext-release-patch`
+
+      process.exitCode = 1
+      return
+    }
+  }
+
+  const fromTitle = 'next-release' + (semver === 'patch' ? '-patch' : '')
+
+  milestone = await confirmRuns(
+    ask`Ok to update ${fromTitle} PRs' milestone to ${nextVersion}?`,
+    () => updatePRsMilestone(fromTitle, nextVersion)
   )
-  await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3Anext-release-patch`
-  process.exit(1)
+
+  /**
+   * Do the release.
+   */
+  switch (semver) {
+    case 'major':
+      await releaseMajor(nextVersion)
+      break
+    case 'minor':
+      await releaseMinor(nextVersion)
+      break
+    case 'patch':
+      await releasePatch(currentVersion, nextVersion)
+      break
+  }
+}
+
+/**
+ * Take the output from `git describe --abbrev=0` (which is something like `'v0.42.1'`),
+ * and return an array of numbers ([0, 42, 1]).
+ *
+ * @param {string} version the version string (obtain by running `git describe --abbrev=0`)
+ * @returns [string, string, string]
+ */
+function parseGitTag(version) {
+  if (version.startsWith('v')) {
+    version = version.substring(1)
+  }
+
+  return version.split('.').map(Number)
 }
 
 export const MERGED_PRS_NO_MILESTONE = `
@@ -231,162 +257,132 @@ export const MERGED_PRS_NEXT_RELEASE_PATCH_MILESTONE = `
   }
 `
 
+// ------------------------
+
+/**
+ * @param {string} nextVersion
+ */
+const releaseMajor = (nextVersion) => releaseMajorOrMinor('major', nextVersion)
+
+/**
+ * @param {string} nextVersion
+ */
+const releaseMinor = (nextVersion) => releaseMajorOrMinor('minor', nextVersion)
+
 /**
  * Right now releasing a major is the same as releasing a minor.
  *
- * @param {string} nextVersion
- */
-// function releaseMajor(nextVersion) {
-//   return releaseMajorOrMinor('major', nextVersion)
-// }
-
-/**
- * @param {string} nextVersion
- */
-function releaseMinor(nextVersion) {
-  return releaseMajorOrMinor('minor', nextVersion)
-}
-
-/**
  * @param {Semver} semver
  * @param {string} nextVersion
  */
 async function releaseMajorOrMinor(semver, nextVersion) {
-  const currentBranch = getCurrentBranch()
   const releaseBranch = ['release', semver, nextVersion].join('/')
   const releaseBranchExists = await branchExists(releaseBranch)
 
-  if (currentBranch !== releaseBranch) {
-    if (releaseBranchExists) {
-      await checkoutExisting(releaseBranch)
-    } else {
-      await confirmRuns(
-        ask`Ok to checkout new branch ${releaseBranch}?`,
-        [() => $`git checkout main`, () => $`git checkout -b ${releaseBranch}`],
-        { name: 'checkout', exit: true }
-      )
-    }
+  if (releaseBranchExists) {
+    await checkoutExisting(releaseBranch)
+  } else {
+    await confirmRuns(
+      ask`Ok to checkout new branch ${releaseBranch}?`,
+      () => $`git checkout -b ${releaseBranch}`,
+      { exitIfNo: true }
+    )
   }
 
   await confirm(
-    ask`Continue to publish or stop here to push this branch to GitHub to create an RC`,
-    { exit: true }
+    ask`Ok to continue to publish, or do you want to stop here so that you can push this branch to GitHub to create an RC?`,
+    { exitIfNo: true, exitCode: 0 }
   )
 
   await cleanInstallUpdate(nextVersion)
   notifier.notify('done')
-
-  await confirm(
-    check`The package versions have been updated. Does everything look ok?`,
-    { exit: true }
-  )
-
+  await confirmPackageVersions()
   await commitTagQA(nextVersion)
   notifier.notify('done')
 
+  const releaseBranchExistsOnOrigin = await branchExistsOnOrigin(releaseBranch)
+
   await confirmRuns(
-    ask`Everything passed local QA. Are you ready to push your branch and tag to GitHub and publish to NPM?`,
+    ask`Everything passed local QA. Ok to push this branch and tag to GitHub and publish to NPM?`,
     [
-      () =>
-        $`git push ${[
-          !releaseBranchExists && `-u origin ${releaseBranch}`,
-        ].filter(Boolean)}`,
+      releaseBranchExistsOnOrigin
+        ? () => $`git push`
+        : () => $`git push -u origin ${releaseBranch}`,
       () => $`git push --tags`,
-      // We've had an issue with this one.
-      async () => {
-        try {
-          await $`yarn lerna publish from-package`
-          console.log(rocketBoxen(`Released ${c.green(nextVersion)}`))
-        } catch (e) {
-          console.log(
-            `Couldn't run ${c.green('yarn lerna publish from-package')}`
-          )
-          console.log(e)
-        }
-      },
+      () => $`yarn lerna publish from-package`,
+      () => console.log(rocketBoxen(`Released ${c.green(nextVersion)}`)),
     ],
-    { exit: true }
+    { exitIfNo: true }
   )
 
-  await confirmRuns(
-    ask`Do you want to generate release notes?`,
-    () => generateReleaseNotes(nextVersion),
-    { name: 'generate-release-notes' }
-  )
-
-  if (milestone) {
-    await confirmRuns(ask`Ok to close milestone ${nextVersion}?`, () =>
-      closeMilestone(milestone.number)
-    )
-  }
+  await cleanUpTasks(semver, nextVersion)
 }
 
 /**
  * @param {string} nextVersion
  */
 async function releasePatch(currentVersion, nextVersion) {
-  const currentBranch = await getCurrentBranch()
   const releaseBranch = ['release', 'patch', nextVersion].join('/')
+  const releaseBranchExists = await branchExists(releaseBranch)
 
-  if (currentBranch !== releaseBranch) {
-    const releaseBranchExists = await branchExists(releaseBranch)
-
-    if (releaseBranchExists) {
-      await checkoutExisting(releaseBranch)
-    } else {
-      await confirmRuns(
-        ask`Ok to checkout new branch ${releaseBranch} from ${currentVersion} tag?`,
-        // See https://git-scm.com/book/en/v2/Git-Basics-Tagging
-        // Scroll down to "Checking out Tags".
-        () => $`git checkout -b ${releaseBranch} ${currentVersion}`,
-        { name: 'checkout', exit: true }
-      )
-    }
+  if (releaseBranchExists) {
+    await checkoutExisting(releaseBranch)
+  } else {
+    await confirmRuns(
+      ask`Ok to checkout new branch ${releaseBranch} from ${currentVersion} tag?`,
+      /**
+       * See https://git-scm.com/book/en/v2/Git-Basics-Tagging
+       * Scroll down to "Checking out Tags".
+       */
+      () => $`git checkout -b ${releaseBranch} ${currentVersion}`,
+      { exitIfNo: true }
+    )
   }
 
   const releaseBranchExistsOnOrigin = await branchExistsOnOrigin(releaseBranch)
+
+  const compareURL = 'https://github.com/redwoodjs/redwood/compare'
 
   if (!releaseBranchExistsOnOrigin) {
     await confirmRuns(
       ask`Ok to push new branch ${releaseBranch} to GitHub and open diff?`,
       [
         () => $`git push -u origin ${releaseBranch}`,
-        () =>
-          $`open https://github.com/redwoodjs/redwood/compare/${currentVersion}...${releaseBranch}`,
+        () => $`open ${compareURL}/${currentVersion}...${releaseBranch}`,
       ],
-      { exit: true }
+      { exitIfNo: true }
     )
-    await confirm('Does the diff look ok?', { exit: true })
 
-    await confirm(
-      ask`${[
-        'Done cherry picking?',
-        'Remember to cherry pick PRs in the same order as they were merged',
-        `And after you're done, run ${`yarn`} and ${`yarn check`}`,
-      ].join('\n')}`,
-      { exit: true }
+    await confirm('Diff look ok?', { exitIfNo: true })
+
+    console.log(
+      [
+        '',
+        `  👇 ${c.bgYellow(c.black(' HEADS UP '))}`,
+        '  Remember to cherry pick PRs _in the same order as they were merged_',
+        "  And after you're done, run... ",
+        '    1. yarn (to update the lock file), and',
+        '    2. yarn check',
+        '',
+      ].join('\n')
     )
+
+    await confirm(ask`Done cherry picking?}`, { exitIfNo: true })
 
     await confirmRuns(
       ask`Ok to push new branch ${releaseBranch} to GitHub and open diff?`,
       [
         () => $`git push`,
-        () =>
-          $`open https://github.com/redwoodjs/redwood/compare/${currentVersion}...${releaseBranch}`,
+        () => $`open ${compareURL}/${currentVersion}...${releaseBranch}`,
       ],
-      { exit: true }
+      { exitIfNo: true }
     )
-    await confirm('Does the diff look ok?', { exit: true })
+    await confirm('Diff look ok?', { exitIfNo: true })
   }
 
   await cleanInstallUpdate(nextVersion)
   notifier.notify('done')
-
-  await confirm(
-    check`The package versions have been updated. Does everything look ok?`,
-    { exit: true }
-  )
-
+  await confirmPackageVersions()
   await commitTagQA(nextVersion)
   notifier.notify('done')
 
@@ -395,37 +391,39 @@ async function releasePatch(currentVersion, nextVersion) {
     [
       () => $`git push`,
       () => $`git push --tags`,
-      // We've had an issue with this one.
-      async () => {
-        try {
-          await $`yarn lerna publish from-package`
-          console.log(rocketBoxen(`Released ${c.green(nextVersion)}`))
-        } catch (e) {
-          console.log(
-            `Couldn't run ${c.green('yarn lerna publish from-package')}`
-          )
-          console.log(e)
-        }
-      },
+      () => $`yarn lerna publish from-package`,
+      () => console.log(rocketBoxen(`Released ${c.green(nextVersion)}`)),
     ],
-    { exit: true }
+    { exitIfNo: true }
   )
 
-  await confirmRuns(
-    ask`Do you want to generate release notes?`,
-    () => generateReleaseNotes(nextVersion),
-    { name: 'generate-release-notes' }
-  )
+  await cleanUpTasks('patch', nextVersion)
+}
 
-  if (milestone) {
-    await confirmRuns(ask`Ok to close milestone ${nextVersion}?`, () =>
-      closeMilestone(milestone.number)
-    )
+/**
+ * @param {string} branch
+ */
+async function branchExists(branch) {
+  const gitBranchPO = await $`git branch`
+
+  const branches = gitBranchPO.stdout
+    .trim()
+    .split('\n')
+    .map((branch) => branch.trim())
+
+  if (branches.includes(branch)) {
+    return true
   }
 
-  await confirm(ask`Did you merge the release branch into main?`)
-  await confirm(ask`Did you update yarn.lock?`)
-  await confirm(ask`Did you delete the release branch?`)
+  return false
+}
+
+function checkoutExisting(releaseBranch) {
+  return confirmRuns(
+    ask`Ok to checkout existing release branch ${releaseBranch}?`,
+    () => $`git checkout ${releaseBranch}`,
+    { exitIfNo: true }
+  )
 }
 
 /**
@@ -439,7 +437,14 @@ function cleanInstallUpdate(nextVersion) {
       () => $`yarn install`,
       () => $`./tasks/update-package-versions ${nextVersion}`,
     ],
-    { name: 'clean-install-update', exit: true }
+    { exitIfNo: true }
+  )
+}
+
+function confirmPackageVersions() {
+  return confirm(
+    check`The package versions have been updated. Does everything look ok?`,
+    { exitIfNo: true }
   )
 }
 
@@ -457,34 +462,9 @@ function commitTagQA(nextVersion) {
       () => $`yarn test`,
     ],
     {
-      name: 'commit-tag-qa',
-      exit: true,
+      exitIfNo: true,
     }
   )
-}
-
-async function getCurrentBranch() {
-  const { stdout } = await $`git branch --show-current`
-  return stdout.trim()
-}
-
-/**
- * @param {string} branch
- */
-// eslint-disable-next-line no-unused-vars
-async function branchExists(branch) {
-  const { stdout } = await $`git branch`
-
-  const branches = stdout
-    .trim()
-    .split('\n')
-    .map((branch) => branch.trim())
-
-  if (branches.includes(branch)) {
-    return true
-  }
-
-  return false
 }
 
 /**
@@ -501,10 +481,104 @@ async function branchExistsOnOrigin(branch) {
   return false
 }
 
-function checkoutExisting(releaseBranch) {
-  confirmRuns(
-    ask`Ok to checkout existing release branch ${releaseBranch}?`,
-    () => $`git checkout ${releaseBranch}`,
-    { name: 'checkout', exit: true }
-  )
+/**
+ * @param {string} message
+ */
+function rocketBoxen(message) {
+  return boxen(message, {
+    padding: 1,
+    margin: 1,
+    borderStyle: {
+      bottomLeft: '🚀',
+      bottomRight: '🚀',
+      horizontal: '—',
+      topLeft: '🚀',
+      topRight: '🚀',
+      vertical: '🚀',
+    },
+  })
 }
+
+/**
+ *
+ * @param {string} nextVersion
+ */
+async function cleanUpTasks(semver, nextVersion) {
+  await confirmRuns(ask`Ok to generate release notes?`, () =>
+    generateReleaseNotes(nextVersion)
+  )
+
+  if (milestone) {
+    await confirmRuns(ask`Ok to close milestone ${nextVersion}?`, () =>
+      closeMilestone(milestone.number)
+    )
+  }
+
+  await confirm(check`Did you delete the release branch?`)
+  await confirm(check`Did you merge the release branch into main?`)
+  await confirm(check`Did you update yarn.lock?`)
+
+  await confirmRuns(ask`Ok to run all contributors?`, [
+    () => cd('./tasks/all-contributors'),
+    async () => {
+      const allContributorsCheckPO =
+        await $`yarn all-contributors check --config .all-contributorsrc`
+
+      const contributors = allContributorsCheckPO.stdout
+        .trim()
+        .split('\n')[1]
+        .split(',')
+        .map((contributor) => contributor.trim())
+        .filter(
+          (contributor) => !ALL_CONTRIBUTORS_IGNORE_LIST.includes(contributor)
+        )
+
+      for (const contributor of contributors) {
+        await $`yarn all-contributors add --config .all-contributorsrc ${contributor} code`
+      }
+
+      await $`yarn all-contributors generate --contributorsPerLine 5 --config .all-contributorsrc`
+    },
+    () => $`git commit -am "Update all contributors"`,
+    () => cd('../..'),
+  ])
+
+  if (semver === 'major' || semver === 'minor') {
+    await confirmRuns(ask`Ok to version the docs?`, [
+      () => cd('./docs'),
+      () => $`yarn`,
+      () => $`yarn clear`,
+      () => $`yarn docusaurus docs:version ${nextVersion}`,
+      () => $`git add .`,
+      () => $`git commit -m "Version docs"`,
+      () => cd('../'),
+    ])
+  }
+}
+
+const ALL_CONTRIBUTORS_IGNORE_LIST = [
+  'peterp',
+  'thedavidprice',
+  'renovate[bot]',
+  'jtoar',
+  'dac09',
+  'cannikin',
+  'Tobbe',
+  'dependabot[bot]',
+  'dthyresson',
+  'mojombo',
+  'RobertBroersma',
+  'kimadeline',
+  'callingmedic911',
+  'aldonline',
+  'forresthayes',
+  'simoncrypta',
+  'KrisCoulson',
+  'realStandal',
+  'virtuoushub',
+  'alicelovescake',
+  'dependabot-preview[bot]',
+  'ajcwebdev',
+  'agiannelli',
+  'codesee-maps[bot]',
+]

--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -514,7 +514,11 @@ async function cleanUpTasks(semver, nextVersion) {
     )
   }
 
-  await confirm(check`Did you delete the release branch?`)
+  await confirmRuns(
+    check`Did you delete the release branch?`,
+    () => $`open https://github.com/redwoodjs/redwood/branches`
+  )
+
   await confirm(check`Did you merge the release branch into main?`)
   await confirm(check`Did you update yarn.lock?`)
 

--- a/tasks/release/updatePRsMilestone.mjs
+++ b/tasks/release/updatePRsMilestone.mjs
@@ -1,4 +1,5 @@
 /* eslint-env node, es2021 */
+
 import { $ } from 'zx'
 
 import octokit from './octokit.mjs'
@@ -12,21 +13,25 @@ export default async function updatePRsMilestone(fromTitle, toTitle) {
   let milestone = await getMilestone(toTitle)
 
   if (!milestone) {
-    const createOk = await confirm(
-      ask`Milestone ${toTitle} doesn't exist. Ok to create it?`
+    const createRes = await confirmRuns(
+      ask`Milestone ${toTitle} doesn't exist. Ok to create it?`,
+      async () => {
+        const {
+          data: { node_id: id, number },
+        } = await createMilestone(toTitle)
+
+        return { id, number }
+      }
     )
-    if (!createOk) {
+
+    if (!createRes) {
       return
     }
 
-    const {
-      data: { node_id: id, number },
-    } = await createMilestone(toTitle)
-
-    milestone = { title: toTitle, id, number }
+    milestone = { title: toTitle, id: createRes.id, number: createRes.number }
   }
 
-  const fromMilestoneId = (await getMilestone(fromTitle)).id
+  const { id: fromMilestoneId } = await getMilestone(fromTitle)
 
   const pullRequestIds = await getPullRequestIdsWithMilestone(fromMilestoneId)
 
@@ -35,48 +40,42 @@ export default async function updatePRsMilestone(fromTitle, toTitle) {
     return
   }
 
-  const updateOk = await confirm(
-    ask`Ok to update the milestone of ${pullRequestIds.length} PRs from ${fromTitle} to ${toTitle}?`
+  const updateRes = await confirmRuns(
+    ask`Ok to update the milestone of ${pullRequestIds.length} PRs from ${fromTitle} to ${toTitle}?`,
+    () =>
+      Promise.all(
+        pullRequestIds.map((pullRequestId) =>
+          updatePullRequestMilestone(pullRequestId, milestone.id)
+        )
+      ),
+    () =>
+      $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3A${toTitle}`
   )
-  if (!updateOk) {
+  if (!updateRes) {
     return
   }
 
-  await Promise.all(
-    pullRequestIds.map((pullRequestId) =>
-      updatePullRequestMilestone(pullRequestId, milestone.id)
-    )
-  )
-
-  await $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3A${toTitle}`
-
   const looksOk = await confirm(
-    check`Updated the milestone of ${pullRequestIds.length} PRs\nDoes everything look ok?`
+    check`Updated the milestone of ${pullRequestIds.length} PRs\Everything look ok?`
   )
   if (looksOk) {
     return milestone
   }
 
-  const undoPRs = await confirm(
-    ask`Do you want to undo the changes to the PRs?`
-  )
-  if (undoPRs) {
-    await Promise.all(
+  await confirmRuns(ask`Ok to undo the changes to the PRs?`, () =>
+    Promise.all(
       pullRequestIds.map((pullRequestId) =>
         updatePullRequestMilestone(pullRequestId, fromMilestoneId)
       )
     )
-  }
+  )
 
-  const undoMilestone = await confirm(ask`Do you want to delete the milestone`)
-  if (undoMilestone) {
-    await deleteMilestone(milestone.number)
-  }
+  await confirmRuns(ask`Ok to delete the milestone`, () =>
+    deleteMilestone(milestone.number)
+  )
 
   return
 }
-
-// Helpers
 
 /**
  * @typedef {{

--- a/tasks/release/updatePRsMilestone.mjs
+++ b/tasks/release/updatePRsMilestone.mjs
@@ -49,7 +49,8 @@ export default async function updatePRsMilestone(fromTitle, toTitle) {
         )
       ),
     () =>
-      $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+milestone%3A${toTitle}`
+      $`open https://github.com/redwoodjs/redwood/pulls?q=is%3Apr+is%3Amerged+milestone%3A${toTitle}
+      `
   )
   if (!updateRes) {
     return


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/5438; this PR adds an updating docs step for majors and minors, and adds an all contributors step. It also just gives the release script some TLC since I had to go through most of it again.

- [x] make delete branch step open link
- [x] fix link on merged prs (add is:merged filter)