### PR TITLE
Fix redwood root schema definition link on GraphQL docs page

### DIFF
--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -407,9 +407,48 @@ query {
 }
 ```
 
-How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L27-L44). The root schema is where things like currentUser are defined.
+How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L27-L44). The root schema is where things like currentUser are defined:
 
-Now that you've seen the sdl, be sure to check out [the resolvers](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L56-L72).
+```graphql
+  scalar BigInt
+  scalar Date
+  scalar Time
+  scalar DateTime
+  scalar JSON
+  scalar JSONObject
+
+  type Redwood {
+    version: String
+    currentUser: JSON
+    prismaVersion: String
+  }
+
+  type Query {
+    redwood: Redwood
+  }
+```
+
+Now that you've seen the sdl, be sure to check out [the resolvers](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L56-L72):
+
+```ts
+export const resolvers: Resolvers = {
+  BigInt: BigIntResolver,
+  Date: DateResolver,
+  Time: TimeResolver,
+  DateTime: DateTimeResolver,
+  JSON: JSONResolver,
+  JSONObject: JSONObjectResolver,
+  Query: {
+    redwood: () => ({
+      version: redwoodVersion,
+      prismaVersion: prismaVersion,
+      currentUser: (_args: any, context: GlobalContext) => {
+        return context?.currentUser
+      },
+    }),
+  },
+}
+```
 
 <!-- ### The query workflow
 

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -407,7 +407,7 @@ query {
 }
 ```
 
-How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L27-L44). The root schema is where things like currentUser are defined:
+How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts). The root schema is where things like currentUser are defined:
 
 ```graphql
   scalar BigInt
@@ -428,7 +428,7 @@ How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/r
   }
 ```
 
-Now that you've seen the sdl, be sure to check out [the resolvers](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L56-L72):
+Now that you've seen the sdl, be sure to check out [the resolvers](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts):
 
 ```ts
 export const resolvers: Resolvers = {

--- a/docs/docs/graphql.md
+++ b/docs/docs/graphql.md
@@ -407,9 +407,9 @@ query {
 }
 ```
 
-How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/redwood/blob/main/packages/api/src/makeMergedSchema/rootSchema.ts#L22-L38). The root schema is where things like currentUser are defined.
+How is this possible? Via Redwood's [root schema](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L27-L44). The root schema is where things like currentUser are defined.
 
-Now that you've seen the sdl, be sure to check out [the resolvers](https://github.com/redwoodjs/redwood/blob/34a6444432b409774d54be17789a7109add9709a/packages/api/src/makeMergedSchema/rootSchema.ts#L31-L45).
+Now that you've seen the sdl, be sure to check out [the resolvers](https://github.com/redwoodjs/redwood/blob/main/packages/graphql-server/src/rootSchema.ts#L56-L72).
 
 <!-- ### The query workflow
 


### PR DESCRIPTION
Just stumbled over this 404 on https://redwoodjs.com/docs/graphql#the-root-schema
