### PR TITLE
Docs: Link to edit has a more descriptive title

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -114,12 +114,12 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // ? — blob? tree?
-          editUrl: 'https://github.com/redwoodjs/redwood/blob/main/docs', // base path for repo edit pages
+          editUrl: 'https://github.com/redwoodjs/redwood/blob/main/docs/versioned_docs', // base path for repo edit pages
           editCurrentVersion: true,
           remarkPlugins: [autoImportTabs, fileExtSwitcher],
           versions: {
             current: {
-              label: 'Canary',
+              label: 'Edit the Canary version of this page',
               path: 'canary',
               banner: 'unreleased',
             },


### PR DESCRIPTION
For #5727

**What it does?**
Changed link to point to `/docs/versioned_docs` instead of `/docs` plus edited label description to better suit where the link points to.

@Tobbe Could you please check if I put the label description in the right place? Honestly, I am not sure about it.