### PR TITLE
Link non-primitive types in JSDoc

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth.ts.template
@@ -65,7 +65,7 @@ type AllowedRoles = string | string[] | undefined
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
+ * @param roles: {@link AllowedRoles} - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -110,12 +110,12 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param roles?: AllowedRoles - When checking role membership, these roles grant access.
+ * @param roles?: {@link AllowedRoles} - When checking role membership, these roles grant access.
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
- * @throws {ForbiddenError} - If the currentUser is not allowed due to role permissions
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/cli/src/commands/setup/auth/templates/auth0.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth0.auth.ts.template
@@ -65,7 +65,7 @@ type AllowedRoles = string | string[] | undefined
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
+ * @param roles: {@link AllowedRoles} - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -110,12 +110,12 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param roles: AllowedRoles - When checking role membership, these roles grant access.
+ * @param roles: {@link AllowedRoles} - When checking role membership, these roles grant access.
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
- * @throws {ForbiddenError} If the currentUser is not allowed due to role permissions
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/cli/src/commands/setup/auth/templates/azureActiveDirectory.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/azureActiveDirectory.auth.ts.template
@@ -47,7 +47,7 @@ type AllowedRoles = string | string[] | undefined
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
+ * @param roles: {@link AllowedRoles} - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -92,12 +92,12 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param roles: AllowedRoles - When checking role membership, these roles grant access.
+ * @param roles: {@link AllowedRoles} - When checking role membership, these roles grant access.
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
- * @throws {ForbiddenError} If the currentUser is not allowed due to role permissions
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/cli/src/commands/setup/auth/templates/clerk.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/clerk.auth.ts.template
@@ -58,7 +58,7 @@ type AllowedRoles = string | string[] | undefined
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
+ * @param roles: {@link AllowedRoles} - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -103,12 +103,12 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param roles: AllowedRoles - When checking role membership, these roles grant access.
+ * @param roles: {@link AllowedRoles} - When checking role membership, these roles grant access.
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
- * @throws {ForbiddenError} If the currentUser is not allowed due to role permissions
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
@@ -43,7 +43,7 @@ type AllowedRoles = string | string[] | undefined
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
+ * @param roles: {@link AllowedRoles} - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -88,12 +88,12 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  * whether or not they are assigned a role, and optionally raise an
  * error if they're not.
  *
- * @param roles: AllowedRoles - When checking role membership, these roles grant access.
+ * @param roles: {@link AllowedRoles} - When checking role membership, these roles grant access.
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
- * @throws {ForbiddenError} If the currentUser is not allowed due to role permissions
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link ForbiddenError} If the currentUser is not allowed due to role permissions
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/cli/src/commands/setup/auth/templates/firebase.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/firebase.auth.ts.template
@@ -47,7 +47,7 @@ export const isAuthenticated = (): boolean => {
  *
  * @returns - If the currentUser is authenticated
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/cli/src/commands/setup/auth/templates/magicLink.auth.js.template
+++ b/packages/cli/src/commands/setup/auth/templates/magicLink.auth.js.template
@@ -43,7 +43,7 @@ export const isAuthenticated = (): boolean => {
  *
  * @returns - If the currentUser is authenticated
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */

--- a/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
+++ b/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
@@ -72,7 +72,7 @@ type AllowedRoles = string | string[] | undefined
 /**
  * Checks if the currentUser is authenticated (and assigned one of the given roles)
  *
- * @param roles: AllowedRoles - Checks if the currentUser is assigned one of these roles
+ * @param roles: {@link AllowedRoles} - Checks if the currentUser is assigned one of these roles
  *
  * @returns {boolean} - Returns true if the currentUser is logged in and assigned one of the given roles,
  * or when no roles are provided to check against. Otherwise returns false.
@@ -121,8 +121,8 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  *
  * @returns - If the currentUser is authenticated (and assigned one of the given roles)
  *
- * @throws {AuthenticationError} - If the currentUser is not authenticated
- * @throws {ForbiddenError} - If the currentUser is not allowed due to role permissions
+ * @throws {@link AuthenticationError} - If the currentUser is not authenticated
+ * @throws {@link ForbiddenError} - If the currentUser is not allowed due to role permissions
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */


### PR DESCRIPTION
This one came to me while i was contemplating over #5856. It's just a nice thing that you can to with JSDoc – it makes the types clickable, so users may navigate to complex return types faster.

Of course these types are so simple that one would hardly ever need to look up their implementations, but if you want to, now you can do it with a single click :grinning: 

Guess there are many areas where this may be very helpful. So maybe something to take up into the coding standards / linting rules / what-have-you going forward.

### Before:
![grafik](https://user-images.githubusercontent.com/1634615/176690830-9175f1af-4154-46ec-aca0-6f8936be3180.png)

### After

![grafik](https://user-images.githubusercontent.com/1634615/176691978-6222985f-6cf3-4ab5-b9bb-6597ab6ef33e.png)
