### PR TITLE
chore: clean up mock auth client

### DIFF
--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 
 import type { AuthContextInterface } from '@redwoodjs/auth'
 import { AuthProvider } from '@redwoodjs/auth'
+import { AuthClient } from '@redwoodjs/auth/src/authClients'
 import { LocationProvider } from '@redwoodjs/router'
 import { RedwoodProvider } from '@redwoodjs/web'
 import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
@@ -20,6 +21,7 @@ const {
   default: UserRouterWithRoutes,
 } = require('~__REDWOOD__USER_ROUTES_FOR_MOCK')
 
+// TODO: make this AuthContextInterface & the below AuthClient more composable/extendable|"overwriteable"
 const fakeUseAuth = (): AuthContextInterface => ({
   loading: false,
   isAuthenticated: false,
@@ -40,17 +42,20 @@ const fakeUseAuth = (): AuthContextInterface => ({
   hasError: false,
 })
 
-export const mockAuthClient = {
+export const mockAuthClient: AuthClient = {
   restoreAuthState: () => {},
-  login: () => {},
+  login: async () => {},
   logout: () => {},
   signup: () => {},
-  getToken: () => {
+  getToken: async () => {
     return 'token'
   },
-  getUserMetadata: () => {
+  getUserMetadata: async () => {
     return mockedUserMeta.currentUser
   },
+  forgotPassword: () => {},
+  resetPassword: () => {},
+  validateResetToken: () => {},
   client: 'Custom',
   type: 'custom',
 }


### PR DESCRIPTION
- add `forgotPassword`, `resetPassword`, and `validateResetToken`.
- also add better typings and comment to improve this mock provider.

_note:_ not sure if the `async` keyword is a 💯 % necessary here (outside of the typings...), and if it will cause issues for downstream users. 

---

For context, I found this over at:

- https://deploy-preview-104--redwoodjs-example-storybook.netlify.app/storybook/?path=/story/generated-dbauth-resetpasswordpage--generated

```
main.ed7cf5c7.iframe.bundle.js:2 Uncaught (in promise) Error: Auth client custom does not implement this function
    at validateResetToken (main.ed7cf5c7.iframe.bundle.js:2:57990)
    at main.ed7cf5c7.iframe.bundle.js:2:110416
    at l (main.ed7cf5c7.iframe.bundle.js:2:2024969)
    at Generator._invoke (main.ed7cf5c7.iframe.bundle.js:2:2024757)
    at Generator.next (main.ed7cf5c7.iframe.bundle.js:2:2025398)
    at c (main.ed7cf5c7.iframe.bundle.js:2:108774)
    at a (main.ed7cf5c7.iframe.bundle.js:2:108977)
    at main.ed7cf5c7.iframe.bundle.js:2:109036
    at new Promise (<anonymous>)
    at main.ed7cf5c7.iframe.bundle.js:2:108917
```

stems from this change: https://github.com/redwoodjs/example-storybook/pull/104/commits/18793b15f3c1698f1c2d67f20ddf91bcc97f64c3