### PR TITLE
Show example of hashing password in seed.js

### DIFF
--- a/packages/api/src/functions/dbAuth/__tests__/DbAuthHandler.test.js
+++ b/packages/api/src/functions/dbAuth/__tests__/DbAuthHandler.test.js
@@ -2238,31 +2238,6 @@ describe('dbAuth', () => {
     })
   })
 
-  describe('hashPassword', () => {
-    it('hashes a password with a given salt and returns both', () => {
-      const dbAuth = new DbAuthHandler(event, context, options)
-      const [hash, salt] = dbAuth._hashPassword(
-        'password',
-        '2ef27f4073c603ba8b7807c6de6d6a89'
-      )
-
-      expect(hash).toEqual(
-        '0c2b24e20ee76a887eac1415cc2c175ff961e7a0f057cead74789c43399dd5ba'
-      )
-      expect(salt).toEqual('2ef27f4073c603ba8b7807c6de6d6a89')
-    })
-
-    it('hashes a password with a generated salt if none provided', () => {
-      const dbAuth = new DbAuthHandler(event, context, options)
-      const [hash, salt] = dbAuth._hashPassword('password')
-
-      expect(hash).toMatch(/^[a-f0-9]+$/)
-      expect(hash.length).toEqual(64)
-      expect(salt).toMatch(/^[a-f0-9]+$/)
-      expect(salt.length).toEqual(32)
-    })
-  })
-
   describe('getAuthMethod', () => {
     it('gets methodName out of the query string', () => {
       event = {

--- a/packages/api/src/functions/dbAuth/__tests__/shared.test.js
+++ b/packages/api/src/functions/dbAuth/__tests__/shared.test.js
@@ -3,6 +3,7 @@ import CryptoJS from 'crypto-js'
 import * as error from '../errors'
 import {
   getSession,
+  hashPassword,
   decryptSession,
   dbAuthSession,
   webAuthnSession,
@@ -95,5 +96,28 @@ describe('webAuthnSession', () => {
     })
 
     expect(output).toEqual('zyxw9876')
+  })
+})
+
+describe('hashPassword', () => {
+  it('hashes a password with a given salt and returns both', () => {
+    const [hash, salt] = hashPassword(
+      'password',
+      '2ef27f4073c603ba8b7807c6de6d6a89'
+    )
+
+    expect(hash).toEqual(
+      '0c2b24e20ee76a887eac1415cc2c175ff961e7a0f057cead74789c43399dd5ba'
+    )
+    expect(salt).toEqual('2ef27f4073c603ba8b7807c6de6d6a89')
+  })
+
+  it('hashes a password with a generated salt if none provided', () => {
+    const [hash, salt] = hashPassword('password')
+
+    expect(hash).toMatch(/^[a-f0-9]+$/)
+    expect(hash.length).toEqual(64)
+    expect(salt).toMatch(/^[a-f0-9]+$/)
+    expect(salt.length).toEqual(32)
   })
 })

--- a/packages/api/src/functions/dbAuth/shared.ts
+++ b/packages/api/src/functions/dbAuth/shared.ts
@@ -87,3 +87,14 @@ export const webAuthnSession = (event: APIGatewayProxyEvent) => {
 
   return webAuthnCookie.split('=')[1].trim()
 }
+
+// hashes a password using either the given `salt` argument, or creates a new
+// salt and hashes using that. Either way, returns an array with [hash, salt]
+export const hashPassword = (text: string, salt?: string) => {
+  const useSalt = salt || CryptoJS.lib.WordArray.random(128 / 8).toString()
+
+  return [
+    CryptoJS.PBKDF2(text, useSalt, { keySize: 256 / 32 }).toString(),
+    useSalt,
+  ]
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,7 +1,7 @@
 export * from './auth'
 export * from './errors'
 export * from './functions/dbAuth/DbAuthHandler'
-export { dbAuthSession } from './functions/dbAuth/shared'
+export { dbAuthSession, hashPassword } from './functions/dbAuth/shared'
 export * from './validations/validations'
 export * from './validations/errors'
 

--- a/packages/create-redwood-app/template/scripts/seed.ts
+++ b/packages/create-redwood-app/template/scripts/seed.ts
@@ -33,6 +33,30 @@ export default async () => {
         console.log(record)
       })
     )
+
+    // If using dbAuth and seeding users, you'll need to add a `hashedPassword`
+    // and associated `salt` to their record. Here's how to create them using
+    // the same algorithm that dbAuth uses internally:
+    //
+    //   import { hashPassword } from '@redwoodjs/api'
+    //
+    //   const users = [
+    //     { name: 'john', email: 'john@example.com', password: 'secret1' },
+    //     { name: 'jane', email: 'jane@example.com', password: 'secret2' }
+    //   ]
+    //
+    //   for (user of users) {
+    //     const [hashedPassword, salt] = hashPassword(user.password)
+    //     await db.user.create({
+    //       data: {
+    //         name: user.name,
+    //         email: user.email,
+    //         hashedPassword,
+    //         salt
+    //       }
+    //     })
+    //   }
+
   } catch (error) {
     console.warn('Please define your seed data.')
     console.error(error)


### PR DESCRIPTION
Required a slight refactor to move the function that hashes passwords into a shared location, similar to `dbAuthSession()` for those that want to extract and read the cookie on the server side.

Closes #6231