### PR TITLE
docs(ts): Add section on core concepts and reorg introduction

### DIFF
--- a/docs/docs/typescript/generated-types.md
+++ b/docs/docs/typescript/generated-types.md
@@ -9,8 +9,10 @@ These generated types not only include your GraphQL operations, but also your na
 
 When you run `yarn rw dev`, the CLI watches files for changes and triggers type generation automatically, but you can trigger it manually too:
 
-```
+```bash
 yarn rw g types
+# or
+# yarn redwood generate types
 ```
 
 :::tip Getting errors trying to generate types?
@@ -26,7 +28,7 @@ If you're curious, you can find the generated types in the `.redwood/types`, `we
 2. types based on your queries and mutations on the web side (in `web/types/graphql.d.ts`)
 3. types for resolvers based on your SDLs on the api side (in `api/types/graphql.d.ts`)
 4. types for testing, `currentUser`, etc.
-5. types for certain functions like `routes.pageName()` and `useAuth()`  
+5. types for certain functions like `routes.pageName()` and `useAuth()`
 
 ## CurrentUser
 
@@ -48,6 +50,12 @@ const getCurrentUser = ({decoded}): MyCurrentUser => {
 ```
 
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
+
+:::info Type of `context.currentUser` unknown?
+This most commonly happens when you don't have the various generated and utility types in your project.
+
+Run `yarn rw g types` and just to be sure, restart your TS server. For example on VSCode, you do this by running searching and running "TypeScript: Restart TS server" in your command pallette (Cmd+Shift+R on Mac, Ctrl+Shift+R on Windows)
+:::
 
 ## Query and Mutation types
 

--- a/docs/docs/typescript/generated-types.md
+++ b/docs/docs/typescript/generated-types.md
@@ -52,9 +52,9 @@ const getCurrentUser = ({decoded}): MyCurrentUser => {
 The types for both `useAuth().currentUser` on the web side and `context.currentUser` on the api side will be the same—the `MyCurrentUser` interface.
 
 :::info Type of `context.currentUser` unknown?
-This most commonly happens when you don't have the various generated and utility types in your project.
-
-Run `yarn rw g types` and just to be sure, restart your TS server. For example on VSCode, you do this by running searching and running "TypeScript: Restart TS server" in your command pallette (Cmd+Shift+R on Mac, Ctrl+Shift+R on Windows)
+This usually happens when you don't have the various generated and utility types in your project.
+Run `yarn rw g types`, and just to be sure, restart your TS server.
+In VSCode, you can do this by running "TypeScript: Restart TS server" in the command palette (Cmd+Shift+P on Mac, Ctrl+Shift+P on Windows)
 :::
 
 ## Query and Mutation types

--- a/docs/docs/typescript/generated-types.md
+++ b/docs/docs/typescript/generated-types.md
@@ -9,7 +9,7 @@ These generated types not only include your GraphQL operations, but also your na
 
 When you run `yarn rw dev`, the CLI watches files for changes and triggers type generation automatically, but you can trigger it manually too:
 
-```bash
+```shell
 yarn rw g types
 # or
 # yarn redwood generate types

--- a/docs/docs/typescript/introduction.md
+++ b/docs/docs/typescript/introduction.md
@@ -1,25 +1,26 @@
 ---
-description: Redwood comes with full TypeScript support
+title: TypeScript in Redwood
+description: Getting started & Core Concepts
 ---
-
-# TypeScript in Redwood
 
 Redwood comes with full TypeScript support, and you don't have to give up any of the conveniences that Redwood offers to enjoy all the benefits of a type-safe codebase.
 
-## Starting a Redwood Project in TypeScript
+
+## Getting Started
+### Starting a Redwood Project in TypeScript
 
 You can use the `--typescript` option on `yarn create redwood-app` to use TypeScript from the start:
 
-```
+```shell
 yarn create redwood-app my-redwood-app --typescript
 ```
 
-## Converting a JavaScript Project to TypeScript
+### Converting a JavaScript Project to TypeScript
 
 Started your project in JavaScript but want to switch to TypeScript?
 Start by using the `tsconfig` setup command:
 
-```
+```shell
 yarn rw setup tsconfig
 ```
 
@@ -31,14 +32,38 @@ In fact, you probably shouldn't.
 Do it incrementally.
 Start by renaming your files from `.js` to `.ts`. (Or, if they have a React component, `.tsx`.)
 
-## Sharing Types between Sides
+---
+
+## Core concepts
+
+### 1. Automatic types
+When you are developing with TypeScript, the Redwood CLI is your trusted companion - you focus on writing your code, and we generate as many of the types as we can.
+
+When you run `yarn rw dev`, the CLI is constantly watching your source code to generate types. More on this in the [Generated types](/typescript/generated-types.md) doc.
+
+But let's say you don't have the dev server running, and are just modifying your code and notice missing types - you can always run `yarn rw g types` to make sure you have all the types you need.
+
+### 2. Use generators to learn about available utility types
+Let's say you generate a Cell using the command `yarn rw g cell Post` - if your project is TypeScript the generated files will contain a bunch of utility types (imported from `@redwoodjs/web`), as well as types specific to your project (these are imported from `types/graphql`).
+
+You don't need to learn all the utility types up front - but they are documented in detail in the [Utility Types](/typescript/utility-types.md) doc.
+
+### 3. We won't force you to type everything
+The Redwood philosophy is to keep things as simple as possible at first. We generate as much as possible, and avoid forcing you to type every little detail, and don't have [strict mode](https://www.typescriptlang.org/tsconfig#strict) switched on by default. Where needed you can make use of generics (e.g. [`DbAuthHandler`](/typescript/utility-types.md#dbauthhandleroptions) to be more specific with your types.
+
+However if you're comfortable with TypeScript, and want that extra level of safety take a look at our [Strict Mode](/typescript/strict-mode.md) doc.
+
+---
+
+## A few useful tips
+### Sharing Types between Sides
 
 To share types between sides:
 
 1. Put them in a directory called `types` at the root of your project (you may have to create this directory)
 2. Restart your editor's TypeScript server. In VSCode, you can do this by running the "TypeScript: Restart TS server" command via the command palette (make sure you're in a `.js` or `.ts` file)
 
-## Running Type Checks
+### Running Type Checks
 
 Behind the scenes, Redwood actually uses Babel to transpile TypeScript.
 This's why you're able to convert your project from JavaScript to TypeScript incrementally, but it also means that, strictly speaking, dev and build don't care about what the TypeScript compiler has to say.
@@ -49,4 +74,4 @@ That's where the `type-check` command comes in:
 yarn rw type-check
 ```
 
-This runs `tsc` on your project and ensures that all the necessary generated types are generated first, including Prisma.
+This runs `tsc` on your project and ensures that all the necessary generated types are generated first. Checkout the [CLI reference for type-check](cli-commands.md#type-check)

--- a/docs/docs/typescript/introduction.md
+++ b/docs/docs/typescript/introduction.md
@@ -5,8 +5,8 @@ description: Getting started & Core Concepts
 
 Redwood comes with full TypeScript support, and you don't have to give up any of the conveniences that Redwood offers to enjoy all the benefits of a type-safe codebase.
 
-
 ## Getting Started
+
 ### Starting a Redwood Project in TypeScript
 
 You can use the `--typescript` option on `yarn create redwood-app` to use TypeScript from the start:
@@ -32,30 +32,31 @@ In fact, you probably shouldn't.
 Do it incrementally.
 Start by renaming your files from `.js` to `.ts`. (Or, if they have a React component, `.tsx`.)
 
----
-
-## Core concepts
+## Core Concepts
 
 ### 1. Automatic types
-When you are developing with TypeScript, the Redwood CLI is your trusted companion - you focus on writing your code, and we generate as many of the types as we can.
 
-When you run `yarn rw dev`, the CLI is constantly watching your source code to generate types. More on this in the [Generated types](/typescript/generated-types.md) doc.
+When you're developing in TypeScript, the Redwood CLI is your trusted companion—focus on writing code and it'll generate as many of the types as it can.
+When you run `yarn rw dev`, the CLI watches files for changes so that it can generate types.
+(More on this in the [Generated Types](/typescript/generated-types.md) doc.)
 
-But let's say you don't have the dev server running, and are just modifying your code and notice missing types - you can always run `yarn rw g types` to make sure you have all the types you need.
+But let's say that you don't have the dev server running, and are just coding and notice missing types.
+You can always run `yarn rw g types` to make sure you have all the types you need.
 
 ### 2. Use generators to learn about available utility types
-Let's say you generate a Cell using the command `yarn rw g cell Post` - if your project is TypeScript the generated files will contain a bunch of utility types (imported from `@redwoodjs/web`), as well as types specific to your project (these are imported from `types/graphql`).
 
-You don't need to learn all the utility types up front - but they are documented in detail in the [Utility Types](/typescript/utility-types.md) doc.
+Let's say you generate a Cell using the command `yarn rw g cell Post`. If your project is in TypeScript, the generated files will contain a bunch of utility types (imported from `@redwoodjs/web`), as well as types specific to your project (imported from `types/graphql`).
+You don't need to learn all the utility types up front, but they're documented in detail in the [Utility Types](/typescript/utility-types.md) doc when you're ready.
 
-### 3. We won't force you to type everything
-The Redwood philosophy is to keep things as simple as possible at first. We generate as much as possible, and avoid forcing you to type every little detail, and don't have [strict mode](https://www.typescriptlang.org/tsconfig#strict) switched on by default. Where needed you can make use of generics (e.g. [`DbAuthHandler`](/typescript/utility-types.md#dbauthhandleroptions) to be more specific with your types.
+### 3. Redwood won't force you to type everything
 
-However if you're comfortable with TypeScript, and want that extra level of safety take a look at our [Strict Mode](/typescript/strict-mode.md) doc.
+The Redwood philosophy is to keep things as simple as possible at first. Redwood generates as much as possible, avoids forcing you to type every little detail, and doesn't have [strict mode](https://www.typescriptlang.org/tsconfig#strict) on by default.
+Where needed (e.g. the [`DbAuthHandler`](/typescript/utility-types.md#dbauthhandleroptions)) you can make use of generics to be more specific with your types.
 
----
+But if you're comfortable with TypeScript and want that extra level of safety, take a look at our [Strict Mode](/typescript/strict-mode.md) doc.
 
-## A few useful tips
+## A Few Useful Tips
+
 ### Sharing Types between Sides
 
 To share types between sides:


### PR DESCRIPTION
Reorganises the typescript intro docs to add a new "core concepts" section. 

This should hopefully make it a little clearer on how TS works with Redwood - but I find it difficult to communicate.

Feel free to edit @jtoar!