### PR TITLE
fix(crwa): Fixes telemetry issues on CRWA

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
   ignorePatterns: [
     'dist',
     'fixtures',
-    'packages/structure/**',
     'packages/internal/src/build/babelPlugins/__tests__/__fixtures__/**/*',
     'packages/core/**/__fixtures__/**/*',
     'packages/codemods/**/__testfixtures__/**/*',
@@ -34,7 +33,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['packages/structure/**'],
+      files: ['packages/structure/src/**'],
       rules: {
         '@typescript-eslint/no-this-alias': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -84,7 +84,7 @@ The installation script is built with [Yargs](https://github.com/yargs/yargs)
 ### Template Codebase
 The project codebase in `template/` uses [Yarn Workspace v1](https://classic.yarnpkg.com/en/docs/workspaces/) for a monorepo project containing the API and Web Sides. Redwood packages are included in `template/package.json`, `template/web/package.json`, and `template/api/package.json`, respectively.
 
-### How to run create-redwood-app and create a project
+### How to run create-redwood-app from your local repo and create a project
 Make sure you to first run `yarn install` in your project root.
 
 Step into the `create-redwood-app` package and run the script:
@@ -98,6 +98,19 @@ This will create a new project using the local `template/` codebase
 
 > Note: the new project will install with the most recent stable Redwood package version by default
 
+
+### How to run other published versions for debugging
+By default yarn create will pick the latest stable version to run, but you can specify a different version via yarn too!
+
+To try the canary version using yarn, run:
+```
+yarn create redwood-app@canary -p create-redwood-app /path/to/project
+```
+
+Note that this will still create a project with the latest stable version, but run the canary version of create-redwood-app, and is only useful for debugging.
+
+You can specify any tag or version instead of `@canary`
+
 ### Develop using the new project
 There are three options for developing with the installed project:
 
@@ -106,10 +119,5 @@ There are three options for developing with the installed project:
 cd /path/to/new/redwood-app
 yarn rw upgrade -t canary
 ```
-**2. Install packages specific to a PR, for example**
-```bash
-cd /path/to/new/redwood-app
-yarn rw upgrade --pr 1703:0.23.0-b06dd35
-```
-**3. Use the workflow and tools for local package development**
+**2. Use the workflow and tools for local package development**
 - [Local Development Instructions](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#local-development)

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -58,7 +58,8 @@
     "string-env-interpolation": "1.0.1",
     "systeminformation": "5.12.4",
     "terminal-link": "2.1.1",
-    "toml": "3.0.0"
+    "toml": "3.0.0",
+    "typescript": "4.7.4"
   },
   "devDependencies": {
     "@babel/cli": "7.18.10",
@@ -70,8 +71,7 @@
     "@types/rimraf": "3.0.2",
     "babel-plugin-tester": "10.1.0",
     "graphql-tag": "2.12.6",
-    "jest": "29.0.3",
-    "typescript": "4.7.4"
+    "jest": "29.0.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/structure/src/hosts.ts
+++ b/packages/structure/src/hosts.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs-extra'
 import glob from 'glob'
 
-import { Paths, getPaths } from '@redwoodjs/internal'
+import type { Paths } from '@redwoodjs/internal/dist/paths'
+import { getPaths } from '@redwoodjs/internal/dist/paths'
 
 import { lazy } from './x/decorators'
 

--- a/packages/structure/src/index.ts
+++ b/packages/structure/src/index.ts
@@ -1,14 +1,13 @@
+export { DiagnosticSeverity } from 'vscode-languageserver-types'
 export { DefaultHost, Host } from './hosts'
 export { RWProject } from './model'
-import { exit } from 'process'
-import { ThrowStatement } from 'ts-morph'
+export { URL_file } from './x/URL'
 import { DefaultHost } from './hosts'
 import { RWProject } from './model'
 import {
   ExtendedDiagnostic_format,
   GetSeverityLabelFunction,
 } from './x/vscode-languageserver-types'
-export { DiagnosticSeverity } from 'vscode-languageserver-types'
 
 export function getProject(projectRoot: string, host = new DefaultHost()) {
   return new RWProject({
@@ -40,15 +39,13 @@ export async function printDiagnostics(
 
     if (warnings === 0 && errors === 0) {
       console.log('\nSuccess: no errors or warnings were detected\n')
-    }
-    else if (errors > 0) {
-      console.error(`\nFailure: ${errors} errors and ${warnings} warnings detected\n`)
+    } else if (errors > 0) {
+      console.error(
+        `\nFailure: ${errors} errors and ${warnings} warnings detected\n`
+      )
       process.exit(1)
     }
-
   } catch (e: any) {
     throw new Error(e.message)
   }
 }
-
-export { URL_file } from './x/URL'

--- a/packages/structure/src/model/RWProject.ts
+++ b/packages/structure/src/model/RWProject.ts
@@ -1,9 +1,9 @@
 import { join } from 'path'
 
+import type { DMMF } from '@prisma/generator-helper'
 import { getDMMF } from '@prisma/internals'
-import { DMMF } from '@prisma/generator-helper'
 
-import { getPaths, processPagesDir } from '@redwoodjs/internal'
+import { getPaths, processPagesDir } from '@redwoodjs/internal/dist/paths'
 
 import { Host } from '../hosts'
 import { BaseNode } from '../ide'

--- a/packages/structure/src/model/RWRouter.ts
+++ b/packages/structure/src/model/RWRouter.ts
@@ -70,12 +70,10 @@ export class RWRouter extends FileNode {
 
       const sets = self.sf
         .getDescendantsOfKind(tsm.SyntaxKind.JsxElement)
-        .filter(
-          (x) => {
-            const tagName = x.getOpeningElement().getTagNameNode().getText()
-            return tagName  === 'Set' || tagName === 'Private'
-          }
-        )
+        .filter((x) => {
+          const tagName = x.getOpeningElement().getTagNameNode().getText()
+          return tagName === 'Set' || tagName === 'Private'
+        })
 
       const prerenderSets = sets.filter((set) =>
         set.getOpeningElement().getAttribute('prerender')

--- a/packages/structure/src/model/__tests__/model.test.ts
+++ b/packages/structure/src/model/__tests__/model.test.ts
@@ -130,12 +130,19 @@ describe('Redwood Route detection', () => {
     })
     expect(prerenderRoutes).toContainEqual({ name: 'fooPage', path: '/foo' })
     expect(prerenderRoutes).toContainEqual({ name: 'barPage', path: '/bar' })
-    expect(prerenderRoutes).toContainEqual({ name: 'privatePage', path: '/private-page' })
+    expect(prerenderRoutes).toContainEqual({
+      name: 'privatePage',
+      path: '/private-page',
+    })
   })
 })
 
 function getFixtureDir(
-  name: 'example-todo-main-with-errors' | 'example-todo-main' | 'empty-project' | 'test-project'
+  name:
+    | 'example-todo-main-with-errors'
+    | 'example-todo-main'
+    | 'empty-project'
+    | 'test-project'
 ) {
   return resolve(__dirname, `../../../../../__fixtures__/${name}`)
 }

--- a/packages/structure/src/outline/outline.ts
+++ b/packages/structure/src/outline/outline.ts
@@ -103,7 +103,9 @@ function _pages(project: RWProject): TreeItem2 {
     menu: {
       kind: 'group',
       add: Command_cli('rw generate page ...'),
-      doc: Command_open('https://redwoodjs.com/docs/tutorial/chapter1/first-page'),
+      doc: Command_open(
+        'https://redwoodjs.com/docs/tutorial/chapter1/first-page'
+      ),
     },
   }
 }

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -1,3 +1,49 @@
 # Telemetry
 
-https://telemetry.redwoodjs.com
+RedwoodJS collects completely anonymous telemetry data about general usage.
+
+Here is an example JSON packet containing the telemetry data for running yarn rw info:
+
+```json
+{
+    type: 'command',
+    command: 'info',         // actual CLI command that was invoked, including flags
+    ci: false,               // whether or not this is running in a CI environment
+    duration: 2353,          // how long the process took, in milliseconds
+    NODE_ENV: 'development', // the value of NODE_ENV, if set
+    complexity: '4.2.6.3',   // a measure of how complex the app is (route, service, cell and page counts)
+    system: '8.32',          // cpu core count, memory in GB
+    sides: 'web,api',        // sides that are in use
+    shell: 'zsh',
+    nodeVersion: '14.17.1',
+    yarnVersion: '14.17.1',
+    npmVersion: '14.17.1',
+    vsCodeVersion: '1.58.0',
+    redwoodVersion: '0.35.1',
+    os: 'macOS',
+    osVersion: '11.4',
+    system: '8.32'          // number of cpu cores and system memory
+  }
+```
+
+## How do I turn it off?
+
+Set an environment variable, either in your app's .env file, or anywhere that creates variables for your user space, like `.bashrc` or `.bash_profile`:
+
+```terminal
+REDWOOD_DISABLE_TELEMETRY=1
+```
+
+## About
+
+See: https://telemetry.redwoodjs.com
+
+## Troubleshooting
+
+If you suspect problems with telemetry when running CRWA, you set the verbose flag to help diagnose issues.
+
+For example,
+
+```terminal
+REDWOOD_VERBOSE_TELEMETRY=true yarn create-redwood-app bazinga
+```

--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -40,7 +40,7 @@ See: https://telemetry.redwoodjs.com
 
 ## Troubleshooting
 
-If you suspect problems with telemetry when running CRWA, you set the verbose flag to help diagnose issues.
+If you suspect problems with telemetry when running CRWA, you can set the verbose flag to help diagnose issues.
 
 For example,
 

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -26,6 +26,7 @@ interface SensitiveArgPositions {
     redactWith: Array<string>
   }
   prisma: {
+    positions?: never
     options: Array<string>
     redactWith: Array<string>
   }


### PR DESCRIPTION
### Diagnosis of the issue
The telmetry script was failing, because it couldn't find the module typescript. 

You can see this by running with the verbose flag: `REDWOOD_VERBOSE_TELEMETRY=true yarn create-redwood-app bazinga`

### Changes

1. `typescript` is an explicit dependency of `rwjs/internal` . This is because we use it for detecting strict mode. 

What was happening was this import sequence:
crwa -> rwjs/structure -> rwjs/internal -> ts

Why is TS even imported here? Because of the import statement in rwjs/structure project.ts and host.ts: 

```
import { getPaths, processPagesDir } from '@redwoodjs/internal'
```


2. Makes sure structure also imports from specific files in internal i.e.
```diff
-import { getPaths, processPagesDir } from '@redwoodjs/internal'
+import { getPaths, processPagesDir } from '@redwoodjs/internal/dist/paths'
```

3. Enables the eslint rule to prevent direct imports in structure too
(as a result, the formatting, etc. happened too)