### PR TITLE
[CLI] partial fixes to `cwd` option, propose that commands import deps lazily

### DIFF
--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -22,32 +22,47 @@ const sendProcessReady = () => {
   return process.send && process.send('ready')
 }
 
-export const commonOptions = {
-  port: { default: getConfig().web?.port || 8910, type: 'number', alias: 'p' },
-  socket: { type: 'string' },
-} as const
+export const getCommonOptions = () =>
+  ({
+    port: {
+      default: getConfig().web?.port || 8910,
+      type: 'number',
+      alias: 'p',
+    },
+    socket: { type: 'string' },
+  } as const)
 
-export const apiCliOptions = {
-  port: { default: getConfig().api?.port || 8911, type: 'number', alias: 'p' },
-  socket: { type: 'string' },
-  apiRootPath: {
-    alias: ['rootPath', 'root-path'],
-    default: '/',
-    type: 'string',
-    desc: 'Root path where your api functions are served',
-    coerce: coerceRootPath,
-  },
-} as const
+export const getApiCliOptions = () =>
+  ({
+    port: {
+      default: getConfig().api?.port || 8911,
+      type: 'number',
+      alias: 'p',
+    },
+    socket: { type: 'string' },
+    apiRootPath: {
+      alias: ['rootPath', 'root-path'],
+      default: '/',
+      type: 'string',
+      desc: 'Root path where your api functions are served',
+      coerce: coerceRootPath,
+    },
+  } as const)
 
-export const webCliOptions = {
-  port: { default: getConfig().web?.port || 8910, type: 'number', alias: 'p' },
-  socket: { type: 'string' },
-  apiHost: {
-    alias: 'api-host',
-    type: 'string',
-    desc: 'Forward requests from the apiUrl, defined in redwood.toml to this host',
-  },
-} as const
+export const getWebCliOptions = () =>
+  ({
+    port: {
+      default: getConfig().web?.port || 8910,
+      type: 'number',
+      alias: 'p',
+    },
+    socket: { type: 'string' },
+    apiHost: {
+      alias: 'api-host',
+      type: 'string',
+      desc: 'Forward requests from the apiUrl, defined in redwood.toml to this host',
+    },
+  } as const)
 
 interface ApiServerArgs extends Omit<HttpServerParams, 'app'> {
   apiRootPath: string // either user supplied or '/'

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -3,9 +3,9 @@ import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 
 import {
-  apiCliOptions,
-  webCliOptions,
-  commonOptions,
+  getApiCliOptions,
+  getWebCliOptions,
+  getCommonOptions,
   apiServerHandler,
   webServerHandler,
   bothServerHandler,
@@ -22,18 +22,18 @@ const positionalArgs = yargs(hideBin(process.argv)).parseSync()._
 if (require.main === module) {
   if (positionalArgs.includes('api') && !positionalArgs.includes('web')) {
     apiServerHandler(
-      yargs(hideBin(process.argv)).options(apiCliOptions).parseSync()
+      yargs(hideBin(process.argv)).options(getApiCliOptions()).parseSync()
     )
   } else if (
     positionalArgs.includes('web') &&
     !positionalArgs.includes('api')
   ) {
     webServerHandler(
-      yargs(hideBin(process.argv)).options(webCliOptions).parseSync()
+      yargs(hideBin(process.argv)).options(getWebCliOptions()).parseSync()
     )
   } else {
     bothServerHandler(
-      yargs(hideBin(process.argv)).options(commonOptions).parseSync()
+      yargs(hideBin(process.argv)).options(getCommonOptions()).parseSync()
     )
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@
     - [Adding an Entry Point Command](#adding-an-entry-point-command)
     - [Adding a Generator](#adding-a-generator)
       - [createYargsForComponentGeneration](#createyargsforcomponentgeneration)
-      - [yargsDefaults](#yargsdefaults)
+      - [getYargsDefaults](#getYargsDefaults)
       - [Testing Generators](#testing-generators)
       - [Adding a Destroyer](#adding-a-destroyer)
     - [Adding a Provider to the Auth Generator](#adding-a-provider-to-the-auth-generator)
@@ -195,7 +195,7 @@ export const description = 'Build for production.'
 
 `builder` configures the positional arguments and options for the command.
 
-While `builder` can be an object, the [positional argument api](https://yargs.js.org/docs/#api-positionalkey-opt) is only available if builder is a function. But that doesn't mean we can't use an object to "build" `builder`. As you'll see in [yargsDefaults](#yargsdefaults), this is what we do with commands that share a lot of options.
+While `builder` can be an object, the [positional argument api](https://yargs.js.org/docs/#api-positionalkey-opt) is only available if builder is a function. But that doesn't mean we can't use an object to "build" `builder`. As you'll see in [getYargsDefaults](#getYargsDefaults), this is what we do with commands that share a lot of options.
 
 Here's an excerpt of `build`'s `builder`:
 
@@ -416,7 +416,7 @@ It has four parameters:
 
 - `componentName`: a string, like `'page'`
 - `filesFn`: a function, usually the one called `files`
-- `optionsObj`: an object, used to construct `options` for yargs. Defaults to [yargsDefaults](#yargsdefaults)
+- `optionsObj`: an object, used to construct `options` for yargs. Defaults to [getYargsDefaults](#getYargsDefaults)
 - `positionalsObj`: an object, used to construct `positionals` for yargs.
 
 The idea here's to export as many constants as you can straight from `createYargsForComponentGeneration`'s returns:
@@ -448,26 +448,26 @@ export const { command, builder, handler } = createYargsForComponentGeneration({
 })
 ```
 
-#### yargsDefaults
+#### getYargsDefaults
 
-If you find yourself not using the `builder` from `createYargsForComponentGeneration` (or just not using `createYargsForComponentGeneration` at all), you should use `yargsDefaults`.
+If you find yourself not using the `builder` from `createYargsForComponentGeneration` (or just not using `createYargsForComponentGeneration` at all), you should use `getYargsDefaults`.
 
 <!-- [todo] -->
 <!-- Link when merged -->
-`yargsDefaults` is an object that contains all the options common to generate commands. It's defined in `generate.js`, the generator entry-point command. So importing it usually looks like:
+`getYargsDefaults` is an object that contains all the options common to generate commands. It's defined in `generate.js`, the generator entry-point command. So importing it usually looks like:
 
 ```javascript
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 ```
 
 <!-- kind of a bad name -->
-We use `yargsDefaults` to "build" the builder. The generate sdl command is a good example. In sdl.js (which is in the generate directory in ./src/commands) `yargsDefault` is spread into another object, `defaults` (the name of this object is another convention):
+We use `getYargsDefaults` to "build" the builder. The generate sdl command is a good example. In sdl.js (which is in the generate directory in ./src/commands) `yargsDefault` is spread into another object, `defaults` (the name of this object is another convention):
 
 ```javascript
 // ./src/commands/generate/sdl/sdl.js
 
 export const defaults = {
-  ...yargsDefaults,
+  ...getYargsDefaults,
   crud: {
     default: false,
     description: 'Also generate mutations',
@@ -607,7 +607,7 @@ Some of the generators have already been converted; use them as a reference (lin
 - [sdl](https://github.com/redwoodjs/redwood/pull/515)
 - [services](https://github.com/redwoodjs/redwood/pull/515)
 
-For most of the generate commands, the option (in the builder) for generating a typescript file is already there, either in the builder returned from `createYargsForComponentGeneration` or in `yargsDefaults` (the former actually uses the latter).
+For most of the generate commands, the option (in the builder) for generating a typescript file is already there, either in the builder returned from `createYargsForComponentGeneration` or in `getYargsDefaults` (the former actually uses the latter).
 
 ### What about...
 

--- a/packages/cli/src/commands/check.js
+++ b/packages/cli/src/commands/check.js
@@ -1,25 +1,27 @@
-import { getPaths } from '../lib'
-import c from '../lib/colors'
-
 export const command = 'check'
+
 export const aliases = ['diagnostics']
+
 export const description =
   'Get structural diagnostics for a Redwood project (experimental)'
 
-export const handler = async () => {
+export async function handler(argv) {
   const { printDiagnostics, DiagnosticSeverity } = await import(
     '@redwoodjs/structure'
   )
+  const { redwoodProject, colors } = argv
 
-  printDiagnostics(getPaths().base, {
+  printDiagnostics(redwoodProject.paths.base, {
     getSeverityLabel: (severity) => {
       if (severity === DiagnosticSeverity.Error) {
-        return c.error('error')
+        return colors.error('error')
       }
+
       if (severity === DiagnosticSeverity.Warning) {
-        return c.warning('warning')
+        return colors.warning('warning')
       }
-      return c.info('info')
+
+      return colors.info('info')
     },
   })
 }

--- a/packages/cli/src/commands/console.js
+++ b/packages/cli/src/commands/console.js
@@ -10,35 +10,9 @@ export const command = 'console'
 export const aliases = ['c']
 export const description = 'Launch an interactive Redwood shell (experimental)'
 
-const paths = getPaths()
-
-const loadPrismaClient = (replContext) => {
-  const { db } = require(path.join(paths.api.lib, 'db'))
-  replContext.db = db
-}
-
-const consoleHistoryFile = path.join(paths.generated.base, 'console_history')
-const persistConsoleHistory = (r) => {
-  fs.appendFileSync(
-    consoleHistoryFile,
-    r.lines.filter((line) => line.trim()).join('\n') + '\n',
-    'utf8'
-  )
-}
-
-const loadConsoleHistory = async (r) => {
-  try {
-    const history = await fs.promises.readFile(consoleHistoryFile, 'utf8')
-    history
-      .split('\n')
-      .reverse()
-      .map((line) => r.history.push(line))
-  } catch (e) {
-    // We can ignore this -- it just means the user doesn't have any history yet
-  }
-}
-
 export const handler = () => {
+  const paths = getPaths()
+
   // Transpile on the fly
   registerApiSideBabelHook({
     plugins: [
@@ -77,9 +51,35 @@ export const handler = () => {
 
   // Persist console history to .redwood/console_history. See
   // https://tjwebb.medium.com/a-custom-node-repl-with-history-is-not-as-hard-as-it-looks-3eb2ca7ec0bd
+  const loadConsoleHistory = async (r) => {
+    try {
+      const history = await fs.promises.readFile(consoleHistoryFile, 'utf8')
+      history
+        .split('\n')
+        .reverse()
+        .map((line) => r.history.push(line))
+    } catch (e) {
+      // We can ignore this -- it just means the user doesn't have any history yet
+    }
+  }
+
+  const consoleHistoryFile = path.join(paths.generated.base, 'console_history')
+  const persistConsoleHistory = (r) => {
+    fs.appendFileSync(
+      consoleHistoryFile,
+      r.lines.filter((line) => line.trim()).join('\n') + '\n',
+      'utf8'
+    )
+  }
+
   loadConsoleHistory(r)
   r.addListener('close', () => persistConsoleHistory(r))
 
   // Make the project's db (i.e. Prisma Client) available
+  const loadPrismaClient = (replContext) => {
+    const { db } = require(path.join(paths.api.lib, 'db'))
+    replContext.db = db
+  }
+
   loadPrismaClient(r.context)
 }

--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import '../../../../lib/test'
 
 import { getPaths, getDefaultArgs } from '../../../../lib'
-import { yargsDefaults as defaults } from '../../../generate'
+import { getYargsDefaults as defaults } from '../../../generate'
 import { files } from '../../../generate/scaffold/scaffold'
 import { tasks } from '../scaffold'
 
@@ -32,7 +32,7 @@ describe('rw destroy scaffold', () => {
     beforeEach(async () => {
       fs.__setMockFiles({
         ...(await files({
-          ...getDefaultArgs(defaults),
+          ...getDefaultArgs(defaults()),
           model: 'Post',
           tests: false,
           nestScaffoldByModel: true,

--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import '../../../../lib/test'
 
 import { getPaths, getDefaultArgs } from '../../../../lib'
-import { yargsDefaults as defaults } from '../../../generate'
+import { getYargsDefaults as defaults } from '../../../generate'
 import { files } from '../../../generate/scaffold/scaffold'
 import { tasks } from '../scaffold'
 
@@ -32,7 +32,7 @@ describe('rw destroy scaffold', () => {
     beforeEach(async () => {
       fs.__setMockFiles({
         ...(await files({
-          ...getDefaultArgs(defaults),
+          ...getDefaultArgs(defaults()),
           model: 'Post',
           tests: false,
           nestScaffoldByModel: false,

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -22,7 +22,7 @@ export const builder = (yargs) =>
     )
 
 /** @type {Record<string, import('yargs').Options>} */
-export const yargsDefaults = {
+export const getYargsDefaults = () => ({
   force: {
     alias: 'f',
     default: false,
@@ -35,4 +35,4 @@ export const yargsDefaults = {
     description: 'Generate TypeScript files',
     type: 'boolean',
   },
-}
+})

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -6,7 +6,7 @@ import { transformTSToJS } from '../../../lib'
 import { isWordPluralizable } from '../../../lib/pluralHelpers'
 import { isPlural, singularize } from '../../../lib/rwPluralize'
 import { getSchema } from '../../../lib/schemaHelpers'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import {
   templateForComponentFile,
   createYargsForComponentGeneration,
@@ -171,7 +171,7 @@ export const { command, description, builder, handler } =
     componentName: 'cell',
     filesFn: files,
     optionsObj: {
-      ...yargsDefaults,
+      ...getYargsDefaults(),
       list: {
         alias: 'l',
         default: false,

--- a/packages/cli/src/commands/generate/dataMigration/dataMigration.js
+++ b/packages/cli/src/commands/generate/dataMigration/dataMigration.js
@@ -7,7 +7,7 @@ import terminalLink from 'terminal-link'
 
 import { getPaths, writeFilesTask } from '../../../lib'
 import c from '../../../lib/colors'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 
 const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
   'After writing your migration, you can run it with:'
@@ -50,7 +50,7 @@ export const builder = (yargs) => {
     )
 
   // Merge generator defaults in
-  Object.entries(yargsDefaults).forEach(([option, config]) => {
+  Object.entries(getYargsDefaults()).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -13,7 +13,7 @@ import {
   writeFilesTask,
 } from '../../../lib'
 import c from '../../../lib/colors'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import { templateForComponentFile } from '../helpers'
 
 const ROUTES = [
@@ -56,7 +56,7 @@ export const builder = (yargs) => {
     )
 
   // Merge generator defaults in
-  Object.entries(yargsDefaults).forEach(([option, config]) => {
+  Object.entries(getYargsDefaults()).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -9,7 +9,7 @@ import { getConfig } from '@redwoodjs/internal'
 
 import { getPaths, writeFilesTask, transformTSToJS } from '../../../lib'
 import c from '../../../lib/colors'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import {
   createYargsForComponentGeneration,
   templateForComponentFile,
@@ -87,7 +87,7 @@ export const { command, description, builder } =
     filesFn: files,
     positionalsObj,
     optionsObj: {
-      ...yargsDefaults,
+      ...getYargsDefaults(),
       type: {
         type: 'string',
         choices: ['validator', 'transformer'],

--- a/packages/cli/src/commands/generate/function/function.js
+++ b/packages/cli/src/commands/generate/function/function.js
@@ -8,7 +8,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { getPaths, transformTSToJS, writeFilesTask } from '../../../lib'
 import c from '../../../lib/colors'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import { templateForComponentFile } from '../helpers'
 
 export const files = ({
@@ -92,7 +92,7 @@ export const description = 'Generate a Function'
 
 // This could be built using createYargsForComponentGeneration;
 // however, functions shouldn't have a `stories` option. createYargs...
-// should be reversed to provide `yargsDefaults` as the default configuration
+// should be reversed to provide `getYargsDefaults` as the default configuration
 // and accept a configuration such as its CURRENT default to append onto a command.
 export const builder = (yargs) => {
   yargs
@@ -108,7 +108,7 @@ export const builder = (yargs) => {
     )
 
   // Add default options, includes '--typescript', '--javascript', '--force', ...
-  Object.entries(yargsDefaults).forEach(([option, config]) => {
+  Object.entries(getYargsDefaults()).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -12,7 +12,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 import { generateTemplate, getPaths, writeFilesTask } from '../../lib'
 import c from '../../lib/colors'
 import { pluralize, isPlural, isSingular } from '../../lib/rwPluralize'
-import { yargsDefaults } from '../generate'
+import { getYargsDefaults } from '../generate'
 
 /**
  * Returns the path to a custom generator template, if found in the app.
@@ -132,7 +132,7 @@ export const createYargsForComponentGeneration = ({
   preTasksFn = (options) => options,
   /** filesFn is not used if generator implements its own `handler` */
   filesFn = () => ({}),
-  optionsObj = yargsDefaults,
+  optionsObj = getYargsDefaults(),
   positionalsObj = {},
   /** function that takes the options object and returns an array of listr tasks */
   includeAdditionalTasks = () => [],

--- a/packages/cli/src/commands/generate/layout/layout.js
+++ b/packages/cli/src/commands/generate/layout/layout.js
@@ -1,5 +1,5 @@
 import { transformTSToJS } from '../../../lib'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import {
   templateForComponentFile,
   createYargsForComponentGeneration,
@@ -69,7 +69,7 @@ const optionsObj = {
     description: 'Generate with skip link',
     type: 'boolean',
   },
-  ...yargsDefaults,
+  ...getYargsDefaults(),
 }
 
 export const { command, description, builder, handler } =

--- a/packages/cli/src/commands/generate/model/model.js
+++ b/packages/cli/src/commands/generate/model/model.js
@@ -6,7 +6,7 @@ import terminalLink from 'terminal-link'
 import { getPaths, writeFilesTask, generateTemplate } from '../../../lib'
 import c from '../../../lib/colors'
 import { verifyModelName } from '../../../lib/schemaHelpers'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'model.js.template')
 
@@ -34,7 +34,7 @@ export const builder = (yargs) => {
       )}`
     )
 
-  Object.entries(yargsDefaults).forEach(([option, config]) => {
+  Object.entries(getYargsDefaults()).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
@@ -5,7 +5,7 @@ import path from 'path'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib'
-import { yargsDefaults as defaults } from '../../../generate'
+import { getYargsDefaults as defaults } from '../../../generate'
 import * as scaffold from '../scaffold'
 
 describe('editable columns', () => {
@@ -14,7 +14,7 @@ describe('editable columns', () => {
 
   beforeAll(async () => {
     files = await scaffold.files({
-      ...getDefaultArgs(defaults),
+      ...getDefaultArgs(defaults()),
       model: 'ExcludeDefault',
       tests: true,
       nestScaffoldByModel: true,

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -5,7 +5,7 @@ import path from 'path'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib'
-import { yargsDefaults as defaults } from '../../../generate'
+import { getYargsDefaults as defaults } from '../../../generate'
 import * as scaffold from '../scaffold'
 
 describe('in javascript (default) mode', () => {
@@ -13,7 +13,7 @@ describe('in javascript (default) mode', () => {
 
   beforeAll(async () => {
     files = await scaffold.files({
-      ...getDefaultArgs(defaults),
+      ...getDefaultArgs(defaults()),
       model: 'Post',
       tests: true,
       nestScaffoldByModel: true,

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldNoNest.test.js
@@ -5,7 +5,7 @@ import path from 'path'
 import '../../../../lib/test'
 
 import { getDefaultArgs } from '../../../../lib'
-import { yargsDefaults as defaults } from '../../../generate'
+import { getYargsDefaults as defaults } from '../../../generate'
 import * as scaffold from '../scaffold'
 
 describe('in javascript (default) mode', () => {
@@ -13,7 +13,7 @@ describe('in javascript (default) mode', () => {
 
   beforeAll(async () => {
     files = await scaffold.files({
-      ...getDefaultArgs(defaults),
+      ...getDefaultArgs(defaults()),
       model: 'Post',
       tests: true,
       nestScaffoldByModel: false,

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -25,7 +25,7 @@ import {
 import c from '../../../lib/colors'
 import { pluralize, singularize } from '../../../lib/rwPluralize'
 import { getSchema, verifyModelName } from '../../../lib/schemaHelpers'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import {
   customOrDefaultTemplatePath,
   relationsForModel,
@@ -656,7 +656,7 @@ export const builder = (yargs) => {
     )
 
   // Merge generator defaults in
-  Object.entries(yargsDefaults).forEach(([option, config]) => {
+  Object.entries(getYargsDefaults()).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -8,7 +8,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { getPaths, writeFilesTask } from '../../../lib'
 import c from '../../../lib/colors'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'script.js.template')
 const TSCONFIG_TEMPLATE = path.resolve(
@@ -49,7 +49,7 @@ export const builder = (yargs) => {
       )}`
     )
 
-  Object.entries(yargsDefaults).forEach(([option, config]) => {
+  Object.entries(getYargsDefaults()).forEach(([option, config]) => {
     yargs.option(option, config)
   })
 }

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -18,7 +18,7 @@ import {
 import c from '../../../lib/colors'
 import { pluralize } from '../../../lib/rwPluralize'
 import { getSchema, getEnum, verifyModelName } from '../../../lib/schemaHelpers'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import { customOrDefaultTemplatePath, relationsForModel } from '../helpers'
 import { files as serviceFiles } from '../service/service'
 
@@ -180,7 +180,7 @@ export const files = async ({ name, crud = true, tests, typescript }) => {
 }
 
 export const defaults = {
-  ...yargsDefaults,
+  ...getYargsDefaults(),
   crud: {
     default: true,
     description: 'Also generate mutations',

--- a/packages/cli/src/commands/generate/service/service.js
+++ b/packages/cli/src/commands/generate/service/service.js
@@ -4,7 +4,7 @@ import terminalLink from 'terminal-link'
 import { transformTSToJS } from '../../../lib'
 import { pluralize, singularize } from '../../../lib/rwPluralize'
 import { getSchema, verifyModelName } from '../../../lib/schemaHelpers'
-import { yargsDefaults } from '../../generate'
+import { getYargsDefaults } from '../../generate'
 import {
   createYargsForComponentGeneration,
   templateForComponentFile,
@@ -327,7 +327,7 @@ export const files = async ({
 }
 
 export const defaults = {
-  ...yargsDefaults,
+  ...getYargsDefaults(),
   tests: {
     description: 'Generate test files',
     type: 'boolean',

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -1,11 +1,17 @@
-// inspired by gatsby/packages/gatsby-cli/src/create-cli.js and
-// and gridsome/packages/cli/lib/commands/info.js
-import envinfo from 'envinfo'
-import terminalLink from 'terminal-link'
+/**
+ * Inspired by:
+ *
+ * - https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/create-cli.ts
+ * - https://github.com/gridsome/gridsome/blob/master/packages/cli/lib/commands/info.js
+ */
 
 export const command = 'info'
-export const description = 'Print your system environment information'
-export const builder = (yargs) => {
+
+export const description = 'Print environment information'
+
+export async function builder(yargs) {
+  const { default: terminalLink } = await import('terminal-link')
+
   yargs.epilogue(
     `Also see the ${terminalLink(
       'Redwood CLI Reference',
@@ -13,9 +19,12 @@ export const builder = (yargs) => {
     )}`
   )
 }
-export const handler = async () => {
+
+export async function handler() {
+  const { run } = await import('envinfo')
+
   try {
-    const output = await envinfo.run({
+    const output = await run({
       System: ['OS', 'Shell'],
       Binaries: ['Node', 'Yarn'],
       Browsers: ['Chrome', 'Edge', 'Firefox', 'Safari'],
@@ -27,6 +36,6 @@ export const handler = async () => {
   } catch (e) {
     console.log('Error: Cannot access environment info')
     console.log(e)
-    process.exit(1)
+    process.exitCode = 1
   }
 }

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -4,9 +4,9 @@ import path from 'path'
 import terminalLink from 'terminal-link'
 
 import {
-  apiCliOptions,
-  webCliOptions,
-  commonOptions,
+  getApiCliOptions,
+  getWebCliOptions,
+  getCommonOptions,
   apiServerHandler,
   webServerHandler,
   bothServerHandler,
@@ -25,19 +25,19 @@ export const builder = (yargs) => {
       command: '$0',
       descriptions: 'Run both api and web servers',
       handler: bothServerHandler,
-      builder: (yargs) => yargs.options(commonOptions),
+      builder: (yargs) => yargs.options(getCommonOptions()),
     })
     .command({
       command: 'api',
       description: 'start server for serving only the api',
       handler: apiServerHandler,
-      builder: (yargs) => yargs.options(apiCliOptions),
+      builder: (yargs) => yargs.options(getApiCliOptions()),
     })
     .command({
       command: 'web',
       description: 'start server for serving only the web side',
       handler: webServerHandler,
-      builder: (yargs) => yargs.options(webCliOptions),
+      builder: (yargs) => yargs.options(getWebCliOptions()),
     })
     .middleware((argv) => {
       // Make sure the relevant side has been built, before serving

--- a/packages/cli/src/commands/setup/generator/generator.js
+++ b/packages/cli/src/commands/setup/generator/generator.js
@@ -37,7 +37,7 @@ const copyGenerator = (name, { force }) => {
 
 // This could be built using createYargsForComponentGeneration;
 // however, functions wouldn't have a `stories` option. createYargs...
-// should be reversed to provide `yargsDefaults` as the default configuration
+// should be reversed to provide `getYargsDefaults` as the default configuration
 // and accept a configuration such as its CURRENT default to append onto a command.
 export const builder = (yargs) => {
   const availableGenerators = fs

--- a/packages/prerender/src/internal.ts
+++ b/packages/prerender/src/internal.ts
@@ -6,10 +6,10 @@ import { fetch } from 'cross-undici-fetch'
 import type { AuthContextInterface } from '@redwoodjs/auth'
 import { getConfig, getPaths } from '@redwoodjs/internal'
 
-const INDEX_FILE = path.join(getPaths().web.dist, 'index.html')
-const DEFAULT_INDEX = path.join(getPaths().web.dist, '200.html')
-
 export const getRootHtmlPath = () => {
+  const INDEX_FILE = path.join(getPaths().web.dist, 'index.html')
+  const DEFAULT_INDEX = path.join(getPaths().web.dist, '200.html')
+
   if (fs.existsSync(DEFAULT_INDEX)) {
     return DEFAULT_INDEX
   } else {

--- a/packages/telemetry/src/telemetry.ts
+++ b/packages/telemetry/src/telemetry.ts
@@ -3,12 +3,15 @@ import path from 'path'
 
 import { getPaths } from '@redwoodjs/internal'
 
-const APP_ROOT = getPaths().base
-
 const spawnProcess = (...args: Array<string>) => {
   spawn(
     process.execPath,
-    [path.join(__dirname, 'scripts', 'invoke.js'), ...args, '--root', APP_ROOT],
+    [
+      path.join(__dirname, 'scripts', 'invoke.js'),
+      ...args,
+      '--root',
+      getPaths().base,
+    ],
     {
       detached: process.env.REDWOOD_VERBOSE_TELEMETRY ? false : true,
       stdio: process.env.REDWOOD_VERBOSE_TELEMETRY ? 'inherit' : 'ignore',


### PR DESCRIPTION
This PR 1) partially fixes the CLI's `cwd` option and 2) gives an idea of some of the tweaks I think we should make to the CLI to increase maintainability (for contributors) and start up time (for users). Note that the diff is mostly the result of of fixing the CLI's `cwd` option.   

In sum, the tweaks I'm suggesting are:

- Take advantage of yargs middleware to remove duplicate code. Basically what was suggested in https://github.com/redwoodjs/redwood/issues/2793
- Lazily import as much as possible to increase startup time (benchmarks, of course, are TBD). See https://mael.dev/clipanion/docs/tips#lazy-evaluation.

To make things more concrete, I've reworked three of the commands to show what they'd look like: [`check`](https://github.com/redwoodjs/redwood/blob/d4b65fcc76e11133bd16959d0d37426fbed3ad7a/packages/cli/src/commands/check.js), [`info`](https://github.com/redwoodjs/redwood/blob/d4b65fcc76e11133bd16959d0d37426fbed3ad7a/packages/cli/src/commands/info.js), and [`lint`](https://github.com/redwoodjs/redwood/blob/d4b65fcc76e11133bd16959d0d37426fbed3ad7a/packages/cli/src/commands/lint.js). The changes are pretty minimal. I'd like for all the commands in the CLI to look more or less like this.

I'll talk about `lint` a bit more. The changes I want to bring attention to are in the `handler` function:

https://github.com/redwoodjs/redwood/blob/d4b65fcc76e11133bd16959d0d37426fbed3ad7a/packages/cli/src/commands/lint.js#L27-L29

> Note that `execa` may not actually be the best example because it's used often enough in the CLI that we may be better off just importing it at the top-level, like colors, but it'll do for now.

All the dependencies used by the `lint` command are now imported inside the `handler` function. There's also a "new" property on `argv`, `redwoodProject`—naming and association with `@redwoodjs/internal`/`structure` TBD—that has "everything you need to know". I.e., no more calling `getPaths`.

Ok, so all the dependencies used by the `lint` command are now imported inside the `handler` function... this may not seem like a big deal. Currently, `execa` is imported outside the `handler` function: 

https://github.com/redwoodjs/redwood/blob/9bea0a3e8373248d96465f3bc585153c838385a1/packages/cli/src/commands/lint.js#L3

It's not that bad for one command but it doesn't scale nicely. The way it is now, if a user runs `yarn rw info`, a command that only uses one dependency, `env-info`, `execa` gets imported even though it's never actually used for anything. And it's way more than `execa`—**it's every dependency every command imports**.

The reason they're all imported is `commandDir` recursively requires every file in the directory it's given (`yargs` has to build the whole CLI before it can figure out what to execute). The consequence is that start-up time is slow. Moving the imports into the `handler` only imports the dependencies if the command is actually invoked.

Again, this isn't a full-on rework of the CLI. If I were to really rework the CLI, I'd probably use [clipanion](https://mael.dev/clipanion/).

Note that the missing improvement here is bundling the CLI. Yargs has a short doc on bundling: https://github.com/yargs/yargs/blob/main/docs/bundling.md. And I've tried to follow it, using ESBuild, but am facing some issues. While I'm hoping to resolve those, note that it may only be beneficial to bundle what's included in the entry-point `index.js` file since bundling lazily-imported dependencies could give us the same slow start-up time we're seeing now. Think of it like the code-splitting the Router does automatically.

### Partially fixing the `cwd` option

Now about the less-interesting change in this PR. The CLI has a `cwd` option that should let you change the working directory so that you can invoke the CLI in another project. 

> There's more than one way to do this, setting the `RWJS_CWD` env var being one of the others. That one works.

One of the reasons it's broken is `getPaths` is called in many places before `getCwdMiddleware` has the chance to set the `cwd`. For example, in `yargsDefaults`, `getPaths` is called as soon as this file is imported, which is before `getCwdMiddleware` runs:

https://github.com/redwoodjs/redwood/blob/f3e034cf1394d6dde645595b2b4e2012e3ee1c4e/packages/cli/src/commands/generate.js#L25-L38

The solution is making constants that use `getPaths` functions so that they wait till it's actually set. So now, after building, you should be able to test out some of the commands like so...

```
~/redwood-framework> node packages/cli/dist/index.js --cwd ~/redwood-project info

  System:
    OS: macOS 12.3.1
    Shell: 5.8 - /bin/zsh
  Binaries:
    Node: 16.15.0 - ~/.nvm/versions/node/v16.15.0/bin/node
    Yarn: 3.2.1 - ~/.nvm/versions/node/v16.15.0/bin/yarn
  Databases:
    SQLite: 3.37.0 - /usr/bin/sqlite3
  Browsers:
    Chrome: 101.0.4951.64
    Safari: 15.4
```

Not all commands work yet for reasons TBD.