### PR TITLE
Harmonize method signatures in initial empty auth stub with current implementation

### DIFF
--- a/__fixtures__/empty-project/api/src/lib/auth.ts
+++ b/__fixtures__/empty-project/api/src/lib/auth.ts
@@ -11,7 +11,12 @@ export const isAuthenticated = () => {
   return true
 }
 
-export const hasRole = ({ roles }) => {
+/**
+ * When checking role membership, roles can be a single value, a list, or none.
+ */
+type AllowedRoles = string | string[] | undefined
+
+export const hasRole = (roles: AllowedRoles) => {
   return roles !== undefined
 }
 
@@ -19,7 +24,7 @@ export const hasRole = ({ roles }) => {
 // in ./api/src/directives/requireAuth
 
 // Roles are passed in by the requireAuth directive if you have auth setup
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const requireAuth = ({ roles }) => {
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   return isAuthenticated()
 }

--- a/packages/create-redwood-app/template/api/src/lib/auth.ts
+++ b/packages/create-redwood-app/template/api/src/lib/auth.ts
@@ -11,7 +11,12 @@ export const isAuthenticated = () => {
   return true
 }
 
-export const hasRole = ({ roles }) => {
+/**
+ * When checking role membership, roles can be a single value, a list, or none.
+ */
+type AllowedRoles = string | string[] | undefined
+
+export const hasRole = (roles: AllowedRoles) => {
   return roles !== undefined
 }
 

--- a/packages/create-redwood-app/template/api/src/lib/auth.ts
+++ b/packages/create-redwood-app/template/api/src/lib/auth.ts
@@ -25,6 +25,6 @@ export const hasRole = (roles: AllowedRoles) => {
 
 // Roles are passed in by the requireAuth directive if you have auth setup
 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-export const requireAuth = ({ roles }) => {
+export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
   return isAuthenticated()
 }


### PR DESCRIPTION
While finalizing #6159, i stumbled over the default stub for auth.ts and thought this should also be synchronized with the changes introduced in #4680 &  #6110.