### PR TITLE
docs: Add missing ArticlePage import to admin routes example

### DIFF
--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -11,7 +11,8 @@ Having the admin screens at `/admin` is a reasonable thing to do. Let's update t
 import { Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
-
+import ArticlePage from './pages/ArticlePage/ArticlePage'
+  
 const Routes = () => {
   return (
     <Router>

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -11,7 +11,7 @@ Having the admin screens at `/admin` is a reasonable thing to do. Let's update t
 import { Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
-import ArticlePage from './pages/ArticlePage/ArticlePage'
+import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
   
 const Routes = () => {
   return (
@@ -45,6 +45,7 @@ export default Routes
 import { Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
+import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
 
 const Routes = () => {
   return (
@@ -212,6 +213,7 @@ Going to the admin section now prevents a non-logged in user from seeing posts, 
 import { Private, Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
+import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
 
 const Routes = () => {
   return (
@@ -248,6 +250,7 @@ export default Routes
 import { Private, Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
+import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
 
 const Routes = () => {
   return (

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -11,7 +11,7 @@ Having the admin screens at `/admin` is a reasonable thing to do. Let's update t
 import { Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
-import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
+import ArticlePage from 'src/pages/ArticlePage'
   
 const Routes = () => {
   return (
@@ -45,7 +45,7 @@ export default Routes
 import { Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
-import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
+import ArticlePage from 'src/pages/ArticlePage'
 
 const Routes = () => {
   return (
@@ -213,7 +213,7 @@ Going to the admin section now prevents a non-logged in user from seeing posts, 
 import { Private, Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
-import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
+import ArticlePage from 'src/pages/ArticlePage'
 
 const Routes = () => {
   return (
@@ -250,7 +250,7 @@ export default Routes
 import { Private, Router, Route, Set } from '@redwoodjs/router'
 import PostsLayout from 'src/layouts/PostsLayout'
 import BlogLayout from 'src/layouts/BlogLayout'
-import ArticlePage from 'src/pages/ArticlePage/ArticlePage'
+import ArticlePage from 'src/pages/ArticlePage'
 
 const Routes = () => {
   return (


### PR DESCRIPTION
There was a missing ArticlePage import in the admin routes example here https://redwoodjs.com/docs/tutorial/chapter4/authentication#an-admin-section