### PR TITLE
Maps JSON GraphQL Scalars to Prisma Json field types for compatibility

### DIFF
--- a/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
@@ -23,8 +23,8 @@ export type Scalars = {
   BigInt: number;
   Date: string;
   DateTime: string;
-  JSON: Record<string, unknown>;
-  JSONObject: Record<string, unknown>;
+  JSON: Prisma.JsonValue;
+  JSONObject: Prisma.JsonObject;
   Time: string;
 };
 
@@ -261,8 +261,8 @@ export type Scalars = {
   BigInt: number;
   Date: string;
   DateTime: string;
-  JSON: Record<string, unknown>;
-  JSONObject: Record<string, unknown>;
+  JSON: Prisma.JsonValue;
+  JSONObject: Prisma.JsonObject;
   Time: string;
 };
 

--- a/packages/internal/src/__tests__/graphqlCodeGen.test.ts
+++ b/packages/internal/src/__tests__/graphqlCodeGen.test.ts
@@ -52,10 +52,9 @@ test('Generate gql typedefs api', async () => {
         expect(file).toMatch(path.join('api', 'types', 'graphql.d.ts'))
         expect(data).toMatchSnapshot()
 
-          // Check that JSON types are imported from prisma
+        // Check that JSON types are imported from prisma
         expect(data).toContain('JSON: Prisma.JsonValue;')
         expect(data).toContain('JSONObject: Prisma.JsonObject;')
-
       }
     )
 
@@ -63,8 +62,6 @@ test('Generate gql typedefs api', async () => {
 
   expect(apiPaths).toHaveLength(1)
   expect(apiPaths[0]).toMatch(path.join('api', 'types', 'graphql.d.ts'))
-
-  
 })
 
 test('respects user provided codegen config', async () => {

--- a/packages/internal/src/__tests__/graphqlCodeGen.test.ts
+++ b/packages/internal/src/__tests__/graphqlCodeGen.test.ts
@@ -51,6 +51,11 @@ test('Generate gql typedefs api', async () => {
       (file: fs.PathOrFileDescriptor, data: string | ArrayBufferView) => {
         expect(file).toMatch(path.join('api', 'types', 'graphql.d.ts'))
         expect(data).toMatchSnapshot()
+
+          // Check that JSON types are imported from prisma
+        expect(data).toContain('JSON: Prisma.JsonValue;')
+        expect(data).toContain('JSONObject: Prisma.JsonObject;')
+
       }
     )
 
@@ -58,6 +63,8 @@ test('Generate gql typedefs api', async () => {
 
   expect(apiPaths).toHaveLength(1)
   expect(apiPaths[0]).toMatch(path.join('api', 'types', 'graphql.d.ts'))
+
+  
 })
 
 test('respects user provided codegen config', async () => {

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -134,8 +134,8 @@ function getPluginConfig() {
 
     // Include Prisma's JSON field types as these types exist to match the types supported by JSON.parse()
     // see: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields
-    prismaModels['JsonObject'] = `.prisma/client#Prisma`
-    prismaModels['JsonValue'] = `.prisma/client#Prisma`
+    // We're doing this to avoid adding an extra import statement just for the Prisma namespace
+    prismaModels['JSON'] = `.prisma/client#Prisma`
   } catch (error) {
     // This means they've not set up prisma types yet
   }
@@ -146,8 +146,6 @@ function getPluginConfig() {
     namingConvention: 'keep', // to allow camelCased query names
     scalars: {
       // We need these, otherwise these scalars are mapped to any
-      // @TODO is there a way we can use scalars defined in
-      // packages/graphql-server/src/rootSchema.ts
       BigInt: 'number',
       DateTime: 'string',
       Date: 'string',

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -131,6 +131,11 @@ function getPluginConfig() {
     if (prismaModels.RW_DataMigration) {
       delete prismaModels.RW_DataMigration
     }
+
+    // Include Prisma's JSON field types as these types exist to match the types supported by JSON.parse()
+    // see: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-fields/working-with-json-fields
+    prismaModels['JsonObject'] = `.prisma/client#Prisma`
+    prismaModels['JsonValue'] = `.prisma/client#Prisma`
   } catch (error) {
     // This means they've not set up prisma types yet
   }
@@ -146,8 +151,8 @@ function getPluginConfig() {
       BigInt: 'number',
       DateTime: 'string',
       Date: 'string',
-      JSON: 'Record<string, unknown>',
-      JSONObject: 'Record<string, unknown>',
+      JSON: 'Prisma.JsonValue',
+      JSONObject: 'Prisma.JsonObject',
       Time: 'string',
     },
     // prevent type names being PetQueryQuery, RW generators already append

--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -20,17 +20,6 @@ export const generateGraphQLSchema = async () => {
     'directives/**/*.{js,ts}': {},
   }
 
-  const config = {
-    scalars: {
-      BigInt: 'number',
-      DateTime: 'string',
-      Date: 'string',
-      JSON: 'Record<string, unknown>',
-      JSONObject: 'Record<string, unknown>',
-      Time: 'string',
-    },
-  }
-
   const loadSchemaConfig: LoadSchemaOptions = {
     assumeValidSDL: true,
     sort: true,
@@ -38,7 +27,6 @@ export const generateGraphQLSchema = async () => {
     includeSources: true,
     cwd: getPaths().api.src,
     schema: Object.keys(schemaPointerMap),
-    config,
     generates: {
       [getPaths().generated.schema]: {
         plugins: ['schema-ast'],
@@ -101,7 +89,7 @@ export const generateGraphQLSchema = async () => {
   }
 
   const options: CodegenTypes.GenerateOptions = {
-    config,
+    config: {},
     plugins: [{ 'schema-ast': {} }],
     pluginMap: { 'schema-ast': schemaAstPlugin },
     schema: {} as unknown as DocumentNode,

--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -89,7 +89,7 @@ export const generateGraphQLSchema = async () => {
   }
 
   const options: CodegenTypes.GenerateOptions = {
-    config: {},
+    config: {}, // no extra config needed for merged schema file generation
     plugins: [{ 'schema-ast': {} }],
     pluginMap: { 'schema-ast': schemaAstPlugin },
     schema: {} as unknown as DocumentNode,


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/5667

For an example of how the JSON scalar used in the SDL causes a type incompatibility with Prisma, see https://github.com/redwoodjs/redwood/issues/5667

In Prisma, the Json field supports a few additional types, such as string and boolean. These additional types exist to match the types supported by [JSON.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).

```ts
export declare type JsonValue =
  | string
  | number
  | boolean
  | null
  | JsonObject
  | JsonArray
```

This PR imports `Prisma` and maps 

```
    JSON: 'Prisma.JsonValue',
    JSONObject: 'Prisma.JsonObject',
```