### PR TITLE
Fix homebrew formula name for postgresql

### DIFF
--- a/docs/docs/local-postgres-setup.md
+++ b/docs/docs/local-postgres-setup.md
@@ -12,7 +12,7 @@ likely going to want to run the same database you use in production locally at s
 If you're on a Mac, we recommend using Homebrew:
 
 ```bash
-brew install postgres@14
+brew install postgresql@14
 ```
 
 > **Install Postgres? I've messed up my Postgres installation so many times, I wish I could just uninstall everything and start over!**


### PR DESCRIPTION
Running the brew install command on https://redwoodjs.com/docs/local-postgres-setup#install-postgres results in
```
No available formula with the name "postgres@14". Did you mean postgresql@14, postgrest, postgresql@12, postgresql@11, postgresql@10 or postgresql@13?
```

I believe this was a typo for postgresql as seen here: https://formulae.brew.sh/formula/postgresql@14