### PR TITLE
[minor] Makes the error message a bit clearer when a navigation url is crashing your app

### DIFF
--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -312,7 +312,7 @@ describe('flattenSearchParams', () => {
 describe('replaceParams', () => {
   it('throws an error on missing params', () => {
     expect(() => replaceParams('/tags/{tag}', {})).toThrowError(
-      "Missing parameter 'tag' for route '/tags/{tag}'."
+      "Missing parameter 'tag' for route '/tags/{tag}' when generating a navigation URL."
     )
   })
 
@@ -348,7 +348,9 @@ describe('replaceParams', () => {
 
     expect(() =>
       replaceParams('/undef/{undef}', { undef: undefined })
-    ).toThrowError("Missing parameter 'undef' for route '/undef/{undef}'.")
+    ).toThrowError(
+      "Missing parameter 'undef' for route '/undef/{undef}' when generating a navigation URL."
+    )
   })
 
   it('handles typed params', () => {

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -235,7 +235,9 @@ export const replaceParams = (
     if (value !== undefined) {
       path = path.replace(match, value as string)
     } else {
-      throw new Error(`Missing parameter '${name}' for route '${route}'.`)
+      throw new Error(
+        `Missing parameter '${name}' for route '${route}' when generating a navigation URL.`
+      )
     }
   })
 


### PR DESCRIPTION
I missed the cause of this error each time (and was figuring my routes were incorrect) until I dug through the error stack, this should raise the key bit of info into the top line