### PR TITLE
Handle special props `ref` and `key` in path and search params

### DIFF
--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1489,3 +1489,23 @@ test('params should be updated if navigated to different route with same page', 
     expect(screen.queryByText('hookparams 99')).toBeInTheDocument()
   })
 })
+
+test('should handle ref and key as search params', async () => {
+  const ParamsPage = () => {
+    const { ref, key } = useParams()
+    return <p>{JSON.stringify({ ref, key })}</p>
+  }
+
+  const TestRouter = () => (
+    <Router>
+      <Route path="/params" page={ParamsPage} name="params" />
+    </Router>
+  )
+
+  const screen = render(<TestRouter />)
+  act(() => navigate('/params?ref=1&key=2'))
+
+  await waitFor(() => {
+    expect(screen.queryByText(`{"ref":"1","key":"2"}`)).toBeInTheDocument()
+  })
+})

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -290,7 +290,7 @@ describe('validatePath', () => {
       expect(validatePath.bind(null, path)).toThrowError(
         [
           `Route contains ref or key as a path parameter: "${path}"`,
-          '`ref` and `key` are special react props.',
+          "`ref` and `key` shouldn't be used as path parameters because they're special React props.",
           'You can fix this by renaming the path parameter.',
         ].join('\n')
       )

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -284,7 +284,15 @@ describe('validatePath', () => {
     expect(validatePath.bind(null, path)).not.toThrow()
   })
 
-  it.each(['/path/{ref}', '/path/{ref:Int}', '/path/{key}', '/path/{key:Int}'])(
+  it.each([
+    '/path/{ref}',
+    '/path/{ref}/bazinga',
+    '/path/{ref:Int}',
+    '/path/{ref:Int}/bazinga',
+    '/path/{key}',
+    '/path/{key}/bazinga',
+    '/path/{key:Int}'
+  ])(
     'rejects paths with ref or key as path parameters: "%s"',
     (path) => {
       expect(validatePath.bind(null, path)).toThrowError(

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -291,24 +291,21 @@ describe('validatePath', () => {
     '/path/{ref:Int}/bazinga',
     '/path/{key}',
     '/path/{key}/bazinga',
-    '/path/{key:Int}'
-  ])(
-    'rejects paths with ref or key as path parameters: "%s"',
-    (path) => {
-      expect(validatePath.bind(null, path)).toThrowError(
-        [
-          `Route contains ref or key as a path parameter: "${path}"`,
-          "`ref` and `key` shouldn't be used as path parameters because they're special React props.",
-          'You can fix this by renaming the path parameter.',
-        ].join('\n')
-      )
-    }
-  )
+    '/path/{key:Int}',
+  ])('rejects paths with ref or key as path parameters: "%s"', (path) => {
+    expect(validatePath.bind(null, path)).toThrowError(
+      [
+        `Route contains ref or key as a path parameter: "${path}"`,
+        "`ref` and `key` shouldn't be used as path parameters because they're special React props.",
+        'You can fix this by renaming the path parameter.',
+      ].join('\n')
+    )
+  })
 
   it.each([
     '/path/{reff}',
     '/path/{reff:Int}',
-    '/path/{reff}/bazinga',    
+    '/path/{reff}/bazinga',
     '/path/{keys}',
     '/path/{keys:Int}',
     '/path/key',

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -283,6 +283,19 @@ describe('validatePath', () => {
   ])('validates correct path "%s"', (path) => {
     expect(validatePath.bind(null, path)).not.toThrow()
   })
+
+  it.each(['/path/{ref}', '/path/{ref:Int}', '/path/{key}', '/path/{key:Int}'])(
+    'rejects paths with ref or key as path parameters: "%s"',
+    (path) => {
+      expect(validatePath.bind(null, path)).toThrowError(
+        [
+          `Route contains ref or key as a path parameter: "${path}"`,
+          '`ref` and `key` are special react props.',
+          'You can fix this by renaming the path parameter.',
+        ].join('\n')
+      )
+    }
+  )
 })
 
 describe('parseSearch', () => {

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -296,6 +296,13 @@ describe('validatePath', () => {
       )
     }
   )
+
+  it.each(['/path/{reff}', '/path/{reff:Int}', '/path/{keys}', '/path/{keys:Int}'])(
+    `doesn't reject paths with variations on ref or key as path parameters: "%s"`,
+    (path) => {
+      expect(validatePath.bind(null, path)).not.toThrowError()
+    }
+  )
 })
 
 describe('parseSearch', () => {

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -297,7 +297,15 @@ describe('validatePath', () => {
     }
   )
 
-  it.each(['/path/{reff}', '/path/{reff:Int}', '/path/{keys}', '/path/{keys:Int}'])(
+  it.each([
+    '/path/{reff}',
+    '/path/{reff:Int}',
+    '/path/{reff}/bazinga',    
+    '/path/{keys}',
+    '/path/{keys:Int}',
+    '/path/key',
+    '/path/key/bazinga',
+  ])(
     `doesn't reject paths with variations on ref or key as path parameters: "%s"`,
     (path) => {
       expect(validatePath.bind(null, path)).not.toThrowError()

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -21,7 +21,7 @@ interface Props {
   path: string
   spec: Spec
   delay?: number
-  params?: Record<string, string>
+  params?: Record<string, unknown>
   whileLoadingPage?: () => React.ReactElement | null
   children?: React.ReactNode
 }

--- a/packages/router/src/active-route-loader.tsx
+++ b/packages/router/src/active-route-loader.tsx
@@ -21,7 +21,7 @@ interface Props {
   path: string
   spec: Spec
   delay?: number
-  params?: Record<string, unknown>
+  params?: Record<string, string>
   whileLoadingPage?: () => React.ReactElement | null
   children?: React.ReactNode
 }

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -113,14 +113,10 @@ const InternalRoute = ({
 
   const Page = activePageContext.loadingState[path]?.page || (() => null)
 
-  // There are two special props in react: `ref` and `key`.
-  // (See https://reactjs.org/warnings/special-props.html.)
-  //
-  // It's very possible that the URL has `ref` as a search param
-  // (e.g. https://redwoodjs.com/?ref=producthunt).
-  //
-  // Since we pass URL params to the page, we have to be careful not to pass `ref` or `key`,
-  // otherwise the page will break. (The page won't actually break if `key` is passed, but it feels unclean.)
+  // There are two special props in React: `ref` and `key`. (See https://reactjs.org/warnings/special-props.html.)
+  // It's very possible that the URL has `ref` as a search param (e.g. https://redwoodjs.com/?ref=producthunt).
+  // Since we pass URL params to the page, we have to be careful not to pass `ref` or `key`, otherwise the page will break.
+  // (The page won't actually break if `key` is passed, but it feels unclean.)
   // If users want to access them, they can use `useParams`.
   ;['ref', 'key'].forEach((specialProp) => {
     if (Object.hasOwn(allParams, specialProp)) {

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -118,11 +118,8 @@ const InternalRoute = ({
   // Since we pass URL params to the page, we have to be careful not to pass `ref` or `key`, otherwise the page will break.
   // (The page won't actually break if `key` is passed, but it feels unclean.)
   // If users want to access them, they can use `useParams`.
-  ;['ref', 'key'].forEach((specialProp) => {
-    if (Object.hasOwn(allParams, specialProp)) {
-      delete allParams[specialProp]
-    }
-  })
+  delete allParams['ref']
+  delete allParams['key']
 
   // Level 3/3 (InternalRoute)
   return <Page {...allParams} />

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -97,7 +97,7 @@ const InternalRoute = ({
   )
 
   const searchParams = parseSearch(location.search)
-  const allParams = { ...searchParams, ...pathParams }
+  const allParams: Record<string, string> = { ...searchParams, ...pathParams }
 
   if (redirect) {
     const newPath = replaceParams(redirect, allParams)

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -113,6 +113,21 @@ const InternalRoute = ({
 
   const Page = activePageContext.loadingState[path]?.page || (() => null)
 
+  // There are two special props in react: `ref` and `key`.
+  // (See https://reactjs.org/warnings/special-props.html.)
+  //
+  // It's very possible that the URL has `ref` as a search param
+  // (e.g. https://redwoodjs.com/?ref=producthunt).
+  //
+  // Since we pass URL params to the page, we have to be careful not to pass `ref` or `key`,
+  // otherwise the page will break. (The page won't actually break if `key` is passed, but it feels unclean.)
+  // If users want to access them, they can use `useParams`.
+  ;['ref', 'key'].forEach((specialProp) => {
+    if (Object.hasOwn(allParams, specialProp)) {
+      delete allParams[specialProp]
+    }
+  })
+
   // Level 3/3 (InternalRoute)
   return <Page {...allParams} />
 }

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -197,7 +197,7 @@ export const validatePath = (path: string) => {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 
-  if (/\{(ref|key)/.test(path)) {
+  if (/\{(ref|key)([^}]*)\}/.test(path)) {
     throw new Error(
       [
         `Route contains ref or key as a path parameter: "${path}"`,

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -173,15 +173,6 @@ export const parseSearch = (
 ) => {
   const searchParams = new URLSearchParams(search)
 
-  for (const [reservedName, altName] of Object.entries(reservedSearchParams)) {
-    if (searchParams.has(reservedName)) {
-      // If we're in here, we've narrowed that `searchParams` has `reservedName`
-      // but TS doesn't seem to know that. So, casting:
-      searchParams.set(altName, searchParams.get(reservedName) as string)
-      searchParams.delete(reservedName)
-    }
-  }
-
   return [...searchParams.keys()].reduce(
     (params, key) => ({
       ...params,
@@ -189,10 +180,6 @@ export const parseSearch = (
     }),
     {}
   )
-}
-
-const reservedSearchParams = {
-  ref: 'referrer',
 }
 
 /**

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -197,7 +197,7 @@ export const validatePath = (path: string) => {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 
-  if (/\{(ref|key)([^}]*)\}/.test(path)) {
+  if (/\{(ref|key)/.test(path)) {
     throw new Error(
       [
         `Route contains ref or key as a path parameter: "${path}"`,

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -197,6 +197,16 @@ export const validatePath = (path: string) => {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 
+  if (/\{(ref|key)([^}]*)\}/.test(path)) {
+    throw new Error(
+      [
+        `Route contains ref or key as a path parameter: "${path}"`,
+        "`ref` and `key` shouldn't be used as path parameters because they're special React props.",
+        'You can fix this by renaming the path parameter.',
+      ].join('\n')
+    )
+  }
+
   // Check for duplicate named params.
   const matches = path.matchAll(/\{([^}]+)\}/g)
   const memo: Record<string, boolean> = {}

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -197,7 +197,7 @@ export const validatePath = (path: string) => {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 
-  if (/\{(ref|key)(:|\})/.test(path)) {
+  if (/{(?:ref|key)(?::|})/.test(path)) {
     throw new Error(
       [
         `Route contains ref or key as a path parameter: "${path}"`,

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -173,10 +173,10 @@ export const parseSearch = (
 ) => {
   const searchParams = new URLSearchParams(search)
 
-  return [...searchParams.keys()].reduce(
+  return [...searchParams.keys()].reduce<Record<string, string>>(
     (params, key) => ({
       ...params,
-      [key]: searchParams.get(key),
+      [key]: searchParams.get(key) as string,
     }),
     {}
   )

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -173,6 +173,15 @@ export const parseSearch = (
 ) => {
   const searchParams = new URLSearchParams(search)
 
+  for (const [reservedName, altName] of Object.entries(reservedSearchParams)) {
+    if (searchParams.has(reservedName)) {
+      // If we're in here, we've narrowed that `searchParams` has `reservedName`
+      // but TS doesn't seem to know that. So, casting:
+      searchParams.set(altName, searchParams.get(reservedName) as string)
+      searchParams.delete(reservedName)
+    }
+  }
+
   return [...searchParams.keys()].reduce(
     (params, key) => ({
       ...params,
@@ -180,6 +189,10 @@ export const parseSearch = (
     }),
     {}
   )
+}
+
+const reservedSearchParams = {
+  ref: 'referrer',
 }
 
 /**

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -173,10 +173,10 @@ export const parseSearch = (
 ) => {
   const searchParams = new URLSearchParams(search)
 
-  return [...searchParams.keys()].reduce<Record<string, string>>(
+  return [...searchParams.keys()].reduce(
     (params, key) => ({
       ...params,
-      [key]: searchParams.get(key) as string,
+      [key]: searchParams.get(key),
     }),
     {}
   )

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -197,7 +197,7 @@ export const validatePath = (path: string) => {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 
-  if (/\{(ref|key)[^}]*\}/.test(path)) {
+  if (/\{(ref|key)(:|\})/.test(path)) {
     throw new Error(
       [
         `Route contains ref or key as a path parameter: "${path}"`,

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -197,7 +197,7 @@ export const validatePath = (path: string) => {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 
-  if (/\{(ref|key)([^}]*)\}/.test(path)) {
+  if (/\{(ref|key)[^}]*\}/.test(path)) {
     throw new Error(
       [
         `Route contains ref or key as a path parameter: "${path}"`,


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/5497. When it comes to the router, it's react components all the way down. The router is a react component; routes are react components; pages are react components. We pass path and search parameters to pages as props, so that you can do things like...

```jsx
const PostPage = ({ id }) => {
  return <PostCell id={id} />
}
```

(You can also get `id` from the params context via `useParams`, but destructuring it from props is more convenient.) When a path or search param is `ref` or `key`, there's an issue. If it's `ref`, the component throws since you can only pass the return of `React.createRef` or `useRef` to `ref`. With `key`, nothing happens, but the component consumes the prop and you don't get access to it. It's still accessible via `useParams`, but this isn't super obvious.

This PR stops the hard break that happens when `ref` is passed. It also stops the router from passing `key`. 