### PR TITLE
Fix: Remove "node:os" import from telemetry

### DIFF
--- a/packages/telemetry/src/telemetry.ts
+++ b/packages/telemetry/src/telemetry.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process'
-import os from 'node:os'
+import os from 'os'
 import path from 'path'
 
 import { getPaths } from '@redwoodjs/internal'


### PR DESCRIPTION
Because of this error here https://github.com/redwoodjs/redwood/pull/5899#issuecomment-1182509983