### PR TITLE
Fix: Fixes an error seen with the Configure Fastify codemod for v3-rc

### DIFF
--- a/packages/codemods/src/codemods/v2.x.x/configureFastify/configureFastify.yargs.ts
+++ b/packages/codemods/src/codemods/v2.x.x/configureFastify/configureFastify.yargs.ts
@@ -6,16 +6,14 @@ import getRWPaths from '../../../lib/getRWPaths'
 import runTransform from '../../../lib/runTransform'
 
 export const command = 'configure-fastify'
-export const description = '(v2.x.x->v2.x.x) Converts world to bazinga'
+export const description =
+  '(v2.x.x->v2.x.x) Updates api side’s server.config.js to configure Fastify'
 
 export const handler = () => {
   task('Configure Fastify', async ({ setOutput }: task.TaskInnerApi) => {
     await runTransform({
       transformPath: path.join(__dirname, 'configureFastify.js'),
-      // Here we know exactly which file we need to transform, but often times you won't.
-      // If you need to transform files based on their name, location, etc, use `fast-glob`.
-      // If you need to transform files based on their contents, use `getFilesWithPattern`.
-      targetPaths: [path.join(getRWPaths().base, 'redwood.toml')],
+      targetPaths: [__dirname],
     })
 
     setOutput('All done! Run `yarn rw lint --fix` to prettify your code')

--- a/packages/codemods/src/codemods/v2.x.x/configureFastify/configureFastify.yargs.ts
+++ b/packages/codemods/src/codemods/v2.x.x/configureFastify/configureFastify.yargs.ts
@@ -1,8 +1,11 @@
+import fs from 'fs'
 import path from 'path'
 
+import fg from 'fast-glob'
 import task from 'tasuku'
 
 import getRWPaths from '../../../lib/getRWPaths'
+import prettify from '../../../lib/prettify'
 import runTransform from '../../../lib/runTransform'
 
 export const command = 'configure-fastify'
@@ -11,10 +14,27 @@ export const description =
 
 export const handler = () => {
   task('Configure Fastify', async ({ setOutput }: task.TaskInnerApi) => {
+    const [API_SERVER_CONFIG_PATH] = fg.sync('server.config.{js,ts}', {
+      cwd: getRWPaths().api.base,
+      absolute: true,
+    })
+
     await runTransform({
       transformPath: path.join(__dirname, 'configureFastify.js'),
-      targetPaths: [__dirname],
+      targetPaths: [API_SERVER_CONFIG_PATH],
     })
+
+    // The transform generates two extra semicolons for some reason:
+    //
+    // ```js
+    // module.exports = { config };;
+    // ```
+    //
+    // They don't show up in tets cause we run prettier. Let's do the same here.
+    fs.writeFileSync(
+      API_SERVER_CONFIG_PATH,
+      prettify(fs.readFileSync(API_SERVER_CONFIG_PATH, 'utf-8'))
+    )
 
     setOutput('All done! Run `yarn rw lint --fix` to prettify your code')
   })


### PR DESCRIPTION
When running

```npx @redwoodjs/codemods@canary configure-fastify```
         
```Processing 1 files... 
Spawning 1 workers...
Sending 1 files to free worker...
⠸ Configure Fastify
 ERR /Users/xxx/redwood.toml Transformation error (Topic reference is used, but the pipelineOperator plugin was not passed a "proposal": "hack" or "smart" option. (1:0))
SyntaxError: Topic reference is used, but the pipelineOperator plugin was not passed a "proposal": "hack" or "smart" option. (1:0)
    at instantiate (/Users/xxx/.npm/_npx/6af5e84efc8d7cdf/node_modules/@babel/parser/lib/index.js:72:32)
    at constructor (/Users/xxx/.npm/_npx/6af5e84efc8d7cdf/node_modules/@babel/parser/lib/index.js:366:12)
    at TypeScriptParserMixin.raise (/Users/xxx/.npm/_npx/6af5e84efc8d7cdf/node_modules/@babel/parser/lib/index.js:3453:19)
    at TypeScriptParserMixin.testTopicReferenceConfiguration (/Users/xxx/.npm/_npx/6af5e84efc8d7cdf/node_modules/@babel/parser/lib/index.js:13322:20)
```

This was likely due to the codemod trying to use the tool file as a target -- and the tool file has comments `#` that were being treated as a pipeline operator topic token (perhaps?).

This fix removes the tool from the target.