### PR TITLE
command_builder: Explicitly convert args to strings

### DIFF
--- a/packages/structure/src/interactive_cli/command_builder.ts
+++ b/packages/structure/src/interactive_cli/command_builder.ts
@@ -60,7 +60,7 @@ class CommandBuilder {
   }
 
   @lazy() get args() {
-    return this.opts.cmd.parsed._
+    return this.opts.cmd.parsed._.map((arg) => arg.toString())
   }
 
   private async generate(type: string) {


### PR DESCRIPTION
I had a TS error in `command_builder.ts`

![image](https://user-images.githubusercontent.com/30793/194761231-f38e4062-fefd-4a09-8f9b-d5169789b94d.png)

This is the error:

![image](https://user-images.githubusercontent.com/30793/194761275-cff40d2b-4d53-4941-9ba1-fbdf297f5eaf.png)

This PR fixes the issue by converting all arguments to strings