### PR TITLE
Updated GraphQL types for Typescript

### DIFF
--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -282,7 +282,8 @@ export const Success = ({ posts }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-import type { ArticlesQuery } from 'types/graphql'
+// highlight-next-line
+import type { FindPosts } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`
@@ -303,7 +304,7 @@ export const Failure = ({ error }: CellFailureProps) => (
 )
 
 // highlight-next-line
-export const Success = ({ posts }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({ posts }: CellSuccessProps<FindPosts>) => {
   return (
     <ul>
       // highlight-next-line

--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -455,7 +455,7 @@ export const Success = ({ articles }) => { ... }
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => { ... }
+export const Success = ({ articles }: CellSuccessProps<FindPosts>) => { ... }
 ```
 
 </TabItem>
@@ -521,7 +521,7 @@ export const Failure = ({ error }: CellFailureProps) => (
 )
 
 // highlight-next-line
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({ articles }: CellSuccessProps<FindPosts>) => {
   return (
     <ul>
       // highlight-next-line
@@ -610,7 +610,7 @@ export const Success = ({ articles }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({ articles }: CellSuccessProps<FindPosts>) => {
   return (
     // highlight-start
     <>


### PR DESCRIPTION
I was going through the tutorial using TypeScript, and it was failing when I created the `ArticlesCell` and made the code changes according to the documentation.  The import of `ArticlesQuery` needs to be changed to `FindPosts`, as well as the usage in the `Success` handler.

I hadn't noticed any call-outs in the documentation for updates specific to TypeScript, so I only made the change in the code.  I also highlighted the import line (the usage line was already highlighted).