### PR TITLE
RWCell: Print error on gql syntax error

### DIFF
--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -43,7 +43,14 @@ export class RWCell extends RWComponent {
     if (!qs) {
       return undefined
     }
-    return parseGraphQL(qs)
+
+    try {
+      return parseGraphQL(qs)
+    } catch (e) {
+      console.error("Can't parse the graphql query string in", this.filePath)
+      console.error(e)
+      return undefined
+    }
   }
 
   // TODO: Move to RWCellQuery


### PR DESCRIPTION
Fixes #5529

When debugging 5529 we traced the error down to this code

https://github.com/redwoodjs/redwood/blob/bc79162f36057c0b6b59d75a29a87cc43a008dae/packages/cli/src/commands/generate/cell/cell.js#L23-L28

Further tracing led me into the structure package and its `queryAst` getter. It tries to parse the gql query in the cell, but that fails because of the syntax error described in #5529. This exception wasn't caught, and caused the cell generator to crash.

I've wrapped the call to `parse` with a try/catch and print out any error that it throws, together with the filename of the cell where the error occurs. I also return `undefined` from the getter, which will propagate all the way up to the cell generator where it'll just be filtered out. So what'll happen in the end is that the cell the user asked to generate will be generated. It will just not consider the name of the query in the broken cell when deciding on the query name in the newly generated cell. The user will also see a helpful error message, so he/she can easily find and fix the broken gql query.

The output will look something like this
![image](https://user-images.githubusercontent.com/30793/168388246-af9c6cc9-3527-4910-8d3a-d230d0745947.png)

The only thing bugging me right now is that the error output will be printed twice. I don't know why. But I've previously seen strange things with the output when using yargs and listr. If I introduce a syntax error in two cells I only get the error output once per cell... Unless someone knows how to easily fix this, I think it's a separate issue to look into that.