### PR TITLE
Chore: remove glob resolution in test project fixture

### DIFF
--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -28,8 +28,5 @@
   "scripts": {
     "postinstall": ""
   },
-  "packageManager": "yarn@3.2.1",
-  "resolutions": {
-    "glob": "7.2.3"
-  }
+  "packageManager": "yarn@3.2.1"
 }


### PR DESCRIPTION
Now that glob has been patched this shouldn't be necessary.
- https://github.com/redwoodjs/redwood/pull/5543
- https://github.com/redwoodjs/redwood/pull/5561