### PR TITLE
Revert "chore(deps): update dependency @actions/core to v1.8.2 (#5523)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vscode-languageserver-types": "3.17.0"
   },
   "devDependencies": {
-    "@actions/core": "1.8.2",
+    "@actions/core": "1.8.0",
     "@actions/exec": "1.1.1",
     "@babel/cli": "7.16.7",
     "@babel/core": "7.16.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,12 +5,12 @@ __metadata:
   version: 6
   cacheKey: 8c0
 
-"@actions/core@npm:1.8.2":
-  version: 1.8.2
-  resolution: "@actions/core@npm:1.8.2"
+"@actions/core@npm:1.8.0":
+  version: 1.8.0
+  resolution: "@actions/core@npm:1.8.0"
   dependencies:
-    "@actions/http-client": ^2.0.1
-  checksum: 15381a3fd2764405b7e3c2c59be6850e928a4b109c75261e3328bd7140700ba420f88efa1a09fb9eacd7f9865b4fccf4684c12b392beed29417a762f39c97c1e
+    "@actions/http-client": ^1.0.11
+  checksum: ad43c4d2ba0e4e3499fc9a6d4e7f0ef0aa78dd52c7fc73f66d9f49d89dfe72cefe0f58a49a59f00235fa0f301a396a8c0688f86250b586a91eb757f62d32c962
   languageName: node
   linkType: hard
 
@@ -23,12 +23,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actions/http-client@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@actions/http-client@npm:2.0.1"
+"@actions/http-client@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@actions/http-client@npm:1.0.11"
   dependencies:
-    tunnel: ^0.0.6
-  checksum: b58987ba2f53d7988f612ede7ff834573a3360c21f8fdea9fea92f26ada0fd0efafb22aa7d83f49c18965a5b765775d5253e2edb8d9476d924c4b304ef726b67
+    tunnel: 0.0.6
+  checksum: e3939d93cd3aa6509cf23109a1b32390007d2efa25a59af56758d6c23b48b220e19a7af703d01ef93a71957b9c542ae910d8f2921529302e56aed660c77dfd54
   languageName: node
   linkType: hard
 
@@ -27137,7 +27137,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@actions/core": 1.8.2
+    "@actions/core": 1.8.0
     "@actions/exec": 1.1.1
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
@@ -29860,7 +29860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tunnel@npm:^0.0.6":
+"tunnel@npm:0.0.6":
   version: 0.0.6
   resolution: "tunnel@npm:0.0.6"
   checksum: e27e7e896f2426c1c747325b5f54efebc1a004647d853fad892b46d64e37591ccd0b97439470795e5262b5c0748d22beb4489a04a0a448029636670bfd801b75


### PR DESCRIPTION
This reverts commit bc79162f36057c0b6b59d75a29a87cc43a008dae.

I'm trying to debug a failing smoke-test in CI (Windows). Will try to not revert this upgrade; just trying to narrow things down.