### PR TITLE
Add GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,139 @@
+name: "🐛 Bug report"
+description: "Is something not working the way it should be?"
+
+title: "[Bug?]: "
+labels: bug/needs-info
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        > **Whoa, what is this?**
+
+        >
+
+        > This is an issue form, a new type of issue template.
+        We're trying it out because we want...
+
+        > 1. issues to be more structured, (specifically, bug reports)
+
+        > 2. to be more upfront about our process—i.e., what happens after you open an issue (see the paragraph below)
+
+        >
+
+        > We want the process of opening an issue to be smooth for you as a contributor,
+        so please do let us know what you think [over on the forums](https://community.redwoodjs.com/t/what-do-you-think-of-the-new-github-issue-forms/3463).
+
+
+        Thanks for taking the time to open an issue!
+        Here's a bit of background on what you can expect about the process:
+
+        - Expect a response from us (the core team) within three to seven days.
+          - Usually we'll respond sooner than that, but sometimes we have a lot on our plate. Thanks for your patience!
+
+        > **But what if this is critical?**
+
+        >
+
+        > We're aware of issues as soon as they're opened,
+        but just don't always respond straightaway.
+        Too much task switching is a productivity killer.
+        So don't worry, we're pretty good about escalating critical issues.
+        But if you think we're taking too long,
+        feel free to ping us (after you open this) on the thread here on GitHub
+        or DM one of us on the [forums](https://community.redwoodjs.com/g/Core-Team) or [Discord](https://discord.gg/redwoodjs)
+
+        - After you open this, the Redwood bot will assign a core team member to it. They'll triage it.
+          - If they don't within three to seven days, the Redwood bot will ping them. You should feel free to ping them too!
+
+  - type: textarea
+    attributes:
+      label: What's not working?
+      description: >
+        Describe the bug here.
+        The more detail you provide, the better,
+        but try to start with a summary to frame the issue.
+        See the placeholder below for an example.
+      placeholder: >
+        The dev server doesn't seem to be working.
+        When I run `yarn rw dev`,
+        the web side doesn't start and throws `TypeError: cli.isMultipleCompiler is not a function`.
+        I was just following the tutorial when I ran into this,
+        so nothing fancy going on here.
+
+
+        I think this probably has to do with [webpack-cli](https://github.com/webpack/webpack-cli).
+        I skimmed the issues on their repo and it looks like they just released a new version.
+        If we bump the version Redwood is using, it may resolve this.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: How do we reproduce the bug?
+      description: >
+        What commands do we need to run?
+        What packages do we need to install?
+        What does the `schema.prisma` need to look like?
+        Again, the more detail, the better!
+
+
+        Have a repo on GitHub with the reproduction? Amazing—include the link here.
+
+
+        Can't provide a reproduction?
+        We understand that you can't always provide one,
+        but it'll be much harder for us to debug without one.
+        Any information is invaluable.
+      placeholder: |
+        1. create a new redwood app
+        2. start the dev server
+
+        ```shell
+        yarn create redwood-app redwood-app
+        # ...
+        cd redwood-app
+        yarn rw dev
+        # ...
+        web | [webpack-cli] TypeError: cli.isMultipleCompiler is not a function
+        ```
+    validations:
+        required: true
+
+  - type: textarea
+    attributes:
+      label: What's your environment?
+      render: shell
+      description: |
+        Run `yarn rw info` and paste the output here.
+      placeholder: |
+        System:
+          OS: macOS 12.3.1
+          Shell: 5.8 - /bin/zsh
+        Binaries:
+          Node: 16.15.1 - /private/var/folders/dt/yks4v5m53k114qxgz6jh4pgw0000gn/T/xfs-0cbbe6f7/node
+          Yarn: 3.2.1 - /private/var/folders/dt/yks4v5m53k114qxgz6jh4pgw0000gn/T/xfs-0cbbe6f7/yarn
+        Databases:
+          SQLite: 3.37.0 - /usr/bin/sqlite3
+        Browsers:
+          Chrome: 102.0.5005.115
+          Safari: 15.4
+        npmPackages:
+          @redwoodjs/core: 1.5.2 => 1.5.2
+    validations:
+        required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you interested in working on this?
+      description: >
+        No pressure—this is totally optional!
+        We just want to invite you to contribute to Redwood.
+        If you choose to contribute, the core team will be there to help you the whole way.
+
+
+        In some cases, if this issue is triaged as being lower priority,
+        your willing- and ableness to work on this will land it faster than waiting for a core team member to pick it up.
+        But if this is critical, it'll of course be escalated.
+      options:
+        - label: I'm interested in working on this

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Have a question or need help?
+    url: https://community.redwoodjs.com/new-topic?category=get-help-and-help-others
+    about: >
+      Have a question about the way Redwood works?
+      Or not sure if you're doing something right?
+      Ask us over on the forums

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,67 @@
+name: "📖 Documentation"
+description: "A catch-all template for issues about documentation"
+
+title: "[Documentation]: "
+labels: topic/docs
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        > **Whoa, what is this?**
+
+        >
+
+        > This is an issue form, a new type of issue template.
+        We're trying it out because we want...
+
+        > 1. issues to be more structured, (specifically, bug reports)
+
+        > 2. to be more upfront about our process—i.e., what happens after you open an issue (see the paragraph below)
+
+        >
+
+        > We want the process of opening an issue to be smooth for you as a contributor,
+        so please do let us know what you think [over on the forums](https://community.redwoodjs.com/t/what-do-you-think-of-the-new-github-issue-forms/3463).
+
+
+        Thanks for taking the time to open an issue!
+        Here's a bit of background on what you can expect about the process:
+
+        - Expect a response from us (the core team) within three to seven days.
+          - Usually we'll respond sooner than that, but sometimes we have a lot on our plate. Thanks for your patience!
+        - After you open this, the Redwood bot will assign a core team member to it. They'll triage it.
+          - If they don't within three to seven days, the Redwood bot will ping them. You should feel free to ping them too!
+
+  - type: textarea
+    attributes:
+      label: Summary and description
+      description: >
+        The body of the issue, just like a regular GitHub issue.
+        The more detail you provide, the better,
+        but try to start with a summary to frame the issue.
+        See the placeholder below for an example.
+      placeholder: >
+        In #5658, we changed the link to edit a page in the docs to always point to the docs in `/docs` instead of `/docs/versioned_docs`.
+        While this was the right move, it's still not exactly clear what that links points to.
+        We should tweak the text to be a little more explicit about what version (i.e. Canary) that it'll take users to.
+
+
+        The text could be "Edit the most recent version of this page", "Edit the latest version of this page" or "Edit the Canary version of this page"—something along those lines.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you interested in working on this? (If it applies)
+      description: >
+        No pressure—this is totally optional!
+        We just want to invite you to contribute to Redwood.
+        If you choose to contribute, the core team will be there to help you the whole way.
+
+
+        In some cases, if this issue is triaged as being lower priority,
+        your willing- and ableness to work on this will land it faster than waiting for a core team member to pick it up.
+        But if this is critical, it'll of course be escalated.
+      options:
+        - label: I'm interested in working on this

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,113 @@
+name: "⭐️ Feature request"
+description: "Have an idea for a new feature?"
+
+title: "[Feature request]: "
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        > **Whoa, what is this?**
+
+        >
+
+        > This is an issue form, a new type of issue template.
+        We're trying it out because we want...
+
+        > 1. issues to be more structured, (specifically, bug reports)
+
+        > 2. to be more upfront about our process—i.e., what happens after you open an issue (see the paragraph below)
+
+        >
+
+        > We want the process of opening an issue to be smooth for you as a contributor,
+        so please do let us know what you think [over on the forums](https://community.redwoodjs.com/t/what-do-you-think-of-the-new-github-issue-forms/3463).
+
+
+        Thanks for taking the time to open an issue!
+        Here's a bit of background on what you can expect about the process:
+
+        - Expect a response from us (the core team) within three to seven days.
+          - Usually we'll respond sooner than that, but sometimes we have a lot on our plate. Thanks for your patience!
+        - After you open this, the Redwood bot will assign a core team member to it. They'll triage it.
+          - If they don't within three to seven days, the Redwood bot will ping them. You should feel free to ping them too!
+
+  - type: textarea
+    attributes:
+      label: Summary and description
+      description: >
+        The body of the issue, just like a regular GitHub issue.
+        The more detail you provide, the better,
+        but try to start with a summary to frame the issue.
+        See the placeholder below for an example.
+
+        Here's a few questions to guide your writing:
+
+        - What is this feature about? The CLI? The web side? The api side? Both?
+          - This'll help us figure out whether it's a minor feature request or a major one
+        - Why does Redwood need this feature?
+          - I.e., what's the problem you're running up against?
+        - What would this feature's API look like?
+          - For example, if it's a new CLI command, what options does it take?
+      placeholder: >
+        This feature request is about the generators.
+        I'd like for them to support writing to arbitrary locations on the file system.
+        (Within a Redwood project of course.)
+
+
+        Right now, generators write to specific locations:
+        components write to `web/src/components`, pages to `web/src/pages`, etc.
+        Except for scaffolds, this isn't configurable.
+        (And even scaffolds are only slightly configurable at that.)
+
+
+        The reason this matters is Redwood projects are meant to scale,
+        and as Redwood projects grow in size
+        (which they do quickly since the generators write a lot of files—tests, stories, mocks, etc.),
+        file organization becomes important fast.
+        So while Redwood likes to be opinionated,
+        I think this is an area where some discretion could be left to the user.
+
+
+        So I suggest adding a new option to all generator CLI commands: `--path`.
+        This option takes a file path, relative to `src`.
+        Here's an example:
+
+
+        ```shell
+        yarn rw g component dialog --path ui
+        ```
+
+
+        This would write to the following location:
+
+
+        ```shell
+
+        web/src/ui/
+
+        └── Dialog/
+          ├── Dialog.js
+          ├── Dialog.stories.js
+          └── Dialog.test.js
+        ```
+
+
+        Thanks for reading!
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Are you interested in working on this? (If it applies)
+      description: >
+        No pressure—this is totally optional!
+        We just want to invite you to contribute to Redwood.
+        If you choose to contribute, the core team will be there to help you the whole way.
+
+
+        In some cases, if this issue is triaged as being lower priority,
+        your willing- and ableness to work on this will land it faster than waiting for a core team member to pick it up.
+        But if this is critical, it'll of course be escalated.
+      options:
+        - label: I'm interested in working on this


### PR DESCRIPTION
This PR adds three GitHub issue forms, one for bug reports, documentation, and feature requests. Now when users open an issue, they'll choose from one of those templates.

The motivation for this is that we want...

1. issues to be more structured, (specifically, bug reports)
2. to be more upfront about our process—i.e., what happens after you open an issue

I used GitHub issue forms when opening an issue in the yarn/berry repo and thought the process was much better than a blank textarea.

Note that the documentation and feature request templates aren't really that different from a blank GitHub issue, but I thought providing a blurb about expectations was worthwhile enough to warrant templates for them. We can add to these templates later if we find that we want more information.

**See it in action**

You can see how this would look like on my fork of redwood here: https://github.com/orgtoar/redwood-test. Try opening an issue. What's also nice is that GitHub renders these files: https://github.com/orgtoar/redwood-test/blob/main/.github/ISSUE_TEMPLATE/bug-report.yml.

**Tape**

https://user-images.githubusercontent.com/32992335/174222888-236fee25-7a03-4a82-b440-334f0d253357.mov