### PR TITLE
Fix yarn rw build web --perf option

### DIFF
--- a/packages/core/config/webpack.perf.js
+++ b/packages/core/config/webpack.perf.js
@@ -22,12 +22,9 @@ const indexOfRulesTest = (regex) => {
   })
 }
 
-const jsBabel = indexOfRulesTest(/\.(js|mjs|jsx)$/)
-config.module.rules[0].oneOf[jsBabel].use[0].options.customize =
-  require.resolve('babel-timing/webpack/babel-loader-customize')
-
-const tsBabel = indexOfRulesTest(/\.(ts|tsx)$/)
-config.module.rules[0].oneOf[tsBabel].use[0].options.customize =
-  require.resolve('babel-timing/webpack/babel-loader-customize')
+const babel = indexOfRulesTest(/\.(js|mjs|jsx|ts|tsx)$/)
+config.module.rules[0].oneOf[babel].use[0].options.customize = require.resolve(
+  'babel-timing/webpack/babel-loader-customize'
+)
 
 module.exports = config


### PR DESCRIPTION
This fix #5425 by updating the regex to find babel rule. 

Before #3719, JS and TS had two different rules. Now that is merged together, the regex for babel rules on webpack.perf.js is not valid anymore. 