### PR TITLE
Fix RedwoodUser type in RW App's auth.ts

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth.ts.template
@@ -5,7 +5,7 @@ import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
  * Represents the user attributes returned by the decoding the
  * Authentication provider's JWT together with an optional list of roles.
  */
-type RedwoodUser = Record<string, unknown> & { roles?: string[] }
+type RedwoodUser = Record<string, unknown> & { roles?: string[] | string }
 
 /**
  * getCurrentUser returns the user information together with

--- a/packages/cli/src/commands/setup/auth/templates/auth0.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth0.auth.ts.template
@@ -5,7 +5,7 @@ import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
  * Represents the user attributes returned by the decoding the
  * Authentication provider's JWT together with an optional list of roles.
  */
-type RedwoodUser = Record<string, unknown> & { roles?: string[] }
+type RedwoodUser = Record<string, unknown> & { roles?: string[] | string }
 
 /**
  * getCurrentUser returns the user information together with


### PR DESCRIPTION
with type `string[]` only, conditions in lines 99 will supposodly always return `false`.