### PR TITLE
[Chore]: Upgrade prisma dependencies and specifiers to v4

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
-    "@prisma/client": "3.15.2",
+    "@prisma/client": "4.0.0",
     "base64url": "3.0.1",
     "core-js": "3.24.0",
     "cross-undici-fetch": "0.4.14",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
-    "@prisma/sdk": "3.15.2",
+    "@prisma/internals": "4.0.0",
     "@redwoodjs/api-server": "2.2.0",
     "@redwoodjs/internal": "2.2.0",
     "@redwoodjs/prerender": "2.2.0",
@@ -57,7 +57,7 @@
     "pascalcase": "1.0.0",
     "pluralize": "8.0.0",
     "prettier": "2.7.1",
-    "prisma": "3.15.2",
+    "prisma": "4.0.0",
     "prompts": "2.4.2",
     "rimraf": "3.0.2",
     "secure-random-password": "0.2.3",

--- a/packages/cli/src/commands/setup/deploy/providers/flightcontrol.js
+++ b/packages/cli/src/commands/setup/deploy/providers/flightcontrol.js
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { EOL } from 'os'
 import path from 'path'
 
-import { getSchema, getConfig } from '@prisma/sdk'
+import { getSchema, getConfig } from '@prisma/internals'
 import Listr from 'listr'
 
 import { errorTelemetry } from '@redwoodjs/telemetry'

--- a/packages/cli/src/commands/setup/deploy/providers/render.js
+++ b/packages/cli/src/commands/setup/deploy/providers/render.js
@@ -2,7 +2,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import { getSchema, getConfig } from '@prisma/sdk'
+import { getSchema, getConfig } from '@prisma/internals'
 import Listr from 'listr'
 
 import { errorTelemetry } from '@redwoodjs/telemetry'

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-import { getConfig, getDMMF } from '@prisma/sdk'
+import { getConfig, getDMMF } from '@prisma/internals'
 
 import { ensureUniquePlural } from './pluralHelpers'
 import { singularize, isPlural } from './rwPluralize'

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -32,7 +32,7 @@
     "@graphql-tools/schema": "8.5.1",
     "@graphql-tools/utils": "8.9.0",
     "@graphql-yoga/common": "2.7.0",
-    "@prisma/client": "3.15.2",
+    "@prisma/client": "4.0.0",
     "@redwoodjs/api": "2.2.0",
     "core-js": "3.24.0",
     "cross-undici-fetch": "0.4.14",

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -28,13 +28,13 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
-    "@prisma/client": "3.15.2",
+    "@prisma/client": "4.0.0",
     "core-js": "3.24.0"
   },
   "devDependencies": {
     "@babel/cli": "7.16.7",
     "@babel/core": "7.16.7",
-    "@prisma/sdk": "3.15.2",
+    "@prisma/internals": "4.0.0",
     "esbuild": "0.14.53",
     "jest": "27.5.1"
   },

--- a/packages/record/src/tasks/parse.js
+++ b/packages/record/src/tasks/parse.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import { getDMMF } from '@prisma/sdk'
+import { getDMMF } from '@prisma/internals'
 import * as esbuild from 'esbuild'
 
 import { getPaths } from '@redwoodjs/internal/dist/paths'

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.16.7",
-    "@prisma/sdk": "3.15.2",
+    "@prisma/internals": "4.0.0",
     "@redwoodjs/internal": "2.2.0",
     "@types/line-column": "1.0.0",
     "camelcase": "6.3.0",

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 
-import { getDMMF } from '@prisma/sdk'
+import { getDMMF } from '@prisma/internals'
 import { DMMF } from '@prisma/generator-helper'
 
 import { getPaths, processPagesDir } from '@redwoodjs/internal'

--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const { getConfig, getDMMF } = require('@prisma/sdk')
+const { getConfig, getDMMF } = require('@prisma/internals')
 
 const { setContext } = require('@redwoodjs/graphql-server')
 const { getPaths } = require('@redwoodjs/internal/dist/paths')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5892,28 +5892,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:3.15.2":
-  version: 3.15.2
-  resolution: "@prisma/client@npm:3.15.2"
+"@prisma/client@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@prisma/client@npm:4.0.0"
   dependencies:
-    "@prisma/engines-version": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
+    "@prisma/engines-version": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
   peerDependencies:
     prisma: "*"
   peerDependenciesMeta:
     prisma:
       optional: true
-  checksum: ef9067c167aa0c4d57587724272f12074152e67b3c037287acc381955534c26e0f65b0b9eea900fd24492edb0f86dba7bcbdb74100eccbf1a82e3d3fc2c33f79
-  languageName: node
-  linkType: hard
-
-"@prisma/debug@npm:3.14.0":
-  version: 3.14.0
-  resolution: "@prisma/debug@npm:3.14.0"
-  dependencies:
-    "@types/debug": 4.1.7
-    ms: 2.1.3
-    strip-ansi: 6.0.1
-  checksum: 087275a5c82125beb427dfa71141d45f3e8be1736f46294a1c6f16a2e8539aa2bed60604689d8ca6b90c55d47c165edae9cb01f9a99f55863c7841b420ab9751
+  checksum: 05f388f1c7e666e1273046bd9ad989fb2d82828e4269067d8dc4fb58af83fa69927b7cc57fc08244dd79006fa57ac106a22fc0ed2e85bb4db99ee80444759e99
   languageName: node
   linkType: hard
 
@@ -5928,14 +5917,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/engine-core@npm:3.15.2":
-  version: 3.15.2
-  resolution: "@prisma/engine-core@npm:3.15.2"
+"@prisma/debug@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@prisma/debug@npm:4.0.0"
   dependencies:
-    "@prisma/debug": 3.15.2
-    "@prisma/engines": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-    "@prisma/generator-helper": 3.15.2
-    "@prisma/get-platform": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
+    "@types/debug": 4.1.7
+    debug: 4.3.4
+    strip-ansi: 6.0.1
+  checksum: d4a2c4f0b0749985b58b58cbc2350b5ed6d4935cb4c5a6840e6a0b3364b34356fc095438ee5ce19681dd8b065fb26425ac69c4e4b74232773e259c4a28df9bed
+  languageName: node
+  linkType: hard
+
+"@prisma/engine-core@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@prisma/engine-core@npm:4.0.0"
+  dependencies:
+    "@prisma/debug": 4.0.0
+    "@prisma/engines": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+    "@prisma/generator-helper": 4.0.0
+    "@prisma/get-platform": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
     chalk: 4.1.2
     execa: 5.1.1
     get-stream: 6.0.1
@@ -5943,31 +5943,31 @@ __metadata:
     new-github-issue-url: 0.2.1
     p-retry: 4.6.2
     strip-ansi: 6.0.1
-    undici: 5.1.1
-  checksum: 644a85f3b3eb724adc64344f959c76cc577b2fb5696418314622d4bb8b5e368491ec1a8c8493eb2a4b85cc866f35d720aea803b4d34a3985b18f0384508bd7dc
+    undici: 5.5.1
+  checksum: c2c853d46f9cf9d42cd350e7e0b1f528391e05a30e0d8d0f80ca19f30de071765182219af14fdab6cd2a380f2fb5878bacfa1d24ac19695a5cfaddadf75d1328
   languageName: node
   linkType: hard
 
-"@prisma/engines-version@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e":
-  version: 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-  resolution: "@prisma/engines-version@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
-  checksum: aaa229a8fce941b1611bd9c7fd0234d1f897b6664c8a827766657e36a399962504cf95fc713264e838f1abe69afd9d2af9934b0dafb8352b8a22816695dc38fe
+"@prisma/engines-version@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version: 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+  resolution: "@prisma/engines-version@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+  checksum: b61728dced33b4aa19f61946256ad40661ab3a6e560fa811826bc8d02a5c34768db143278b2e6ff204cfa85ac3141fcd07d85020c34afa5113b401fb5e06d99c
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e":
-  version: 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-  resolution: "@prisma/engines@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
-  checksum: 05d5a9bbfa824afad6a854ca9ebeb589e5cffe4232d6ff209a1a07208c9620704e17243de41bbecbe4d80e76b0d133d3ff935c701bfe3fa5e2d898e3d4050e19
+"@prisma/engines@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version: 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+  resolution: "@prisma/engines@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+  checksum: 01eec16f88d614b3fe8dc2be6834452e338d0945a3ef14c0128c3256ba4ee4d2dca6957787226c72442000767548df0ba3a6bacd94363d13105ba953fb7f6549
   languageName: node
   linkType: hard
 
-"@prisma/fetch-engine@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e":
-  version: 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-  resolution: "@prisma/fetch-engine@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
+"@prisma/fetch-engine@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version: 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+  resolution: "@prisma/fetch-engine@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
   dependencies:
-    "@prisma/debug": 3.14.0
-    "@prisma/get-platform": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
+    "@prisma/debug": 3.15.2
+    "@prisma/get-platform": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
     chalk: 4.1.2
     execa: 5.1.1
     find-cache-dir: 3.3.2
@@ -5983,44 +5983,44 @@ __metadata:
     rimraf: 3.0.2
     temp-dir: 2.0.0
     tempy: 1.0.1
-  checksum: 1044e17bfbb983f6a9d9d7063ce2b9d98f4c9c18634f40dbc96007321a293f5ab8a8c5d45c31439ebaf392065292039024710a0234a687ce6058d6f450284947
+  checksum: 972a9d401b60ace029e4f1fa560f15871694e2fcbc19690f2b24666e9eedf4b33be9926a6391b6ae95d8b828a9373430d59f9353edccf0e8d4f784abfd51f7b8
   languageName: node
   linkType: hard
 
-"@prisma/generator-helper@npm:3.15.2":
-  version: 3.15.2
-  resolution: "@prisma/generator-helper@npm:3.15.2"
+"@prisma/generator-helper@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@prisma/generator-helper@npm:4.0.0"
   dependencies:
-    "@prisma/debug": 3.15.2
+    "@prisma/debug": 4.0.0
     "@types/cross-spawn": 6.0.2
     chalk: 4.1.2
     cross-spawn: 7.0.3
-  checksum: 362b903eb1b32f610e0eec0fb6c2c9368072a5aad9bf2c8071c15b2469aa9168b52a71ed1a2c7b95647137a3b5ef2ffa1aaa1d8c9cdfffe1ca50506737ef14a8
+  checksum: 2d089e1a2569e866cfb97a84cce8ac98cfe7e4fcbfdfb9041c1fe5244bdf8da9cf42848f5a068fec33633ca60bfb1a3d414eb91f2a66624831c7776e6b776874
   languageName: node
   linkType: hard
 
-"@prisma/get-platform@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e":
-  version: 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-  resolution: "@prisma/get-platform@npm:3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e"
-  dependencies:
-    "@prisma/debug": 3.14.0
-  checksum: 18be5cb6302a0d1d92faab6866b2137d32ad4e11fb4283131fce1707707788060df8931e9ab3532a3946dcdab49872434f12422514435d33e1cd557488230f01
-  languageName: node
-  linkType: hard
-
-"@prisma/sdk@npm:3.15.2":
-  version: 3.15.2
-  resolution: "@prisma/sdk@npm:3.15.2"
+"@prisma/get-platform@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version: 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+  resolution: "@prisma/get-platform@npm:3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
   dependencies:
     "@prisma/debug": 3.15.2
-    "@prisma/engine-core": 3.15.2
-    "@prisma/engines": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-    "@prisma/fetch-engine": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
-    "@prisma/generator-helper": 3.15.2
-    "@prisma/get-platform": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
+  checksum: fa5467a9d8ebfbd6debd6f13f553e8660795fef6c9f21debaf8c8704ccac61ce63e60e03985b896af5124eb523efef7b32e5f97a6af35af8a7292c60e3d7155b
+  languageName: node
+  linkType: hard
+
+"@prisma/internals@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@prisma/internals@npm:4.0.0"
+  dependencies:
+    "@prisma/debug": 4.0.0
+    "@prisma/engine-core": 4.0.0
+    "@prisma/engines": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+    "@prisma/fetch-engine": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
+    "@prisma/generator-helper": 4.0.0
+    "@prisma/get-platform": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
     "@timsuchanek/copy": 1.4.5
     archiver: 5.3.1
-    arg: 5.0.1
+    arg: 5.0.2
     chalk: 4.1.2
     checkpoint-client: 1.1.21
     cli-truncate: 2.1.0
@@ -6045,7 +6045,7 @@ __metadata:
     prompts: 2.4.2
     read-pkg-up: 7.0.1
     replace-string: 3.1.0
-    resolve: 1.22.0
+    resolve: 1.22.1
     rimraf: 3.0.2
     shell-quote: 1.7.3
     string-width: 4.2.3
@@ -6058,7 +6058,7 @@ __metadata:
     terminal-link: 2.1.1
     tmp: 0.2.1
     ts-pattern: ^4.0.1
-  checksum: c6a15bba8daca145fa44215088549606909fa626d51cca4e796645829a0d6692d65b2a0cb00ee04bab1e61e95997751382ee1942b6abb3b254a7eb09c4821cf5
+  checksum: 5fac5ee1a217396c7821c5ecfeed56ea98864a45b757b404614b97a7213f9b73daf74b56c15c62fa50613867c5ad48be8f13edfbe04143c20c32573500409c9e
   languageName: node
   linkType: hard
 
@@ -6208,7 +6208,7 @@ __metadata:
     "@babel/core": 7.16.7
     "@babel/runtime-corejs3": 7.16.7
     "@clerk/clerk-sdk-node": 3.9.2
-    "@prisma/client": 3.15.2
+    "@prisma/client": 4.0.0
     "@redwoodjs/auth": 2.2.0
     "@simplewebauthn/server": 5.4.0
     "@types/aws-lambda": 8.10.101
@@ -6305,7 +6305,7 @@ __metadata:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
     "@babel/runtime-corejs3": 7.16.7
-    "@prisma/sdk": 3.15.2
+    "@prisma/internals": 4.0.0
     "@redwoodjs/api-server": 2.2.0
     "@redwoodjs/internal": 2.2.0
     "@redwoodjs/prerender": 2.2.0
@@ -6335,7 +6335,7 @@ __metadata:
     pascalcase: 1.0.0
     pluralize: 8.0.0
     prettier: 2.7.1
-    prisma: 3.15.2
+    prisma: 4.0.0
     prompts: 2.4.2
     rimraf: 3.0.2
     secure-random-password: 0.2.3
@@ -6535,7 +6535,7 @@ __metadata:
     "@graphql-tools/schema": 8.5.1
     "@graphql-tools/utils": 8.9.0
     "@graphql-yoga/common": 2.7.0
-    "@prisma/client": 3.15.2
+    "@prisma/client": 4.0.0
     "@redwoodjs/api": 2.2.0
     "@redwoodjs/auth": 2.2.0
     "@types/lodash.merge": 4.6.7
@@ -6641,8 +6641,8 @@ __metadata:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
     "@babel/runtime-corejs3": 7.16.7
-    "@prisma/client": 3.15.2
-    "@prisma/sdk": 3.15.2
+    "@prisma/client": 4.0.0
+    "@prisma/internals": 4.0.0
     core-js: 3.24.0
     esbuild: 0.14.53
     jest: 27.5.1
@@ -6678,7 +6678,7 @@ __metadata:
     "@babel/cli": 7.16.7
     "@babel/core": 7.16.7
     "@babel/runtime-corejs3": 7.16.7
-    "@prisma/sdk": 3.15.2
+    "@prisma/internals": 4.0.0
     "@redwoodjs/internal": 2.2.0
     "@types/fs-extra": 9.0.13
     "@types/line-column": 1.0.0
@@ -10541,10 +10541,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arg@npm:5.0.1":
-  version: 5.0.1
-  resolution: "arg@npm:5.0.1"
-  checksum: b7087004468507db9bb5dbd00de408e0b589b63620e09ca8c45bef0731fce337ce43f66fb1dd88551648f31e8ae081a60a8ed27a60213d3968b6f65b7b1f5930
+"arg@npm:5.0.2":
+  version: 5.0.2
+  resolution: "arg@npm:5.0.2"
+  checksum: ccaf86f4e05d342af6666c569f844bec426595c567d32a8289715087825c2ca7edd8a3d204e4d2fb2aa4602e09a57d0c13ea8c9eea75aac3dbb4af5514e6800e
   languageName: node
   linkType: hard
 
@@ -25523,15 +25523,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prisma@npm:3.15.2":
-  version: 3.15.2
-  resolution: "prisma@npm:3.15.2"
+"prisma@npm:4.0.0":
+  version: 4.0.0
+  resolution: "prisma@npm:4.0.0"
   dependencies:
-    "@prisma/engines": 3.15.1-1.461d6a05159055555eb7dfb337c9fb271cbd4d7e
+    "@prisma/engines": 3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11
   bin:
     prisma: build/index.js
     prisma2: build/index.js
-  checksum: d308e67be18dc9fc908f0b06af9bdb3e551698d585c24ab778ea53ebda5cfffdb58a693fda252f7dc78eb980c389040a54417ca0e2ad1493c72a82a5e995a62b
+  checksum: a51ac4b527a32796c5f57aaad3f8752669c4b4dfa79dfbb8ea8ad38ed419420a6af830a6db9394bcca7f8dee91bfb70ddc18aa4d0675347dc420a9a9a4232fdc
   languageName: node
   linkType: hard
 
@@ -27107,20 +27107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:1.22.0":
-  version: 1.22.0
-  resolution: "resolve@npm:1.22.0"
-  dependencies:
-    is-core-module: ^2.8.1
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: efe07a7cd69015a95a5f4e6cc3d372354b93d67a70410ec686413b2054dfa0d5ef16ff52c057a83634debb17f278b99db6dbc60367a4475ae01dda29c6eaa6e4
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.12.0, resolve@npm:^1.13.1, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.3.2, resolve@npm:^1.9.0":
+"resolve@npm:1.22.1, resolve@npm:^1.10.0, resolve@npm:^1.11.1, resolve@npm:^1.12.0, resolve@npm:^1.13.1, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.3.2, resolve@npm:^1.9.0":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -27143,20 +27130,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@1.22.0#~builtin<compat/resolve>":
-  version: 1.22.0
-  resolution: "resolve@patch:resolve@npm%3A1.22.0#~builtin<compat/resolve>::version=1.22.0&hash=07638b"
-  dependencies:
-    is-core-module: ^2.8.1
-    path-parse: ^1.0.7
-    supports-preserve-symlinks-flag: ^1.0.0
-  bin:
-    resolve: bin/resolve
-  checksum: ef8061e81f40c39070748e8e263c8767d8fcc7c34e9ee85211b29fbc2aedb1ae7cda7d735c2cdbe9367060e9f85ec11c2694e370c121c6bcbb472a7bd0b19555
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -30288,13 +30262,6 @@ __metadata:
   version: 2.0.5
   resolution: "undefsafe@npm:2.0.5"
   checksum: 96c0466a5fbf395917974a921d5d4eee67bca4b30d3a31ce7e621e0228c479cf893e783a109af6e14329b52fe2f0cb4108665fad2b87b0018c0df6ac771261d5
-  languageName: node
-  linkType: hard
-
-"undici@npm:5.1.1":
-  version: 5.1.1
-  resolution: "undici@npm:5.1.1"
-  checksum: 7902dffe78f913501b88a7bf1244d9d4b0bbfea3f81ff7c0a175d9f0e19616190432786d430aa2dc382455b0aa88f5844d6d753deec5573b4606358f7bf13de1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Prisma 4 renames the `@prisma/sdk` package to `@prisma/internals` to dissaude using it since it won't be subject to SemVer: https://www.prisma.io/docs/guides/upgrade-guides/upgrading-versions/upgrading-to-prisma-4#prisma-no-longer-exports-prismadmmfschema-into-the-generated-prisma-client.

Besides the rename, the only other change that's important for us on the framework side is that Prisma is dropping Node.js 12 support.

While this upgrade looks like it'll be simple, more work may need to be done in the future if `getDMMF` or any of the other functions we import from `@prisma/internals` change, which could now happen in any Prisma version.