### PR TITLE
Leverage PROJECT_CWD to set cwd in yarn 3 bin "proxies"

### DIFF
--- a/packages/api/src/bins/redwood.ts
+++ b/packages/api/src/bins/redwood.ts
@@ -7,9 +7,10 @@ const requireFromCli = createRequire(
 
 const bins = requireFromCli('./package.json')['bin']
 
-// Ensure we run all commands from the base of the RW project
-// even if you invoke from ./web or ./api
-const rwProjectRoot = requireFromCli('./dist/lib/index.js').getPaths().base
-process.chdir(rwProjectRoot)
+// If this is defined, we're running through yarn and need to change the cwd.
+// See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+if (process.env.PROJECT_CWD) {
+  process.chdir(process.env.PROJECT_CWD)
+}
 
 requireFromCli(bins['redwood'])

--- a/packages/api/src/bins/rwfw.ts
+++ b/packages/api/src/bins/rwfw.ts
@@ -7,9 +7,10 @@ const requireFromCli = createRequire(
 
 const bins = requireFromCli('./package.json')['bin']
 
-// Ensure we run all commands from the base of the RW project
-// even if you invoke from ./web or ./api
-const rwProjectRoot = requireFromCli('./dist/lib/index.js').getPaths().base
-process.chdir(rwProjectRoot)
+// If this is defined, we're running through yarn and need to change the cwd.
+// See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+if (process.env.PROJECT_CWD) {
+  process.chdir(process.env.PROJECT_CWD)
+}
 
 requireFromCli(bins['rwfw'])

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -79,7 +79,7 @@ const loadDotEnvDefaultsMiddleware = () => {
   config({
     path: path.join(getPaths().base, '.env'),
     defaults: path.join(getPaths().base, '.env.defaults'),
-    encoding: 'utf8',
+    multiline: true,
   })
 }
 

--- a/packages/core/src/bins/cross-env.ts
+++ b/packages/core/src/bins/cross-env.ts
@@ -7,4 +7,5 @@ const requireFromCrossEnv = createRequire(
 
 const bins = requireFromCrossEnv('./package.json')['bin']
 
+// Most package.json's list their bins as relative paths, but not cross-env.
 requireFromCrossEnv(`./${bins['cross-env']}`)

--- a/packages/core/src/bins/redwood.ts
+++ b/packages/core/src/bins/redwood.ts
@@ -1,37 +1,33 @@
 #!/usr/bin/env node
 /**
- * A proxy for running the `redwood` @redwoodjs/cli bin (`yarn redwood`, or `yarn rw`) from @redwoodjs/core.
+ * A proxy for running the "redwood" @redwoodjs/cli bin (`yarn redwood`, or `yarn rw`) from @redwoodjs/core.
  *
- * @remarks
- * `createRequire` is for ES6 modules.
- * Some modules can only be imported via require and not via ES6 import/export syntax.
- * But require doesn't exist in ES6, so you have to create it.
+ * createRequire is for ES modules. require literally doesn't exist in ES modules,
+ * so if you want to use it, you have to create it.
  *
- * But that's not the reason we're using it here.
- * We're using it here to require files from other packages for yarn 3 reasons--
- * something kinda along these lines:
+ * But that's not why we're using it here. We're using it here to require files from other packages for yarn 3 reasons:
  *
  * > If your package is something that automatically loads plugins (for example eslint),
  * > peer dependencies obviously aren't an option as you can't reasonably list all plugins.
- * > Instead, you should use the createRequire function to load plugins
- * > on behalf of the configuration file that lists the plugins to load
- * > be it the package.json or a custom one like the .eslintrc.js file.
+ * > Instead, you should use the createRequire function to load plugins on behalf of the configuration file
+ * > that lists the plugins to load, be it the package.json or a custom one like the .eslintrc.js file.
  *
- * @see {@link https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies}
- * @see {@link https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules}
+ * See...
+ *
+ * - https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies
+ * - https://yarnpkg.com/advanced/rulebook#modules-shouldnt-hardcode-node_modules-paths-to-access-other-modules
  */
 import { createRequire } from 'module'
 
-// You can think about the argument we're passing to createRequire as being kinda like setting the `cwd`.
+// You can think about the argument we're passing to `createRequire` as being kinda like setting the `cwd`:
+//
+// > It's using the path/URL to resolve relative paths (e.g.: createRequire('/foo/bar')('./baz') may load /foo/baz/index.js)
+//
+// See https://github.com/nodejs/node/issues/40567#issuecomment-949825461.
 const requireFromCli = createRequire(
   require.resolve('@redwoodjs/cli/package.json')
 )
 
 const bins = requireFromCli('./package.json')['bin']
-
-// Ensure we run all commands from the base of the RW project
-// even if you invoke from ./web or ./api
-const rwProjectRoot = requireFromCli('./dist/lib/index.js').getPaths().base
-process.chdir(rwProjectRoot)
 
 requireFromCli(bins['redwood'])

--- a/packages/core/src/bins/rwfw.ts
+++ b/packages/core/src/bins/rwfw.ts
@@ -7,9 +7,4 @@ const requireFromCli = createRequire(
 
 const bins = requireFromCli('./package.json')['bin']
 
-// Ensure we run all commands from the base of the RW project
-// even if you invoke from ./web or ./api
-const rwProjectRoot = requireFromCli('./dist/lib/index.js').getPaths().base
-process.chdir(rwProjectRoot)
-
 requireFromCli(bins['rwfw'])

--- a/packages/web/src/bins/msw.ts
+++ b/packages/web/src/bins/msw.ts
@@ -5,5 +5,5 @@ const requireFromMSW = createRequire(require.resolve('msw/package.json'))
 
 const bins = requireFromMSW('./package.json')['bin']
 
-// Most `package.json`s list their bins as relative paths, but not MSW.
+// Most package.json's list their bins as relative paths, but not MSW.
 requireFromMSW(`./${bins['msw']}`)

--- a/packages/web/src/bins/redwood.ts
+++ b/packages/web/src/bins/redwood.ts
@@ -7,9 +7,10 @@ const requireFromCli = createRequire(
 
 const bins = requireFromCli('./package.json')['bin']
 
-// Ensure we run all commands from the base of the RW project
-// even if you invoke from ./web or ./api
-const rwProjectRoot = requireFromCli('./dist/lib/index.js').getPaths().base
-process.chdir(rwProjectRoot)
+// If this is defined, we're running through yarn and need to change the cwd.
+// See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+if (process.env.PROJECT_CWD) {
+  process.chdir(process.env.PROJECT_CWD)
+}
 
 requireFromCli(bins['redwood'])

--- a/packages/web/src/bins/rwfw.ts
+++ b/packages/web/src/bins/rwfw.ts
@@ -7,9 +7,10 @@ const requireFromCli = createRequire(
 
 const bins = requireFromCli('./package.json')['bin']
 
-// Ensure we run all commands from the base of the RW project
-// even if you invoke from ./web or ./api
-const rwProjectRoot = requireFromCli('./dist/lib/index.js').getPaths().base
-process.chdir(rwProjectRoot)
+// If this is defined, we're running through yarn and need to change the cwd.
+// See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.
+if (process.env.PROJECT_CWD) {
+  process.chdir(process.env.PROJECT_CWD)
+}
 
 requireFromCli(bins['rwfw'])


### PR DESCRIPTION
To upgrade RW projects to yarn 3, we had to make bin "proxy" files so that we could still access the bins of our dependencies. See https://github.com/redwoodjs/redwood/pull/4444 for the full break down.

When you run a bin, yarn 3 sets the cwd to the workspace calling it. This revealed a hidden dependency in many of our CLI commands that expect the cwd to be the root, so we imported `getPaths` from `@redwoodjs/cli` (an export of the one in `@redwoodjs/internal`) in many of the bin proxy files to find the root and change to it.

This works and has worked for a long time, but turns out to be a not-so-great idea because it means pulling in a massive amount of `@redwoodjs/internal` for any CLI command, and possibly introducing some indeterminacy around the way env vars are loaded.

Instead of importing `getPaths`, this PR leverages the `PROJECT_CWD` env var provided by yarn 3. It's value is what you expect. See https://yarnpkg.com/advanced/lifecycle-scripts/#environment-variables.

Next step is to confirm whether or not this change fixes https://github.com/redwoodjs/redwood/issues/5657.

Here's a visualization of the change using `0x` to generate a flamegraph:

![bin-proxies](https://user-images.githubusercontent.com/32992335/184097717-01446dbf-ffa4-4a8e-967d-756714038f0b.png)

The exact command for reproduction is

```
yarn dlx 0x -o ~/your-rw-project/node_modules/@redwoodjs/core/dist/bins/redwood.js --help
```