### PR TITLE
Better understanding where's command "create post"

### DIFF
--- a/docs/docs/tutorial/chapter2/getting-dynamic.md
+++ b/docs/docs/tutorial/chapter2/getting-dynamic.md
@@ -77,6 +77,10 @@ From now on we'll use the shorter `rw` alias instead of the full `redwood` argum
 
 You'll be prompted to give this migration a name. Something that describes what it does is ideal, so how about "create post" (without the quotes, of course). This is for your own benefit—neither Redwood nor Prisma care about the migration's name, it's just a reference when looking through old migrations and trying to find when you created or modified something specific.
 
+```bash
+create post
+```
+
 After the command completes you'll see a new subdirectory created under `api/db/migrations` that has a timestamp and the name you gave the migration. It will contain a single file named `migration.sql` that contains the SQL necessary to bring the database structure up-to-date with whatever `schema.prisma` looked like at the time the migration was created. So, you always have a single `schema.prisma` file that describes what the database structure should look like right *now* and the migrations trace the history of the changes that took place to get to the current state. It's kind of like version control for your database structure, which can be pretty handy.
 
 In addition to creating the migration file, the above command will also execute the SQL against the database, which "applies" the migration. The final result is a new database table called `Post` with the fields we defined above.


### PR DESCRIPTION
I was following the tutorial now with the new updates 4 days ago, a couple of friends of mine at class, got crazy finding "create post" command, from video: minute 2:15,
So we decided to put it on the guide as a command, for future devs, to encounter this easier to understand and do not jump one step of the commands.
Great work Redwood! Amazing!

The Idea contributing at the project as a contributor improving the guide, is that with this improvement, make anyone understand it better, where the command is a command, must be visible like others.

```
create post
```

Better understanding where's command "create post"