### PR TITLE
Fix typo in ArticleCell code snippet of Tutorial 2 docs

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -749,7 +749,7 @@ export const Failure = ({ error }) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ articles }) => (
+export const Success = ({ article }) => (
   // highlight-next-line
   <Article article={article} />
 )
@@ -784,7 +784,7 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ articles }: CellSuccessProps<ArticleQuery>) => (
+export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => (
   // highlight-next-line
   <Article article={article} />
 )


### PR DESCRIPTION
### PR Human Explanation:
[Tutorial 2 ](https://redwoodjs.com/docs/tutorial/chapter2/routing-params)of the official Redwood docs has a typo in the last example code snippet that forces the tutorial website to fail.
I ran into this issue this afternoon and it looks like @mdkess ran into this yesterday.

### Issue Fixed:
#5693 

## Other Notes:
I don't have much experience contributing  to open source projects. I've already read the [official contributing docs,](https://redwoodjs.com/docs/contributing) but didn't have the time to watch the official contributing  [Youtube video.](https://www.youtube.com/watch?v=aZs_9g-5Ms8)  If there are any subtle PR/contributing etiquette things I'm missing, feel free to point them out. 