### PR TITLE
docs: Fix not being able to fullscreen YouTube embeds

### DIFF
--- a/docs/docs/a11y.md
+++ b/docs/docs/a11y.md
@@ -166,5 +166,5 @@ export default ContactPage
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form is focused—the first field of the form they're here to fill out.
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>

--- a/docs/docs/contributing-walkthrough.md
+++ b/docs/docs/contributing-walkthrough.md
@@ -26,8 +26,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -292,7 +292,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Redwood is composed of several popular libraries to make full-stack web development easier. Unfortunately, we can't teach all of those technologies from scratch during this tutorial, so we're going to assume you are already familiar with a few core concepts:

--- a/docs/docs/tutorial/chapter2/getting-dynamic.md
+++ b/docs/docs/tutorial/chapter2/getting-dynamic.md
@@ -1,7 +1,7 @@
 # Getting Dynamic
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 These two pages are great and all but where are the actual blog posts in this blog? Let's work on those next.

--- a/docs/docs/tutorial/chapter3/forms.md
+++ b/docs/docs/tutorial/chapter3/forms.md
@@ -1,7 +1,7 @@
 # Building a Form
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Wait, don't close your browser! You had to know this was coming eventually, didn't you? And you've probably realized by now we wouldn't even have this section in the tutorial unless Redwood had figured out a way to make forms less soul-sucking than usual. In fact, Redwood might even make you _love_ building forms.

--- a/docs/versioned_docs/version-1.0/contributing-walkthrough.md
+++ b/docs/versioned_docs/version-1.0/contributing-walkthrough.md
@@ -21,8 +21,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/versioned_docs/version-1.0/graphql.md
+++ b/docs/versioned_docs/version-1.0/graphql.md
@@ -299,7 +299,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/versioned_docs/version-1.1/a11y.md
+++ b/docs/versioned_docs/version-1.1/a11y.md
@@ -166,5 +166,5 @@ export default ContactPage
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form is focused—the first field of the form they're here to fill out.
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>

--- a/docs/versioned_docs/version-1.1/contributing-walkthrough.md
+++ b/docs/versioned_docs/version-1.1/contributing-walkthrough.md
@@ -26,8 +26,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/versioned_docs/version-1.1/graphql.md
+++ b/docs/versioned_docs/version-1.1/graphql.md
@@ -292,7 +292,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/versioned_docs/version-1.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.1/tutorial/chapter1/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Redwood is composed of several popular libraries to make full-stack web development easier. Unfortunately, we can't teach all of those technologies from scratch during this tutorial, so we're going to assume you are already familiar with a few core concepts:

--- a/docs/versioned_docs/version-1.1/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-1.1/tutorial/chapter2/getting-dynamic.md
@@ -1,7 +1,7 @@
 # Getting Dynamic
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 These two pages are great and all but where are the actual blog posts in this blog? Let's work on those next.

--- a/docs/versioned_docs/version-1.1/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-1.1/tutorial/chapter3/forms.md
@@ -1,7 +1,7 @@
 # Building a Form
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Wait, don't close your browser! You had to know this was coming eventually, didn't you? And you've probably realized by now we wouldn't even have this section in the tutorial unless Redwood had figured out a way to make forms less soul-sucking than usual. In fact, Redwood might even make you _love_ building forms.

--- a/docs/versioned_docs/version-1.2/a11y.md
+++ b/docs/versioned_docs/version-1.2/a11y.md
@@ -166,5 +166,5 @@ export default ContactPage
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form is focused—the first field of the form they're here to fill out.
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>

--- a/docs/versioned_docs/version-1.2/contributing-walkthrough.md
+++ b/docs/versioned_docs/version-1.2/contributing-walkthrough.md
@@ -26,8 +26,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/versioned_docs/version-1.2/graphql.md
+++ b/docs/versioned_docs/version-1.2/graphql.md
@@ -292,7 +292,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/versioned_docs/version-1.2/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.2/tutorial/chapter1/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Redwood is composed of several popular libraries to make full-stack web development easier. Unfortunately, we can't teach all of those technologies from scratch during this tutorial, so we're going to assume you are already familiar with a few core concepts:

--- a/docs/versioned_docs/version-1.2/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-1.2/tutorial/chapter2/getting-dynamic.md
@@ -1,7 +1,7 @@
 # Getting Dynamic
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 These two pages are great and all but where are the actual blog posts in this blog? Let's work on those next.

--- a/docs/versioned_docs/version-1.2/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-1.2/tutorial/chapter3/forms.md
@@ -1,7 +1,7 @@
 # Building a Form
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Wait, don't close your browser! You had to know this was coming eventually, didn't you? And you've probably realized by now we wouldn't even have this section in the tutorial unless Redwood had figured out a way to make forms less soul-sucking than usual. In fact, Redwood might even make you _love_ building forms.

--- a/docs/versioned_docs/version-1.3/a11y.md
+++ b/docs/versioned_docs/version-1.3/a11y.md
@@ -166,5 +166,5 @@ export default ContactPage
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form is focused—the first field of the form they're here to fill out.
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>

--- a/docs/versioned_docs/version-1.3/contributing-walkthrough.md
+++ b/docs/versioned_docs/version-1.3/contributing-walkthrough.md
@@ -26,8 +26,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/versioned_docs/version-1.3/graphql.md
+++ b/docs/versioned_docs/version-1.3/graphql.md
@@ -292,7 +292,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/versioned_docs/version-1.3/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.3/tutorial/chapter1/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Redwood is composed of several popular libraries to make full-stack web development easier. Unfortunately, we can't teach all of those technologies from scratch during this tutorial, so we're going to assume you are already familiar with a few core concepts:

--- a/docs/versioned_docs/version-1.3/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-1.3/tutorial/chapter2/getting-dynamic.md
@@ -1,7 +1,7 @@
 # Getting Dynamic
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 These two pages are great and all but where are the actual blog posts in this blog? Let's work on those next.

--- a/docs/versioned_docs/version-1.3/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-1.3/tutorial/chapter3/forms.md
@@ -1,7 +1,7 @@
 # Building a Form
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Wait, don't close your browser! You had to know this was coming eventually, didn't you? And you've probably realized by now we wouldn't even have this section in the tutorial unless Redwood had figured out a way to make forms less soul-sucking than usual. In fact, Redwood might even make you _love_ building forms.

--- a/docs/versioned_docs/version-1.4/a11y.md
+++ b/docs/versioned_docs/version-1.4/a11y.md
@@ -166,5 +166,5 @@ export default ContactPage
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form is focused—the first field of the form they're here to fill out.
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>

--- a/docs/versioned_docs/version-1.4/contributing-walkthrough.md
+++ b/docs/versioned_docs/version-1.4/contributing-walkthrough.md
@@ -26,8 +26,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/versioned_docs/version-1.4/graphql.md
+++ b/docs/versioned_docs/version-1.4/graphql.md
@@ -292,7 +292,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/versioned_docs/version-1.4/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.4/tutorial/chapter1/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Redwood is composed of several popular libraries to make full-stack web development easier. Unfortunately, we can't teach all of those technologies from scratch during this tutorial, so we're going to assume you are already familiar with a few core concepts:

--- a/docs/versioned_docs/version-1.4/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-1.4/tutorial/chapter2/getting-dynamic.md
@@ -1,7 +1,7 @@
 # Getting Dynamic
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 These two pages are great and all but where are the actual blog posts in this blog? Let's work on those next.

--- a/docs/versioned_docs/version-1.4/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-1.4/tutorial/chapter3/forms.md
@@ -1,7 +1,7 @@
 # Building a Form
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Wait, don't close your browser! You had to know this was coming eventually, didn't you? And you've probably realized by now we wouldn't even have this section in the tutorial unless Redwood had figured out a way to make forms less soul-sucking than usual. In fact, Redwood might even make you _love_ building forms.

--- a/docs/versioned_docs/version-1.5/a11y.md
+++ b/docs/versioned_docs/version-1.5/a11y.md
@@ -166,5 +166,5 @@ export default ContactPage
 `RouteFocus` tells the router to send focus to it's child on page change. In the example above, when the user navigates to the contact page, the name text field on the form is focused—the first field of the form they're here to fill out.
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/T1zs77LU68w?t=3240" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>

--- a/docs/versioned_docs/version-1.5/contributing-walkthrough.md
+++ b/docs/versioned_docs/version-1.5/contributing-walkthrough.md
@@ -26,8 +26,7 @@ The following recording is from a Contributing Workshop, following through the e
   style={{ height: '24rem' }}
   src="https://www.youtube.com/embed/aZs_9g-5Ms8"
   frameborder="0"
-  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0"
-  allowfullscreen
+  allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"
 ></iframe>
 
 ## Prologue: Getting Started with Redwood and GitHub (and git)

--- a/docs/versioned_docs/version-1.5/graphql.md
+++ b/docs/versioned_docs/version-1.5/graphql.md
@@ -292,7 +292,7 @@ Now that you've seen the sdl, be sure to check out [the resolvers](https://githu
 The GraphQL Playground's nice, but if you're a power user, you'll want to be using something a little more dedicated and always on; where you can save things like environments...
 
 <div class="relative pb-9/16">
-  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/watch?v=SU4g9_K0H1c" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 - todo

--- a/docs/versioned_docs/version-1.5/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.5/tutorial/chapter1/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Redwood is composed of several popular libraries to make full-stack web development easier. Unfortunately, we can't teach all of those technologies from scratch during this tutorial, so we're going to assume you are already familiar with a few core concepts:

--- a/docs/versioned_docs/version-1.5/tutorial/chapter2/getting-dynamic.md
+++ b/docs/versioned_docs/version-1.5/tutorial/chapter2/getting-dynamic.md
@@ -1,7 +1,7 @@
 # Getting Dynamic
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/cb_PseqpoG8?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 These two pages are great and all but where are the actual blog posts in this blog? Let's work on those next.

--- a/docs/versioned_docs/version-1.5/tutorial/chapter3/forms.md
+++ b/docs/versioned_docs/version-1.5/tutorial/chapter3/forms.md
@@ -1,7 +1,7 @@
 # Building a Form
 
 <div class="video-container">
-  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+  <iframe src="https://www.youtube.com/embed/b0x8an_UZ98?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
 </div>
 
 Wait, don't close your browser! You had to know this was coming eventually, didn't you? And you've probably realized by now we wouldn't even have this section in the tutorial unless Redwood had figured out a way to make forms less soul-sucking than usual. In fact, Redwood might even make you _love_ building forms.


### PR DESCRIPTION
This PR fixes #5737 and the issue where YouTube embeds in docs can't be fullscreened.

For example:
```diff
- <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0" allowfullscreen></iframe>
+ <iframe src="https://www.youtube.com/embed/HJOzmp8oCIQ?rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture; modestbranding; showinfo=0; fullscreen"></iframe>
```