### PR TITLE
Avoid typescript warning when no roles key is supplied

### DIFF
--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
@@ -100,7 +100,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
  *
  * @see https://github.com/redwoodjs/redwood/tree/main/packages/auth for examples
  */
-export const requireAuth = ({ roles }: { roles: AllowedRoles }) => {
+export const requireAuth = ({ roles }: { roles?: AllowedRoles }) => {
   if (!isAuthenticated()) {
     throw new AuthenticationError("You don't have permission to do that.")
   }


### PR DESCRIPTION
Line 108 indicates that this method can be used without supplying roles at all:

https://github.com/redwoodjs/redwood/blob/4707b988f0d5ff58da057afee9a13bf1f6f08710/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template#L108

However, this would trigger a typescript warning:

```bash
Argument of type '{}' is not assignable to parameter of type '{ roles: AllowedRoles; }'.
  Property 'roles' is missing in type '{}' but required in type '{ roles: AllowedRoles; }'.ts(2345)
auth.ts(101, 42): 'roles' is declared here.
```

This fixes it.