### PR TITLE
Decouple auth web side with useAuthService Hook

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -1,20 +1,13 @@
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import React, { ReactNode } from 'react'
 
-import { createAuthClient } from './authClients'
 import type {
   AuthClient,
   SupportedAuthTypes,
-  SupportedAuthConfig,
+  // SupportedAuthConfig,
   SupportedAuthClients,
   SupportedUserMetadata,
 } from './authClients'
-import type { WebAuthnClientType } from './webAuthn'
+// import type { WebAuthnClientType } from './webAuthn'
 
 export interface CurrentUser {
   roles?: Array<string> | string
@@ -95,45 +88,47 @@ const AuthUpdateListener = ({
   return null
 }
 
-type AuthProviderProps =
-  | {
-      client: SupportedAuthClients
-      type: Omit<SupportedAuthTypes, 'clerk' | 'dbAuth'>
-      config?: never
-      skipFetchCurrentUser?: boolean
-      children?: ReactNode | undefined
-    }
-  | {
-      client?: never
-      type: 'clerk'
-      config?: never
-      skipFetchCurrentUser?: boolean
-      children?: ReactNode | undefined
-    }
-  | {
-      client?: WebAuthnClientType
-      type: 'dbAuth'
-      config?: SupportedAuthConfig
-      skipFetchCurrentUser?: boolean
-      children?: ReactNode | undefined
-    }
+// type AuthProviderProps =
+//   | {
+//       client: SupportedAuthClients
+//       type: Omit<SupportedAuthTypes, 'clerk' | 'dbAuth'>
+//       config?: never
+//       skipFetchCurrentUser?: boolean
+//       children?: ReactNode | undefined
+//     }
+//   | {
+//       client?: never
+//       type: 'clerk'
+//       config?: never
+//       skipFetchCurrentUser?: boolean
+//       children?: ReactNode | undefined
+//     }
+//   | {
+//       client?: WebAuthnClientType
+//       type: 'dbAuth'
+//       config?: SupportedAuthConfig
+//       skipFetchCurrentUser?: boolean
+//       children?: ReactNode | undefined
+//     }
 
-type AuthProviderState = {
-  loading: boolean
-  isAuthenticated: boolean
-  userMetadata: null | Record<string, any>
-  currentUser: null | CurrentUser
-  hasError: boolean
-  error?: Error
-}
+type AuthProviderProps = { service: any; children?: ReactNode | undefined }
 
-const defaultAuthProviderState: AuthProviderState = {
-  loading: true,
-  isAuthenticated: false,
-  userMetadata: null,
-  currentUser: null,
-  hasError: false,
-}
+// type AuthProviderState = {
+//   loading: boolean
+//   isAuthenticated: boolean
+//   userMetadata: null | Record<string, any>
+//   currentUser: null | CurrentUser
+//   hasError: boolean
+//   error?: Error
+// }
+
+// const defaultAuthProviderState: AuthProviderState = {
+//   loading: true,
+//   isAuthenticated: false,
+//   userMetadata: null,
+//   currentUser: null,
+//   hasError: false,
+// }
 
 /**
  * @example
@@ -146,293 +141,19 @@ const defaultAuthProviderState: AuthProviderState = {
  * ```
  */
 export const AuthProvider = (props: AuthProviderProps) => {
-  const skipFetchCurrentUser = props.skipFetchCurrentUser || false
-
-  const [hasRestoredState, setHasRestoredState] = useState(false)
-
-  const [authProviderState, setAuthProviderState] = useState(
-    defaultAuthProviderState
-  )
-
-  const [rwClient, setRwClient] = useState<AuthClient>()
-
-  const rwClientPromise: Promise<AuthClient> = useMemo(async () => {
-    // If ever we rebuild the rwClient, we need to re-restore the state.
-    // This is not desired behavior, but may happen if for some reason the host app's
-    // auth configuration changes mid-flight.
-    setHasRestoredState(false)
-
-    const client = await createAuthClient(
-      props.client as SupportedAuthClients,
-      props.type as SupportedAuthTypes,
-      props.config as SupportedAuthConfig
-    )
-
-    setRwClient(client)
-
-    return client
-  }, [props.client, props.type, props.config])
-
-  /**
-   * Clients should always return null or token string.
-   * It is expected that they catch any errors internally.
-   * This catch is a last resort effort in case any errors are
-   * missed or slip through.
-   */
-  const getToken = useCallback(async () => {
-    const client = await rwClientPromise
-
-    try {
-      const token = await client.getToken()
-      return token
-    } catch (e) {
-      console.error('Caught internal:', e)
-      return null
-    }
-  }, [rwClientPromise])
-
-  const getCurrentUser = useCallback(async (): Promise<
-    Record<string, unknown>
-  > => {
-    const client = await rwClientPromise
-    // Always get a fresh token, rather than use the one in state
-    const token = await getToken()
-    const response = await global.fetch(global.RWJS_API_GRAPHQL_URL, {
-      method: 'POST',
-      // TODO: how can user configure this? inherit same `config` options given to auth client?
-      credentials: 'include',
-      headers: {
-        'content-type': 'application/json',
-        'auth-provider': client.type,
-        authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        query:
-          'query __REDWOOD__AUTH_GET_CURRENT_USER { redwood { currentUser } }',
-      }),
-    })
-
-    if (response.ok) {
-      const { data } = await response.json()
-      return data?.redwood?.currentUser
-    } else {
-      throw new Error(
-        `Could not fetch current user: ${response.statusText} (${response.status})`
-      )
-    }
-  }, [rwClientPromise, getToken])
-
-  const reauthenticate = useCallback(async () => {
-    const client = await rwClientPromise
-    const notAuthenticatedState: AuthProviderState = {
-      isAuthenticated: false,
-      currentUser: null,
-      userMetadata: null,
-      loading: false,
-      hasError: false,
-    }
-
-    try {
-      const userMetadata = await client.getUserMetadata()
-      if (!userMetadata) {
-        setAuthProviderState(notAuthenticatedState)
-      } else {
-        await getToken()
-
-        const currentUser = skipFetchCurrentUser ? null : await getCurrentUser()
-
-        setAuthProviderState((oldState) => ({
-          ...oldState,
-          userMetadata,
-          currentUser,
-          isAuthenticated: true,
-          loading: false,
-        }))
-      }
-    } catch (e: any) {
-      setAuthProviderState({
-        ...notAuthenticatedState,
-        hasError: true,
-        error: e as Error,
-      })
-    }
-  }, [
-    getToken,
-    rwClientPromise,
-    setAuthProviderState,
-    skipFetchCurrentUser,
-    getCurrentUser,
-  ])
-
-  /**
-   * @example
-   * ```js
-   *  hasRole("editor")
-   *  hasRole(["editor"])
-   *  hasRole(["editor", "author"])
-   * ```
-   *
-   * Checks if the "currentUser" from the api side
-   * is assigned a role or one of a list of roles.
-   * If the user is assigned any of the provided list of roles,
-   * the hasRole is considered to be true.
-   */
-  const hasRole = useCallback(
-    (rolesToCheck: string | string[]): boolean => {
-      const currentUser = authProviderState.currentUser
-
-      if (currentUser?.roles) {
-        if (typeof rolesToCheck === 'string') {
-          if (typeof currentUser.roles === 'string') {
-            // rolesToCheck is a string, currentUser.roles is a string
-            return currentUser.roles === rolesToCheck
-          } else if (Array.isArray(currentUser.roles)) {
-            // rolesToCheck is a string, currentUser.roles is an array
-            return currentUser.roles?.some(
-              (allowedRole) => rolesToCheck === allowedRole
-            )
-          }
-        }
-
-        if (Array.isArray(rolesToCheck)) {
-          if (Array.isArray(currentUser.roles)) {
-            // rolesToCheck is an array, currentUser.roles is an array
-            return currentUser.roles?.some((allowedRole) =>
-              rolesToCheck.includes(allowedRole)
-            )
-          } else if (typeof currentUser.roles === 'string') {
-            // rolesToCheck is an array, currentUser.roles is a string
-            return rolesToCheck.some(
-              (allowedRole) => currentUser?.roles === allowedRole
-            )
-          }
-        }
-      }
-
-      return false
-    },
-    [authProviderState.currentUser]
-  )
-
-  const logIn = useCallback(
-    async (options?: any) => {
-      setAuthProviderState(defaultAuthProviderState)
-      const client = await rwClientPromise
-      const loginOutput = await client.login(options)
-      await reauthenticate()
-
-      return loginOutput
-    },
-    [rwClientPromise, reauthenticate]
-  )
-
-  const logOut = useCallback(
-    async (options?: any) => {
-      const client = await rwClientPromise
-      await client.logout(options)
-      setAuthProviderState({
-        userMetadata: null,
-        currentUser: null,
-        isAuthenticated: false,
-        hasError: false,
-        error: undefined,
-        loading: false,
-      })
-    },
-    [rwClientPromise]
-  )
-
-  const signUp = useCallback(
-    async (options?: any) => {
-      const client = await rwClientPromise
-      const signupOutput = await client.signup(options)
-      await reauthenticate()
-      return signupOutput
-    },
-    [rwClientPromise, reauthenticate]
-  )
-
-  const forgotPassword = useCallback(
-    async (username: string) => {
-      const client = await rwClientPromise
-
-      if (client.forgotPassword) {
-        return await client.forgotPassword(username)
-      } else {
-        throw new Error(
-          `Auth client ${client.type} does not implement this function`
-        )
-      }
-    },
-    [rwClientPromise]
-  )
-
-  const resetPassword = useCallback(
-    async (options?: any) => {
-      const client = await rwClientPromise
-
-      if (client.resetPassword) {
-        return await client.resetPassword(options)
-      } else {
-        throw new Error(
-          `Auth client ${client.type} does not implement this function`
-        )
-      }
-    },
-    [rwClientPromise]
-  )
-
-  const validateResetToken = useCallback(
-    async (resetToken: string | null) => {
-      const client = await rwClientPromise
-
-      if (client.validateResetToken) {
-        return await client.validateResetToken(resetToken)
-      } else {
-        throw new Error(
-          `Auth client ${client.type} does not implement this function`
-        )
-      }
-    },
-    [rwClientPromise]
-  )
-
-  /** Whenever the rwClient is ready to go, restore auth and reauthenticate */
-  useEffect(() => {
-    if (rwClient && !hasRestoredState) {
-      setHasRestoredState(true)
-
-      const doRestoreState = async () => {
-        await rwClient.restoreAuthState?.()
-        reauthenticate()
-      }
-
-      doRestoreState()
-    }
-  }, [rwClient, reauthenticate, hasRestoredState])
-
-  const { client, type, children } = props
+  const { rwClient, ...rest } = props.service
 
   return (
     <AuthContext.Provider
       value={{
-        ...authProviderState,
-        logIn,
-        logOut,
-        signUp,
-        getToken,
-        getCurrentUser,
-        hasRole,
-        reauthenticate,
-        forgotPassword,
-        resetPassword,
-        validateResetToken,
-        client,
-        type: type as SupportedAuthTypes,
+        ...rest,
       }}
     >
-      {children}
-      <AuthUpdateListener rwClient={rwClient} reauthenticate={reauthenticate} />
+      {props.children}
+      <AuthUpdateListener
+        rwClient={rwClient}
+        reauthenticate={props.service.reauthenticate}
+      />
     </AuthContext.Provider>
   )
 }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,6 @@
 export { SupportedAuthTypes } from './authClients'
 export { AuthProvider, AuthContextInterface, CurrentUser } from './AuthProvider'
 export { useAuth } from './useAuth'
+export { useAuthService } from './useAuthService'
+export { dbAuth } from './authClients/dbAuth'
+export { supabase as supabaseAuthClient } from './authClients/supabase'

--- a/packages/auth/src/useAuth.ts
+++ b/packages/auth/src/useAuth.ts
@@ -3,8 +3,19 @@ import React from 'react'
 import { AuthContext } from './AuthProvider'
 import type { AuthContextInterface } from './AuthProvider'
 
-export const useAuth = (): AuthContextInterface => {
-  return React.useContext(AuthContext) as AuthContextInterface
+export const useAuth = (provider?: string): AuthContextInterface => {
+  const context = React.useContext(AuthContext) as any
+
+  if (context?.services && provider !== undefined) {
+    return context?.services[provider]
+  }
+
+  if (context?.services && provider === undefined) {
+    const p = context.determineAuth(context.services)
+    return context?.services[p]
+  }
+
+  return context
 }
 
 global.__REDWOOD__USE_AUTH = useAuth

--- a/packages/auth/src/useAuthService.ts
+++ b/packages/auth/src/useAuthService.ts
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+// import { createAuthClient } from './authClients'
+import type {
+  AuthClient,
+  SupportedAuthTypes,
+  // SupportedAuthConfig,
+  SupportedAuthClients,
+  // SupportedUserMetadata,
+} from './authClients'
+
+export interface CurrentUser {
+  roles?: Array<string> | string
+}
+
+interface AuthProviderState {
+  loading: boolean
+  isAuthenticated: boolean
+  userMetadata: null | Record<string, any>
+  currentUser: null | CurrentUser
+  hasError: boolean
+  error?: Error
+}
+
+const defaultAuthProviderState: AuthProviderState = {
+  loading: true,
+  isAuthenticated: false,
+  userMetadata: null,
+  currentUser: null,
+  hasError: false,
+}
+
+export const useAuthService = (
+  authClient: SupportedAuthClients,
+  options = {} as { skipFetchCurrentUser: boolean; type: string; config: any }
+) => {
+  const skipFetchCurrentUser = options?.skipFetchCurrentUser || false
+
+  const [hasRestoredState, setHasRestoredState] = useState(false)
+
+  const [authProviderState, setAuthProviderState] = useState(
+    defaultAuthProviderState
+  )
+
+  const [rwClient, setRwClient] = useState<AuthClient>()
+
+  const rwClientPromise: Promise<AuthClient> = useMemo(async () => {
+    // If ever we rebuild the rwClient, we need to re-restore the state.
+    // This is not desired behavior, but may happen if for some reason the host app's
+    // auth configuration changes mid-flight.
+    setHasRestoredState(false)
+
+    // const client = await createAuthClient(
+    //   authClient as SupportedAuthClients,
+    //   options.type as SupportedAuthTypes,
+    //   options.config as SupportedAuthConfig
+    // )
+
+    setRwClient(authClient)
+
+    return authClient
+  }, [authClient])
+
+  /**
+   * Clients should always return null or token string.
+   * It is expected that they catch any errors internally.
+   * This catch is a last resort effort in case any errors are
+   * missed or slip through.
+   */
+  const getToken = useCallback(async () => {
+    const client = await rwClientPromise
+
+    try {
+      const token = await client.getToken()
+      return token
+    } catch (e) {
+      console.error('Caught internal:', e)
+      return null
+    }
+  }, [rwClientPromise])
+
+  const getCurrentUser = useCallback(async (): Promise<
+    Record<string, unknown>
+  > => {
+    const client = await rwClientPromise
+    // Always get a fresh token, rather than use the one in state
+    const token = await getToken()
+    const response = await global.fetch(global.RWJS_API_GRAPHQL_URL, {
+      method: 'POST',
+      // TODO: how can user configure this? inherit same `config` options given to auth client?
+      credentials: 'include',
+      headers: {
+        'content-type': 'application/json',
+        'auth-provider': client.type,
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        query:
+          'query __REDWOOD__AUTH_GET_CURRENT_USER { redwood { currentUser } }',
+      }),
+    })
+
+    if (response.ok) {
+      const { data } = await response.json()
+      return data?.redwood?.currentUser
+    } else {
+      throw new Error(
+        `Could not fetch current user: ${response.statusText} (${response.status})`
+      )
+    }
+  }, [rwClientPromise, getToken])
+
+  const reauthenticate = useCallback(async () => {
+    const client = await rwClientPromise
+    const notAuthenticatedState: AuthProviderState = {
+      isAuthenticated: false,
+      currentUser: null,
+      userMetadata: null,
+      loading: false,
+      hasError: false,
+    }
+
+    try {
+      const userMetadata = await client.getUserMetadata()
+      if (!userMetadata) {
+        setAuthProviderState(notAuthenticatedState)
+      } else {
+        await getToken()
+
+        const currentUser = skipFetchCurrentUser ? null : await getCurrentUser()
+
+        setAuthProviderState((oldState) => ({
+          ...oldState,
+          userMetadata,
+          currentUser,
+          isAuthenticated: true,
+          loading: false,
+        }))
+      }
+    } catch (e: any) {
+      setAuthProviderState({
+        ...notAuthenticatedState,
+        hasError: true,
+        error: e as Error,
+      })
+    }
+  }, [
+    getToken,
+    rwClientPromise,
+    setAuthProviderState,
+    skipFetchCurrentUser,
+    getCurrentUser,
+  ])
+
+  /**
+   * @example
+   * ```js
+   *  hasRole("editor")
+   *  hasRole(["editor"])
+   *  hasRole(["editor", "author"])
+   * ```
+   *
+   * Checks if the "currentUser" from the api side
+   * is assigned a role or one of a list of roles.
+   * If the user is assigned any of the provided list of roles,
+   * the hasRole is considered to be true.
+   */
+  const hasRole = useCallback(
+    (rolesToCheck: string | string[]): boolean => {
+      const currentUser = authProviderState.currentUser
+
+      if (currentUser?.roles) {
+        if (typeof rolesToCheck === 'string') {
+          if (typeof currentUser.roles === 'string') {
+            // rolesToCheck is a string, currentUser.roles is a string
+            return currentUser.roles === rolesToCheck
+          } else if (Array.isArray(currentUser.roles)) {
+            // rolesToCheck is a string, currentUser.roles is an array
+            return currentUser.roles?.some(
+              (allowedRole) => rolesToCheck === allowedRole
+            )
+          }
+        }
+
+        if (Array.isArray(rolesToCheck)) {
+          if (Array.isArray(currentUser.roles)) {
+            // rolesToCheck is an array, currentUser.roles is an array
+            return currentUser.roles?.some((allowedRole) =>
+              rolesToCheck.includes(allowedRole)
+            )
+          } else if (typeof currentUser.roles === 'string') {
+            // rolesToCheck is an array, currentUser.roles is a string
+            return rolesToCheck.some(
+              (allowedRole) => currentUser?.roles === allowedRole
+            )
+          }
+        }
+      }
+
+      return false
+    },
+    [authProviderState.currentUser]
+  )
+
+  const logIn = useCallback(
+    async (options?: any) => {
+      setAuthProviderState(defaultAuthProviderState)
+      const client = await rwClientPromise
+      const loginOutput = await client.login(options)
+      await reauthenticate()
+
+      return loginOutput
+    },
+    [rwClientPromise, reauthenticate]
+  )
+
+  const logOut = useCallback(
+    async (options?: any) => {
+      const client = await rwClientPromise
+      await client.logout(options)
+      setAuthProviderState({
+        userMetadata: null,
+        currentUser: null,
+        isAuthenticated: false,
+        hasError: false,
+        error: undefined,
+        loading: false,
+      })
+    },
+    [rwClientPromise]
+  )
+
+  const signUp = useCallback(
+    async (options?: any) => {
+      const client = await rwClientPromise
+      const signupOutput = await client.signup(options)
+      await reauthenticate()
+      return signupOutput
+    },
+    [rwClientPromise, reauthenticate]
+  )
+
+  const forgotPassword = useCallback(
+    async (username: string) => {
+      const client = await rwClientPromise
+
+      if (client.forgotPassword) {
+        return await client.forgotPassword(username)
+      } else {
+        throw new Error(
+          `Auth client ${client.type} does not implement this function`
+        )
+      }
+    },
+    [rwClientPromise]
+  )
+
+  const resetPassword = useCallback(
+    async (options?: any) => {
+      const client = await rwClientPromise
+
+      if (client.resetPassword) {
+        return await client.resetPassword(options)
+      } else {
+        throw new Error(
+          `Auth client ${client.type} does not implement this function`
+        )
+      }
+    },
+    [rwClientPromise]
+  )
+
+  const validateResetToken = useCallback(
+    async (resetToken: string | null) => {
+      const client = await rwClientPromise
+
+      if (client.validateResetToken) {
+        return await client.validateResetToken(resetToken)
+      } else {
+        throw new Error(
+          `Auth client ${client.type} does not implement this function`
+        )
+      }
+    },
+    [rwClientPromise]
+  )
+
+  /** Whenever the rwClient is ready to go, restore auth and reauthenticate */
+  useEffect(() => {
+    if (rwClient && !hasRestoredState) {
+      setHasRestoredState(true)
+
+      const doRestoreState = async () => {
+        await rwClient.restoreAuthState?.()
+        reauthenticate()
+      }
+
+      doRestoreState()
+    }
+  }, [rwClient, reauthenticate, hasRestoredState])
+
+  const { type } = options
+
+  return {
+    ...authProviderState,
+    logIn,
+    logOut,
+    signUp,
+    getToken,
+    getCurrentUser,
+    hasRole,
+    reauthenticate,
+    forgotPassword,
+    resetPassword,
+    validateResetToken,
+    client: authClient,
+    type: type as SupportedAuthTypes,
+    rwClient,
+  }
+}

--- a/packages/testing/src/web/MockProviders.tsx
+++ b/packages/testing/src/web/MockProviders.tsx
@@ -62,7 +62,7 @@ export const mockAuthClient: AuthClient = {
 
 export const MockProviders: React.FunctionComponent = ({ children }) => {
   return (
-    <AuthProvider client={mockAuthClient} type="custom">
+    <AuthProvider service={mockAuthClient}>
       <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
         <RedwoodApolloProvider useAuth={fakeUseAuth}>
           <UserRouterWithRoutes />


### PR DESCRIPTION
After our decouple auth chat I wanted to clear up some of my thoughts. This PR is what decoupled auth could look like if we exposed a hook to the end-user.

Relates to - https://github.com/redwoodjs/redwood/pull/5985

Currently only tested this with supabase and dbAuth and everything seemed great. I need to check with clerk I saw some changes that just got added [last week ](https://github.com/redwoodjs/redwood/pull/4880/files)that might not work as is.





In User App.

```
// App.js
import { createClient } from '@supabase/supabase-js'
import {  AuthProvider,  useAuthService } from '@redwoodjs/auth'
import createAuthClient from '@redwoodjs/auth/clients/supabase' <--- decoupled can be maintained anywhere

const supabaseClient = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY)

const supabaseAuthClient = createAuthClient(supabaseClient)

const App = () => {
  const service = useAuthService(supabaseAuthClient)

  return (
        <AuthProvider service={service}>
            ...
        </AuthProvider>
  )
}




```


### TODO


To be able to add additional configuration a second parameter will be added to `useAuthService`

```
const service = useAuthService(authClient, { skipFetchCurrentUser: true, getCurrentUser })
```



NOTE: This currently doesn't add support for multiple providers but I think that can be done with some tweaks to `useAuth` and `AuthProvider`

I think it would look something like this
```
const App = () => {
  const supbaseAuthService = useAuthService(supabaseAuthClient)
  const dbAuthService = useAuthService(dbAuthClient)

  return (
        <AuthProvider service={{ supabase: supbaseAuthService, dbAuth: dbAuthService}}>
            ...
        </AuthProvider>
  )
}


// useAuth

const { isAuthenticated } = useAuth('supabase')
const { isAuthenticated } = useAuth('dbAuth')
```


