### PR TITLE
fix: remove types/graphql import and use

### DIFF
--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -631,13 +631,6 @@ import {
   SubmitHandler,
 } from '@redwoodjs/forms'
 
-// highlight-start
-import {
-  CreateContactMutation,
-  CreateContactMutationVariables,
-} from 'types/graphql'
-// highlight-end
-
 const CREATE_CONTACT = gql`
   mutation CreateContactMutation($input: CreateContactInput!) {
     createContact(input: $input) {
@@ -654,10 +647,7 @@ interface FormValues {
 
 const ContactPage = () => {
   // highlight-start
-  const [create] = useMutation<
-    CreateContactMutation,
-    CreateContactMutationVariables
-  >(CREATE_CONTACT)
+  const [create] = useMutation(CREATE_CONTACT)
   // highlight-end
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
@@ -830,11 +820,6 @@ import {
   SubmitHandler,
 } from '@redwoodjs/forms'
 
-import {
-  CreateContactMutation,
-  CreateContactMutationVariables,
-} from 'types/graphql'
-
 const CREATE_CONTACT = gql`
   mutation CreateContactMutation($input: CreateContactInput!) {
     createContact(input: $input) {
@@ -850,10 +835,7 @@ interface FormValues {
 }
 
 const ContactPage = () => {
-  const [create] = useMutation<
-    CreateContactMutation,
-    CreateContactMutationVariables
-  >(CREATE_CONTACT)
+  const [create] = useMutation(CREATE_CONTACT)
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     // highlight-next-line
@@ -965,10 +947,7 @@ const ContactPage = () => {
 
 const ContactPage = () => {
   // highlight-next-line
-  const [create, { loading, error }] = useMutation<
-    CreateContactMutation,
-    CreateContactMutationVariables
-  >(CREATE_CONTACT)
+  const [create, { loading, error }] = useMutation(CREATE_CONTACT)
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     create({ variables: { input: data } })
@@ -1132,11 +1111,6 @@ import {
   SubmitHandler,
 } from '@redwoodjs/forms'
 
-import {
-  CreateContactMutation,
-  CreateContactMutationVariables,
-} from 'types/graphql'
-
 const CREATE_CONTACT = gql`
   mutation CreateContactMutation($input: CreateContactInput!) {
     createContact(input: $input) {
@@ -1153,10 +1127,7 @@ interface FormValues {
 
 const ContactPage = () => {
   // highlight-start
-  const [create, { loading, error }] = useMutation<
-    CreateContactMutation,
-    CreateContactMutationVariables
-  >(CREATE_CONTACT, {
+  const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
     onCompleted: () => {
       toast.success('Thank you for your submission!')
     },
@@ -1439,11 +1410,6 @@ import {
   SubmitHandler,
 } from '@redwoodjs/forms'
 
-import {
-  CreateContactMutation,
-  CreateContactMutationVariables,
-} from 'types/graphql'
-
 const CREATE_CONTACT = gql`
   mutation CreateContactMutation($input: CreateContactInput!) {
     createContact(input: $input) {
@@ -1459,10 +1425,7 @@ interface FormValues {
 }
 
 const ContactPage = () => {
-  const [create, { loading, error }] = useMutation<
-    CreateContactMutation,
-    CreateContactMutationVariables
-  >(CREATE_CONTACT, {
+  const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
     onCompleted: () => {
       toast.success('Thank you for your submission!')
     },
@@ -1769,10 +1732,7 @@ const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
 // ...
 
-const [create, { loading, error }] = useMutation<
-  CreateContactMutation,
-  CreateContactMutationVariables
->(CREATE_CONTACT, {
+const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
   onCompleted: () => {
     toast.success('Thank you for your submission!')
     // highlight-next-line
@@ -1909,11 +1869,6 @@ import {
   useForm,
 } from '@redwoodjs/forms'
 
-import {
-  CreateContactMutation,
-  CreateContactMutationVariables,
-} from 'types/graphql'
-
 const CREATE_CONTACT = gql`
   mutation CreateContactMutation($input: CreateContactInput!) {
     createContact(input: $input) {
@@ -1931,10 +1886,7 @@ interface FormValues {
 const ContactPage = () => {
   const formMethods = useForm()
 
-  const [create, { loading, error }] = useMutation<
-    CreateContactMutation,
-    CreateContactMutationVariables
-  >(CREATE_CONTACT, {
+  const [create, { loading, error }] = useMutation(CREATE_CONTACT, {
     onCompleted: () => {
       toast.success('Thank you for your submission!')
       formMethods.reset()


### PR DESCRIPTION
I'm following the tutorial page and I didn't found any relation or "how to create" this CreateContactMutation/CreateContactMutationVariables types inside `types/graphql`, this piece of code make the tutorial a little bit confuse on this part, so when I saw the video tutorial and see that this is not required I've completely removed it from my code, everything works without this element.

Can we remove this needs on saving-data page inside chapter 3?