### PR TITLE
Tutorial: Use curly braces and `return` in ArticleCell Success

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -796,10 +796,10 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => (
+export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => {
   // highlight-next-line
-  <Article article={article} />
-)
+  return <Article article={article} />
+}
 ```
 
 </TabItem>


### PR DESCRIPTION
Fixes #6205 #6214 

The scaffold generator produces cell components that use curly braces and a return statement. This PR updates the code snippet in the tutorial to match.