### PR TITLE
Try adding glob resolution to test project

### DIFF
--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -28,5 +28,8 @@
   "scripts": {
     "postinstall": ""
   },
-  "packageManager": "yarn@3.2.1"
+  "packageManager": "yarn@3.2.1",
+  "resolutions": {
+    "glob": "7.2.0"
+  }
 }


### PR DESCRIPTION
Opening this PR to see if it fixes CI. Using the workaround here: https://github.com/isaacs/node-glob/issues/471#issuecomment-1126739067.

Update: it looks like this works. I'm going to merge this for now so that we can keep our velocity. I'll make a note to remove it when the Storybook patch comes in.

Note that this resolution is for the test project fixture, not create redwood app.