### PR TITLE
Bump framer motion version to 6.* as recommended

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
@@ -31,7 +31,7 @@ export async function handler({ force, install }) {
     '@chakra-ui/react@^1',
     '@emotion/react@^11',
     '@emotion/styled@^11',
-    'framer-motion@^4',
+    'framer-motion@^6',
   ]
 
   const tasks = new Listr([


### PR DESCRIPTION
According to https://v1.chakra-ui.com/guides/getting-started/redwoodjs-guide#manual this is the correct version for Chakra UI 1.8.8 (not 4.x).

I can also confirm from experience that this configuration worked like a charm from the get-go in our project for several months now.