### PR TITLE
fix(sls): Package nested functions too

### DIFF
--- a/docs/docs/deploy/serverless.md
+++ b/docs/docs/deploy/serverless.md
@@ -55,6 +55,13 @@ Once that command completes you should see a message including the URL of your s
 
 From now on you can simply run `yarn rw deploy serverless` when you're ready to deploy (which will also be much faster).
 
+
+:::info
+Remember, if you add or generate new serverless functions (or endpoints), you'll need to update the configuration in your serverless.yml in `./api/serverless.yml`.
+
+By default we only configure the `auth` and `graphql` functions for you.
+:::
+
 ## Environment Variables
 
 For local deployment (meaning you're deploying from your own machine, or another that you're in control of) you can put any ENV vars that are production-only into `.env.production`. They will override any same-named vars in `.env`. Make sure neither of these files is checked into your code repository!
@@ -99,6 +106,6 @@ Note that `production` is the default stage when you deploy with `yarn rw server
 
 This will take several minutes, so grab your favorite beverage and enjoy your new $0 monthly bill!
 
-> Pro tip: if you get tired of typing `serverless` each time, you can use the much shorter `sls` alias:
->
->   `yarn rw deploy sls`
+:::tip Pro tip
+If you get tired of typing `serverless` each time, you can use the much shorter `sls` alias: `yarn rw deploy sls`
+:::

--- a/packages/api-server/src/__tests__/withWebServer.test.ts
+++ b/packages/api-server/src/__tests__/withWebServer.test.ts
@@ -13,7 +13,6 @@ const FIXTURE_PATH = path.resolve(
 // because its gitignored
 jest.mock('@redwoodjs/internal', () => {
   return {
-    // @ts-expect-error spread error unnecessarily
     ...jest.requireActual('@redwoodjs/internal'),
     findPrerenderedHtml: () => {
       return ['about.html', 'mocked.html', 'posts/new.html', 'index.html']

--- a/packages/cli/__mocks__/@vercel/nft.js
+++ b/packages/cli/__mocks__/@vercel/nft.js
@@ -1,0 +1,3 @@
+module.exports = {
+  nodeFileTrace: jest.fn(),
+}

--- a/packages/cli/src/commands/deploy/__tests__/nftPack.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/nftPack.test.js
@@ -1,0 +1,70 @@
+import fs from 'fs'
+import path from 'path'
+
+import { buildApi, findApiDistFunctions } from '@redwoodjs/internal'
+
+import nftPacker from '../packing/nft'
+
+const FIXTURE_PATH = path.resolve(
+  __dirname,
+  '../../../../../../__fixtures__/example-todo-main'
+)
+
+let functionDistFiles
+
+beforeAll(() => {
+  process.env.RWJS_CWD = FIXTURE_PATH
+
+  // Actually build the fixture, if we need it
+  if (!fs.existsSync(path.join(FIXTURE_PATH, 'api/dist/functions'))) {
+    buildApi()
+  }
+
+  functionDistFiles = findApiDistFunctions()
+})
+
+afterAll(() => {
+  delete process.env.RWJS_CWD
+})
+
+test('Check packager detects all functions', () => {
+  const packageFileMock = jest
+    .spyOn(nftPacker, 'packageSingleFunction')
+    .mockResolvedValue(true)
+
+  nftPacker.nftPack()
+
+  expect(packageFileMock).toHaveBeenCalledTimes(5)
+})
+
+test('Creates entry file for nested functions correctly', () => {
+  const nestedFunction = functionDistFiles.find((fPath) =>
+    fPath.includes('nested')
+  )
+
+  const [outputPath, content] = nftPacker.generateEntryFile(
+    nestedFunction,
+    'nested'
+  )
+
+  expect(outputPath).toBe('./api/dist/zipball/nested/nested.js')
+  expect(content).toMatchInlineSnapshot(
+    `"module.exports = require('./api/dist/functions/nested/nested.js')"`
+  )
+})
+
+test('Creates entry file for top level functions correctly', () => {
+  const graphqlFunction = functionDistFiles.find((fPath) =>
+    fPath.includes('graphql')
+  )
+
+  const [outputPath, content] = nftPacker.generateEntryFile(
+    graphqlFunction,
+    'graphql'
+  )
+
+  expect(outputPath).toBe('./api/dist/zipball/graphql/graphql.js')
+  expect(content).toMatchInlineSnapshot(
+    `"module.exports = require('./api/dist/functions/graphql.js')"`
+  )
+})

--- a/packages/cli/src/commands/deploy/packing/nft.js
+++ b/packages/cli/src/commands/deploy/packing/nft.js
@@ -4,6 +4,8 @@ import { nodeFileTrace } from '@vercel/nft'
 import archiver from 'archiver'
 import fse from 'fs-extra'
 
+import { findApiDistFunctions, getPaths } from '@redwoodjs/internal'
+
 const ZIPBALL_DIR = './api/dist/zipball'
 
 function zipDirectory(source, out) {
@@ -21,8 +23,18 @@ function zipDirectory(source, out) {
   })
 }
 
+// returns a tuple of [filename, fileContent]
+function generateEntryFile(functionAbsolutePath, name) {
+  const relativeImport = path.relative(getPaths().base, functionAbsolutePath)
+  return [
+    `${ZIPBALL_DIR}/${name}/${name}.js`,
+    `module.exports = require('./${relativeImport}')`,
+  ]
+}
+
 async function packageSingleFunction(functionFile) {
   const { name: functionName } = path.parse(functionFile)
+
   const { fileList: functionDependencyFileList } = await nodeFileTrace([
     functionFile,
   ])
@@ -35,14 +47,16 @@ async function packageSingleFunction(functionFile) {
       )
     )
   }
-  const functionEntryPromise = fse.outputFile(
-    `${ZIPBALL_DIR}/${functionName}/${functionName}.js`,
-    `module.exports = require('${functionFile}')`
-  )
+
+  const [entryFilePath, content] = generateEntryFile(functionFile, functionName)
+
+  // This generates an "entry" file, that just proxies the actual
+  // function that is nested in api/dist/
+  const functionEntryPromise = fse.outputFile(entryFilePath, content)
   copyPromises.push(functionEntryPromise)
 
   await Promise.all(copyPromises)
-  await zipDirectory(
+  await exports.zipDirectory(
     `${ZIPBALL_DIR}/${functionName}`,
     `${ZIPBALL_DIR}/${functionName}.zip`
   )
@@ -50,11 +64,18 @@ async function packageSingleFunction(functionFile) {
   return
 }
 
-async function ntfPack() {
-  const filesToBePacked = (await fse.readdir('./api/dist/functions'))
-    .filter((path) => path.endsWith('.js'))
-    .map((path) => `./api/dist/functions/${path}`)
-  return Promise.all(filesToBePacked.map(packageSingleFunction))
+function nftPack() {
+  const filesToBePacked = findApiDistFunctions()
+  return Promise.all(filesToBePacked.map(exports.packageSingleFunction))
 }
 
-export default ntfPack
+// We do this, so we can spy the functions in the test
+// It didn't make sense to separate into different files
+const exports = {
+  nftPack,
+  packageSingleFunction,
+  generateEntryFile,
+  zipDirectory,
+}
+
+export default exports

--- a/packages/cli/src/commands/deploy/serverless.js
+++ b/packages/cli/src/commands/deploy/serverless.js
@@ -83,7 +83,7 @@ export const buildCommands = ({ sides }) => {
       task: async () => {
         // Dynamically import this function
         // becuase its dependencies are only installed when `rw setup deploy serverless` is run
-        const { default: nftPack } = await import('./packing/nft')
+        const { nftPack } = await (await import('./packing/nft')).default
 
         await nftPack()
       },


### PR DESCRIPTION
Fixes #5675

### Background
See issue, but the gist is: the nft packer wasn't picking up nested functions, so when trying to deploy anything but graphql and auth functions, `rw sls deploy` was failing 

### What does this PR do?
- Fixes packaging nested functions into zipballs too, and makes sure it uses the same globbing function from rwjs/internal like everything else
- Refactors the nft packer to be more testable
- Adds tests