### PR TITLE
Harmonize optional chaining across all `hasRole` flavors & reduce duplication, avoiding errors on empty currentUser

### DIFF
--- a/__fixtures__/test-project/api/src/lib/auth.ts
+++ b/__fixtures__/test-project/api/src/lib/auth.ts
@@ -73,11 +73,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context?.currentUser?.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -751,11 +751,9 @@ export const hasRole = (roles) => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context?.currentUser?.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 
@@ -818,11 +816,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context?.currentUser?.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 

--- a/docs/docs/tutorial/chapter4/authentication.md
+++ b/docs/docs/tutorial/chapter4/authentication.md
@@ -761,7 +761,7 @@ export const hasRole = (roles) => {
   return false
 }
 
-export const requireAuth = ({ roles }) => {
+export const requireAuth = ({ roles } = {}) => {
   if (!isAuthenticated()) {
     throw new AuthenticationError("You don't have permission to do that.")
   }

--- a/docs/docs/tutorial/chapter7/rbac.md
+++ b/docs/docs/tutorial/chapter7/rbac.md
@@ -141,11 +141,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context?.currentUser?.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 

--- a/docs/docs/typescript/strict-mode.md
+++ b/docs/docs/typescript/strict-mode.md
@@ -158,11 +158,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
 -      return currentUserRoles?.some((allowedRole) =>
 -        roles.includes(allowedRole)
 -      )
--    } else if (typeof context?.currentUser?.roles === 'string') {
+-    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
 -    }
   }
 

--- a/packages/cli/src/commands/setup/auth/templates/auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/auth.ts.template
@@ -93,11 +93,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context.currentUser.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 

--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.ts.template
@@ -73,10 +73,10 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context?.currentUser?.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
       return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
+        (allowedRole) => currentUserRoles === allowedRole
       )
     }
   }

--- a/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.webAuthn.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/dbAuth.auth.webAuthn.ts.template
@@ -72,11 +72,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context.currentUser.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 

--- a/packages/cli/src/commands/setup/auth/templates/okta.auth.ts.template
+++ b/packages/cli/src/commands/setup/auth/templates/okta.auth.ts.template
@@ -59,11 +59,9 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context.currentUser.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
-      return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
-      )
+      return roles.some((allowedRole) => currentUserRoles === allowedRole)
     }
   }
 


### PR DESCRIPTION
I noticed two things (fixed via d481ca52ab11079a2b9d37ba07f27703bc872904):
* some inconsistencies in the optional javascript chaining, e.g. in dbAuth there was an empty check on context in dbAuth (but only on one execution path), on the majority it was `context.currentUser?.roles`, but on some execution paths (okta, webauthn) there was no chaining at all 
* default auth, dbAuth, webauthn and okta all had execution paths that did not consistently use the `currentUserRoles` constant yet, without any obvious reason

I've now changed `currentUserRoles` to also optionally chain `context` (see a7e85cbb2), so no errors can be thrown from that function anymore should context be undefined – which is exactly what at least one execution path of dbAuth already did :wink:

---

When approved, kindly keep in mind that tutorial section 4.1 also needs an update as well then. Depending on which gets merged first (this one or #6158) this one or the latter could profit from an additional commit on top for that.

---

Oh yeah, and https://redwoodjs.com/docs/canary/typescript/strict-mode#roles-checks-for-currentuser-in-srclibauth would also need a little update.