### PR TITLE
docs(ts): Update some TS links, and add a tip to the tutorial

### DIFF
--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -96,9 +96,9 @@ A guideline for when to use cells is if your component needs some data from the 
 
 :::tip Wait... what are those types?
 
-Redwood comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript.md).
+Redwood comes with some built-in utility types. You can see two of them in the example above: `CellSuccessProps` and `CellFailureProps`. Read more about them [here](typescript/utility-types.md).
 
-Also notice the `FindPosts` type imported from `types/graphql`. This and other types are generated for you automatically—when you have the dev server running—based on the GraphQL query in your Cell. More about generated types [here](typescript.md).
+Also notice the `FindPosts` type imported from `types/graphql`. This and other types are generated for you automatically—when you have the dev server running—based on the GraphQL query in your Cell. More about generated types [here](typescript/generated-types.md).
 
 :::
 

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -182,6 +182,18 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 </TabItem>
 </Tabs>
 
+<ShowForTs>
+
+:::info Wait... why am I getting a TypeScript error?
+
+When you have your dev server running, the Redwood CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
+
+In this case, the path `/article/{id}` doesn't specify the type of `id` - so it defaults to `string` - where as our article id is actually a `number`. We'll tackle this in in the next few sections - so you can ignore the red squiggle for now, and power through!
+:::
+
+</ShowForTs>
+
+
 For routes with route parameters, the named route function expects an object where you specify a value for each parameter. If you click on the link now, it will indeed take you to `/article/1` (or `/article/2`, etc, depending on the ID of the post).
 
 You may have noticed that when trying to view the new single-article page that you're getting an error. This is because the boilerplate code included with the page when it was generated includes a link to the page itself—a link which now requires an `id`. Remove the link and your page should be working again:

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -725,7 +725,7 @@ Just a quick reminder that Redwood will automatically generate types for your Gr
 
 Once you define the `CreateContactMutation` (the GraphQL one), Redwood will generate the `CreateContactMutation` and `CreateContactMutationVariables` types from it for you.
 
-Take a look at our [TypeScript](typescript.md) docs for a deeper dive!
+Take a look at our [Generated Types](typescript/generated-types.md) docs for a deeper dive!
 
 :::
 

--- a/docs/docs/typescript/generated-types.md
+++ b/docs/docs/typescript/generated-types.md
@@ -26,6 +26,7 @@ If you're curious, you can find the generated types in the `.redwood/types`, `we
 2. types based on your queries and mutations on the web side (in `web/types/graphql.d.ts`)
 3. types for resolvers based on your SDLs on the api side (in `api/types/graphql.d.ts`)
 4. types for testing, `currentUser`, etc.
+5. types for certain functions like `routes.pageName()` and `useAuth()`  
 
 ## CurrentUser
 

--- a/docs/versioned_docs/version-2.2/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter2/routing-params.md
@@ -182,6 +182,17 @@ Cool, cool, cool. Now we need to construct a link that has the ID of a post in i
 </TabItem>
 </Tabs>
 
+<ShowForTs>
+
+:::info Wait... why am I getting a TypeScript error?
+
+When you have your dev server running, the Redwood CLI will watch your project and generate types. You can regenerate these types manually too, by running `yarn rw g types`.
+
+In this case, the path `/article/{id}` doesn't specify the type of `id` - so it defaults to `string` - where as our article id is actually a `number`. We'll tackle this in in the next few sections - so you can ignore the red squiggle for now, and power through!
+:::
+
+</ShowForTs>
+
 For routes with route parameters, the named route function expects an object where you specify a value for each parameter. If you click on the link now, it will indeed take you to `/article/1` (or `/article/2`, etc, depending on the ID of the post).
 
 You may have noticed that when trying to view the new single-article page that you're getting an error. This is because the boilerplate code included with the page when it was generated includes a link to the page itself—a link which now requires an `id`. Remove the link and your page should be working again:


### PR DESCRIPTION
1. Updates the links for generated and utlity types. 
2. Adds a tip in the tutorial where we'd get a TypeScript error (see here #5878)
