### PR TITLE
📝 Add documentation for custom input fields

### DIFF
--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -335,6 +335,47 @@ For example:
 ```
 will return `undefined` if the field is empty.
 
+### Custom Input Fields
+
+You can create a custom field that integrates with Redwood through the use of `useRegister` and `useErrorStyles`. Each of these serving a different purpose depending on what you are trying to build.
+
+`useRegister` registers the field with react-hook-form and is a wrapper for [`register`](https://react-hook-form.com/api/useform/register).
+
+`useErrorStyles` sets up error styling for your custom input field.
+
+Using these two together you can create custom input fields that replicate a redwood input field while also allowing for custom domain logic.
+
+In the following example we have an all-in-one custom required input field with label, input, and error display.
+
+```jsx
+import { FieldError, useErrorStyles, useRegister } from '@redwoodjs/forms'
+
+const RequiredField = ({label, name, validation}) => {
+  const register = useRegister({
+    name,
+    validation: {...validation, required: true}
+  })
+
+  const labelStyles = useErrorStyles({
+    className: `my-label-class`,
+    errorClassName: `my-label-error-class`,
+    name,
+  })
+
+  const inputStyles = useErrorStyles({
+    className: `my-input-class`,
+    errorClassName: `my-input-error-class`,
+    name,
+  })
+
+  return (
+    <label {...labelStyles}>{label}</label>
+    <input type="text" {...inputStyles} {...register} />
+    <FieldError name={name}>
+  )
+}
+```
+
 ## `<SelectField>`
 
 Renders an HTML `<select>` tag.

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -337,7 +337,7 @@ will return `undefined` if the field is empty.
 
 ### Custom Input Fields
 
-You can create a custom field that integrates with Redwood through the use of `useRegister` and `useErrorStyles`. Each of these serving a different purpose depending on what you are trying to build.
+You can create a custom field that integrates with Redwood through the use of Redwood's `useRegister` and `useErrorStyles` hooks. Each of these serving a different purpose depending on what you are trying to build.
 
 `useRegister` registers the field with react-hook-form and is a wrapper for [`register`](https://react-hook-form.com/api/useform/register).
 
@@ -351,7 +351,7 @@ In the following example we have an all-in-one custom required input field with 
 import { FieldError, useErrorStyles, useRegister } from '@redwoodjs/forms'
 
 const RequiredField = ({ label, name, validation }) => {
-  const { onBlur, onChange, ref } = useRegister({
+  const register = useRegister({
     name,
     validation: {...validation, required: true}
   })
@@ -373,12 +373,9 @@ const RequiredField = ({ label, name, validation }) => {
       <label className={labelClassName} style={labelStyle}>{label}</label>
       <input
         className={inputClassName}
-        name={name}
-        onBlur={onBlur}
-        onChange={onChange}
-        ref={ref}
         style={inputStyle}
         type="text"
+        {...register}
       />
       <FieldError name={name}>
     </>

--- a/docs/docs/forms.md
+++ b/docs/docs/forms.md
@@ -343,35 +343,45 @@ You can create a custom field that integrates with Redwood through the use of `u
 
 `useErrorStyles` sets up error styling for your custom input field.
 
-Using these two together you can create custom input fields that replicate a redwood input field while also allowing for custom domain logic.
+Using these two together you can create custom input fields that replicate a Redwood input field while also allowing for custom domain logic.
 
 In the following example we have an all-in-one custom required input field with label, input, and error display.
 
 ```jsx
 import { FieldError, useErrorStyles, useRegister } from '@redwoodjs/forms'
 
-const RequiredField = ({label, name, validation}) => {
-  const register = useRegister({
+const RequiredField = ({ label, name, validation }) => {
+  const { onBlur, onChange, ref } = useRegister({
     name,
     validation: {...validation, required: true}
   })
 
-  const labelStyles = useErrorStyles({
+  const { className: labelClassName, style: labelStyle } = useErrorStyles({
     className: `my-label-class`,
     errorClassName: `my-label-error-class`,
     name,
   })
 
-  const inputStyles = useErrorStyles({
+  const { className: inputClassName, style: inputStyle } = useErrorStyles({
     className: `my-input-class`,
     errorClassName: `my-input-error-class`,
     name,
   })
 
   return (
-    <label {...labelStyles}>{label}</label>
-    <input type="text" {...inputStyles} {...register} />
-    <FieldError name={name}>
+    <>
+      <label className={labelClassName} style={labelStyle}>{label}</label>
+      <input
+        className={inputClassName}
+        name={name}
+        onBlur={onBlur}
+        onChange={onChange}
+        ref={ref}
+        style={inputStyle}
+        type="text"
+      />
+      <FieldError name={name}>
+    </>
   )
 }
 ```


### PR DESCRIPTION
# Description

Update documentation on the "Input Fields" section of [Forms](https://redwoodjs.com/docs/forms)

## Reason

I needed to build a more complicated custom input field for my application. I ended up finding that `useRegister` and `useErrorStyles` was recently added to things I could use. This is to document their availability and possible usage to build a custom input.

## Implementation

I added a section under "Input Fields" called "Custom Input Fields". There I describe use of `useRegister` and `useErrorStyles` along with a simple example.

## Screenshot

![Screen Shot 2022-06-07 at 6 34 05 AM](https://user-images.githubusercontent.com/2641685/172359464-80c5c793-43dd-49bd-a35e-6f02081d3fca.png)

## Notes

Open to any critiques or changes needed/desired. I don't love the example, but wanted to keep it short & simple.