### PR TITLE
[Build] Bump Node.js target from 12 to 14

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ const packageJSON = require(path.join(__dirname, 'package.json'))
 
 // RedwoodJS targets Node.js 12.x because this is the default version
 // for Netlify's functions.
-const TARGETS_NODE = '12.16'
+const TARGETS_NODE = '14.20'
 
 // Run `npx browserslist "defaults, not IE 11, not IE_Mob 11"` to see a list
 // of target browsers.

--- a/packages/internal/src/__tests__/build_api.test.ts
+++ b/packages/internal/src/__tests__/build_api.test.ts
@@ -516,7 +516,6 @@ test('core-js polyfill list', () => {
    */
   expect(list).toMatchInlineSnapshot(`
     Array [
-      "es.math.hypot",
       "es.typed-array.set",
       "esnext.aggregate-error",
       "esnext.array.last-index",
@@ -586,7 +585,6 @@ test('core-js polyfill list', () => {
       "esnext.set.union",
       "esnext.string.at",
       "esnext.string.code-points",
-      "esnext.string.match-all",
       "esnext.string.replace-all",
       "esnext.symbol.dispose",
       "esnext.symbol.observable",

--- a/packages/internal/src/build/api.ts
+++ b/packages/internal/src/build/api.ts
@@ -64,7 +64,7 @@ export const transpileApi = (files: string[], options = {}) => {
     absWorkingDir: rwjsPaths.api.base,
     entryPoints: files,
     platform: 'node',
-    target: 'node12', // Netlify defaults NodeJS 12: https://answers.netlify.com/t/aws-lambda-now-supports-node-js-14/31789/3
+    target: 'node14',
     format: 'cjs',
     bundle: false,
     outdir: rwjsPaths.api.dist,

--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -14,7 +14,7 @@ import {
   getCommonPlugins,
 } from './common'
 
-export const TARGETS_NODE = '12.16'
+export const TARGETS_NODE = '14.20'
 // Warning! Use the minor core-js version: "corejs: '3.6'", instead of "corejs: 3",
 // because we want to include the features added in the minor version.
 // https://github.com/zloirock/core-js/blob/master/README.md#babelpreset-env


### PR DESCRIPTION
Getting the bump-the-node-target part of https://github.com/redwoodjs/redwood/pull/6209 in because we're leaning towards taking our time with the polyfills.