### PR TITLE
[Fix] Swap `testURL` for `testEnvironmentOptions.url` in Jest web preset

### DIFF
--- a/packages/testing/config/jest/web/jest-preset.js
+++ b/packages/testing/config/jest/web/jest-preset.js
@@ -11,7 +11,9 @@ module.exports = {
   rootDir: rwjsPaths.base,
   roots: [path.join(rwjsPaths.web.src)],
   testEnvironment: path.join(__dirname, './RedwoodWebJestEnv.js'),
-  testURL: 'https://redwoodjs.com',
+  testEnvironmentOptions: {
+    url: 'https://redwoodjs.com',
+ },
   displayName: {
     color: 'blueBright',
     name: 'web',


### PR DESCRIPTION
Follow up to the [v2.2.2](https://github.com/redwoodjs/redwood/releases/tag/v2.2.2) patch; jest 28 changes this option to `testEnvironmentOptions.url`. See https://jestjs.io/docs/upgrading-to-jest28#testurl.