### PR TITLE
fix: The error was caused by not declaring the variable $id.

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -731,7 +731,7 @@ Last but not least we can update the `ArticleCell` to properly display our blog 
 import Article from 'src/components/Article'
 
 export const QUERY = gql`
-  query ArticleQuery {
+  query ArticleQuery($id: Int!) {
     article: post(id: $id) {
       id
       title
@@ -766,7 +766,7 @@ import type { ArticleQuery } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`
-  query ArticleQuery {
+  query ArticleQuery($id: Int!) {
     article: post(id: $id) {
       id
       title

--- a/docs/versioned_docs/version-1.5/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-1.5/tutorial/chapter2/routing-params.md
@@ -766,7 +766,7 @@ import type { ArticleQuery } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`
-  query ArticleQuery {
+  query ArticleQuery($id: Int!) {
     article: post(id: $id) {
       id
       title


### PR DESCRIPTION
The error was caused by not declaring the variable $id.

======== Actual Error Notation ========
Error: Response not successful: Received status code 400