### PR TITLE
Fix: try pinning @mswjs/interceptors internally

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,6 +25,9 @@
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
+  "resolutions": {
+    "@mswjs/interceptors": "0.15.1"
+  },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
     "@redwoodjs/auth": "1.4.2",
@@ -62,8 +65,5 @@
     "@babel/core": "7.16.7",
     "typescript": "4.6.4"
   },
-  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
-  "resolutions": {
-    "@mswjs/interceptors": "0.15.1"
-  }
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -62,5 +62,8 @@
     "@babel/core": "7.16.7",
     "typescript": "4.6.4"
   },
-  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
+  "resolutions": {
+    "@mswjs/interceptors": "0.15.1"
+  }
 }


### PR DESCRIPTION
Tries to close https://github.com/redwoodjs/redwood/issues/5612. Will only consider this a legit fix if users don't have to do anything downstream. 