### PR TITLE
fix(ts): Finally fix "distributivity" issue when using prisma findUnique

### DIFF
--- a/docs/docs/typescript/strict-mode.md
+++ b/docs/docs/typescript/strict-mode.md
@@ -67,21 +67,6 @@ We realize that this isn't a perfect solution, but the tension comes from the fa
 
 :::
 
-### Returning Prisma's `findUnique` operation in Services
-
-In strict mode, TypeScript becomes a lot more pedantic about null checks. One place where you'll encounter this in particular is when returning Prisma's `findUnique` operation in Service functions.
-
-The tension here is that Prisma returns promises in the form of `Promise<Model | null>`, but the resolver types expect it in the form of `Promise<Model> | Promise<null>`. At runtime, this has no effect. But the TS compiler needs to be told that it's okay:
-
-```ts
-export const post: QueryResolvers['post'] = ({ id }) => {
-  return db.post.findUnique({
-    where: { id },
-    // highlight-next-line
-  }) as Promise<Post> | Promise<null>
-}
-```
-
 ### `null` and `undefined` in Services
 
 One of the challenges in the GraphQL-Prisma world is the difference in the way they treats optionals:

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -188,14 +188,14 @@ export const getResolverFnType = () => {
     return `(
       args: TArgs,
       obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-    ) => TResult extends PromiseLike<infer TResultAwaited>
+    ) => [TResult] extends [PromiseLike<infer TResultAwaited>]
       ? Promise<Partial<TResultAwaited>>
       : Promise<Partial<TResult>> | Partial<TResult>;`
   } else {
     return `(
       args?: TArgs,
       obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-    ) => TResult extends PromiseLike<infer TResultAwaited>
+    ) => [TResult] extends [PromiseLike<infer TResultAwaited>]
       ? Promise<Partial<TResultAwaited>>
       : Promise<Partial<TResult>> | Partial<TResult>;`
   }


### PR DESCRIPTION
Finally fixes the long running issue we've had with Prisma's types vs graphql-codegen types, when using `findUnique`.

### What is the fix? 
Adds 4 special characters to make sure `QueryResolvers` and `MutationResolvers` return:
- `Promise<TResult | null>` ✅
-  ⚠️ and not Promise<TResult> | Promise<null>

This happened when we try to "unwrap" the types in `ResolverFn` so that we could wrap it in a Partial (see https://github.com/dotansimha/graphql-code-generator/issues/8050). 

But the way TS handles conditional types with generics is:

> When conditional types act on a generic type, they become distributive when given a union type.
>    ...
 >   Typically, distributivity is the desired behavior. To avoid that behavior, you can surround each side of the extends keyword with square brackets.

[TypeScript handbook](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types)

