### PR TITLE
Preserve trailing whitespace for Markdown, HTML & MJML (RedwoodJS project + create-redwood-app template)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     "**/__fixtures__": true,
     ".yarn-packages-cache": true
   },
-  "[markdown]": {
+  "[markdown][html][mjml]": {
     "files.trimTrailingWhitespace": false
   },
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,9 @@
     "**/__fixtures__": true,
     ".yarn-packages-cache": true
   },
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
   "peacock.color": "#b85833"
 }

--- a/__fixtures__/test-project-rsa/.vscode/settings.json
+++ b/__fixtures__/test-project-rsa/.vscode/settings.json
@@ -5,9 +5,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "[markdown]": {
+  "[markdown][html][mjml]": {
     "files.trimTrailingWhitespace": false
-  },  
+  },
   "[prisma]": {
     "editor.formatOnSave": true
   }

--- a/__fixtures__/test-project-rsa/.vscode/settings.json
+++ b/__fixtures__/test-project-rsa/.vscode/settings.json
@@ -5,6 +5,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },  
   "[prisma]": {
     "editor.formatOnSave": true
   }

--- a/docs/docs/project-configuration-dev-test-build.mdx
+++ b/docs/docs/project-configuration-dev-test-build.mdx
@@ -222,3 +222,17 @@ Admittedly, the `.yarn` folder won't change that often, so this may not be
 the best example. But we thought we'd share this technique with you
 so that you'd know how to apply it to any folders that you know change very often,
 and how to tell VSCode not to bother wasting any CPU cycles on them.
+
+## Trailing whitespace
+
+If you're using VS Code, or another editor that supports
+[EditorConfig](https://editorconfig.org), trailing whitespace will be trimmed
+in source files, but preserved in html, markdown and mjml files when saving.
+
+This behavior is controlled by `.vscode/settings` or `.editorconfig` depending
+on your editor.
+
+In JavaScript and TypeScript files trailing whitespace has no significance,
+but for html, markdown and mjml it does. That's why the behavior is different
+for those files. If you don't like the default behavior Redwood has configured
+for you, you're free to change the settings in those two files.

--- a/packages/create-redwood-app/templates/js/.editorconfig
+++ b/packages/create-redwood-app/templates/js/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/create-redwood-app/templates/js/.editorconfig
+++ b/packages/create-redwood-app/templates/js/.editorconfig
@@ -9,5 +9,5 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
+[*.{md,html,mjml}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
While trailing whitespace is just bit noise in code (well, 99 % of the time...), for markdown it has actual signifiance.

This used to drive me crazy for a while until i found this setting. This will save others the trouble.

---

There was some scope creep in the discussion below, so this PR now both introduces changes and also fixes intended behaviour, namely:

-  (Fix) Bring VSCode settings in line with `.editorconfig` in the RedwoodJS main project
   - this is particularly nice b/c trailing whitespace is now preserved when editing the docs
- (change) Not only preserve whitespace for markdown, but also HTML & MJML files in the project template