### PR TITLE
Fix misnamed forbidden page route

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -120,7 +120,7 @@ const Routes = () => {
     <Router>
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={LoginPage} name="login" />
-      <Route path="/forbidden" page={ForbiddenPage} name="login" />
+      <Route path="/forbidden" page={ForbiddenPage} name="forbidden" />
 
       <Private unauthenticated="login">
         <Route path="/secret-page" page={SecretPage} name="secret" />


### PR DESCRIPTION
I haven't tried, but as the whole example doesn't show a single route of `name='forbidden'` i believe the two private sets at the bottom cannot redirect anywhere.

Also, route `name`s are supposed to be unique, correct?