### PR TITLE
Move mockCurrentUser to when testproject is generated

### DIFF
--- a/__fixtures__/test-project/web/src/pages/ProfilePage/ProfilePage.stories.tsx
+++ b/__fixtures__/test-project/web/src/pages/ProfilePage/ProfilePage.stories.tsx
@@ -1,7 +1,13 @@
 import ProfilePage from './ProfilePage'
 
-export const generated = () => {
-  return <ProfilePage />
+export const generated = (args) => {
+  mockCurrentUser({
+    email: 'ba@zinga.com',
+    id: 55,
+    roles: 'ADMIN',
+  })
+
+  return <ProfilePage {...args} />
 }
 
 export default { title: 'Pages/ProfilePage' }

--- a/tasks/smoke-test/tests/storybook.spec.ts
+++ b/tasks/smoke-test/tests/storybook.spec.ts
@@ -92,32 +92,8 @@ storybookTest(
 )
 
 storybookTest(
-  'Mocks current user, and updates UI while dev server is running',
+  'Mocks current user in storybook',
   async ({ port, page, server }: PlaywrightTestArgs & StorybookFixture) => {
-    const profileStoryPath = path.join(
-      process.env.PROJECT_PATH,
-      'web/src/pages/ProfilePage/ProfilePage.stories.tsx'
-    )
-
-    // Modify profile page stories to mockCurrentUser
-    const profilePageStoryContent = fs.readFileSync(profileStoryPath, 'utf-8')
-
-    if (!profilePageStoryContent.includes('mockCurrentUser')) {
-      fs.writeFileSync(
-        profileStoryPath,
-        profilePageStoryContent.replace(
-          'export const generated = () => {',
-          `export const generated = () => {
-        mockCurrentUser({
-        email: 'ba@zinga.com',
-        id: 55,
-        roles: 'ADMIN',
-      })
-    `
-        )
-      )
-    }
-
     // We do this to make sure playwright doesn't bring the server down
     console.log(server)
     const STORYBOOK_URL = `http://localhost:${port}/`

--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -302,14 +302,13 @@ async function webTasks(outputPath, { linkWithLatestFwBuild, verbose }) {
             fs.writeFileSync(
               profileStoryPath,
               profilePageStoryContent.replace(
-                'export const generated = () => {',
-                `export const generated = () => {
-              mockCurrentUser({
-              email: 'ba@zinga.com',
-              id: 55,
-              roles: 'ADMIN',
-            })
-          `
+                'export const generated = (args) => {',
+                `export const generated = (args) => {
+                  mockCurrentUser({
+                  email: 'ba@zinga.com',
+                  id: 55,
+                  roles: 'ADMIN',
+                })`
               )
             )
           }

--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -284,6 +284,37 @@ async function webTasks(outputPath, { linkWithLatestFwBuild, verbose }) {
           )
         },
       },
+      {
+        title: 'Mock currentUser in ProfilePage story',
+        task: () => {
+          const profileStoryPath = path.join(
+            OUTPUT_PATH,
+            'web/src/pages/ProfilePage/ProfilePage.stories.tsx'
+          )
+
+          // Modify profile page stories to mockCurrentUser
+          const profilePageStoryContent = fs.readFileSync(
+            profileStoryPath,
+            'utf-8'
+          )
+
+          if (!profilePageStoryContent.includes('mockCurrentUser')) {
+            fs.writeFileSync(
+              profileStoryPath,
+              profilePageStoryContent.replace(
+                'export const generated = () => {',
+                `export const generated = () => {
+              mockCurrentUser({
+              email: 'ba@zinga.com',
+              id: 55,
+              roles: 'ADMIN',
+            })
+          `
+              )
+            )
+          }
+        },
+      },
     ],
     {
       exitOnError: true,


### PR DESCRIPTION
Modifies the smoke test to check for currentUser in storybook.

**Previously:** Would modiy the story file after dev server starts
**Now**: Modifies the story file as part of the test project generator.

Why? Hotreloading is flakey in smoke tests. While it would've been nice to have this test, I think it causes more trouble than its worth.