### PR TITLE
Fix: add missing dep terminal link to internal

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -56,6 +56,7 @@
     "rimraf": "3.0.2",
     "string-env-interpolation": "1.0.1",
     "systeminformation": "5.11.15",
+    "terminal-link": "2.1.1",
     "toml": "3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6215,6 +6215,7 @@ __metadata:
     rimraf: 3.0.2
     string-env-interpolation: 1.0.1
     systeminformation: 5.11.15
+    terminal-link: 2.1.1
     toml: 3.0.0
     typescript: 4.6.4
   bin:


### PR DESCRIPTION
`@redwoodjs/internal` imports from `terminal-link` but doesn't require it in its package.json. Should fix https://github.com/redwoodjs/redwood/issues/5584.