### PR TITLE
Check if test-project fixture needs updating when updating cli-helpers

### DIFF
--- a/.github/actions/check_test_project_fixture/check_test_project_fixture.mjs
+++ b/.github/actions/check_test_project_fixture/check_test_project_fixture.mjs
@@ -32,6 +32,7 @@ if (hasFixtureOkLabel) {
       (file) =>
         file.startsWith('packages/cli/src/commands/generate') ||
         file.startsWith('packages/cli/src/commands/setup') ||
+        file.startsWith('packages/cli-helpers/src/') ||
         file.startsWith('packages/create-redwood-app/template')
     )
 


### PR DESCRIPTION
The test project uses dbAuth, and the dbAuth setup will soon use cli-helpers. So it's possible that the test project fixture will have to be updated when something has changed in cli-helpers.