### PR TITLE
Fix type errors in `lib/auth.ts` when using a non-RBAC `dbAuth` setup

### DIFF
--- a/packages/internal/src/generate/templates/all-currentUser.d.ts.template
+++ b/packages/internal/src/generate/templates/all-currentUser.d.ts.template
@@ -6,11 +6,22 @@ import { getCurrentUser } from '../../../api/src/lib/auth'
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T
 export type InferredCurrentUser = ThenArg<ReturnType<typeof getCurrentUser>>
 
+type UndefinedRoles = {
+  /**
+   * ⚠️ Heads-Up: This is undefined unless `roles: true` is added to the `select: {…}`
+   * object in {@link getCurrentUser()}.
+   *
+   * You may look into to https://redwoodjs.com/docs/tutorial/chapter7/rbac for a tutorial on
+   * how to add fully-fledged RBAC (Role-based Access Control) to your database model.
+   */
+  roles?: unknown | unknown[]
+}
+
 type Overwrite<T, U> = Omit<T, keyof U> & U
 
 declare module '@redwoodjs/graphql-server' {
   interface GlobalContext {
-    currentUser?: Overwrite<{ roles? }, InferredCurrentUser>
+    currentUser?: Overwrite<UndefinedRoles, InferredCurrentUser>
   }
 }
 

--- a/packages/internal/src/generate/templates/all-currentUser.d.ts.template
+++ b/packages/internal/src/generate/templates/all-currentUser.d.ts.template
@@ -8,10 +8,9 @@ export type InferredCurrentUser = ThenArg<ReturnType<typeof getCurrentUser>>
 
 type UndefinedRoles = {
   /**
-   * ⚠️ Heads-Up: This is undefined unless `roles: true` is added to the `select: {…}`
-   * object in {@link getCurrentUser()}.
+   * ⚠️ Heads-Up: This is undefined unless roles key is returned from {@link getCurrentUser()}
    *
-   * You may look into to https://redwoodjs.com/docs/tutorial/chapter7/rbac for a tutorial on
+   * You may take a look at https://redwoodjs.com/docs/tutorial/chapter7/rbac for a tutorial on
    * how to add fully-fledged RBAC (Role-based Access Control) to your database model.
    */
   roles?: unknown | unknown[]

--- a/packages/internal/src/generate/templates/all-currentUser.d.ts.template
+++ b/packages/internal/src/generate/templates/all-currentUser.d.ts.template
@@ -6,9 +6,11 @@ import { getCurrentUser } from '../../../api/src/lib/auth'
 type ThenArg<T> = T extends PromiseLike<infer U> ? U : T
 export type InferredCurrentUser = ThenArg<ReturnType<typeof getCurrentUser>>
 
+type Overwrite<T, U> = Omit<T, keyof U> & U
+
 declare module '@redwoodjs/graphql-server' {
   interface GlobalContext {
-    currentUser?: InferredCurrentUser
+    currentUser?: Overwrite<{ roles? }, InferredCurrentUser>
   }
 }
 


### PR DESCRIPTION
Closes #5038

No breaking change, no codemods or other updates needed to existing projects.

---

This fixes a typescript error that has been bugging me for some time. Whenever generating the `dbAuth` setup, but not implementing any role-based access control (RBAC), vscode goes full on red on `auth.ts`:

![grafik](https://user-images.githubusercontent.com/1634615/176688800-01b80316-2937-455d-917c-a62420e04f1a.png)

I know one may debate whether this is actually a problem or not (imho generated code should always pass 100 % of all rules in order maximize trust in the framework, i know e.g. @dac09 has a different stance on this), but this one is that severe that it comes up when running `yarn rw type-check`

![grafik](https://user-images.githubusercontent.com/1634615/176689601-5bf17e8f-2976-4243-944f-6d2f85cd73e8.png)

Don't know if this is the perfect solution and am open to better ones. But i feel it's just good enough, in my test the `rules`-type got properly overwritten (becoming mandatory) as soon as one changes `getCurrentUser` to also return it.
