### PR TITLE
[Build] Add more api-side polyfill tests

### DIFF
--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -1,121 +1,30 @@
-/**
- * Redwood targets Node.js 12, but that doesn't factor into what gets polyfilled
- * because Redwood uses the plugin-transform-runtime polyfill strategy.
- *
- * Also, plugin-transform-runtime is pinned to core-js v3.0.0,
- * so the list of available polyfill is a little outdated.
- * Some "ES Next" polyfills have landed in v12+ Node.js versions.
- *
- * Key:
- * - ✅ -> plugin-transform-runtime polyfills this
- * - ❌  -> plugin-transform-runtime doesn't polyfill this
- *
- * Note that these polyfills comprise...
- *
- * - features that landed in more-recent versions of Node.js (ES)
- * - proposals (ES Next)
- *
- * These examples have been taken from the core-js README, the proposal's README, or MDN.
- */
+// These examples have been taken from the core-js README, the proposal's README, or MDN.
 
-/**
- * # ES
- */
-// ✅ / Node.js 13 / es.math.hypot
 Math.hypot(3, 4)
 
-// ❌ / Node.js 17 / es.typed-array.set
-//
-// This is overriden in core-js-pure.
-// See https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/es.typed-array.set.js.
-const buffer = new ArrayBuffer(8)
-const uint8 = new Uint8Array(buffer)
-uint8.set([1, 2, 3], 3)
-
-/**
- * # ES Next
- */
-// ✅ / Node.js 15 / esnext.aggregate-error
-// Starts with esnext cause core-js is pinned to v3.0.0.
 const error1 = new TypeError('Error 1')
 const error2 = new TypeError('Error 2')
 const aggregate = new AggregateError([error1, error2], 'Collected errors')
 
-/**
- * ## Array
- *
- * ❌ / Stage 1 proposal / esnext.array.last-index, esnext.array.last-item
- *
- * These are overriden in core-js-pure. See...
- * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-index.js,
- * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-item.js
- */
-;[1, 2, 3].lastItem
+const buffer = new ArrayBuffer(8)
+const uint8 = new Uint8Array(buffer)
+uint8.set([1, 2, 3], 3)
+
 ;[1, 2, 3].lastIndex
+;[1, 2, 3].lastItem
 
 const array = [1, 2, 3]
 array.lastItem = 4
 
-new Array(1, 2, 3).lastItem
 new Array(1, 2, 3).lastIndex
+new Array(1, 2, 3).lastItem
 
-/**
- * ## compositeKey, compositeSymbol
- *
- * ✅ / Stage 1 proposal / esnext.composite-key, esnext.composite-symbol
- */
 const key = compositeKey({})
 const symbol = compositeSymbol({})
 
-/**
- * ## Map
- *
- * ✅
- *
- * Stage 1 proposal:
- * - esnext.map.delete-all
- * - esnext.map.every
- * - esnext.map.filter
- * - esnext.map.find
- * - esnext.map.find-key
- * - esnext.map.from
- * - esnext.map.group-by
- * - esnext.map.includes
- * - esnext.map.key-by
- * - esnext.map.key-of
- * - esnext.map.map-keys
- * - esnext.map.map-values
- * - esnext.map.merge
- * - esnext.map.of
- * - esnext.map.reduce
- * - esnext.map.some
- * - esnext.map.update
- */
 const m = new Map()
 m.deleteAll()
 
-/**
- * ## Math
- *
- * ✅
- *
- * Stage 1 proposal:
- * - esnext.math.clamp
- * - esnext.math.deg-per-rad
- * - esnext.math.degrees
- * - esnext.math.fscale
- * - esnext.math.rad-per-deg
- * - esnext.math.radians
- * - esnext.math.scale
- * - esnext.math.signbit
- *
- * Will be removed in core-js 4:
- * - esnext.math.iaddh
- * - esnext.math.imulh
- * - esnext.math.isubh
- * - esnext.math.umulh
- * - esnext.math.seeded-prng
- */
 Math.clamp(2, 1, 3)
 Math.DEG_PER_RAD
 Math.degrees(1)
@@ -136,18 +45,8 @@ for (let x of Math.seededPRNG({ seed: 42 })) {
   if (x > .8) break;
 }
 
-/**
- * ## Number.fromString
- *
- * ✅ / Stage 1 proposal / esnext.number.from-string
- */
 Number.fromString('42')
 
-/**
- * ## Observable
- *
- * ✅ / Stage 1 proposal / esnext.observable
- */
 new Observable(observer => {
   observer.next('hello')
   observer.next('world')
@@ -156,17 +55,8 @@ new Observable(observer => {
   next(it) { console.log(it) },
   complete() { console.log('!') }
 })
-
 Symbol.observable
 
-/**
- * ## Promise
- *
- * ✅ / Node.js 15  / esnext.promise.any
- * Starts with esnext cause core-js is pinned to v3.0.0.
- *
- * ✅ / Will be removed in core-js 4 / esnext.promise.try
- */
 Promise.any([
   Promise.resolve(1),
   Promise.reject(2),
@@ -181,70 +71,14 @@ Promise.any([
 Promise.try(() => 42).then(it => console.log(`Promise, resolved as ${it}`))
 Promise.try(() => { throw 42; }).catch(it => console.log(`Promise, rejected as ${it}`))
 
-/**
- * ## Reflect metadata
- *
- * ✅
- *
- * Stage ? proposal:
- * - esnext.reflect.define-metadata
- * - esnext.reflect.delete-metadata
- * - esnext.reflect.get-metadata
- * - esnext.reflect.get-metadata-keys
- * - esnext.reflect.get-own-metadata
- * - esnext.reflect.get-own-metadata-keys
- * - esnext.reflect.has-metadata
- * - esnext.reflect.has-own-metadata
- * - esnext.reflect.metadata
- */
 let object = {}
 Reflect.defineMetadata('foo', 'bar', object)
 Reflect.getOwnMetadataKeys(object)
 Reflect.getOwnMetadata('foo', object)
 
-/**
- * ## Set
- *
- * ✅
- *
- * Stage 1 proposal:
- * - esnext.set.add-all
- * - esnext.set.delete-all
- * - esnext.set.difference
- * - esnext.set.every
- * - esnext.set.filter
- * - esnext.set.find
- * - esnext.set.from
- * - esnext.set.intersection
- * - esnext.set.is-disjoint-from
- * - esnext.set.is-subset-of
- * - esnext.set.is-superset-of
- * - esnext.set.join
- * - esnext.set.map
- * - esnext.set.of
- * - esnext.set.reduce
- * - esnext.set.some
- * - esnext.set.symmetric-difference
- * - esnext.set.union
- */
 const s = new Set()
 s.addAll()
 
-/**
- * ## String
- *
- * ✅
- *
- * Stage 1 proposal / esnext.string.code-points
- *
- * Node.js 14 / esnext.string.match-all
- * Starts with esnext cause core-js is pinned to v3.0.0.
- *
- * Node.js 15 / esnext.string.replace-all
- * Starts with esnext cause core-js is pinned to v3.0.0.
- *
- * Will be removed in core-js 4 / esnext.string.at
- */
 for (let { codePoint, position } of 'qwe'.codePoints()) {
   console.log(codePoint)
   console.log(position)
@@ -259,30 +93,11 @@ for (let [_, d, D] of '1111a2b3cccc'.matchAll(/(\d)(\D)/g)) {
 'a𠮷b'.at(1)
 'a𠮷b'.at(1).length
 
-/**
- * ## Symbol
- *
- * ✅
- *
- * Stage 1 proposal / esnext.symbol.pattern-match
- *
- * Stage 2 proposal / esnext.symbol.dispose
- */
 Symbol.patternMatch
 Symbol.dispose
 
-/**
- * ## WeakMap
- *
- * ✅ / Stage 1 proposal / esnext.weak-map.delete-all, esnext.weak-map.from, esnext.weak-map.of
- */
 const wm = new WeakMap()
 wm.deleteAll()
 
-/**
- * ## WeakSet
- *
- * ✅ / Stage 1 proposal / esnext.weak-set.add-all, esnext.weak-set.delete-all, esnext.weak-set.from, esnext.weak-set.of
- */
 const ws = new WeakSet()
 ws.addAll()

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -2,46 +2,56 @@
  * Redwood targets Node.js 12, but that doesn't factor into what gets polyfilled
  * because Redwood uses the plugin-transform-runtime polyfill strategy.
  *
- * Also, plugin-transform-runtime is pinned to core-js v3 (no minors, no patches),
+ * Also, plugin-transform-runtime is pinned to core-js v3.0.0,
  * so the list of available polyfill is a little outdated.
- *
- * Most of these examples are taken from the core-js README, the proposal's README, or MDN.
+ * Some "ES Next" polyfills have landed in v12+ Node.js versions.
  *
  * Key:
- * - ✅ -> plugin-transform-runtime successfully polyfills this
- * - ❌  -> plugin-transform-runtime fails to polyfill this
+ * - ✅ -> plugin-transform-runtime polyfills this
+ * - ❌  -> plugin-transform-runtime doesn't polyfill this
+ *
+ * Note that these polyfills comprise...
+ *
+ * - feautres that landed in more-recent versions of Node.js (ES)
+ * - proposals (ES Next)
+ *
+ * These examples have been taken from the core-js README, the proposal's README, or MDN.
  */
 
 /**
  * # ES
  */
-// Node.js 13
-// ✅ es.math.hypot
+// ✅ / Node.js 13 / es.math.hypot
 Math.hypot(3, 4)
 
-// ❌ es.typed-array.set
-// Node.js 17
-const buffer = new ArrayBuffer(8);
-const uint8 = new Uint8Array(buffer);
-uint8.set([1, 2, 3], 3);
+// ❌ / Node.js 17 / es.typed-array.set
+//
+// This is overriden in core-js-pure.
+// See https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/es.typed-array.set.js.
+const buffer = new ArrayBuffer(8)
+const uint8 = new Uint8Array(buffer)
+uint8.set([1, 2, 3], 3)
 
 /**
  * # ES Next
  */
-// Node.js 15
-// ✅ esnext.aggregate-error
-const error1 = new TypeError('Error 1');
-const error2 = new TypeError('Error 2');
-const aggregate = new AggregateError([error1, error2], 'Collected errors');
+// ✅ / Node.js 15 / esnext.aggregate-error
+// Starts with esnext cause core-js is pinned to v3.0.0.
+const error1 = new TypeError('Error 1')
+const error2 = new TypeError('Error 2')
+const aggregate = new AggregateError([error1, error2], 'Collected errors')
 
 /**
  * ## Array
  *
- * Stage 1 proposal
- * ❌ esnext.array.last-index, esnext.array.last-item
+ * ❌ / Stage 1 proposal / esnext.array.last-index, esnext.array.last-item
+ *
+ * These are overriden in core-js-pure. See...
+ * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-index.js,
+ * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-item.js
  */
-[1, 2, 3].lastItem // => 3
-[1, 2, 3].lastIndex // => 2
+[1, 2, 3].lastItem
+[1, 2, 3].lastIndex
 
 const array = [1, 2, 3]
 array.lastItem = 4
@@ -52,39 +62,34 @@ new Array(1, 2, 3).lastIndex
 /**
  * ## compositeKey, compositeSymbol
  *
- * Stage 1 proposal
- * ✅ esnext.composite-key, esnext.composite-symbol
+ * ✅ / Stage 1 proposal / esnext.composite-key, esnext.composite-symbol
  */
-const key = compositeKey({});
-console.log(typeof key); // => 'object'
-
-const symbol = compositeSymbol({});
-console.log(typeof symbol); // => 'symbol'
+const key = compositeKey({})
+const symbol = compositeSymbol({})
 
 /**
  * ## Map
  *
  * ✅
  *
- * Stage 1 proposal
- *
- * esnext.map.delete-all
- * esnext.map.every
- * esnext.map.filter
- * esnext.map.find
- * esnext.map.find-key
- * esnext.map.from
- * esnext.map.group-by
- * esnext.map.includes
- * esnext.map.key-by
- * esnext.map.key-of
- * esnext.map.map-keys
- * esnext.map.map-values
- * esnext.map.merge
- * esnext.map.of
- * esnext.map.reduce
- * esnext.map.some
- * esnext.map.update
+ * Stage 1 proposal:
+ * - esnext.map.delete-all
+ * - esnext.map.every
+ * - esnext.map.filter
+ * - esnext.map.find
+ * - esnext.map.find-key
+ * - esnext.map.from
+ * - esnext.map.group-by
+ * - esnext.map.includes
+ * - esnext.map.key-by
+ * - esnext.map.key-of
+ * - esnext.map.map-keys
+ * - esnext.map.map-values
+ * - esnext.map.merge
+ * - esnext.map.of
+ * - esnext.map.reduce
+ * - esnext.map.some
+ * - esnext.map.update
  */
 const m = new Map()
 m.deleteAll()
@@ -94,24 +99,22 @@ m.deleteAll()
  *
  * ✅
  *
- * Stage 1 proposal
- *
- * esnext.math.clamp
- * esnext.math.deg-per-rad
- * esnext.math.degrees
- * esnext.math.fscale
- * esnext.math.rad-per-deg
- * esnext.math.radians
- * esnext.math.scale
- * esnext.math.signbit
+ * Stage 1 proposal:
+ * - esnext.math.clamp
+ * - esnext.math.deg-per-rad
+ * - esnext.math.degrees
+ * - esnext.math.fscale
+ * - esnext.math.rad-per-deg
+ * - esnext.math.radians
+ * - esnext.math.scale
+ * - esnext.math.signbit
  *
  * Will be removed in core-js 4:
- *
- * esnext.math.iaddh
- * esnext.math.imulh
- * esnext.math.isubh
- * esnext.math.umulh
- * esnext.math.seeded-prng
+ * - esnext.math.iaddh
+ * - esnext.math.imulh
+ * - esnext.math.isubh
+ * - esnext.math.umulh
+ * - esnext.math.seeded-prng
  */
 Math.clamp(2, 1, 3)
 Math.DEG_PER_RAD
@@ -121,39 +124,37 @@ Math.RAD_PER_DEG
 Math.radians(360)
 Math.scale(5, 1, 1, 2, 2)
 
-for (let x of Math.seededPRNG({ seed: 42 })) {
-  console.log(x); // => 0.16461519912315087, 0.2203933906000046, 0.8249682894209105
-  if (x > .8) break;
-}
-
-Math.signbit(NaN); // => false
+Math.signbit(NaN)
 
 Math.iaddh(lo0, hi0, lo1, hi1)
 Math.imulh(a, b)
 Math.isubh(lo0, hi0, lo1, hi1)
 Math.umulh(a, b)
 
+for (let x of Math.seededPRNG({ seed: 42 })) {
+  console.log(x)
+  if (x > .8) break;
+}
+
 /**
  * ## Number.fromString
  *
- * Stage 1 proposal
- * ✅ esnext.number.from-string
+ * ✅ / Stage 1 proposal / esnext.number.from-string
  */
 Number.fromString('42')
 
 /**
  * ## Observable
  *
- * Stage 1 proposal
- * ✅ esnext.observable
+ * ✅ / Stage 1 proposal / esnext.observable
  */
 new Observable(observer => {
-  observer.next('hello');
-  observer.next('world');
-  observer.complete();
+  observer.next('hello')
+  observer.next('world')
+  observer.complete()
 }).subscribe({
-  next(it) { console.log(it); },
-  complete() { console.log('!'); }
+  next(it) { console.log(it) },
+  complete() { console.log('!') }
 })
 
 Symbol.observable
@@ -161,17 +162,16 @@ Symbol.observable
 /**
  * ## Promise
  *
- * Node.js 15
- * ✅ esnext.promise.any
+ * ✅ / Node.js 15  / esnext.promise.any
+ * Starts with esnext cause core-js is pinned to v3.0.0.
  *
- * Will be removed in core-js 4:
- * ✅ esnext.promise.try
+ * ✅ / Will be removed in core-js 4 / esnext.promise.try
  */
 Promise.any([
   Promise.resolve(1),
   Promise.reject(2),
   Promise.resolve(3),
-]).then(console.log); // => 1
+]).then(console.log)
 Promise.any([
   Promise.reject(1),
   Promise.reject(2),
@@ -186,17 +186,16 @@ Promise.try(() => { throw 42; }).catch(it => console.log(`Promise, rejected as $
  *
  * ✅
  *
- * Stage ? proposal
- *
- * esnext.reflect.define-metadata
- * esnext.reflect.delete-metadata
- * esnext.reflect.get-metadata
- * esnext.reflect.get-metadata-keys
- * esnext.reflect.get-own-metadata
- * esnext.reflect.get-own-metadata-keys
- * esnext.reflect.has-metadata
- * esnext.reflect.has-own-metadata
- * esnext.reflect.metadata
+ * Stage ? proposal:
+ * - esnext.reflect.define-metadata
+ * - esnext.reflect.delete-metadata
+ * - esnext.reflect.get-metadata
+ * - esnext.reflect.get-metadata-keys
+ * - esnext.reflect.get-own-metadata
+ * - esnext.reflect.get-own-metadata-keys
+ * - esnext.reflect.has-metadata
+ * - esnext.reflect.has-own-metadata
+ * - esnext.reflect.metadata
  */
 let object = {}
 Reflect.defineMetadata('foo', 'bar', object)
@@ -209,26 +208,25 @@ Reflect.getOwnMetadata('foo', object)
  *
  * ✅
  *
- * Stage 1 proposal
- *
- * esnext.set.add-all
- * esnext.set.delete-all
- * esnext.set.difference
- * esnext.set.every
- * esnext.set.filter
- * esnext.set.find
- * esnext.set.from
- * esnext.set.intersection
- * esnext.set.is-disjoint-from
- * esnext.set.is-subset-of
- * esnext.set.is-superset-of
- * esnext.set.join
- * esnext.set.map
- * esnext.set.of
- * esnext.set.reduce
- * esnext.set.some
- * esnext.set.symmetric-difference
- * esnext.set.union
+ * Stage 1 proposal:
+ * - esnext.set.add-all
+ * - esnext.set.delete-all
+ * - esnext.set.difference
+ * - esnext.set.every
+ * - esnext.set.filter
+ * - esnext.set.find
+ * - esnext.set.from
+ * - esnext.set.intersection
+ * - esnext.set.is-disjoint-from
+ * - esnext.set.is-subset-of
+ * - esnext.set.is-superset-of
+ * - esnext.set.join
+ * - esnext.set.map
+ * - esnext.set.of
+ * - esnext.set.reduce
+ * - esnext.set.some
+ * - esnext.set.symmetric-difference
+ * - esnext.set.union
  */
 const s = new Set()
 s.addAll()
@@ -238,19 +236,16 @@ s.addAll()
  *
  * ✅
  *
- * Stage 1 proposal
- * esnext.string.code-points
+ * Stage 1 proposal / esnext.string.code-points
  *
- * Node.js 14
- * esnext.string.match-all
+ * Node.js 14 / esnext.string.match-all
+ * Starts with esnext cause core-js is pinned to v3.0.0.
  *
- * Node.js 15
- * esnext.string.replace-all
+ * Node.js 15 / esnext.string.replace-all
+ * Starts with esnext cause core-js is pinned to v3.0.0.
  *
- * Will be removed in core-js 4
- * esnext.string.at
+ * Will be removed in core-js 4 / esnext.string.at
  */
-
 for (let { codePoint, position } of 'qwe'.codePoints()) {
   console.log(codePoint)
   console.log(position)
@@ -270,12 +265,9 @@ for (let [_, d, D] of '1111a2b3cccc'.matchAll(/(\d)(\D)/g)) {
  *
  * ✅
  *
- * Stage 1 proposal
- * This was renamed matcher at some point
- * esnext.symbol.pattern-match
+ * Stage 1 proposal / esnext.symbol.pattern-match
  *
- * Stage 2 proposal
- * esnext.symbol.dispose
+ * Stage 2 proposal / esnext.symbol.dispose
  */
 Symbol.patternMatch
 Symbol.dispose
@@ -283,8 +275,7 @@ Symbol.dispose
 /**
  * ## WeakMap
  *
- * Stage 1 proposal
- * ✅ esnext.weak-map.delete-all, esnext.weak-map.from, esnext.weak-map.of
+ * ✅ / Stage 1 proposal / esnext.weak-map.delete-all, esnext.weak-map.from, esnext.weak-map.of
  */
 const wm = new WeakMap()
 wm.deleteAll()
@@ -292,8 +283,7 @@ wm.deleteAll()
 /**
  * ## WeakSet
  *
- * Stage 1 proposal
- * ✅ esnext.weak-set.add-all, esnext.weak-set.delete-all, esnext.weak-set.from, esnext.weak-set.of
+ * ✅ / Stage 1 proposal / esnext.weak-set.add-all, esnext.weak-set.delete-all, esnext.weak-set.from, esnext.weak-set.of
  */
 const ws = new WeakSet()
 ws.addAll()

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -50,8 +50,8 @@ const aggregate = new AggregateError([error1, error2], 'Collected errors')
  * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-index.js,
  * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-item.js
  */
-[1, 2, 3].lastItem
-[1, 2, 3].lastIndex
+;[1, 2, 3].lastItem
+;[1, 2, 3].lastIndex
 
 const array = [1, 2, 3]
 array.lastItem = 4

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -1,14 +1,59 @@
 // These examples have been taken from the core-js README, the proposal's README, or MDN.
 
+/**
+ * # ES
+ */
+
+// ## Node.js 13
+
 Math.hypot(3, 4)
+
+// ## Node.js 14
+
+for (let [_, d, D] of '1111a2b3cccc'.matchAll(/(\d)(\D)/g)) {
+  console.log(d, D)
+}
+
+// ## Node.js 15
 
 const error1 = new TypeError('Error 1')
 const error2 = new TypeError('Error 2')
 const aggregate = new AggregateError([error1, error2], 'Collected errors')
 
+Promise.any([
+  Promise.resolve(1),
+  Promise.reject(2),
+  Promise.resolve(3),
+]).then(console.log)
+Promise.any([
+  Promise.reject(1),
+  Promise.reject(2),
+  Promise.reject(3),
+]).catch(({ errors }) => console.log(errors))
+
+'Test abc test test abc test.'.replaceAll('abc', 'foo')
+
 const buffer = new ArrayBuffer(8)
 const uint8 = new Uint8Array(buffer)
 uint8.set([1, 2, 3], 3)
+
+/**
+ * # ES Next
+ */
+
+// ## Pre-stage 0
+
+Reflect.defineMetadata(metadataKey, metadataValue, target)
+Reflect.deleteMetadata(metadataKey, target)
+Reflect.getMetadata(metadataKey, target)
+Reflect.getMetadataKeys(target)
+Reflect.getOwnMetadata(metadataKey, target)
+Reflect.getOwnMetadataKeys(target)
+Reflect.hasMetadata(metadataKey, target)
+Reflect.hasOwnMetadata(metadataKey, target)
+Reflect.metadata(metadataKey, metadataValue)
+
+// Stage 1
 
 ;[1, 2, 3].lastIndex
 ;[1, 2, 3].lastItem
@@ -24,6 +69,12 @@ const symbol = compositeSymbol({})
 
 const m = new Map()
 m.deleteAll()
+const s = new Set()
+s.addAll()
+const wm = new WeakMap()
+wm.deleteAll()
+const ws = new WeakSet()
+ws.addAll()
 
 Math.clamp(2, 1, 3)
 Math.DEG_PER_RAD
@@ -34,16 +85,6 @@ Math.radians(360)
 Math.scale(5, 1, 1, 2, 2)
 
 Math.signbit(NaN)
-
-Math.iaddh(lo0, hi0, lo1, hi1)
-Math.imulh(a, b)
-Math.isubh(lo0, hi0, lo1, hi1)
-Math.umulh(a, b)
-
-for (let x of Math.seededPRNG({ seed: 42 })) {
-  console.log(x)
-  if (x > .8) break;
-}
 
 Number.fromString('42')
 
@@ -57,47 +98,37 @@ new Observable(observer => {
 })
 Symbol.observable
 
-Promise.any([
-  Promise.resolve(1),
-  Promise.reject(2),
-  Promise.resolve(3),
-]).then(console.log)
-Promise.any([
-  Promise.reject(1),
-  Promise.reject(2),
-  Promise.reject(3),
-]).catch(({ errors }) => console.log(errors))
-
-Promise.try(() => 42).then(it => console.log(`Promise, resolved as ${it}`))
-Promise.try(() => { throw 42; }).catch(it => console.log(`Promise, rejected as ${it}`))
-
-let object = {}
-Reflect.defineMetadata('foo', 'bar', object)
-Reflect.getOwnMetadataKeys(object)
-Reflect.getOwnMetadata('foo', object)
-
-const s = new Set()
-s.addAll()
-
 for (let { codePoint, position } of 'qwe'.codePoints()) {
   console.log(codePoint)
   console.log(position)
 }
 
-for (let [_, d, D] of '1111a2b3cccc'.matchAll(/(\d)(\D)/g)) {
-  console.log(d, D)
-}
+Symbol.patternMatch
 
-'Test abc test test abc test.'.replaceAll('abc', 'foo')
+// Stage 2
+
+Symbol.dispose
+
+/**
+ * Withdrawn ES Next
+ */
+
+Math.iaddh(lo0, hi0, lo1, hi1)
+Math.imulh(a, b)
+Math.isubh(lo0, hi0, lo1, hi1)
+Math.umulh(a, b)
+
+Promise.try(() => 42).then(it => console.log(`Promise, resolved as ${it}`))
+Promise.try(() => { throw 42; }).catch(it => console.log(`Promise, rejected as ${it}`))
 
 'a𠮷b'.at(1)
 'a𠮷b'.at(1).length
 
-Symbol.patternMatch
-Symbol.dispose
+/**
+ * Unstable
+ */
 
-const wm = new WeakMap()
-wm.deleteAll()
-
-const ws = new WeakSet()
-ws.addAll()
+for (let x of Math.seededPRNG({ seed: 42 })) {
+  console.log(x)
+  if (x > .8) break;
+}

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -1,25 +1,15 @@
 /**
- * We target Node.js 12, but it doesn't factor into what gets polyfilled.
- * Babel only considers what's available in core-js 3.0.0,
- * but implementations are core-js 3+
+ * Redwood targets Node.js 12, but that doesn't factor into what gets polyfilled
+ * because Redwood uses the plugin-transform-runtime polyfill strategy.
  *
- * This list is based on data from core-js-compat:
+ * Also, plugin-transform-runtime is pinned to core-js v3 (no minors, no patches),
+ * so the list of available polyfill is a little outdated.
  *
- * ```js
- * import compat from 'core-js-compat'
+ * Most of these examples are taken from the core-js README, the proposal's README, or MDN.
  *
- * const { list } = compat({
- *   // our target
- *   targets: { node: '12.16' },
- *   // core-js version
- *   version: 3,
- * })
- *
- * console.log(list)
- * ```
- *
- * See http://es6.zloirock.ru/compat.
- * Sometimes this conflicts with MDN's.
+ * Key:
+ * - ✅ -> plugin-transform-runtime successfully polyfills this
+ * - ❌  -> plugin-transform-runtime fails to polyfill this
  */
 
 /**

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -199,7 +199,6 @@ Promise.try(() => { throw 42; }).catch(it => console.log(`Promise, rejected as $
  */
 let object = {}
 Reflect.defineMetadata('foo', 'bar', object)
-Reflect.ownKeys(object)
 Reflect.getOwnMetadataKeys(object)
 Reflect.getOwnMetadata('foo', object)
 

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -12,7 +12,7 @@
  *
  * Note that these polyfills comprise...
  *
- * - feautres that landed in more-recent versions of Node.js (ES)
+ * - features that landed in more-recent versions of Node.js (ES)
  * - proposals (ES Next)
  *
  * These examples have been taken from the core-js README, the proposal's README, or MDN.

--- a/__fixtures__/example-todo-main/api/src/lib/polyfill.js
+++ b/__fixtures__/example-todo-main/api/src/lib/polyfill.js
@@ -1,1 +1,309 @@
-''.replaceAll('a', 'b')
+/**
+ * We target Node.js 12, but it doesn't factor into what gets polyfilled.
+ * Babel only considers what's available in core-js 3.0.0,
+ * but implementations are core-js 3+
+ *
+ * This list is based on data from core-js-compat:
+ *
+ * ```js
+ * import compat from 'core-js-compat'
+ *
+ * const { list } = compat({
+ *   // our target
+ *   targets: { node: '12.16' },
+ *   // core-js version
+ *   version: 3,
+ * })
+ *
+ * console.log(list)
+ * ```
+ *
+ * See http://es6.zloirock.ru/compat.
+ * Sometimes this conflicts with MDN's.
+ */
+
+/**
+ * # ES
+ */
+// Node.js 13
+// ✅ es.math.hypot
+Math.hypot(3, 4)
+
+// ❌ es.typed-array.set
+// Node.js 17
+const buffer = new ArrayBuffer(8);
+const uint8 = new Uint8Array(buffer);
+uint8.set([1, 2, 3], 3);
+
+/**
+ * # ES Next
+ */
+// Node.js 15
+// ✅ esnext.aggregate-error
+const error1 = new TypeError('Error 1');
+const error2 = new TypeError('Error 2');
+const aggregate = new AggregateError([error1, error2], 'Collected errors');
+
+/**
+ * ## Array
+ *
+ * Stage 1 proposal
+ * ❌ esnext.array.last-index, esnext.array.last-item
+ */
+[1, 2, 3].lastItem // => 3
+[1, 2, 3].lastIndex // => 2
+
+const array = [1, 2, 3]
+array.lastItem = 4
+
+new Array(1, 2, 3).lastItem
+new Array(1, 2, 3).lastIndex
+
+/**
+ * ## compositeKey, compositeSymbol
+ *
+ * Stage 1 proposal
+ * ✅ esnext.composite-key, esnext.composite-symbol
+ */
+const key = compositeKey({});
+console.log(typeof key); // => 'object'
+
+const symbol = compositeSymbol({});
+console.log(typeof symbol); // => 'symbol'
+
+/**
+ * ## Map
+ *
+ * ✅
+ *
+ * Stage 1 proposal
+ *
+ * esnext.map.delete-all
+ * esnext.map.every
+ * esnext.map.filter
+ * esnext.map.find
+ * esnext.map.find-key
+ * esnext.map.from
+ * esnext.map.group-by
+ * esnext.map.includes
+ * esnext.map.key-by
+ * esnext.map.key-of
+ * esnext.map.map-keys
+ * esnext.map.map-values
+ * esnext.map.merge
+ * esnext.map.of
+ * esnext.map.reduce
+ * esnext.map.some
+ * esnext.map.update
+ */
+const m = new Map()
+m.deleteAll()
+
+/**
+ * ## Math
+ *
+ * ✅
+ *
+ * Stage 1 proposal
+ *
+ * esnext.math.clamp
+ * esnext.math.deg-per-rad
+ * esnext.math.degrees
+ * esnext.math.fscale
+ * esnext.math.rad-per-deg
+ * esnext.math.radians
+ * esnext.math.scale
+ * esnext.math.signbit
+ *
+ * Will be removed in core-js 4:
+ *
+ * esnext.math.iaddh
+ * esnext.math.imulh
+ * esnext.math.isubh
+ * esnext.math.umulh
+ * esnext.math.seeded-prng
+ */
+Math.clamp(2, 1, 3)
+Math.DEG_PER_RAD
+Math.degrees(1)
+Math.fscale(5, 1, 1, 2, 2)
+Math.RAD_PER_DEG
+Math.radians(360)
+Math.scale(5, 1, 1, 2, 2)
+
+for (let x of Math.seededPRNG({ seed: 42 })) {
+  console.log(x); // => 0.16461519912315087, 0.2203933906000046, 0.8249682894209105
+  if (x > .8) break;
+}
+
+Math.signbit(NaN); // => false
+
+Math.iaddh(lo0, hi0, lo1, hi1)
+Math.imulh(a, b)
+Math.isubh(lo0, hi0, lo1, hi1)
+Math.umulh(a, b)
+
+/**
+ * ## Number.fromString
+ *
+ * Stage 1 proposal
+ * ✅ esnext.number.from-string
+ */
+Number.fromString('42')
+
+/**
+ * ## Observable
+ *
+ * Stage 1 proposal
+ * ✅ esnext.observable
+ */
+new Observable(observer => {
+  observer.next('hello');
+  observer.next('world');
+  observer.complete();
+}).subscribe({
+  next(it) { console.log(it); },
+  complete() { console.log('!'); }
+})
+
+Symbol.observable
+
+/**
+ * ## Promise
+ *
+ * Node.js 15
+ * ✅ esnext.promise.any
+ *
+ * Will be removed in core-js 4:
+ * ✅ esnext.promise.try
+ */
+Promise.any([
+  Promise.resolve(1),
+  Promise.reject(2),
+  Promise.resolve(3),
+]).then(console.log); // => 1
+Promise.any([
+  Promise.reject(1),
+  Promise.reject(2),
+  Promise.reject(3),
+]).catch(({ errors }) => console.log(errors))
+
+Promise.try(() => 42).then(it => console.log(`Promise, resolved as ${it}`))
+Promise.try(() => { throw 42; }).catch(it => console.log(`Promise, rejected as ${it}`))
+
+/**
+ * ## Reflect metadata
+ *
+ * ✅
+ *
+ * Stage ? proposal
+ *
+ * esnext.reflect.define-metadata
+ * esnext.reflect.delete-metadata
+ * esnext.reflect.get-metadata
+ * esnext.reflect.get-metadata-keys
+ * esnext.reflect.get-own-metadata
+ * esnext.reflect.get-own-metadata-keys
+ * esnext.reflect.has-metadata
+ * esnext.reflect.has-own-metadata
+ * esnext.reflect.metadata
+ */
+let object = {}
+Reflect.defineMetadata('foo', 'bar', object)
+Reflect.ownKeys(object)
+Reflect.getOwnMetadataKeys(object)
+Reflect.getOwnMetadata('foo', object)
+
+/**
+ * ## Set
+ *
+ * ✅
+ *
+ * Stage 1 proposal
+ *
+ * esnext.set.add-all
+ * esnext.set.delete-all
+ * esnext.set.difference
+ * esnext.set.every
+ * esnext.set.filter
+ * esnext.set.find
+ * esnext.set.from
+ * esnext.set.intersection
+ * esnext.set.is-disjoint-from
+ * esnext.set.is-subset-of
+ * esnext.set.is-superset-of
+ * esnext.set.join
+ * esnext.set.map
+ * esnext.set.of
+ * esnext.set.reduce
+ * esnext.set.some
+ * esnext.set.symmetric-difference
+ * esnext.set.union
+ */
+const s = new Set()
+s.addAll()
+
+/**
+ * ## String
+ *
+ * ✅
+ *
+ * Stage 1 proposal
+ * esnext.string.code-points
+ *
+ * Node.js 14
+ * esnext.string.match-all
+ *
+ * Node.js 15
+ * esnext.string.replace-all
+ *
+ * Will be removed in core-js 4
+ * esnext.string.at
+ */
+
+for (let { codePoint, position } of 'qwe'.codePoints()) {
+  console.log(codePoint)
+  console.log(position)
+}
+
+for (let [_, d, D] of '1111a2b3cccc'.matchAll(/(\d)(\D)/g)) {
+  console.log(d, D)
+}
+
+'Test abc test test abc test.'.replaceAll('abc', 'foo')
+
+'a𠮷b'.at(1)
+'a𠮷b'.at(1).length
+
+/**
+ * ## Symbol
+ *
+ * ✅
+ *
+ * Stage 1 proposal
+ * This was renamed matcher at some point
+ * esnext.symbol.pattern-match
+ *
+ * Stage 2 proposal
+ * esnext.symbol.dispose
+ */
+Symbol.patternMatch
+Symbol.dispose
+
+/**
+ * ## WeakMap
+ *
+ * Stage 1 proposal
+ * ✅ esnext.weak-map.delete-all, esnext.weak-map.from, esnext.weak-map.of
+ */
+const wm = new WeakMap()
+wm.deleteAll()
+
+/**
+ * ## WeakSet
+ *
+ * Stage 1 proposal
+ * ✅ esnext.weak-set.add-all, esnext.weak-set.delete-all, esnext.weak-set.from, esnext.weak-set.of
+ */
+const ws = new WeakSet()
+ws.addAll()

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -2,12 +2,14 @@ import fs from 'fs'
 import path from 'path'
 
 import * as babel from '@babel/core'
+import compat from 'core-js-compat'
 
 import { cleanApiBuild, prebuildApiFiles } from '../build/api'
 import {
   getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   getApiSideDefaultBabelConfig,
+  TARGETS_NODE,
 } from '../build/babel/api'
 import { findApiFiles } from '../files'
 import { ensurePosixPath, getPaths } from '../paths'
@@ -93,9 +95,195 @@ test.skip('api prebuild transforms gql with `babel-plugin-graphql-tag`', () => {
 
 test('Pretranspile polyfills unsupported functionality', () => {
   const p = prebuiltFiles.filter((p) => p.endsWith('polyfill.js')).pop()
+
   const code = fs.readFileSync(p, 'utf-8')
+
   expect(code).toContain(
-    'import _replaceAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/replace-all"'
+    `import _Math$hypot from "@babel/runtime-corejs3/core-js/math/hypot";`
+  )
+
+  expect(code).toContain(
+    `import _AggregateError from "@babel/runtime-corejs3/core-js/aggregate-error";`
+  )
+
+  expect(code).toContain(
+    `import _compositeKey from "@babel/runtime-corejs3/core-js/composite-key";`
+  )
+  expect(code).toContain(
+    `import _compositeSymbol from "@babel/runtime-corejs3/core-js/composite-symbol";`
+  )
+
+  expect(code).toContain(
+    `import _Map from "@babel/runtime-corejs3/core-js/map";`
+  )
+  const _Map = require('@babel/runtime-corejs3/core-js/map')
+  expect(_Map).toHaveProperty('deleteAll')
+  expect(_Map).toHaveProperty('every')
+  expect(_Map).toHaveProperty('filter')
+  expect(_Map).toHaveProperty('find')
+  expect(_Map).toHaveProperty('findKey')
+  expect(_Map).toHaveProperty('from')
+  expect(_Map).toHaveProperty('groupBy')
+  expect(_Map).toHaveProperty('includes')
+  expect(_Map).toHaveProperty('keyBy')
+  expect(_Map).toHaveProperty('keyOf')
+  expect(_Map).toHaveProperty('mapKeys')
+  expect(_Map).toHaveProperty('mapValues')
+  expect(_Map).toHaveProperty('merge')
+  expect(_Map).toHaveProperty('of')
+  expect(_Map).toHaveProperty('reduce')
+  expect(_Map).toHaveProperty('some')
+  expect(_Map).toHaveProperty('update')
+
+  expect(code).toContain(
+    `import _Math$clamp from "@babel/runtime-corejs3/core-js/math/clamp";`
+  )
+  expect(code).toContain(
+    `import _Math$DEG_PER_RAD from "@babel/runtime-corejs3/core-js/math/deg-per-rad";`
+  )
+  expect(code).toContain(
+    `import _Math$degrees from "@babel/runtime-corejs3/core-js/math/degrees";`
+  )
+  expect(code).toContain(
+    `import _Math$fscale from "@babel/runtime-corejs3/core-js/math/fscale";`
+  )
+  expect(code).toContain(
+    `import _Math$RAD_PER_DEG from "@babel/runtime-corejs3/core-js/math/rad-per-deg";`
+  )
+  expect(code).toContain(
+    `import _Math$radians from "@babel/runtime-corejs3/core-js/math/radians";`
+  )
+  expect(code).toContain(
+    `import _Math$scale from "@babel/runtime-corejs3/core-js/math/scale";`
+  )
+  expect(code).toContain(
+    `import _Math$seededPRNG from "@babel/runtime-corejs3/core-js/math/seeded-prng";`
+  )
+  expect(code).toContain(
+    `import _Math$signbit from "@babel/runtime-corejs3/core-js/math/signbit";`
+  )
+  expect(code).toContain(
+    `import _Math$iaddh from "@babel/runtime-corejs3/core-js/math/iaddh";`
+  )
+  expect(code).toContain(
+    `import _Math$imulh from "@babel/runtime-corejs3/core-js/math/imulh";`
+  )
+  expect(code).toContain(
+    `import _Math$isubh from "@babel/runtime-corejs3/core-js/math/isubh";`
+  )
+  expect(code).toContain(
+    `import _Math$umulh from "@babel/runtime-corejs3/core-js/math/umulh";`
+  )
+
+  expect(code).toContain(
+    `import _Number$fromString from "@babel/runtime-corejs3/core-js/number/from-string";`
+  )
+
+  expect(code).toContain(
+    `import _Observable from "@babel/runtime-corejs3/core-js/observable";`
+  )
+  expect(code).toContain(
+    `import _Symbol$observable from "@babel/runtime-corejs3/core-js/symbol/observable";`
+  )
+
+  expect(code).toContain(
+    `import _Promise from "@babel/runtime-corejs3/core-js/promise";`
+  )
+  const _Promise = require('@babel/runtime-corejs3/core-js/promise')
+  expect(_Promise).toHaveProperty('any')
+  expect(_Promise).toHaveProperty('try')
+
+  expect(code).toContain(
+    `import _Reflect$defineMetadata from "@babel/runtime-corejs3/core-js/reflect/define-metadata";`
+  )
+  expect(code).toContain(
+    `import _Reflect$ownKeys from "@babel/runtime-corejs3/core-js/reflect/own-keys";`
+  )
+  expect(code).toContain(
+    `import _Reflect$getOwnMetadataKeys from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata-keys";`
+  )
+  expect(code).toContain(
+    `import _Reflect$getOwnMetadata from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata";`
+  )
+
+  expect(code).toContain(
+    `import _Set from "@babel/runtime-corejs3/core-js/set";`
+  )
+  const _Set = require('@babel/runtime-corejs3/core-js/set')
+  expect(_Set).toHaveProperty('addAll')
+  expect(_Set).toHaveProperty('deleteAll')
+  expect(_Set).toHaveProperty('difference')
+  expect(_Set).toHaveProperty('every')
+  expect(_Set).toHaveProperty('filter')
+  expect(_Set).toHaveProperty('find')
+  expect(_Set).toHaveProperty('from')
+  expect(_Set).toHaveProperty('intersection')
+  expect(_Set).toHaveProperty('isDisjointFrom')
+  expect(_Set).toHaveProperty('isSubsetOf')
+  expect(_Set).toHaveProperty('isSupersetOf')
+  expect(_Set).toHaveProperty('join')
+  expect(_Set).toHaveProperty('map')
+  expect(_Set).toHaveProperty('of')
+  expect(_Set).toHaveProperty('reduce')
+  expect(_Set).toHaveProperty('some')
+  expect(_Set).toHaveProperty('symmetricDifference')
+  expect(_Set).toHaveProperty('union')
+
+  expect(code).toContain(
+    `import _codePointsInstanceProperty from "@babel/runtime-corejs3/core-js/instance/code-points";`
+  )
+  expect(code).toContain(
+    `import _matchAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/match-all";`
+  )
+  expect(code).toContain(
+    `import _replaceAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/replace-all";`
+  )
+  expect(code).toContain(
+    `import _atInstanceProperty from "@babel/runtime-corejs3/core-js/instance/at";`
+  )
+  expect(code).toContain(
+    `import _Symbol$patternMatch from "@babel/runtime-corejs3/core-js/symbol/pattern-match";`
+  )
+  expect(code).toContain(
+    `import _Symbol$dispose from "@babel/runtime-corejs3/core-js/symbol/dispose";`
+  )
+
+  expect(code).toContain(
+    `import _WeakMap from "@babel/runtime-corejs3/core-js/weak-map";`
+  )
+  const _WeakMap = require('@babel/runtime-corejs3/core-js/weak-map')
+  expect(_WeakMap).toHaveProperty('deleteAll')
+  expect(_WeakMap).toHaveProperty('from')
+  expect(_WeakMap).toHaveProperty('of')
+
+  expect(code).toContain(
+    `import _WeakSet from "@babel/runtime-corejs3/core-js/weak-set";`
+  )
+  const _WeakSet = require('@babel/runtime-corejs3/core-js/weak-set')
+  expect(_WeakSet).toHaveProperty('addAll')
+  expect(_WeakSet).toHaveProperty('deleteAll')
+  expect(_WeakSet).toHaveProperty('from')
+  expect(_WeakSet).toHaveProperty('of')
+
+  // Expect these to remain unchanged.
+  expect(code).toContain(
+    [
+      `const buffer = new ArrayBuffer(8);`,
+      `const uint8 = new Uint8Array(buffer);`,
+      `uint8.set([1, 2, 3], 3);`,
+    ].join('\n')
+  )
+
+  expect(code).toContain(
+    [
+      `[1, 2, 3].lastItem // => 3`,
+      `[(1, 2, 3)].lastIndex; // => 2`,
+      '',
+      `const array = [1, 2, 3];`,
+      `array.lastItem = 4;`,
+      `new Array(1, 2, 3).lastItem;`,
+      `new Array(1, 2, 3).lastIndex;`,
+    ].join('\n')
   )
 })
 
@@ -147,4 +335,98 @@ test('jest mock statements also handle', () => {
   expect(outputForJest).toContain('import dog from "../../lib/dog"')
   // Step 3: check that output has correct jest.mock path
   expect(outputForJest).toContain('jest.mock("../../lib/dog"')
+})
+
+test('core-js polyfill list', () => {
+  const { list } = compat({
+    targets: { node: TARGETS_NODE },
+    version: 3,
+  })
+
+  expect(list).toMatchInlineSnapshot(`
+    Array [
+      "es.math.hypot",
+      "es.typed-array.set",
+      "esnext.aggregate-error",
+      "esnext.array.last-index",
+      "esnext.array.last-item",
+      "esnext.composite-key",
+      "esnext.composite-symbol",
+      "esnext.map.delete-all",
+      "esnext.map.every",
+      "esnext.map.filter",
+      "esnext.map.find",
+      "esnext.map.find-key",
+      "esnext.map.from",
+      "esnext.map.group-by",
+      "esnext.map.includes",
+      "esnext.map.key-by",
+      "esnext.map.key-of",
+      "esnext.map.map-keys",
+      "esnext.map.map-values",
+      "esnext.map.merge",
+      "esnext.map.of",
+      "esnext.map.reduce",
+      "esnext.map.some",
+      "esnext.map.update",
+      "esnext.math.clamp",
+      "esnext.math.deg-per-rad",
+      "esnext.math.degrees",
+      "esnext.math.fscale",
+      "esnext.math.iaddh",
+      "esnext.math.imulh",
+      "esnext.math.isubh",
+      "esnext.math.rad-per-deg",
+      "esnext.math.radians",
+      "esnext.math.scale",
+      "esnext.math.seeded-prng",
+      "esnext.math.signbit",
+      "esnext.math.umulh",
+      "esnext.number.from-string",
+      "esnext.observable",
+      "esnext.promise.any",
+      "esnext.promise.try",
+      "esnext.reflect.define-metadata",
+      "esnext.reflect.delete-metadata",
+      "esnext.reflect.get-metadata",
+      "esnext.reflect.get-metadata-keys",
+      "esnext.reflect.get-own-metadata",
+      "esnext.reflect.get-own-metadata-keys",
+      "esnext.reflect.has-metadata",
+      "esnext.reflect.has-own-metadata",
+      "esnext.reflect.metadata",
+      "esnext.set.add-all",
+      "esnext.set.delete-all",
+      "esnext.set.difference",
+      "esnext.set.every",
+      "esnext.set.filter",
+      "esnext.set.find",
+      "esnext.set.from",
+      "esnext.set.intersection",
+      "esnext.set.is-disjoint-from",
+      "esnext.set.is-subset-of",
+      "esnext.set.is-superset-of",
+      "esnext.set.join",
+      "esnext.set.map",
+      "esnext.set.of",
+      "esnext.set.reduce",
+      "esnext.set.some",
+      "esnext.set.symmetric-difference",
+      "esnext.set.union",
+      "esnext.string.at",
+      "esnext.string.code-points",
+      "esnext.string.match-all",
+      "esnext.string.replace-all",
+      "esnext.symbol.dispose",
+      "esnext.symbol.observable",
+      "esnext.symbol.pattern-match",
+      "esnext.weak-map.delete-all",
+      "esnext.weak-map.from",
+      "esnext.weak-map.of",
+      "esnext.weak-set.add-all",
+      "esnext.weak-set.delete-all",
+      "esnext.weak-set.from",
+      "esnext.weak-set.of",
+    ]
+  `)
 })

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -99,22 +99,22 @@ test('Pretranspile polyfills unsupported functionality', () => {
   const code = fs.readFileSync(p, 'utf-8')
 
   expect(code).toContain(
-    `import _Math$hypot from "@babel/runtime-corejs3/core-js/math/hypot";`
+    `import _Math$hypot from "@babel/runtime-corejs3/core-js/math/hypot"`
   )
 
   expect(code).toContain(
-    `import _AggregateError from "@babel/runtime-corejs3/core-js/aggregate-error";`
+    `import _AggregateError from "@babel/runtime-corejs3/core-js/aggregate-error"`
   )
 
   expect(code).toContain(
-    `import _compositeKey from "@babel/runtime-corejs3/core-js/composite-key";`
+    `import _compositeKey from "@babel/runtime-corejs3/core-js/composite-key"`
   )
   expect(code).toContain(
-    `import _compositeSymbol from "@babel/runtime-corejs3/core-js/composite-symbol";`
+    `import _compositeSymbol from "@babel/runtime-corejs3/core-js/composite-symbol"`
   )
 
   expect(code).toContain(
-    `import _Map from "@babel/runtime-corejs3/core-js/map";`
+    `import _Map from "@babel/runtime-corejs3/core-js/map"`
   )
   const _Map = require('@babel/runtime-corejs3/core-js/map')
   expect(_Map).toHaveProperty('deleteAll')
@@ -136,75 +136,75 @@ test('Pretranspile polyfills unsupported functionality', () => {
   expect(_Map).toHaveProperty('update')
 
   expect(code).toContain(
-    `import _Math$clamp from "@babel/runtime-corejs3/core-js/math/clamp";`
+    `import _Math$clamp from "@babel/runtime-corejs3/core-js/math/clamp"`
   )
   expect(code).toContain(
-    `import _Math$DEG_PER_RAD from "@babel/runtime-corejs3/core-js/math/deg-per-rad";`
+    `import _Math$DEG_PER_RAD from "@babel/runtime-corejs3/core-js/math/deg-per-rad"`
   )
   expect(code).toContain(
-    `import _Math$degrees from "@babel/runtime-corejs3/core-js/math/degrees";`
+    `import _Math$degrees from "@babel/runtime-corejs3/core-js/math/degrees"`
   )
   expect(code).toContain(
-    `import _Math$fscale from "@babel/runtime-corejs3/core-js/math/fscale";`
+    `import _Math$fscale from "@babel/runtime-corejs3/core-js/math/fscale"`
   )
   expect(code).toContain(
-    `import _Math$RAD_PER_DEG from "@babel/runtime-corejs3/core-js/math/rad-per-deg";`
+    `import _Math$RAD_PER_DEG from "@babel/runtime-corejs3/core-js/math/rad-per-deg"`
   )
   expect(code).toContain(
-    `import _Math$radians from "@babel/runtime-corejs3/core-js/math/radians";`
+    `import _Math$radians from "@babel/runtime-corejs3/core-js/math/radians"`
   )
   expect(code).toContain(
-    `import _Math$scale from "@babel/runtime-corejs3/core-js/math/scale";`
+    `import _Math$scale from "@babel/runtime-corejs3/core-js/math/scale"`
   )
   expect(code).toContain(
-    `import _Math$seededPRNG from "@babel/runtime-corejs3/core-js/math/seeded-prng";`
+    `import _Math$seededPRNG from "@babel/runtime-corejs3/core-js/math/seeded-prng"`
   )
   expect(code).toContain(
-    `import _Math$signbit from "@babel/runtime-corejs3/core-js/math/signbit";`
+    `import _Math$signbit from "@babel/runtime-corejs3/core-js/math/signbit"`
   )
   expect(code).toContain(
-    `import _Math$iaddh from "@babel/runtime-corejs3/core-js/math/iaddh";`
+    `import _Math$iaddh from "@babel/runtime-corejs3/core-js/math/iaddh"`
   )
   expect(code).toContain(
-    `import _Math$imulh from "@babel/runtime-corejs3/core-js/math/imulh";`
+    `import _Math$imulh from "@babel/runtime-corejs3/core-js/math/imulh"`
   )
   expect(code).toContain(
-    `import _Math$isubh from "@babel/runtime-corejs3/core-js/math/isubh";`
+    `import _Math$isubh from "@babel/runtime-corejs3/core-js/math/isubh"`
   )
   expect(code).toContain(
-    `import _Math$umulh from "@babel/runtime-corejs3/core-js/math/umulh";`
-  )
-
-  expect(code).toContain(
-    `import _Number$fromString from "@babel/runtime-corejs3/core-js/number/from-string";`
+    `import _Math$umulh from "@babel/runtime-corejs3/core-js/math/umulh"`
   )
 
   expect(code).toContain(
-    `import _Observable from "@babel/runtime-corejs3/core-js/observable";`
-  )
-  expect(code).toContain(
-    `import _Symbol$observable from "@babel/runtime-corejs3/core-js/symbol/observable";`
+    `import _Number$fromString from "@babel/runtime-corejs3/core-js/number/from-string"`
   )
 
   expect(code).toContain(
-    `import _Promise from "@babel/runtime-corejs3/core-js/promise";`
+    `import _Observable from "@babel/runtime-corejs3/core-js/observable"`
+  )
+  expect(code).toContain(
+    `import _Symbol$observable from "@babel/runtime-corejs3/core-js/symbol/observable"`
+  )
+
+  expect(code).toContain(
+    `import _Promise from "@babel/runtime-corejs3/core-js/promise"`
   )
   const _Promise = require('@babel/runtime-corejs3/core-js/promise')
   expect(_Promise).toHaveProperty('any')
   expect(_Promise).toHaveProperty('try')
 
   expect(code).toContain(
-    `import _Reflect$defineMetadata from "@babel/runtime-corejs3/core-js/reflect/define-metadata";`
+    `import _Reflect$defineMetadata from "@babel/runtime-corejs3/core-js/reflect/define-metadata"`
   )
   expect(code).toContain(
-    `import _Reflect$getOwnMetadataKeys from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata-keys";`
+    `import _Reflect$getOwnMetadataKeys from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata-keys"`
   )
   expect(code).toContain(
-    `import _Reflect$getOwnMetadata from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata";`
+    `import _Reflect$getOwnMetadata from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata"`
   )
 
   expect(code).toContain(
-    `import _Set from "@babel/runtime-corejs3/core-js/set";`
+    `import _Set from "@babel/runtime-corejs3/core-js/set"`
   )
   const _Set = require('@babel/runtime-corejs3/core-js/set')
   expect(_Set).toHaveProperty('addAll')
@@ -227,26 +227,26 @@ test('Pretranspile polyfills unsupported functionality', () => {
   expect(_Set).toHaveProperty('union')
 
   expect(code).toContain(
-    `import _codePointsInstanceProperty from "@babel/runtime-corejs3/core-js/instance/code-points";`
+    `import _codePointsInstanceProperty from "@babel/runtime-corejs3/core-js/instance/code-points"`
   )
   expect(code).toContain(
-    `import _matchAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/match-all";`
+    `import _matchAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/match-all"`
   )
   expect(code).toContain(
-    `import _replaceAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/replace-all";`
+    `import _replaceAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/replace-all"`
   )
   expect(code).toContain(
-    `import _atInstanceProperty from "@babel/runtime-corejs3/core-js/instance/at";`
+    `import _atInstanceProperty from "@babel/runtime-corejs3/core-js/instance/at"`
   )
   expect(code).toContain(
-    `import _Symbol$patternMatch from "@babel/runtime-corejs3/core-js/symbol/pattern-match";`
+    `import _Symbol$patternMatch from "@babel/runtime-corejs3/core-js/symbol/pattern-match"`
   )
   expect(code).toContain(
-    `import _Symbol$dispose from "@babel/runtime-corejs3/core-js/symbol/dispose";`
+    `import _Symbol$dispose from "@babel/runtime-corejs3/core-js/symbol/dispose"`
   )
 
   expect(code).toContain(
-    `import _WeakMap from "@babel/runtime-corejs3/core-js/weak-map";`
+    `import _WeakMap from "@babel/runtime-corejs3/core-js/weak-map"`
   )
   const _WeakMap = require('@babel/runtime-corejs3/core-js/weak-map')
   expect(_WeakMap).toHaveProperty('deleteAll')
@@ -254,7 +254,7 @@ test('Pretranspile polyfills unsupported functionality', () => {
   expect(_WeakMap).toHaveProperty('of')
 
   expect(code).toContain(
-    `import _WeakSet from "@babel/runtime-corejs3/core-js/weak-set";`
+    `import _WeakSet from "@babel/runtime-corejs3/core-js/weak-set"`
   )
   const _WeakSet = require('@babel/runtime-corejs3/core-js/weak-set')
   expect(_WeakSet).toHaveProperty('addAll')
@@ -273,9 +273,8 @@ test('Pretranspile polyfills unsupported functionality', () => {
 
   expect(code).toContain(
     [
-      `[1, 2, 3].lastItem // => 3`,
-      `[(1, 2, 3)].lastIndex; // => 2`,
-      '',
+      `[1, 2, 3].lastItem;`,
+      `[1, 2, 3].lastIndex;`,
       `const array = [1, 2, 3];`,
       `array.lastItem = 4;`,
       `new Array(1, 2, 3).lastItem;`,

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -197,9 +197,6 @@ test('Pretranspile polyfills unsupported functionality', () => {
     `import _Reflect$defineMetadata from "@babel/runtime-corejs3/core-js/reflect/define-metadata";`
   )
   expect(code).toContain(
-    `import _Reflect$ownKeys from "@babel/runtime-corejs3/core-js/reflect/own-keys";`
-  )
-  expect(code).toContain(
     `import _Reflect$getOwnMetadataKeys from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata-keys";`
   )
   expect(code).toContain(

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -98,7 +98,7 @@ test.skip('api prebuild transforms gql with `babel-plugin-graphql-tag`', () => {
  * ✅ -> plugin-transform-runtime polyfills this
  * ❌  -> plugin-transform-runtime doesn't polyfill this
  */
-describe.only('api prebuild polyfills unsupported functionality', () => {
+describe('api prebuild polyfills unsupported functionality', () => {
   let code
 
   beforeAll(() => {

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -9,6 +9,7 @@ import {
   getApiSideBabelConfigPath,
   getApiSideBabelPlugins,
   getApiSideDefaultBabelConfig,
+  BABEL_PLUGIN_TRANSFORM_RUNTIME_OPTIONS,
   TARGETS_NODE,
 } from '../build/babel/api'
 import { findApiFiles } from '../files'
@@ -588,7 +589,7 @@ test('jest mock statements also handle', () => {
 test('core-js polyfill list', () => {
   const { list } = compat({
     targets: { node: TARGETS_NODE },
-    version: 3,
+    version: BABEL_PLUGIN_TRANSFORM_RUNTIME_OPTIONS.corejs.version,
   })
 
   /**

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -93,194 +93,446 @@ test.skip('api prebuild transforms gql with `babel-plugin-graphql-tag`', () => {
   expect(code.includes('gql`')).toEqual(false)
 })
 
-test('Pretranspile polyfills unsupported functionality', () => {
-  const p = prebuiltFiles.filter((p) => p.endsWith('polyfill.js')).pop()
+/**
+ * ✅ -> plugin-transform-runtime polyfills this
+ * ❌  -> plugin-transform-runtime doesn't polyfill this
+ */
+describe.only('api prebuild polyfills unsupported functionality', () => {
+  let code
 
-  const code = fs.readFileSync(p, 'utf-8')
+  beforeAll(() => {
+    const p = prebuiltFiles.filter((p) => p.endsWith('polyfill.js')).pop()
+    code = fs.readFileSync(p, 'utf-8')
+  })
 
-  expect(code).toContain(
-    `import _Math$hypot from "@babel/runtime-corejs3/core-js/math/hypot"`
-  )
+  /**
+   * # ES
+   */
+  describe('ES features', () => {
+    describe('Node.js 13', () => {
+      // ✅ / Node.js 13 / es.math.hypot
+      it('polyfills Math.hypot', () => {
+        expect(code).toContain(
+          `import _Math$hypot from "@babel/runtime-corejs3/core-js/math/hypot"`
+        )
+      })
+    })
 
-  expect(code).toContain(
-    `import _AggregateError from "@babel/runtime-corejs3/core-js/aggregate-error"`
-  )
+    describe('Node.js 14', () => {
+      // ✅ / Node.js 14 / esnext.string.match-all
+      // Starts with esnext cause core-js is pinned to v3.0.0.
+      it('polyfills String.matchAll', () => {
+        expect(code).toContain(
+          `import _matchAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/match-all"`
+        )
+      })
+    })
 
-  expect(code).toContain(
-    `import _compositeKey from "@babel/runtime-corejs3/core-js/composite-key"`
-  )
-  expect(code).toContain(
-    `import _compositeSymbol from "@babel/runtime-corejs3/core-js/composite-symbol"`
-  )
+    describe('Node.js 15', () => {
+      // ✅ / Node.js 15 / esnext.aggregate-error
+      // Starts with esnext cause core-js is pinned to v3.0.0.
+      it('polyfills AggregateError', () => {
+        expect(code).toContain(
+          `import _AggregateError from "@babel/runtime-corejs3/core-js/aggregate-error"`
+        )
+      })
 
-  expect(code).toContain(
-    `import _Map from "@babel/runtime-corejs3/core-js/map"`
-  )
-  const _Map = require('@babel/runtime-corejs3/core-js/map')
-  expect(_Map).toHaveProperty('deleteAll')
-  expect(_Map).toHaveProperty('every')
-  expect(_Map).toHaveProperty('filter')
-  expect(_Map).toHaveProperty('find')
-  expect(_Map).toHaveProperty('findKey')
-  expect(_Map).toHaveProperty('from')
-  expect(_Map).toHaveProperty('groupBy')
-  expect(_Map).toHaveProperty('includes')
-  expect(_Map).toHaveProperty('keyBy')
-  expect(_Map).toHaveProperty('keyOf')
-  expect(_Map).toHaveProperty('mapKeys')
-  expect(_Map).toHaveProperty('mapValues')
-  expect(_Map).toHaveProperty('merge')
-  expect(_Map).toHaveProperty('of')
-  expect(_Map).toHaveProperty('reduce')
-  expect(_Map).toHaveProperty('some')
-  expect(_Map).toHaveProperty('update')
+      // ✅ / Node.js 15  / esnext.promise.any
+      // Starts with esnext cause core-js is pinned to v3.0.0.
+      //
+      // The reason we're testing it this way is that core-js polyfills the entire Promise built in.
+      //
+      // So this...
+      //
+      // ```
+      // const map = new Map()
+      // map.deleteAll()
+      // ```
+      //
+      // becomes...
+      //
+      // ```
+      // import _Map from "@babel/runtime-corejs3/core-js/map"
+      // const map = _new Map()
+      // map.deleteAll()
+      // ```
+      //
+      // We still have no idea if it supports `deleteAll`, or `every`, or `filter`.
+      // So we have to check if the methods are available as properties.
+      it('polyfills Promise.any', () => {
+        expect(code).toContain(
+          `import _Promise from "@babel/runtime-corejs3/core-js/promise"`
+        )
+        const _Promise = require('@babel/runtime-corejs3/core-js/promise')
+        expect(_Promise).toHaveProperty('any')
+      })
 
-  expect(code).toContain(
-    `import _Math$clamp from "@babel/runtime-corejs3/core-js/math/clamp"`
-  )
-  expect(code).toContain(
-    `import _Math$DEG_PER_RAD from "@babel/runtime-corejs3/core-js/math/deg-per-rad"`
-  )
-  expect(code).toContain(
-    `import _Math$degrees from "@babel/runtime-corejs3/core-js/math/degrees"`
-  )
-  expect(code).toContain(
-    `import _Math$fscale from "@babel/runtime-corejs3/core-js/math/fscale"`
-  )
-  expect(code).toContain(
-    `import _Math$RAD_PER_DEG from "@babel/runtime-corejs3/core-js/math/rad-per-deg"`
-  )
-  expect(code).toContain(
-    `import _Math$radians from "@babel/runtime-corejs3/core-js/math/radians"`
-  )
-  expect(code).toContain(
-    `import _Math$scale from "@babel/runtime-corejs3/core-js/math/scale"`
-  )
-  expect(code).toContain(
-    `import _Math$seededPRNG from "@babel/runtime-corejs3/core-js/math/seeded-prng"`
-  )
-  expect(code).toContain(
-    `import _Math$signbit from "@babel/runtime-corejs3/core-js/math/signbit"`
-  )
-  expect(code).toContain(
-    `import _Math$iaddh from "@babel/runtime-corejs3/core-js/math/iaddh"`
-  )
-  expect(code).toContain(
-    `import _Math$imulh from "@babel/runtime-corejs3/core-js/math/imulh"`
-  )
-  expect(code).toContain(
-    `import _Math$isubh from "@babel/runtime-corejs3/core-js/math/isubh"`
-  )
-  expect(code).toContain(
-    `import _Math$umulh from "@babel/runtime-corejs3/core-js/math/umulh"`
-  )
+      // ✅ / Node.js 15 / esnext.string.replace-all
+      // Starts with esnext cause core-js is pinned to v3.0.0.
+      it('polyfills String.replaceAll', () => {
+        expect(code).toContain(
+          `import _replaceAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/replace-all"`
+        )
+      })
+    })
 
-  expect(code).toContain(
-    `import _Number$fromString from "@babel/runtime-corejs3/core-js/number/from-string"`
-  )
+    describe('Node.js 17', () => {
+      // ❌ / Node.js 17 / es.typed-array.set
+      //
+      // This is overriden in core-js-pure.
+      // See https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/es.typed-array.set.js.
+      it("doesn't polyfill TypedArray.set", () => {
+        expect(code).toContain(
+          [
+            `const buffer = new ArrayBuffer(8);`,
+            `const uint8 = new Uint8Array(buffer);`,
+            `uint8.set([1, 2, 3], 3);`,
+          ].join('\n')
+        )
+      })
+    })
+  })
 
-  expect(code).toContain(
-    `import _Observable from "@babel/runtime-corejs3/core-js/observable"`
-  )
-  expect(code).toContain(
-    `import _Symbol$observable from "@babel/runtime-corejs3/core-js/symbol/observable"`
-  )
+  /**
+   * # ES Next
+   */
+  describe('ES Next features', () => {
+    describe('Stage ? proposals', () => {
+      /**
+       * ## Reflect metadata
+       *
+       * ✅ / Stage ? proposal /
+       * - esnext.reflect.define-metadata
+       * - esnext.reflect.delete-metadata
+       * - esnext.reflect.get-metadata
+       * - esnext.reflect.get-metadata-keys
+       * - esnext.reflect.get-own-metadata
+       * - esnext.reflect.get-own-metadata-keys
+       * - esnext.reflect.has-metadata
+       * - esnext.reflect.has-own-metadata
+       * - esnext.reflect.metadata
+       */
+      it('polyfills Reflect methods', () => {
+        expect(code).toContain(
+          `import _Reflect$defineMetadata from "@babel/runtime-corejs3/core-js/reflect/define-metadata"`
+        )
+        expect(code).toContain(
+          `import _Reflect$getOwnMetadataKeys from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata-keys"`
+        )
+        expect(code).toContain(
+          `import _Reflect$getOwnMetadata from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata"`
+        )
+      })
+    })
 
-  expect(code).toContain(
-    `import _Promise from "@babel/runtime-corejs3/core-js/promise"`
-  )
-  const _Promise = require('@babel/runtime-corejs3/core-js/promise')
-  expect(_Promise).toHaveProperty('any')
-  expect(_Promise).toHaveProperty('try')
+    describe('Stage 1 proposals', () => {
+      /**
+       * ## Array
+       *
+       * ❌ / Stage 1 proposal / esnext.array.last-index, esnext.array.last-item
+       *
+       * These are overriden in core-js-pure. See...
+       * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-index.js,
+       * - https://github.com/zloirock/core-js/blob/master/packages/core-js-pure/override/modules/esnext.array.last-item.js
+       */
+      it("doesn't polyfill Array.lastIndex or Array.lastItem", () => {
+        expect(code).toContain(
+          [
+            `[1, 2, 3].lastIndex;`,
+            `[1, 2, 3].lastItem;`,
+            `const array = [1, 2, 3];`,
+            `array.lastItem = 4;`,
+            `new Array(1, 2, 3).lastIndex;`,
+            `new Array(1, 2, 3).lastItem;`,
+          ].join('\n')
+        )
+      })
 
-  expect(code).toContain(
-    `import _Reflect$defineMetadata from "@babel/runtime-corejs3/core-js/reflect/define-metadata"`
-  )
-  expect(code).toContain(
-    `import _Reflect$getOwnMetadataKeys from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata-keys"`
-  )
-  expect(code).toContain(
-    `import _Reflect$getOwnMetadata from "@babel/runtime-corejs3/core-js/reflect/get-own-metadata"`
-  )
+      /**
+       * ## compositeKey, compositeSymbol
+       *
+       * ✅ / Stage 1 proposal / esnext.composite-key, esnext.composite-symbol
+       */
+      it('polyfills compositeKey and compositeSymbol', () => {
+        expect(code).toContain(
+          `import _compositeKey from "@babel/runtime-corejs3/core-js/composite-key"`
+        )
+        expect(code).toContain(
+          `import _compositeSymbol from "@babel/runtime-corejs3/core-js/composite-symbol"`
+        )
+      })
 
-  expect(code).toContain(
-    `import _Set from "@babel/runtime-corejs3/core-js/set"`
-  )
-  const _Set = require('@babel/runtime-corejs3/core-js/set')
-  expect(_Set).toHaveProperty('addAll')
-  expect(_Set).toHaveProperty('deleteAll')
-  expect(_Set).toHaveProperty('difference')
-  expect(_Set).toHaveProperty('every')
-  expect(_Set).toHaveProperty('filter')
-  expect(_Set).toHaveProperty('find')
-  expect(_Set).toHaveProperty('from')
-  expect(_Set).toHaveProperty('intersection')
-  expect(_Set).toHaveProperty('isDisjointFrom')
-  expect(_Set).toHaveProperty('isSubsetOf')
-  expect(_Set).toHaveProperty('isSupersetOf')
-  expect(_Set).toHaveProperty('join')
-  expect(_Set).toHaveProperty('map')
-  expect(_Set).toHaveProperty('of')
-  expect(_Set).toHaveProperty('reduce')
-  expect(_Set).toHaveProperty('some')
-  expect(_Set).toHaveProperty('symmetricDifference')
-  expect(_Set).toHaveProperty('union')
+      /**
+       * ## Map
+       *
+       * ✅ / Stage 1 proposal /
+       * - esnext.map.delete-all
+       * - esnext.map.every
+       * - esnext.map.filter
+       * - esnext.map.find
+       * - esnext.map.find-key
+       * - esnext.map.from
+       * - esnext.map.group-by
+       * - esnext.map.includes
+       * - esnext.map.key-by
+       * - esnext.map.key-of
+       * - esnext.map.map-keys
+       * - esnext.map.map-values
+       * - esnext.map.merge
+       * - esnext.map.of
+       * - esnext.map.reduce
+       * - esnext.map.some
+       * - esnext.map.update
+       */
+      it('polyfills Map', () => {
+        expect(code).toContain(
+          `import _Map from "@babel/runtime-corejs3/core-js/map"`
+        )
+        // See the comments on Promise above for more of an explanation
+        // of why we're testing for properties.
+        const _Map = require('@babel/runtime-corejs3/core-js/map')
+        expect(_Map).toHaveProperty('deleteAll')
+        expect(_Map).toHaveProperty('every')
+        expect(_Map).toHaveProperty('filter')
+        expect(_Map).toHaveProperty('find')
+        expect(_Map).toHaveProperty('findKey')
+        expect(_Map).toHaveProperty('from')
+        expect(_Map).toHaveProperty('groupBy')
+        expect(_Map).toHaveProperty('includes')
+        expect(_Map).toHaveProperty('keyBy')
+        expect(_Map).toHaveProperty('keyOf')
+        expect(_Map).toHaveProperty('mapKeys')
+        expect(_Map).toHaveProperty('mapValues')
+        expect(_Map).toHaveProperty('merge')
+        expect(_Map).toHaveProperty('of')
+        expect(_Map).toHaveProperty('reduce')
+        expect(_Map).toHaveProperty('some')
+        expect(_Map).toHaveProperty('update')
+      })
 
-  expect(code).toContain(
-    `import _codePointsInstanceProperty from "@babel/runtime-corejs3/core-js/instance/code-points"`
-  )
-  expect(code).toContain(
-    `import _matchAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/match-all"`
-  )
-  expect(code).toContain(
-    `import _replaceAllInstanceProperty from "@babel/runtime-corejs3/core-js/instance/replace-all"`
-  )
-  expect(code).toContain(
-    `import _atInstanceProperty from "@babel/runtime-corejs3/core-js/instance/at"`
-  )
-  expect(code).toContain(
-    `import _Symbol$patternMatch from "@babel/runtime-corejs3/core-js/symbol/pattern-match"`
-  )
-  expect(code).toContain(
-    `import _Symbol$dispose from "@babel/runtime-corejs3/core-js/symbol/dispose"`
-  )
+      /**
+       * ## Math
+       *
+       * ✅ / Stage 1 proposal /
+       * - esnext.math.clamp
+       * - esnext.math.deg-per-rad
+       * - esnext.math.degrees
+       * - esnext.math.fscale
+       * - esnext.math.rad-per-deg
+       * - esnext.math.radians
+       * - esnext.math.scale
+       * - esnext.math.signbit
+       *
+       * ✅ / Stage 1 proposal / Will be removed in core-js 4 /
+       * - esnext.math.iaddh
+       * - esnext.math.imulh
+       * - esnext.math.isubh
+       * - esnext.math.umulh
+       * - esnext.math.seeded-prng
+       */
+      it('polyfills Math methods and properties', () => {
+        expect(code).toContain(
+          `import _Math$clamp from "@babel/runtime-corejs3/core-js/math/clamp"`
+        )
+        expect(code).toContain(
+          `import _Math$DEG_PER_RAD from "@babel/runtime-corejs3/core-js/math/deg-per-rad"`
+        )
+        expect(code).toContain(
+          `import _Math$degrees from "@babel/runtime-corejs3/core-js/math/degrees"`
+        )
+        expect(code).toContain(
+          `import _Math$fscale from "@babel/runtime-corejs3/core-js/math/fscale"`
+        )
+        expect(code).toContain(
+          `import _Math$RAD_PER_DEG from "@babel/runtime-corejs3/core-js/math/rad-per-deg"`
+        )
+        expect(code).toContain(
+          `import _Math$radians from "@babel/runtime-corejs3/core-js/math/radians"`
+        )
+        expect(code).toContain(
+          `import _Math$scale from "@babel/runtime-corejs3/core-js/math/scale"`
+        )
+        expect(code).toContain(
+          `import _Math$signbit from "@babel/runtime-corejs3/core-js/math/signbit"`
+        )
 
-  expect(code).toContain(
-    `import _WeakMap from "@babel/runtime-corejs3/core-js/weak-map"`
-  )
-  const _WeakMap = require('@babel/runtime-corejs3/core-js/weak-map')
-  expect(_WeakMap).toHaveProperty('deleteAll')
-  expect(_WeakMap).toHaveProperty('from')
-  expect(_WeakMap).toHaveProperty('of')
+        expect(code).toContain(
+          `import _Math$iaddh from "@babel/runtime-corejs3/core-js/math/iaddh"`
+        )
+        expect(code).toContain(
+          `import _Math$imulh from "@babel/runtime-corejs3/core-js/math/imulh"`
+        )
+        expect(code).toContain(
+          `import _Math$isubh from "@babel/runtime-corejs3/core-js/math/isubh"`
+        )
+        expect(code).toContain(
+          `import _Math$umulh from "@babel/runtime-corejs3/core-js/math/umulh"`
+        )
+        expect(code).toContain(
+          `import _Math$seededPRNG from "@babel/runtime-corejs3/core-js/math/seeded-prng"`
+        )
+      })
 
-  expect(code).toContain(
-    `import _WeakSet from "@babel/runtime-corejs3/core-js/weak-set"`
-  )
-  const _WeakSet = require('@babel/runtime-corejs3/core-js/weak-set')
-  expect(_WeakSet).toHaveProperty('addAll')
-  expect(_WeakSet).toHaveProperty('deleteAll')
-  expect(_WeakSet).toHaveProperty('from')
-  expect(_WeakSet).toHaveProperty('of')
+      /**
+       * ## Number.fromString
+       *
+       * ✅ / Stage 1 proposal / esnext.number.from-string
+       */
+      it('polyfills Number.fromString', () => {
+        expect(code).toContain(
+          `import _Number$fromString from "@babel/runtime-corejs3/core-js/number/from-string"`
+        )
+      })
 
-  // Expect these to remain unchanged.
-  expect(code).toContain(
-    [
-      `const buffer = new ArrayBuffer(8);`,
-      `const uint8 = new Uint8Array(buffer);`,
-      `uint8.set([1, 2, 3], 3);`,
-    ].join('\n')
-  )
+      /**
+       * ## Observable
+       *
+       * ✅ / Stage 1 proposal / esnext.observable
+       */
+      it('polyfills Observable', () => {
+        expect(code).toContain(
+          `import _Observable from "@babel/runtime-corejs3/core-js/observable"`
+        )
+        expect(code).toContain(
+          `import _Symbol$observable from "@babel/runtime-corejs3/core-js/symbol/observable"`
+        )
+      })
 
-  expect(code).toContain(
-    [
-      `[1, 2, 3].lastItem;`,
-      `[1, 2, 3].lastIndex;`,
-      `const array = [1, 2, 3];`,
-      `array.lastItem = 4;`,
-      `new Array(1, 2, 3).lastItem;`,
-      `new Array(1, 2, 3).lastIndex;`,
-    ].join('\n')
-  )
+      /**
+       * ## Promise
+       *
+       * ✅ / Stage 1 proposal / Will be removed in core-js 4 / esnext.promise.try
+       */
+      it('polyfills Promise', () => {
+        const _Promise = require('@babel/runtime-corejs3/core-js/promise')
+        expect(_Promise).toHaveProperty('try')
+      })
+
+      /**
+       * ## Set
+       *
+       * ✅ / Stage 1 proposal /
+       * - esnext.set.add-all
+       * - esnext.set.delete-all
+       * - esnext.set.difference
+       * - esnext.set.every
+       * - esnext.set.filter
+       * - esnext.set.find
+       * - esnext.set.from
+       * - esnext.set.intersection
+       * - esnext.set.is-disjoint-from
+       * - esnext.set.is-subset-of
+       * - esnext.set.is-superset-of
+       * - esnext.set.join
+       * - esnext.set.map
+       * - esnext.set.of
+       * - esnext.set.reduce
+       * - esnext.set.some
+       * - esnext.set.symmetric-difference
+       * - esnext.set.union
+       */
+      it('polyfills Set', () => {
+        expect(code).toContain(
+          `import _Set from "@babel/runtime-corejs3/core-js/set"`
+        )
+        // See the comments on Promise above for more of an explanation
+        // of why we're testing for properties.
+        const _Set = require('@babel/runtime-corejs3/core-js/set')
+        expect(_Set).toHaveProperty('addAll')
+        expect(_Set).toHaveProperty('deleteAll')
+        expect(_Set).toHaveProperty('difference')
+        expect(_Set).toHaveProperty('every')
+        expect(_Set).toHaveProperty('filter')
+        expect(_Set).toHaveProperty('find')
+        expect(_Set).toHaveProperty('from')
+        expect(_Set).toHaveProperty('intersection')
+        expect(_Set).toHaveProperty('isDisjointFrom')
+        expect(_Set).toHaveProperty('isSubsetOf')
+        expect(_Set).toHaveProperty('isSupersetOf')
+        expect(_Set).toHaveProperty('join')
+        expect(_Set).toHaveProperty('map')
+        expect(_Set).toHaveProperty('of')
+        expect(_Set).toHaveProperty('reduce')
+        expect(_Set).toHaveProperty('some')
+        expect(_Set).toHaveProperty('symmetricDifference')
+        expect(_Set).toHaveProperty('union')
+      })
+
+      /**
+       * ## String
+       *
+       * ✅ / Stage 1 proposal / esnext.string.code-points
+       * ✅ / Stage 1 proposal / Will be removed in core-js 4 / esnext.string.at
+       */
+      it('polyfills String methods', () => {
+        expect(code).toContain(
+          `import _codePointsInstanceProperty from "@babel/runtime-corejs3/core-js/instance/code-points"`
+        )
+        expect(code).toContain(
+          `import _atInstanceProperty from "@babel/runtime-corejs3/core-js/instance/at"`
+        )
+      })
+
+      /**
+       * ## Symbol
+       *
+       * ✅ / Stage 1 proposal / esnext.symbol.pattern-match
+       */
+      it('polyfills Symbol', () => {
+        expect(code).toContain(
+          `import _Symbol$patternMatch from "@babel/runtime-corejs3/core-js/symbol/pattern-match"`
+        )
+      })
+
+      /**
+       * ## WeakMap
+       *
+       * ✅ / Stage 1 proposal / esnext.weak-map.delete-all, esnext.weak-map.from, esnext.weak-map.of
+       */
+      it('polyfills WeakMap', () => {
+        expect(code).toContain(
+          `import _WeakMap from "@babel/runtime-corejs3/core-js/weak-map"`
+        )
+        // See the comments on Promise above for more of an explanation
+        // of why we're testing for properties.
+        const _WeakMap = require('@babel/runtime-corejs3/core-js/weak-map')
+        expect(_WeakMap).toHaveProperty('deleteAll')
+        expect(_WeakMap).toHaveProperty('from')
+        expect(_WeakMap).toHaveProperty('of')
+      })
+
+      /**
+       * ## WeakSet
+       *
+       * ✅ / Stage 1 proposal / esnext.weak-set.add-all, esnext.weak-set.delete-all, esnext.weak-set.from, esnext.weak-set.of
+       */
+      it('polyfills WeakSet', () => {
+        expect(code).toContain(
+          `import _WeakSet from "@babel/runtime-corejs3/core-js/weak-set"`
+        )
+        // See the comments on Promise above for more of an explanation
+        // of why we're testing for properties.
+        const _WeakSet = require('@babel/runtime-corejs3/core-js/weak-set')
+        expect(_WeakSet).toHaveProperty('addAll')
+        expect(_WeakSet).toHaveProperty('deleteAll')
+        expect(_WeakSet).toHaveProperty('from')
+        expect(_WeakSet).toHaveProperty('of')
+      })
+    })
+
+    describe('Stage 2 proposals', () => {
+      /**
+       * ## Symbol
+       *
+       * ✅ / Stage 2 proposal / esnext.symbol.dispose
+       */
+      it('polyfills Symbol', () => {
+        expect(code).toContain(
+          `import _Symbol$dispose from "@babel/runtime-corejs3/core-js/symbol/dispose"`
+        )
+      })
+    })
+  })
 })
 
 test('Pretranspile uses corejs3 aliasing', () => {
@@ -339,6 +591,14 @@ test('core-js polyfill list', () => {
     version: 3,
   })
 
+  /**
+   * Redwood targets Node.js 12, but that doesn't factor into what gets polyfilled
+   * because Redwood uses the plugin-transform-runtime polyfill strategy.
+   *
+   * Also, plugin-transform-runtime is pinned to core-js v3.0.0,
+   * so the list of available polyfill is a little outdated.
+   * Some "ES Next" polyfills have landed in v12+ Node.js versions.
+   */
   expect(list).toMatchInlineSnapshot(`
     Array [
       "es.math.hypot",

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -439,7 +439,7 @@ describe('api prebuild polyfills unsupported functionality', () => {
     })
   })
 
-  describe('Unstable', () => {
+  describe('Unstable (will be removed in core-js 4)', () => {
     // Seeded pseudo-random numbers
     // See https://github.com/zloirock/core-js#seeded-pseudo-random-numbers
     it('polyfills Seeded pseudo-random numbers', () => {

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -14,7 +14,7 @@ import {
   getCommonPlugins,
 } from './common'
 
-const TARGETS_NODE = '12.16'
+export const TARGETS_NODE = '12.16'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -50,6 +50,16 @@ export const getApiSideBabelPresets = (
   ].filter(Boolean) as TransformOptions['presets']
 }
 
+export const BABEL_PLUGIN_TRANSFORM_RUNTIME_OPTIONS = {
+  // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#core-js-aliasing
+  // Setting the version here also requires `@babel/runtime-corejs3`
+  corejs: { version: 3, proposals: true },
+  // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#version
+  // Transform-runtime assumes that @babel/runtime@7.0.0 is installed.
+  // Specifying the version can result in a smaller bundle size.
+  version: RUNTIME_CORE_JS_VERSION,
+}
+
 export const getApiSideBabelPlugins = ({ forJest } = { forJest: false }) => {
   const rwjsPaths = getPaths()
   // Plugin shape: [ ["Target", "Options", "name"] ],
@@ -88,18 +98,7 @@ export const getApiSideBabelPlugins = ({ forJest } = { forJest: false }) => {
      *  See table on https://babeljs.io/docs/en/babel-plugin-transform-runtime#corejs
      *
      */
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#core-js-aliasing
-        // Setting the version here also requires `@babel/runtime-corejs3`
-        corejs: { version: 3, proposals: true },
-        // https://babeljs.io/docs/en/babel-plugin-transform-runtime/#version
-        // Transform-runtime assumes that @babel/runtime@7.0.0 is installed.
-        // Specifying the version can result in a smaller bundle size.
-        version: RUNTIME_CORE_JS_VERSION,
-      },
-    ],
+    ['@babel/plugin-transform-runtime', BABEL_PLUGIN_TRANSFORM_RUNTIME_OPTIONS],
     // // still needed for jest.mock
     forJest && [
       'babel-plugin-module-resolver',


### PR DESCRIPTION
This PR adds more api-side polyfill tests so that I can better gauge the changes in (formerly https://github.com/redwoodjs/redwood/pull/5405, new branch in the works), which upgrades babel, bumps the Node.js target, and changes the polyfill strategy. I only added more api-side tests because 1) I was just trying to do one thing at a time and 2) the web side doesn't pin polyfills the way the api side does. 

More on the second point: the web side uses Babel's preset-env polyfill strategy which takes the target into account. The api side 1) uses the plugin-transform-runtime polyfill strategy which doesn't take the target into account and 2) pins the version of core-js it uses to 3. So the changes I'm making to Redwood's Babel config in (formerly https://github.com/redwoodjs/redwood/pull/5405, new branch in the works) affect the api side way more than the web side.

Most of the time I spent on this was devoted to figuring out which polyfills to test. What I ended up doing was running a [core-js-compat query](https://github.com/zloirock/core-js/blob/master/packages/core-js-compat/README.md) to see which Node.js 12+ features we're currently polyfilling. This is a bit tricky because we've pinned the version of core-js plugin-transform-runtime uses to 3, so the data it has is a little outdated (e.g., it still thinks `Promise.any` is proposal. It landed in Node.js 15). This actually doesn't matter too much because the only thing that could've happened to a proposal is either 1) it's in Node.js now, but not Node.js 12, so it needs to be polyfilled anyway 2) it was dropped. The latter isn't so great cause now we're polyfilling things that will never land in JS. Luckily there's not too many of those, and they're very esoteric (a bunch of methods on `Math`). 

But it turns out we're polyfilling a lot of Stage 1 proposals, so a lot of code that you probably didn't think would work actually does. For example...

```js
// You'll get a linting error, but you technically can use this as if it was a native JS object

new Observable(observer => {
  observer.next('hello');
  observer.next('world');
  observer.complete();
}).subscribe({
  next(it) { console.log(it); },
  complete() { console.log('!'); }
})
```

Is this a good idea? I'd say no. Babel stopped aggressively transforming Stage 0, 1, and 2 syntax proposals in v7 (I think). But the point of this PR is we had no idea really, and now it's explicit.
