### PR TITLE
Fix typo in tutorial

### DIFF
--- a/docs/docs/tutorial/chapter1/file-structure.md
+++ b/docs/docs/tutorial/chapter1/file-structure.md
@@ -14,7 +14,7 @@ Don't worry about trying to memorize this directory structure right now, it's ju
 ```
 ├── api
 │   ├── db
-│   │   ├── schema.prisma
+│   │   └── schema.prisma
 │   ├── dist
 │   ├── src
 │   │   ├── directives


### PR DESCRIPTION
I found some typo on diagram of "files and directories".

"`├`" should be replaced by "`└`".