### PR TITLE
docs: Replacing Prisma.xxx types with types from 'types/graphql'

### DIFF
--- a/docs/docs/tutorial/chapter2/side-quest.md
+++ b/docs/docs/tutorial/chapter2/side-quest.md
@@ -137,42 +137,33 @@ export const deletePost = ({ id }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```javascript title="api/src/services/posts/posts.ts"
-import type { Prisma } from '@prisma/client'
-
 import { db } from 'src/lib/db'
+import type { QueryResolvers, MutationResolvers } from 'types/graphql'
 
-export const posts = () => {
+export const posts: QueryResolvers['posts'] = () => {
   return db.post.findMany()
 }
 
-export const post = ({ id }: Prisma.PostWhereUniqueInput) => {
+export const post: QueryResolvers['post'] = ({ id }) => {
   return db.post.findUnique({
     where: { id },
   })
 }
 
-interface CreatePostArgs {
-  input: Prisma.PostCreateInput
-}
-
-export const createPost = ({ input }: CreatePostArgs) => {
+export const createPost: MutationResolvers['createPost'] = ({ input }) => {
   return db.post.create({
     data: input,
   })
 }
 
-interface UpdatePostArgs extends Prisma.PostWhereUniqueInput {
-  input: Prisma.PostUpdateInput
-}
-
-export const updatePost = ({ id, input }: UpdatePostArgs) => {
+export const updatePost: MutationResolvers['updatePost'] = ({ id, input }) => {
   return db.post.update({
     data: input,
     where: { id },
   })
 }
 
-export const deletePost = ({ id }: Prisma.PostWhereUniqueInput) => {
+export const deletePost: MutationResolvers['deletePost'] = ({ id }) => {
   return db.post.delete({
     where: { id },
   })


### PR DESCRIPTION
Changed the TS code for the posts service to use QueryResolvers and MutationResolvers types from 'types/graphql'? The current documentation uses Prisma.xxx types like so:

![image](https://user-images.githubusercontent.com/73743535/173178868-7e28d385-2a32-4d73-b2d5-e4f6b5168a04.png)

But as I was following along with the tutorial, I found that the code generated by redwood for the posts service was using the types from 'types/graphql' like so:

![image](https://user-images.githubusercontent.com/73743535/173178884-6a76ea22-40dd-4dad-8198-e075e1c34e54.png)
