### PR TITLE
fix: Added default port ssh port 22 and forwarding of config port setting

### DIFF
--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -156,6 +156,7 @@ This lists a single server, in the `production` environment, providing the hostn
 #### Config Options
 
 * `host` - hostname to the server
+* `port` - [optional] ssh port for server connection, defaults to 22
 * `username` - the user to login as
 * `password` - [optional] if you are using password authentication, include that here
 * `privateKey` - [optional] if you connect with a private key, include the content of the key here, as a buffer: `privateKey: Buffer.from('...')`. Use this *or* `privateKeyPath`, not both.

--- a/docs/docs/deploy/baremetal.md
+++ b/docs/docs/deploy/baremetal.md
@@ -268,7 +268,7 @@ sudo mkdir -p /var/www/myapp
 sudo chown deploy:deploy /var/www/myapp
 ```
 
-You'll want to create an `.env` file in this directory containing any environment variables that are needed by your by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
+You'll want to create an `.env` file in this directory containing any environment variables that are needed by your app (like `DATABASE_URL` at a minimum). This will be symlinked to each release directory so that it's available as the app expects (in the root directory of the codebase).
 
 :::caution SSH and Non-interactive Sessions
 

--- a/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
@@ -131,6 +131,7 @@ describe('serverConfigWithDefaults', () => {
 
   it('overrides defaults with custom', () => {
     const serverConfig = {
+      port: 12345,
       branch: 'venus',
       packageManagerCommand: 'npm',
       monitorCommand: 'god',

--- a/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
@@ -142,6 +142,11 @@ describe('serverConfigWithDefaults', () => {
     expect(config).toEqual(serverConfig)
   })
 
+  it('provides default port as 22', () => {
+    const config = baremetal.serverConfigWithDefaults({}, {})
+    expect(config.port).toEqual(22)
+  })
+
   it('provides default branch name', () => {
     const config = baremetal.serverConfigWithDefaults({}, {})
     expect(config.branch).toEqual('main')

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -16,6 +16,7 @@ const SYMLINK_FLAGS = '-nsf'
 const CURRENT_RELEASE_SYMLINK_NAME = 'current'
 const LIFECYCLE_HOOKS = ['before', 'after']
 export const DEFAULT_SERVER_CONFIG = {
+  port: 22,
   branch: 'main',
   packageManagerCommand: 'yarn',
   monitorCommand: 'pm2',
@@ -634,6 +635,7 @@ export const commands = (yargs, ssh) => {
       task: () =>
         ssh.connect({
           host: serverConfig.host,
+          port: serverConfig.port,
           username: serverConfig.username,
           password: serverConfig.password,
           privateKey: serverConfig.privateKey,


### PR DESCRIPTION
Related to #6426.

I have added in the default port option to the default server config `DEFAULT_SERVER_CONFIG` and have ensured the configured port setting is passed through to the node-ssh connection.

This is my first open-source contribution so thanks for your patience with me.