### PR TITLE
Update routing-params.md

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -798,7 +798,7 @@ export const Failure = ({ error }: CellFailureProps) => (
 
 export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => (
   // highlight-next-line
-  <Article article={article} />
+  return <Article article={article} />
 )
 ```
 


### PR DESCRIPTION
Missing `return` before `<Article article={article} />` at line 801.