### PR TITLE
Revert "Fix: try pinning @mswjs/interceptors internally (#5613)"

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -25,9 +25,6 @@
     "test": "jest src",
     "test:watch": "yarn test --watch"
   },
-  "resolutions": {
-    "@mswjs/interceptors": "0.15.1"
-  },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
     "@redwoodjs/auth": "1.4.2",


### PR DESCRIPTION
This reverts commit 4a7e6fa800560c3d60322ff889cfdeabead35d57. Still not sure how to set resolutions that take effect downstream. We had the same problem with react types.