### PR TITLE
Fix type error in TS article ID

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -175,7 +175,7 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 
 ```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
 <h2>
-  <Link to={routes.article({ id: article.id })}>{article.title}</Link>
+  <Link to={routes.article({ id: article.id.toString() })}>{article.title}</Link>
 </h2>
 ```
 


### PR DESCRIPTION
Type 'number' is not assignable to type 'string'. ts(2322)

![image](https://user-images.githubusercontent.com/7833360/177240848-a55fcb62-18ce-413d-8e17-eec6ffa8a85d.png)

Not sure if we should update both JS and TS and/or add additional documentation explaining this