### PR TITLE
fix: have user config for `addons` and `stories` take precedence

### DIFF
--- a/packages/testing/config/storybook/main.js
+++ b/packages/testing/config/storybook/main.js
@@ -142,7 +142,9 @@ const mergeUserStorybookConfig = (baseConfig) => {
     // https://github.com/survivejs/webpack-merge#mergewithcustomize-customizearray-customizeobject-configuration--configuration
     customizeArray(baseConfig, userStorybookConfig, key) {
       if (key === 'addons' || key === 'stories') {
-        // allows userStorybookConfig to override baseConfig
+        // Allows userStorybookConfig to override baseConfig.
+        // Since this is an array, we spread the user config first (so that it comes first)
+        // Also, arrays don't dedupe the way objects do when spreading, so we do a conversion to and from a Set in order to remove duplicates.
         let combinedArrays = [
           ...new Set([...userStorybookConfig, ...baseConfig]),
         ]

--- a/packages/testing/config/storybook/main.js
+++ b/packages/testing/config/storybook/main.js
@@ -149,12 +149,12 @@ const mergeUserStorybookConfig = (baseConfig) => {
           ...new Set([...userStorybookConfig, ...baseConfig]),
         ]
         // To avoid `WARN Expected '@storybook/addon-actions' (or '@storybook/addon-essentials') to be listed before '@storybook/addon-interactions' in main Storybook config.`
-      if (key === 'addons') {
+        if (key === 'addons') {
           let key = '@storybook/addon-actions'
           combinedArrays = moveKeyToFrontOfArray(combinedArrays, key)
           key = '@storybook/addon-essentials'
           combinedArrays = moveKeyToFrontOfArray(combinedArrays, key)
-      }
+        }
         return combinedArrays
       }
       // Fall back to default merging

--- a/tasks/smoke-test/tests/storybook.spec.ts
+++ b/tasks/smoke-test/tests/storybook.spec.ts
@@ -173,7 +173,7 @@ storybookTest(
     await page.goto(STORYBOOK_URL)
 
     // Click text=Redwood
-    await page.locator('text=Redwood').click()
+    await page.locator('data-item-id=redwood--page').click()
 
     await expect(page).toHaveURL(
       `http://localhost:${port}/?path=/story/redwood--page`

--- a/tasks/smoke-test/tests/storybook.spec.ts
+++ b/tasks/smoke-test/tests/storybook.spec.ts
@@ -173,7 +173,7 @@ storybookTest(
     await page.goto(STORYBOOK_URL)
 
     // Click text=Redwood
-    await page.locator('data-item-id=redwood--page').click()
+    await page.locator('css=[data-item-id=redwood--page]').click()
 
     await expect(page).toHaveURL(
       `http://localhost:${port}/?path=/story/redwood--page`


### PR DESCRIPTION
Order for [`stories`](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) matters [in order to let you define which story is default](https://stackoverflow.com/a/68097205).

Our current implementation has the RW defaults take precedence.