### PR TITLE
Return reply from fastify handler

### DIFF
--- a/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
+++ b/packages/api-server/src/requestHandlers/awsLambdaFastify.ts
@@ -47,6 +47,8 @@ const fastifyResponseForLambdaResult = (
   } else {
     reply.send(body)
   }
+
+  return reply
 }
 
 const fastifyResponseForLambdaError = (


### PR DESCRIPTION
See https://www.fastify.io/docs/latest/Guides/Migration-Guide-V4/#need-to-return-reply-to-signal-a-fork-of-the-promise-chain

This fixes returning a Stream as the body of the response from an api function.