### PR TITLE
chore(react): use `updater` callback function

### DIFF
--- a/packages/auth/src/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider.tsx
@@ -264,12 +264,14 @@ export class AuthProvider extends React.Component<
           ? null
           : await this.getCurrentUser()
 
-        this.setState({
-          ...this.state,
-          userMetadata,
-          currentUser,
-          isAuthenticated: true,
-          loading: false,
+        this.setState((prevState) => {
+          return {
+            ...prevState,
+            userMetadata,
+            currentUser,
+            isAuthenticated: true,
+            loading: false,
+          }
         })
       }
     } catch (e: any) {

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -87,11 +87,17 @@ const mockUseAuth =
       useState(isAuthenticated)
 
     useEffect(() => {
+      let timer: NodeJS.Timeout | undefined
       if (loadingTimeMs) {
-        setTimeout(() => {
+        timer = setTimeout(() => {
           setAuthLoading(false)
           setAuthIsAuthenticated(true)
         }, loadingTimeMs)
+      }
+      return () => {
+        if (timer) {
+          clearTimeout(timer)
+        }
       }
     }, [])
 
@@ -763,7 +769,8 @@ test('can display a loading screen with a hook', async () => {
     const [showStill, setShowStill] = useState(false)
 
     useEffect(() => {
-      setTimeout(() => setShowStill(true), 100)
+      const timer = setTimeout(() => setShowStill(true), 100)
+      return () => clearTimeout(timer)
     }, [])
 
     return <>{showStill ? 'Still authenticating...' : 'Authenticating...'}</>


### PR DESCRIPTION
callback takes the previous state as the first argument.

> setState() does not always immediately update the component. It may batch or defer the update until later. This makes reading this.state right after calling setState() a potential pitfall. Instead, use componentDidUpdate or a setState callback (setState(updater, callback)), either of which are guaranteed to fire after the update has been applied. If you need to set the state based on the previous state, read about the updater argument below.

see:
- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md
- https://reactjs.org/docs/react-component.html#setstate

Closes #5627 