### PR TITLE
[Chore] Add cherry pick CI

### DIFF
--- a/.github/actions/only_doc_changes/only_doc_changes.mjs
+++ b/.github/actions/only_doc_changes/only_doc_changes.mjs
@@ -1,9 +1,11 @@
 import { exec, getExecOutput } from '@actions/exec'
 import core from '@actions/core'
 
-await exec('git fetch origin main')
+const branch = process.env.GITHUB_BASE_REF
 
-const { stdout } = await getExecOutput('git diff origin/main --name-only')
+await exec(`git fetch origin ${branch}`)
+
+const { stdout } = await getExecOutput(`git diff origin/${branch} --name-only`)
 
 const changedFiles = stdout.toString().trim().split('\n').filter(Boolean)
 

--- a/.github/workflows/cherry-pick-into-release-pr.yml
+++ b/.github/workflows/cherry-pick-into-release-pr.yml
@@ -1,0 +1,29 @@
+# When a PR is merged into the main branch, this workflow opens a PR against the release branch
+# with the squashed commit that went into main.
+
+name: 🍒 Cherry pick into release PR
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  cherry-pick-into-release-pr:
+    name: 🍒 Cherry pick into release PR
+    runs-on: ubuntu-latest
+    # Don't cherry pick things that are breaking.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:feature-breaking') }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cherry pick into release PR
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.2
+        with:
+          # We specify a token because we want other workflows (like CI) to run on this PR.
+          # If we omit this, it uses the default token (GITHUB_TOKEN) which doesn't trigger other workflows.
+          token: ${{ secrets.JTOAR_TOKEN }}
+          branch: release
+          labels: cherry-pick

--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -1,0 +1,20 @@
+name: 🤖 Enable auto merge
+
+on:
+  pull_request_target:
+    branches: [release]
+    # We're using labeled here because we don't want to enable auto merge for every PR against release.
+    # Just the ones created by the cherry pick action.
+    types: [labeled]
+
+jobs:
+  enable-auto-merge:
+    name: 🤖 Auto merge release PR
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'cherry-pick')
+    steps:
+      - name: Enable auto-merge
+        uses: reitermarkus/automerge@v2.1.2
+        with:
+          token: ${{ secrets.JTOAR_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
This PR adds two new workflows that 1) create PRs against the release branch when a PR is merged to the main branch (as long as the PR isn't breaking) and 2) enables auto-merge on said PRs. I've tested these workflows on my fork of Redwood, but they may still need some work.

We're trying out a new branch strategy so that we can merge breaking changes into main while still releasing minors and patches. I won't go into all the details right now, but this is one of the first things we need.