### PR TITLE
fix: unable to set multiple cookie

### DIFF
--- a/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
+++ b/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
@@ -4,6 +4,7 @@ import type {
   Handler,
 } from 'aws-lambda'
 import type { FastifyRequest, FastifyReply } from 'fastify'
+import omit from 'lodash/omit'
 import qs from 'qs'
 
 import { mergeMultiValueHeaders, parseBody } from './utils'
@@ -32,13 +33,33 @@ const fastifyResponseForLambdaResult = (
 ) => {
   const {
     statusCode = 200,
-    headers,
+    headers = {},
     body = '',
-    multiValueHeaders,
+    multiValueHeaders = {},
   } = lambdaResult
   const h = mergeMultiValueHeaders(headers, multiValueHeaders)
-  reply.headers(h)
+  const headersWithoutCookie = omit(h, 'set-cookie')
+  reply.headers(headersWithoutCookie)
   reply.status(statusCode)
+
+  console.log(mergeMultiValueHeaders, headers)
+
+  Object.keys(multiValueHeaders).forEach((key) => {
+    const isSetCookie = key.toLowerCase() === 'set-cookie'
+    const isArrayCookie = Array.isArray(multiValueHeaders[key])
+    if (isArrayCookie && isSetCookie) {
+      multiValueHeaders[key].forEach((cookieHeader) => {
+        reply.header('set-cookie', cookieHeader)
+      })
+    }
+  })
+
+  Object.keys(headers).forEach((key) => {
+    const isSetCookie = key.toLowerCase() === 'set-cookie'
+    if (isSetCookie) {
+      reply.header('set-cookie', headers[key])
+    }
+  })
 
   if (lambdaResult.isBase64Encoded) {
     // Correctly handle base 64 encoded binary data. See


### PR DESCRIPTION
Currently in redwoodjs. When we send `multiValueHeaders` containing multiple `set-cookie`. It's merged by redwood into one `set-cookie`. 
While browser actually expect multiple `set-cookie` (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)

With this condition. Everythings that rely on multiple `set-cookie` is broken.

some codes in this file might be helpful https://github.com/fastify/aws-lambda-fastify/blob/master/index.js