### PR TITLE
fix(cli): Modify existence check of jest.config to check for both .js and .ts extensions in rw test

### DIFF
--- a/packages/cli/src/commands/testHandler.js
+++ b/packages/cli/src/commands/testHandler.js
@@ -33,7 +33,11 @@ function isJestConfigFile(sides) {
   for (let side of sides) {
     try {
       if (sides.includes(side)) {
-        if (!fs.existsSync(path.join(side, 'jest.config.js'))) {
+        const jestConfigExists =
+          fs.existsSync(path.join(side, 'jest.config.js')) ||
+          fs.existsSync(path.join(side, 'jest.config.ts'))
+
+        if (!jestConfigExists) {
           console.error(
             c.error(
               `\nError: Missing Jest config file ${side}/jest.config.js` +


### PR DESCRIPTION
Fixes #6063

