### PR TITLE
Tutorial 6.3: Fix prisma type error on comment creation

### DIFF
--- a/docs/docs/tutorial/chapter6/comments-schema.md
+++ b/docs/docs/tutorial/chapter6/comments-schema.md
@@ -805,7 +805,9 @@ describe('comments', () => {
       input: {
         name: 'Billy Bob',
         body: 'What is your favorite tree bark?',
-        postId: scenario.post.bark.id,
+        post: {
+          connect: { id: scenario.post.bark.id },
+        },
       },
     })
 
@@ -844,7 +846,9 @@ describe('comments', () => {
         input: {
           name: 'Billy Bob',
           body: 'What is your favorite tree bark?',
-          postId: scenario.post.bark.id,
+          post: {
+            connect: { id: scenario.post.bark.id },
+          },
         },
       })
 

--- a/docs/docs/tutorial/chapter6/comments-schema.md
+++ b/docs/docs/tutorial/chapter6/comments-schema.md
@@ -869,6 +869,34 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
+:::info What's that post…connect…id-Voodoo?! Can't we simply pass the Post's ID directly here?
+
+What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
+core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
+in Prisma-land.
+
+<ShowForTs>
+Note that if you try to use `postId` that would give you red squiggles, because that input would violate the `CreateCommentArgs` interface definition in
+`api/src/services/comments/comments.ts`. In order to use the `postId` input, that'd need to be changed to
+
+```ts
+interface CreateCommentArgs {
+  input: Prisma.CommentUncheckedCreateInput
+}
+```
+
+or
+
+```ts
+interface CreateCommentArgs {
+  input: Prisma.CommentCreateInput | Prisma.CommentUncheckedCreateInput
+}
+```
+in case we wanted to allow both ways – which Prisma generally allows, however [it doesn't allow to pick and mix](https://stackoverflow.com/a/69169106/1246547) within the same input.
+</ShowForTs>
+
+:::
+
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the Javascript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right *now*, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
 :::info What's up with the names for scenario data? posts.bark? Really?


### PR DESCRIPTION
Using `postId` in the input for the createComment-test in `api/src/services/comments/comments.test.ts` gives the following red squiggle:

```bash
Type '{ name: string; body: string; postId: number; }' is not assignable to type 'CommentCreateInput'.
  Object literal may only specify known properties, but 'postId' does not exist in type 'CommentCreateInput'. Did you mean to write 'post'?ts(2322)
comments.ts(22, 3): The expected type comes from property 'input' which is declared here on type 'CreateCommentArgs'
```

## Solutions up for debate:

1. use `Prisma.CommentUncheckedCreateInput` instead of `Prisma.CommentCreateInput`, thus being able to reuse the current JS test code on the TS tab solution without getting a type warning. This is what 53dfb680f9e6bf71363c05ae1cc2364e495cecff does
2. Don't use `postId`, but rather **`connect`** the comment to the existing post using Prisma logic for both JS and TS code:  
    ```ts
      const comment = await createComment({
        input: {
          name: 'Billy Bob',
          body: 'What is your favorite tree bark?',
          post: { connect: { id: scenario.post.bark.id } },     👈🏻
        },
      })
    ```

I had just commited the approach for 1. when i remembered the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record) from Prisma. I'm unsure about the implications (which is faster, what is being done under the hood, are there additional checks), but as the only alternative to using the connect-syntax is using the "unchecked" input – that may be a hint that the "proper" / preferred Prisma-way of doing this would be the approach 2.

Looking forward to hear other people's thoughts on this.