### PR TITLE
[Fix]: Change `type` to `interface` in page generator

### DIFF
--- a/packages/cli/src/commands/generate/layout/templates/layout.tsx.template
+++ b/packages/cli/src/commands/generate/layout/templates/layout.tsx.template
@@ -1,4 +1,4 @@
-type ${singularPascalName}LayoutProps = {
+interface ${singularPascalName}LayoutProps {
   children?: React.ReactNode
 }
 

--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
@@ -377,7 +377,7 @@ exports[`generates typescript pages 4`] = `
 "import { Link, routes } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 
-type TsParamFilesPageProps = {
+interface TsParamFilesPageProps {
   id: string
 }
 
@@ -407,7 +407,7 @@ exports[`generates typescript pages 5`] = `
 "import { Link, routes } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 
-type TsParamTypeFilesPageProps = {
+interface TsParamTypeFilesPageProps {
   id: number
 }
 

--- a/packages/cli/src/commands/generate/page/templates/page.tsx.template
+++ b/packages/cli/src/commands/generate/page/templates/page.tsx.template
@@ -1,7 +1,7 @@
 import { Link, routes } from '@redwoodjs/router'
 import { MetaTags } from '@redwoodjs/web'
 <% if (paramName !== '') { %>
-type ${pascalName}PageProps = {
+interface ${pascalName}PageProps {
   ${paramName}: ${paramType}
 }
 <% } %>


### PR DESCRIPTION
Rereading https://github.com/redwoodjs/redwood/issues/5833 reminded that we prefer `interface` to `type` for React component props, so even if we haven't implemented that RFC, maybe we should stop generating the page template with `type` (if it has a route parameter)?