### PR TITLE
[create-redwood-app]: Remove devDeps from deps

### DIFF
--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -27,6 +27,7 @@ Want great developer experience and easy scaling? How about an integrated front-
 <h2>Quick Start</h2>
 
 Redwood requires Node.js >=14.x <=16.x and Yarn v1.15 (or newer).
+
 ```console
 yarn create redwood-app redwood-project
 cd redwood-project
@@ -66,6 +67,7 @@ This package creates and installs a Redwood project, which is the entry point fo
 > _For information about contributing to the Redwood Framework in general, [please start here](https://redwoodjs.com/docs/contributing)._
 
 ## Package Leads
+
 - [@peterp](https://github.com/peterp)
 - [@thedavidprice](https://github.com/thedavidprice)
 
@@ -79,12 +81,15 @@ v1 Priorities:
 ## Local Development
 
 ### Installation Script
+
 The installation script is built with [Yargs](https://github.com/yargs/yargs)
 
 ### Template Codebase
+
 The project codebase in `template/` uses [Yarn Workspace v1](https://classic.yarnpkg.com/en/docs/workspaces/) for a monorepo project containing the API and Web Sides. Redwood packages are included in `template/package.json`, `template/web/package.json`, and `template/api/package.json`, respectively.
 
 ### How to run create-redwood-app and create a project
+
 Make sure you to first run `yarn install` in your project root.
 
 Step into the `create-redwood-app` package and run the script:
@@ -99,17 +104,22 @@ This will create a new project using the local `template/` codebase
 > Note: the new project will install with the most recent stable Redwood package version by default
 
 ### Develop using the new project
+
 There are three options for developing with the installed project:
 
 **1. Upgrade the project to use the latest canary release**
+
 ```bash
 cd /path/to/new/redwood-app
 yarn rw upgrade -t canary
 ```
+
 **2. Install packages specific to a PR, for example**
+
 ```bash
 cd /path/to/new/redwood-app
 yarn rw upgrade --pr 1703:0.23.0-b06dd35
 ```
+
 **3. Use the workflow and tools for local package development**
 - [Local Development Instructions](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#local-development)

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -99,7 +99,7 @@ cd packages/create-redwood-app
 yarn babel-node src/create-redwood-app.js /path/to/new/redwood-app
 ```
 
-This will create a new project using the local `template/` codebase
+This will create a new project using the local `template/` codebase.
 
 > Note: the new project will install with the most recent stable Redwood package version by default
 
@@ -114,12 +114,5 @@ cd /path/to/new/redwood-app
 yarn rw upgrade -t canary
 ```
 
-**2. Install packages specific to a PR, for example**
-
-```bash
-cd /path/to/new/redwood-app
-yarn rw upgrade --pr 1703:0.23.0-b06dd35
-```
-
-**3. Use the workflow and tools for local package development**
+**2. Use the workflow and tools for local package development**
 - [Local Development Instructions](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#local-development)

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -21,8 +21,6 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
-    "@babel/core": "7.16.7",
-    "@babel/node": "7.16.7",
     "@babel/runtime-corejs3": "7.16.7",
     "@redwoodjs/internal": "2.1.0",
     "@redwoodjs/telemetry": "2.1.0",
@@ -36,6 +34,8 @@
   },
   "devDependencies": {
     "@babel/cli": "7.16.7",
+    "@babel/core": "7.16.7",
+    "@babel/node": "7.16.7",
     "jest": "27.5.1",
     "typescript": "4.7.4"
   },


### PR DESCRIPTION
These are dev dependencies so they shouldn't be listed in dependencies. But I mostly made this PR to get Nx Cloud going. 