### PR TITLE
fix(ts): Avoid using partial resolver return types in codegen

### DIFF
--- a/docs/docs/typescript/strict-mode.md
+++ b/docs/docs/typescript/strict-mode.md
@@ -67,21 +67,6 @@ We realize that this isn't a perfect solution, but the tension comes from the fa
 
 :::
 
-### Returning Prisma's `findUnique` operation in Services
-
-In strict mode, TypeScript becomes a lot more pedantic about null checks. One place where you'll encounter this in particular is when returning Prisma's `findUnique` operation in Service functions.
-
-The tension here is that Prisma returns promises in the form of `Promise<Model | null>`, but the resolver types expect it in the form of `Promise<Model> | Promise<null>`. At runtime, this has no effect. But the TS compiler needs to be told that it's okay:
-
-```ts
-export const post: QueryResolvers['post'] = ({ id }) => {
-  return db.post.findUnique({
-    where: { id },
-    // highlight-next-line
-  }) as Promise<Post> | Promise<null>
-}
-```
-
 ### `null` and `undefined` in Services
 
 One of the challenges in the GraphQL-Prisma world is the difference in the way they treats optionals:

--- a/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
@@ -12,9 +12,7 @@ export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Mayb
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
       args?: TArgs,
       obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-    ) => TResult extends PromiseLike<infer TResultAwaited>
-      ? Promise<Partial<TResultAwaited>>
-      : Promise<Partial<TResult>> | Partial<TResult>;
+    ) => TResult | Promise<TResult>
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/packages/internal/src/__tests__/resolverFn.test.ts
+++ b/packages/internal/src/__tests__/resolverFn.test.ts
@@ -39,9 +39,7 @@ describe('ResovlerFn types', () => {
       "(
             args?: TArgs,
             obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-          ) => TResult extends PromiseLike<infer TResultAwaited>
-            ? Promise<Partial<TResultAwaited>>
-            : Promise<Partial<TResult>> | Partial<TResult>;"
+          ) => TResult | Promise<TResult>"
     `)
   })
 
@@ -60,9 +58,7 @@ describe('ResovlerFn types', () => {
       "(
             args?: TArgs,
             obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-          ) => TResult extends PromiseLike<infer TResultAwaited>
-            ? Promise<Partial<TResultAwaited>>
-            : Promise<Partial<TResult>> | Partial<TResult>;"
+          ) => TResult | Promise<TResult>"
     `)
   })
 
@@ -82,9 +78,7 @@ describe('ResovlerFn types', () => {
       "(
             args: TArgs,
             obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-          ) => TResult extends PromiseLike<infer TResultAwaited>
-            ? Promise<Partial<TResultAwaited>>
-            : Promise<Partial<TResult>> | Partial<TResult>;"
+          ) => TResult | Promise<TResult>"
     `)
   })
 })

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -188,16 +188,12 @@ export const getResolverFnType = () => {
     return `(
       args: TArgs,
       obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-    ) => TResult extends PromiseLike<infer TResultAwaited>
-      ? Promise<Partial<TResultAwaited>>
-      : Promise<Partial<TResult>> | Partial<TResult>;`
+    ) => TResult | Promise<TResult>`
   } else {
     return `(
       args?: TArgs,
       obj?: { root: TParent; context: TContext; info: GraphQLResolveInfo }
-    ) => TResult extends PromiseLike<infer TResultAwaited>
-      ? Promise<Partial<TResultAwaited>>
-      : Promise<Partial<TResult>> | Partial<TResult>;`
+    ) => TResult | Promise<TResult>`
   }
 }
 


### PR DESCRIPTION
This reverts the change I tried to make to allow resolvers to return partial Prisma models.

My change however would:
a) Make all the resolvers partial - which is definitely not desired behaviour
b) Cause issues in service tests


This returns the behaviour back to how it was - which unfortunately is to require complete prisma models to be returned from resolvers.