### PR TITLE
Adds `privateKeyPath` option to Baremetal deploy

### DIFF
--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -158,7 +158,8 @@ This lists a single server, in the `production` environment, providing the hostn
 * `host` - hostname to the server
 * `username` - the user to login as
 * `password` - [optional] if you are using password authentication, include that here
-* `privateKey` - [optional] if you connect with a private key, include the path to the key here
+* `privateKey` - [optional] if you connect with a private key, include the content of the key here, as a buffer: `privateKey: Buffer.from('...')`. Use this *or* `privateKeyPath`, not both.
+* `privateKeyPath` - [optional] if you connect with a private key, include the path to the key here: `privateKeyPath: path.join('path','to','key.pem')` Use this *or* `privateKey`, not both.
 * `passphrase` - [optional] if your private key contains a passphrase, enter it here
 * `agentForward` - [optional] if you have [agent forwarding](https://docs.github.com/en/developers/overview/using-ssh-agent-forwarding) enabled, set this to `true` and your own credentials will be used for further SSH connections from the server (like when connecting to GitHub)
 * `sides` - An array of sides that will be built on this server

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -637,6 +637,7 @@ export const commands = (yargs, ssh) => {
           username: serverConfig.username,
           password: serverConfig.password,
           privateKey: serverConfig.privateKey,
+          privateKeyPath: serverConfig.privateKeyPath,
           passphrase: serverConfig.passphrase,
           agent: serverConfig.agentForward && process.env.SSH_AUTH_SOCK,
           agentForward: serverConfig.agentForward,

--- a/packages/cli/src/commands/setup/deploy/templates/baremetal.js
+++ b/packages/cli/src/commands/setup/deploy/templates/baremetal.js
@@ -21,7 +21,8 @@ export const DEPLOY = `# This file contains config for a baremetal deployment
 # * port - defaults to 22
 # * username - required, the user you're connecting as
 # * password - only set if you're not using key-based authentication
-# * privateKey - local file path to a private key that will be sent with the connection request
+# * privateKey - a Buffer containing the private key (use this _or_ \'privateKeyPath\', not both)
+# * privateKeyPath - local file path to a private key that will be sent with the connection request
 # * passphrase - used if your private key has a passphrase
 # * agentForward - set to \`true\` to forward the client machine's ssh credentials
 #


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/6363

## Release Notes

If you're using Baremetal deploy, we've got an easier way to specify your private key. Previously, if you wanted to connect the [private key option](https://redwoodjs.com/docs/intro-to-servers#private-key), you needed to include the actual content of the private key itself as a `Buffer` in the `privateKey` config option. That option still remains, but we now also include a `privateKeyPath` option if you just want to include the path to the key:

```diff
  [[production.servers]]
  host = "server.com"
  username = "user"
+ privateKeyPath = "/Users/rob/.ssh/private.pem"
  sides = ["api","web"]
  path = "/var/www/app"
  processNames = ["serve"]
  repo = "git@github.com:myorg/myapp.git"
  branch = "main"
  keepReleases = 5
```