### PR TITLE
fix(jest): Fix watchmode on api tests 

### DIFF
--- a/packages/testing/config/jest/api/jest-preset.js
+++ b/packages/testing/config/jest/api/jest-preset.js
@@ -1,203 +1,14 @@
 // @ts-check
-const fs = require('fs')
 const path = require('path')
-
-const { getConfig: getPrismaConfig, getDMMF } = require('@prisma/internals')
 
 const {
   getApiSideDefaultBabelConfig,
-  registerApiSideBabelHook,
 } = require('@redwoodjs/internal/dist/build/babel/api')
 const { getPaths } = require('@redwoodjs/internal/dist/paths')
-const { defineScenario } = require('@redwoodjs/testing/dist/api/scenario')
 
 const rwjsPaths = getPaths()
 const NODE_MODULES_PATH = path.join(rwjsPaths.base, 'node_modules')
 const { babelrc } = getApiSideDefaultBabelConfig()
-
-// We need this to (a) load the user's prisma client in src/lib/db.ts
-// (b) load the scenario files in buildScenario
-registerApiSideBabelHook()
-
-// Error codes thrown by [MySQL, SQLite, Postgres] when foreign key constraint
-// fails on DELETE
-const FOREIGN_KEY_ERRORS = [1451, 1811, 23503]
-const TEARDOWN_CACHE_PATH = path.join(
-  rwjsPaths.generated.base,
-  'scenarioTeardown.json'
-)
-const DEFAULT_SCENARIO = 'standard'
-let teardownOrder = []
-let originalTeardownOrder = []
-
-const deepCopy = (obj) => {
-  return JSON.parse(JSON.stringify(obj))
-}
-
-const isIdenticalArray = (a, b) => {
-  return JSON.stringify(a) === JSON.stringify(b)
-}
-
-const configureTeardown = async () => {
-  // @NOTE prisma utils are available in cli lib/schemaHelpers
-  // But avoid importing them, to prevent memory leaks in jest
-  const schema = await getDMMF({ datamodelPath: rwjsPaths.api.dbSchema })
-  const schemaModels = schema.datamodel.models.map((m) => m.dbName || m.name)
-
-  // check if pre-defined delete order already exists and if so, use it to start
-  if (fs.existsSync(TEARDOWN_CACHE_PATH)) {
-    teardownOrder = JSON.parse(fs.readFileSync(TEARDOWN_CACHE_PATH).toString())
-  }
-
-  // check the number of models in case we've added/removed since cache was built
-  if (teardownOrder.length !== schemaModels.length) {
-    teardownOrder = schemaModels
-  }
-
-  // keep a copy of the original order to compare against
-  originalTeardownOrder = deepCopy(teardownOrder)
-}
-
-// Lazy load the project db
-let projectDb
-const getProjectDb = () => {
-  if (!projectDb) {
-    // So that we can load the user's prisma client
-    // The file itself maybe TS/ES6 - and may have middlewares configured
-    const { db } = require(path.join(rwjsPaths.api.lib, 'db'))
-
-    projectDb = db
-  }
-
-  return projectDb
-}
-
-let quoteStyle
-// determine what kind of quotes are needed around table names in raw SQL
-const getQuoteStyle = async () => {
-  if (!quoteStyle) {
-    const config = await getPrismaConfig({
-      datamodel: fs.readFileSync(rwjsPaths.api.dbSchema).toString(),
-    })
-
-    switch (config.datasources?.[0]?.provider) {
-      case 'mysql':
-        quoteStyle = '`'
-        break
-      default:
-        quoteStyle = '"'
-    }
-  }
-
-  return quoteStyle
-}
-
-// Build scenario is the function that actually loads *.scenario.ts,js files
-// global.defineScenario has to be defined in THIS file because it's the context where the scenario is loaded
-// Functions only used in tests, are defined in the jest.setup.js file
-global.defineScenario = defineScenario
-
-const buildScenario =
-  (it, testPath) =>
-  (...args) => {
-    let scenarioName, testName, testFunc
-
-    if (args.length === 3) {
-      ;[scenarioName, testName, testFunc] = args
-    } else if (args.length === 2) {
-      scenarioName = DEFAULT_SCENARIO
-      ;[testName, testFunc] = args
-    } else {
-      throw new Error('scenario() requires 2 or 3 arguments')
-    }
-
-    return it(testName, async () => {
-      const testFileDir = path.parse(testPath)
-      // e.g. ['comments', 'test'] or ['signup', 'state', 'machine', 'test']
-      const testFileNameParts = testFileDir.name.split('.')
-      const testFilePath = `${testFileDir.dir}/${testFileNameParts
-        .slice(0, testFileNameParts.length - 1)
-        .join('.')}.scenarios`
-      let allScenarios, scenario, result
-
-      try {
-        allScenarios = require(testFilePath)
-      } catch (e) {
-        // ignore error if scenario file not found, otherwise re-throw
-        if (e.code !== 'MODULE_NOT_FOUND') {
-          throw e
-        }
-      }
-
-      if (allScenarios) {
-        if (allScenarios[scenarioName]) {
-          scenario = allScenarios[scenarioName]
-        } else {
-          throw new Error(
-            `UndefinedScenario: There is no scenario named "${scenarioName}" in ${testFilePath}.{js,ts}`
-          )
-        }
-      }
-
-      const scenarioData = await seedScenario(scenario)
-      result = await testFunc(scenarioData)
-
-      return result
-    })
-  }
-
-const teardown = async () => {
-  const quoteStyle = await getQuoteStyle()
-
-  for (const modelName of teardownOrder) {
-    try {
-      await getProjectDb().$executeRawUnsafe(
-        `DELETE FROM ${quoteStyle}${modelName}${quoteStyle}`
-      )
-    } catch (e) {
-      const match = e.message.match(/Code: `(\d+)`/)
-      if (match && FOREIGN_KEY_ERRORS.includes(parseInt(match[1]))) {
-        const index = teardownOrder.indexOf(modelName)
-        teardownOrder[index] = null
-        teardownOrder.push(modelName)
-      } else {
-        throw e
-      }
-    }
-  }
-
-  // remove nulls
-  teardownOrder = teardownOrder.filter((val) => val)
-
-  // if the order of delete changed, write out the cached file again
-  if (!isIdenticalArray(teardownOrder, originalTeardownOrder)) {
-    originalTeardownOrder = deepCopy(teardownOrder)
-    fs.writeFileSync(TEARDOWN_CACHE_PATH, JSON.stringify(teardownOrder))
-  }
-}
-
-const seedScenario = async (scenario) => {
-  if (scenario) {
-    const scenarios = {}
-    for (const [model, namedFixtures] of Object.entries(scenario)) {
-      scenarios[model] = {}
-      for (const [name, createArgs] of Object.entries(namedFixtures)) {
-        if (typeof createArgs === 'function') {
-          scenarios[model][name] = await getProjectDb()[model].create(
-            createArgs(scenarios)
-          )
-        } else {
-          scenarios[model][name] = await getProjectDb()[model].create(
-            createArgs
-          )
-        }
-      }
-    }
-    return scenarios
-  } else {
-    return {}
-  }
-}
 
 /** @type {import('jest').Config} */
 module.exports = {
@@ -209,10 +20,12 @@ module.exports = {
   testEnvironment: path.join(__dirname, './RedwoodApiJestEnv.js'),
   globals: {
     __RWJS__TEST_IMPORTS: {
-      configureTeardown,
-      teardown,
-      buildScenario,
       apiSrcPath: rwjsPaths.api.src,
+      tearDownCachePath: path.join(
+        rwjsPaths.generated.base,
+        'scenarioTeardown.json'
+      ),
+      dbSchemaPath: rwjsPaths.api.dbSchema,
     },
   },
   sandboxInjectedGlobals: ['__RWJS__TEST_IMPORTS'],

--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -5,12 +5,188 @@
 // will remain undefined in the user's tests
 // Remember to use specific imports
 const { setContext } = require('@redwoodjs/graphql-server/dist/globalContext')
+const { defineScenario } = require('@redwoodjs/testing/dist/api/scenario')
 
 // @NOTE we do this because jest.setup.js runs every time in each context
 // while jest-preset runs once. This significantly reduces memory footprint, and testing time
 // The key is to reduce the amount of imports in this file, because the require.cache is not shared between each test context
-const { configureTeardown, teardown, buildScenario, apiSrcPath } =
+const { apiSrcPath, tearDownCachePath, dbSchemaPath } =
   global.__RWJS__TEST_IMPORTS
+
+global.defineScenario = defineScenario
+
+// Error codes thrown by [MySQL, SQLite, Postgres] when foreign key constraint
+// fails on DELETE
+const FOREIGN_KEY_ERRORS = [1451, 1811, 23503]
+const TEARDOWN_CACHE_PATH = tearDownCachePath
+const DEFAULT_SCENARIO = 'standard'
+let teardownOrder = []
+let originalTeardownOrder = []
+
+const deepCopy = (obj) => {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+const isIdenticalArray = (a, b) => {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+const configureTeardown = async () => {
+  const { getDMMF } = require('@prisma/internals')
+  const fs = require('fs')
+
+  // @NOTE prisma utils are available in cli lib/schemaHelpers
+  // But avoid importing them, to prevent memory leaks in jest
+  const schema = await getDMMF({ datamodelPath: dbSchemaPath })
+  const schemaModels = schema.datamodel.models.map((m) => m.dbName || m.name)
+
+  // check if pre-defined delete order already exists and if so, use it to start
+  if (fs.existsSync(TEARDOWN_CACHE_PATH)) {
+    teardownOrder = JSON.parse(fs.readFileSync(TEARDOWN_CACHE_PATH).toString())
+  }
+
+  // check the number of models in case we've added/removed since cache was built
+  if (teardownOrder.length !== schemaModels.length) {
+    teardownOrder = schemaModels
+  }
+
+  // keep a copy of the original order to compare against
+  originalTeardownOrder = deepCopy(teardownOrder)
+}
+
+let quoteStyle
+// determine what kind of quotes are needed around table names in raw SQL
+const getQuoteStyle = async () => {
+  const { getConfig: getPrismaConfig } = require('@prisma/internals')
+  const fs = require('fs')
+
+  if (!quoteStyle) {
+    const config = await getPrismaConfig({
+      datamodel: fs.readFileSync(dbSchemaPath).toString(),
+    })
+
+    switch (config.datasources?.[0]?.provider) {
+      case 'mysql':
+        quoteStyle = '`'
+        break
+      default:
+        quoteStyle = '"'
+    }
+  }
+
+  return quoteStyle
+}
+
+const getProjectDb = () => {
+  const { db } = require(`${apiSrcPath}/lib/db`)
+
+  return db
+}
+
+const buildScenario =
+  (it, testPath) =>
+  (...args) => {
+    let scenarioName, testName, testFunc
+
+    if (args.length === 3) {
+      ;[scenarioName, testName, testFunc] = args
+    } else if (args.length === 2) {
+      scenarioName = DEFAULT_SCENARIO
+      ;[testName, testFunc] = args
+    } else {
+      throw new Error('scenario() requires 2 or 3 arguments')
+    }
+
+    return it(testName, async () => {
+      const path = require('path')
+      const testFileDir = path.parse(testPath)
+      // e.g. ['comments', 'test'] or ['signup', 'state', 'machine', 'test']
+      const testFileNameParts = testFileDir.name.split('.')
+      const testFilePath = `${testFileDir.dir}/${testFileNameParts
+        .slice(0, testFileNameParts.length - 1)
+        .join('.')}.scenarios`
+      let allScenarios, scenario, result
+
+      try {
+        allScenarios = require(testFilePath)
+      } catch (e) {
+        // ignore error if scenario file not found, otherwise re-throw
+        if (e.code !== 'MODULE_NOT_FOUND') {
+          throw e
+        }
+      }
+
+      if (allScenarios) {
+        if (allScenarios[scenarioName]) {
+          scenario = allScenarios[scenarioName]
+        } else {
+          throw new Error(
+            `UndefinedScenario: There is no scenario named "${scenarioName}" in ${testFilePath}.{js,ts}`
+          )
+        }
+      }
+
+      const scenarioData = await seedScenario(scenario)
+      result = await testFunc(scenarioData)
+
+      return result
+    })
+  }
+
+const teardown = async () => {
+  const fs = require('fs')
+
+  const quoteStyle = await getQuoteStyle()
+
+  for (const modelName of teardownOrder) {
+    try {
+      await getProjectDb().$executeRawUnsafe(
+        `DELETE FROM ${quoteStyle}${modelName}${quoteStyle}`
+      )
+    } catch (e) {
+      const match = e.message.match(/Code: `(\d+)`/)
+      if (match && FOREIGN_KEY_ERRORS.includes(parseInt(match[1]))) {
+        const index = teardownOrder.indexOf(modelName)
+        teardownOrder[index] = null
+        teardownOrder.push(modelName)
+      } else {
+        throw e
+      }
+    }
+  }
+
+  // remove nulls
+  teardownOrder = teardownOrder.filter((val) => val)
+
+  // if the order of delete changed, write out the cached file again
+  if (!isIdenticalArray(teardownOrder, originalTeardownOrder)) {
+    originalTeardownOrder = deepCopy(teardownOrder)
+    fs.writeFileSync(TEARDOWN_CACHE_PATH, JSON.stringify(teardownOrder))
+  }
+}
+
+const seedScenario = async (scenario) => {
+  if (scenario) {
+    const scenarios = {}
+    for (const [model, namedFixtures] of Object.entries(scenario)) {
+      scenarios[model] = {}
+      for (const [name, createArgs] of Object.entries(namedFixtures)) {
+        if (typeof createArgs === 'function') {
+          scenarios[model][name] = await getProjectDb()[model].create(
+            createArgs(scenarios)
+          )
+        } else {
+          scenarios[model][name] = await getProjectDb()[model].create(
+            createArgs
+          )
+        }
+      }
+    }
+    return scenarios
+  } else {
+    return {}
+  }
+}
 
 global.scenario = buildScenario(global.it, global.testPath)
 global.scenario.only = buildScenario(global.it.only, global.testPath)
@@ -52,8 +228,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (wasDbUsed()) {
-    const { db } = require(`${apiSrcPath}/lib/db`)
-    db.$disconnect()
+    getProjectDb().$disconnect()
   }
 })
 


### PR DESCRIPTION
...by loading scenarios in the same context as jest.

This unfortunately is a compromise, because the work I did to improve the memory usage of our scenario tests gets a little nullified now. 

### What is the change?
One of the memory optimisations I did was to make sure scenarios are loaded and seeded _outside_ the context/VM that the tests run in. This seemed to really help with memory usage, but unfortunately breaks tests in watch mode, with a cryptic DB/Prisma error (on Postgres):
```
    ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(EXX000), message: "cache lookup failed for type 226432", detail: None, hint: None, position: None, where_: Some("unnamed portal parameter $3"), schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("lsyscache.c"), line: Some(2904), routine: Some("getTypeBinaryInputInfo") }) }) })
```


This PR now puts back the scenario loading and seeding back in the same context, while keeping some of the other minor optimisations, as well as the tests that don't use scenarios being fast.


### What do I do if my api side tests run out of memory on CI?
One of the things we can suggest is to use Jest 28+'s sharding.

e.g. 
```
yarn rw test api --no-watch --shard 1/3
yarn rw test api --no-watch --shard 2/3
yarn rw test api --no-watch --shard 3/3
```
(adjust the number of shards as needed. 50 or so test-suites per shard is a good number!) 

This will allow tests to run to completion
