### PR TITLE
Remove existing mirrored cells before generating new

### DIFF
--- a/packages/internal/src/__tests__/typeDefinitions.test.ts
+++ b/packages/internal/src/__tests__/typeDefinitions.test.ts
@@ -1,6 +1,15 @@
 import fs from 'fs'
 import path from 'path'
 
+jest.mock('fs', () => {
+  return {
+    ...jest.requireActual('fs'),
+    // Don't actually remove any files, because if we do, we can't run the same
+    // test twice
+    rmSync: () => {},
+  }
+})
+
 import { findCells, findDirectoryNamedModules } from '../files'
 import {
   generateMirrorCells,
@@ -24,11 +33,13 @@ const FIXTURE_PATH = path.resolve(
 beforeAll(() => {
   process.env.RWJS_CWD = FIXTURE_PATH
 })
+
 afterAll(() => {
   delete process.env.RWJS_CWD
+  jest.clearAllMocks()
 })
 
-const cleanPaths = (p) => {
+const cleanPaths = (p: string) => {
   return ensurePosixPath(path.relative(FIXTURE_PATH, p))
 }
 

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -99,15 +99,15 @@ export const findPrerenderedHtml = (cwd = getPaths().web.dist) =>
   fg.sync('**/*.html', { cwd, ignore: ['200.html', '404.html'] })
 
 export const isCellFile = (p: string) => {
-  const { dir, name } = path.parse(p)
+  const { name } = path.parse(p)
 
   // If the path isn't on the web side it cannot be a cell
   if (!isFileInsideFolder(p, getPaths().web.src)) {
     return false
   }
 
-  // A Cell must be a directory named module.
-  if (!dir.endsWith(name)) {
+  // A cell must end with "Cell.{jsx,js,tsx}".
+  if (!name.endsWith('Cell')) {
     return false
   }
 

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -94,7 +94,9 @@ export const generateMirrorDirectoryNamedModule = (
 
 export const generateMirrorCells = () => {
   const rwjsPaths = getPaths()
-  return findCells().map((p) => generateMirrorCell(p, rwjsPaths))
+  const paths = findCells().map((p) => generateMirrorCell(p, rwjsPaths))
+
+  return paths
 }
 
 export const mirrorPathForCell = (p: string, rwjsPaths = getPaths()) => {

--- a/packages/internal/src/generate/watch.ts
+++ b/packages/internal/src/generate/watch.ts
@@ -4,12 +4,13 @@ import fs from 'fs'
 import path from 'path'
 
 import chokidar from 'chokidar'
+import fse from 'fs-extra'
 
 import {
   isCellFile,
-  isPageFile,
   isDirectoryNamedModuleFile,
   isGraphQLSchemaFile,
+  isFileInsideFolder,
 } from '../files'
 import { getPaths } from '../paths'
 
@@ -28,57 +29,75 @@ import {
   mirrorPathForCell,
 } from './typeDefinitions'
 
-const rwjsPaths = getPaths()
+// Can't use `isPageFile()` from ../files because that ones looks at the
+// content of the file, and that doesn't work for deleted files that we
+// sometimes have in the watcher callback
+function isPageFile(p: string) {
+  const { name } = path.parse(p)
 
-const watcher = chokidar.watch('**/src/**/*.{ts,js,jsx,tsx}', {
-  persistent: true,
-  ignored: ['node_modules', '.redwood'],
-  ignoreInitial: true,
-  cwd: rwjsPaths.base,
-  awaitWriteFinish: true,
-})
+  // A page must end with "Page.{jsx,js,tsx}".
+  if (!name.endsWith('Page')) {
+    return false
+  }
+
+  // A page should be in the `web/src/pages` directory.
+  if (!isFileInsideFolder(p, getPaths().web.pages)) {
+    return false
+  }
+
+  return true
+}
+
+const rwjsPaths = getPaths()
 
 const action = {
   add: 'Created',
   unlink: 'Deleted',
+  unlinkDir: 'Deleted',
   change: 'Modified',
 }
 
-watcher
-  .on('ready', async () => {
-    console.log('Generating TypeScript definitions and GraphQL schemas...')
-    const files = await generate()
-    console.log(files.length, 'files generated')
-  })
-  .on('all', async (eventName, p) => {
-    if (!['add', 'change', 'unlink'].includes(eventName)) {
-      return
-    }
-    eventName = eventName as 'add' | 'change' | 'unlink'
+const apiWatcher = chokidar.watch('src/**/*.{ts,js}', {
+  persistent: true,
+  ignored: ['node_modules', '.redwood'],
+  ignoreInitial: true,
+  cwd: rwjsPaths.api.base,
+  awaitWriteFinish: true,
+})
 
-    const absPath = path.join(rwjsPaths.base, p)
+const dirWatcher = chokidar.watch('src', {
+  cwd: rwjsPaths.web.base,
+  ignoreInitial: true,
+  awaitWriteFinish: true,
+})
 
-    if (absPath.indexOf('Cell') !== -1 && isCellFile(absPath)) {
-      await generateTypeDefGraphQLWeb()
-      if (eventName === 'unlink') {
-        fs.unlinkSync(mirrorPathForCell(absPath, rwjsPaths)[0])
-      } else {
-        generateMirrorCell(absPath, rwjsPaths)
-      }
+apiWatcher.on('all', async (eventName, p) => {
+  if (!['add', 'change', 'unlink'].includes(eventName)) {
+    return
+  }
 
-      console.log(action[eventName], 'Cell:', '\x1b[2m', p, '\x1b[0m')
-    } else if (absPath === rwjsPaths.web.routes) {
-      generateTypeDefRouterRoutes()
-      console.log(action[eventName], 'Routes:', '\x1b[2m', p, '\x1b[0m')
-    } else if (absPath.indexOf('Page') !== -1 && isPageFile(absPath)) {
-      generateTypeDefRouterPages()
-      console.log(action[eventName], 'Page:', '\x1b[2m', p, '\x1b[0m')
-    } else if (isDirectoryNamedModuleFile(absPath)) {
-      if (eventName === 'unlink') {
+  eventName = eventName as 'add' | 'change' | 'unlink'
+
+  const absPath = path.join(rwjsPaths.api.base, p)
+
+  if (isDirectoryNamedModuleFile(absPath)) {
+    if (eventName === 'unlink') {
+      try {
         fs.unlinkSync(mirrorPathForDirectoryNamedModules(absPath, rwjsPaths)[0])
-      } else {
-        generateMirrorDirectoryNamedModule(absPath, rwjsPaths)
+
+        console.log(
+          action[eventName],
+          'Directory named module:',
+          '\x1b[2m',
+          p,
+          '\x1b[0m'
+        )
+      } catch {
+        // Ignoring any errors for the same reasons as for Cell
       }
+    } else {
+      generateMirrorDirectoryNamedModule(absPath, rwjsPaths)
+
       console.log(
         action[eventName],
         'Directory named module:',
@@ -86,9 +105,114 @@ watcher
         p,
         '\x1b[0m'
       )
-    } else if (isGraphQLSchemaFile(absPath)) {
-      await generateGraphQLSchema()
-      await generateTypeDefGraphQLApi()
-      console.log(action[eventName], 'GraphQL Schema:', '\x1b[2m', p, '\x1b[0m')
+    }
+  } else if (isGraphQLSchemaFile(absPath)) {
+    await generateGraphQLSchema()
+    await generateTypeDefGraphQLApi()
+    console.log(action[eventName], 'GraphQL Schema:', '\x1b[2m', p, '\x1b[0m')
+  }
+})
+
+dirWatcher
+  .on('ready', async () => {
+    console.log('Generating TypeScript definitions and GraphQL schemas...')
+    const files = await generate()
+    console.log(files.length, 'files generated')
+  })
+  .on('all', async (eventName, p) => {
+    if (!['add', 'change', 'unlink', 'unlinkDir'].includes(eventName)) {
+      return
+    }
+
+    eventName = eventName as 'add' | 'change' | 'unlink' | 'unlinkDir'
+
+    const absPath = path.join(rwjsPaths.web.base, p)
+
+    if (eventName === 'unlinkDir') {
+      if (absPath.endsWith('Cell')) {
+        const mirrorDir = path.join(
+          rwjsPaths.generated.types.mirror,
+          path.relative(rwjsPaths.base, p)
+        )
+
+        try {
+          fse.remove(mirrorDir)
+        } catch {
+          // Ignore
+        }
+      }
+
+      return
+    }
+
+    if (eventName === 'unlink') {
+      // When unlinking (i.e. removing or renaming) a file we can't use
+      // `isCellFile()` because that function needs to look inside the file to
+      // determine if it's a cell or not, and it can't do that on a file that
+      // doesn't exist anymore
+
+      const { name } = path.parse(p)
+
+      if (name.endsWith('Cell')) {
+        // Probably a cell, but we can never be sure. But if it was indeed a
+        // cell it should have had a mirror cell that we now need to remove
+        try {
+          fs.unlinkSync(mirrorPathForCell(absPath, rwjsPaths)[0])
+
+          console.log(action[eventName], 'Cell:', '\x1b[2m', p, '\x1b[0m')
+        } catch {
+          // Unlinking will fail if the mirror cell doesn't exist. Just ignore
+          // the exception in that case.
+          // Unlinking can also fail, especially on Windows, if the file is
+          // open somewhere, like in some editor window. Let's just ignore that
+          // as well for now
+        }
+      }
+    }
+
+    if (eventName !== 'unlink' && isCellFile(absPath)) {
+      await generateTypeDefGraphQLWeb()
+      generateMirrorCell(absPath, rwjsPaths)
+
+      console.log(action[eventName], 'Cell:', '\x1b[2m', p, '\x1b[0m')
+    } else if (absPath === rwjsPaths.web.routes) {
+      generateTypeDefRouterRoutes()
+      console.log(action[eventName], 'Routes:', '\x1b[2m', p, '\x1b[0m')
+    } else if (isPageFile(absPath)) {
+      generateTypeDefRouterPages()
+      console.log(action[eventName], 'Page:', '\x1b[2m', p, '\x1b[0m')
+    } else if (isDirectoryNamedModuleFile(absPath)) {
+      // Remember that files ending with Cell can also be just a regular
+      // Directory Named Module, for example <TableCell> used as wrapper for
+      // simple <td>s. If <TableCell> lived in /TableCell/TableCell.tsx it'd
+      // be a Directory Named Module and it's mirror needs to be deleted
+
+      if (eventName === 'unlink') {
+        try {
+          fs.unlinkSync(
+            mirrorPathForDirectoryNamedModules(absPath, rwjsPaths)[0]
+          )
+
+          console.log(
+            action[eventName],
+            'Directory named module:',
+            '\x1b[2m',
+            p,
+            '\x1b[0m'
+          )
+        } catch {
+          // Ignoring any errors for the same reasons as for Cell
+        }
+      } else {
+        generateMirrorDirectoryNamedModule(absPath, rwjsPaths)
+
+        console.log(
+          action[eventName],
+          'Directory named module:',
+          '\x1b[2m',
+          p,
+          '\x1b[0m'
+        )
+      }
     }
   })


### PR DESCRIPTION
Fixes #5775 

Splits the generator file watching into two. One for the API side and one for the Web side.
The Web side watcher now also watches for directory changes. It was the only way to catch directories that were being renamed. When a Cell directory is unlinked we now also remove the corresponding mirror directory.