### PR TITLE
Fix type in docs.

### DIFF
--- a/docs/docs/tutorial/chapter2/getting-dynamic.md
+++ b/docs/docs/tutorial/chapter2/getting-dynamic.md
@@ -181,7 +181,7 @@ As far as the generators are concerned:
 - Pages that come with the scaffolds are plural or singular depending on whether they deal with many or one post. When using the `page` generator it will stick with whatever name you give on the command line.
 - Layouts use the name you give them on the command line.
 - Components and cells, like pages, will be plural or singular depending on context when created by the scaffold generator, otherwise they'll use the given name on the command line.
-- Route names for scaffolded pages are singular or plural, the same as the pages they're routing to, otherwise they are identical the name of the page you generated.
+- Route names for scaffolded pages are singular or plural, the same as the pages they're routing to, otherwise they are identical to the name of the page you generated.
 
 Also note that it's the model name part that's singular or plural, not the whole word. So it's `PostsCell` and `PostsPage`, not `PostCells` or `PostPages`.
 


### PR DESCRIPTION
```
... otherwise they are identical **to** the name of the page you generated.
```