### PR TITLE
Gitpod hot reload fix

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,7 +27,7 @@ tasks:
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
     command: |
       cd /workspace/rw-test-app
-      yarn rw dev
+      yarn rw dev --fwd="--allowed-hosts localhost --allowed-hosts $(gp url 8910 | sed -e "s/https:\/\///g") --client-web-socket-url=$(gp url 8910 | sed -e "s/https/wss/g")/ws"
 
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,7 +27,7 @@ tasks:
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
     command: |
       cd /workspace/rw-test-app
-      yarn rw dev --fwd="--allowed-hosts localhost --allowed-hosts $(gp url 8910 | sed -e "s/https:\/\///g") --client-web-socket-url=$(gp url 8910 | sed -e "s/https/wss/g")/ws"
+      yarn rw dev --fwd="--allowed-hosts localhost --allowed-hosts $(gp url 8910 | cut -c 9-) --client-web-socket-url=$(gp url 8910 | sed -e "s/https/wss/g")/ws"
 
 
 ports:


### PR DESCRIPTION
Hot reload wasn't working when using Gitpod, unless you were using their [localhost companion](https://www.gitpod.io/blog/local-app) and accessing the interface via `localhost:8910`, rather than the workspace's URL (e.g., `https://8910-redwoodjs-redwood-xzxlx1hg055.ws-us53.gitpod.io/`).

This PR adds a few webpack configs to the `yarn rw dev` command in `gitpod.yml`, which enables hot reload to work without local companion and for both `localhost` and the workspace's URL.