### PR TITLE
docs: Defined `id` in the Props interface

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -515,6 +515,7 @@ export const Success = ({ article, id, rand }) => {
 
 ```tsx
 interface Props extends CellSuccessProps<ArticleQuery> {
+  id: number
   rand: number
 }
 


### PR DESCRIPTION
Without this definition, we encounter the TS error: "Property 'id' does not exist on type 'Props'"

![id definition commented](https://user-images.githubusercontent.com/73743535/194943064-1739262a-e89b-48ad-908d-3a0809964d88.png)

![id defined](https://user-images.githubusercontent.com/73743535/194943126-13d47a3c-989c-4fe8-8871-e51fda2dc011.png)

