### PR TITLE
fix: stop polyfilling map

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -36,7 +36,7 @@ module.exports = {
           // List of supported proposals: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#ecmascript-proposals
           proposals: true,
         },
-        exclude: ['es.error.cause'],
+        exclude: ['es.error.cause', 'es.map'],
       },
     ],
     '@babel/preset-react',


### PR DESCRIPTION
This a test fix for the core-js error seen in CI (see https://github.com/redwoodjs/redwood/pull/6444). I'm not sure if this is the solution, but just want to see if it works.