### PR TITLE
Lint generated files

### DIFF
--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -45,4 +45,10 @@ export const yargsDefaults = {
     description: 'Generate TypeScript files',
     type: 'boolean',
   },
+  lint: {
+    alias: 'l',
+    default: true,
+    description: 'Lint generated files',
+    type: 'boolean',
+  },
 }

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -158,7 +158,7 @@ export const handler = async (args) => {
         title: 'Linting ...',
         task: (_ctx, task) => {
           if (args.lint) {
-            return lintFilesTask(files({ ...args, type: directiveType })) // passing directiveType to prevent files() error
+            return lintFilesTask(files({ ...args, type: directiveType })) // We pass directiveType to prevent files() error
           } else {
             task.skip('Skipping lint.')
           }

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -7,7 +7,12 @@ import prompts from 'prompts'
 
 import { getConfig } from '@redwoodjs/internal/dist/config'
 
-import { getPaths, writeFilesTask, transformTSToJS } from '../../../lib'
+import {
+  getPaths,
+  writeFilesTask,
+  transformTSToJS,
+  lintFilesTask,
+} from '../../../lib'
 import c from '../../../lib/colors'
 import { yargsDefaults } from '../../generate'
 import {
@@ -147,6 +152,16 @@ export const handler = async (args) => {
           return writeFilesTask(files({ ...args, type: directiveType }), {
             overwriteExisting: args.force,
           })
+        },
+      },
+      {
+        title: 'Linting ...',
+        task: (_ctx, task) => {
+          if (args.lint) {
+            return lintFilesTask(files({ ...args }))
+          } else {
+            task.skip('Skipping lint.')
+          }
         },
       },
       {

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -158,7 +158,7 @@ export const handler = async (args) => {
         title: 'Linting ...',
         task: (_ctx, task) => {
           if (args.lint) {
-            return lintFilesTask(files({ ...args }))
+            return lintFilesTask(files({ ...args, type: directiveType })) // passing directiveType to prevent files() error
           } else {
             task.skip('Skipping lint.')
           }

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -428,7 +428,7 @@ export const addScaffoldImport = () => {
   return 'Added scaffold import to App.{js,tsx}'
 }
 
-const removeEmtpySet = (routesContent, layout) => {
+const removeEmptySet = (routesContent, layout) => {
   const setWithLayoutReg = new RegExp(
     `\\s*<Set[^>]*wrap={${layout}}[^<]*>([^<]*)<\/Set>`
   )
@@ -458,7 +458,7 @@ export const removeRoutesFromRouterTask = (routes, layout) => {
   }, routesContent)
 
   const routesWithoutEmptySet = layout
-    ? removeEmtpySet(newRoutesContent, layout)
+    ? removeEmptySet(newRoutesContent, layout)
     : newRoutesContent
 
   writeFile(redwoodPaths.web.routes, routesWithoutEmptySet, {

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -266,7 +266,6 @@ export const transformTSToJS = (filename, content) => {
  *
  * @param files - {[filepath]: contents}
  */
-// TODO Add lint here, if not false
 export const writeFilesTask = (files, options) => {
   const { base } = getPaths()
   return new Listr(
@@ -304,7 +303,7 @@ export const deleteFilesTask = (files) => {
 }
 
 /**
- * Creates a list of tasks that write files to the disk.
+ * Creates a list of files to lint after creation.
  *
  * @param files - {[filepath]: contents}
  */
@@ -315,6 +314,7 @@ export const lintFilesTask = (files, options) => {
       const contents = files[file]
       return {
         title: `...waiting to lint file \`./${path.relative(base, file)}\`...`,
+        // TODO: Is it necessary to have (ctx, task)?
         task: (ctx, task) => lintFile(file, contents, options, task),
       }
     })

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -147,10 +147,8 @@ export const lintFile = (target, contents, task = {}) => {
   const { base } = getPaths()
   task.title = `Linting \`./${path.relative(base, target)}\``
 
-  const filename = path.basename(target)
-  const targetDir = target.replace(filename, '')
-  fs.mkdirSync(targetDir, { recursive: true })
-  fs.writeFileSync(target, contents)
+  // const filename = path.basename(target)
+  // const targetDir = target.replace(filename, '')
   execa('yarn rw lint --fix --path ', [`./${path.relative(base, target)}`], {
     stdio: 'pipe',
     shell: true,
@@ -310,7 +308,6 @@ export const deleteFilesTask = (files) => {
  *
  * @param files - {[filepath]: contents}
  */
-// TODO Add lint here, if not false
 export const lintFilesTask = (files, options) => {
   const { base } = getPaths()
   return new Listr(


### PR DESCRIPTION
For [[Generators] generated code should be linted and formatted #1551](https://github.com/redwoodjs/redwood/issues/1551)
and perhaps [[Bug]: Scaffold generator creates a big block of whitespace in Form component #6097](https://github.com/redwoodjs/redwood/issues/6097)
and touches this: [Generated Content has Lint Issues #4824](https://github.com/redwoodjs/redwood/issues/4824)

✅ What it does

Adds args -l --lint : "Lint Generated Files" : default: true to generator cli
Runs lint --fix on generated files.

Currently only works on "Directives."

I wanted to get the PR started to see if this was the route to go with this. Beyond the technical implementation, there is this nagging question surfaced in the issues linked above, which is summed up by @thedavidprice:

> However, it's probably not as easy as globally running lint --fix:
>
> we should consider whether or not it's OK to fix any/all pre-existing issues
> there are many cases where generator boilerplate has unused vars
> ... ?

**Approach:**
I copied the writeFilesTask and made lintFilesTask, which calls lintFile (which is a copy of writeFile).

This is exported and called as a task in the Directives generator file.

🔮 What needs to be verified

Is this the approach to take?
I feel like it is still linting even after it says it is done. I do not know how to check to see if this is the case.
Is there a better way to call or abstract the writeFilesTask/lintFilesTask. 
Confirm if we want to run lint files after every generator.


🚧 What is left to do

Add linting task to other appropriate generator files
Add testing?

👏 Credits
> If you’re looking for an example of “what makes a good PR”, look no further than this one by Kim-Adeline:
>
> [Convert component generator to TS #632](https://github.com/redwoodjs/redwood/pull/632)