### PR TITLE
chore: ignore sort-package-json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,7 @@
     "pretty-bytes",
     "is-port-reachable",
     "pretty-ms",
-    "camelcase"
+    "camelcase",
+    "sort-package-json"
   ]
 }


### PR DESCRIPTION
It's ESM-only now. See https://github.com/redwoodjs/redwood/pull/6591.