### PR TITLE
graphql-server: Stricter types

### DIFF
--- a/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
+++ b/packages/graphql-server/src/functions/__tests__/fixtures/auth.ts
@@ -1,5 +1,6 @@
 import { parseJWT } from '@redwoodjs/api'
 import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
+import { APIGatewayEvent } from 'aws-lambda'
 
 interface Context extends Record<string, any> {}
 
@@ -36,7 +37,7 @@ export const getCurrentUser = async (
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   { token, type },
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-  { event, context }
+  req?: { event: APIGatewayEvent, context: Context }
 ): Promise<RedwoodUser> => {
   // if (!decoded) {
   //   return null
@@ -82,6 +83,7 @@ export const hasRole = (roles: AllowedRoles): boolean => {
     return false
   }
 
+  // @ts-expect-error - When not testing we have better types for currentUser
   const currentUserRoles = context.currentUser?.roles
 
   if (typeof roles === 'string') {
@@ -100,10 +102,10 @@ export const hasRole = (roles: AllowedRoles): boolean => {
       return currentUserRoles?.some((allowedRole) =>
         roles.includes(allowedRole)
       )
-    } else if (typeof context.currentUser.roles === 'string') {
+    } else if (typeof currentUserRoles === 'string') {
       // roles to check is an array, currentUser.roles is a string
       return roles.some(
-        (allowedRole) => context.currentUser?.roles === allowedRole
+        (allowedRole) => currentUserRoles === allowedRole
       )
     }
   }

--- a/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
+++ b/packages/graphql-server/src/functions/__tests__/useRequireAuth.test.ts
@@ -1,6 +1,7 @@
 import type { APIGatewayEvent, Context } from 'aws-lambda'
 
 import { AuthenticationError } from '../../errors'
+import type { UseRequireAuth } from '../useRequireAuth'
 
 import { getCurrentUser } from './fixtures/auth'
 
@@ -8,10 +9,12 @@ type RedwoodUser = Record<string, unknown> & { roles?: string[] }
 
 export const mockedAuthenticationEvent = ({
   headers = {},
+}: {
+  headers: Record<string, any> | null | undefined
 }): APIGatewayEvent => {
   return {
     body: 'MOCKED_BODY',
-    headers,
+    headers: headers || {},
     multiValueHeaders: {},
     httpMethod: 'POST',
     isBase64Encoded: false,
@@ -136,7 +139,7 @@ const handlerWithError = async (
 
 const getCurrentUserWithError = async (
   _decoded,
-  { _token }
+  { token: _token }
 ): Promise<RedwoodUser> => {
   throw Error('Something went wrong getting the user info')
 }
@@ -160,7 +163,9 @@ describe('useRequireAuth', () => {
     // @MARK
     // Because we use context inside useRequireAuth, we only want to import this function
     // once we disable context isolation for our test
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -174,7 +179,7 @@ describe('useRequireAuth', () => {
 
     const output = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers }),
-      {}
+      {} as Context
     )
 
     const response = JSON.parse(output.body)
@@ -185,7 +190,9 @@ describe('useRequireAuth', () => {
     // @MARK
     // Because we use context inside useRequireAuth, we only want to import this function
     // once we disable context isolation for our test
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -209,8 +216,8 @@ describe('useRequireAuth', () => {
 
     const output = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: headersWithRoles }),
-      {}
-    ) // ?
+      {} as Context
+    )
 
     const response = JSON.parse(output.body)
     expect(response.currentUser.name).toEqual('John Editor')
@@ -218,7 +225,9 @@ describe('useRequireAuth', () => {
   })
 
   it('is 200 status if an error occurs when getting current user info', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -232,7 +241,7 @@ describe('useRequireAuth', () => {
 
     const output = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: customHeaders }),
-      {}
+      {} as Context
     )
 
     expect(output.statusCode).toEqual(200)
@@ -241,7 +250,9 @@ describe('useRequireAuth', () => {
   })
 
   it('is 200 status if no auth headers present', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -252,7 +263,7 @@ describe('useRequireAuth', () => {
 
     const output = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: missingHeaders }),
-      {}
+      {} as Context
     )
 
     expect(output.statusCode).toEqual(200)
@@ -261,7 +272,9 @@ describe('useRequireAuth', () => {
   })
 
   it('is 200 status with token if the auth provider is unsupported', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -275,7 +288,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: unsupportedProviderHeaders }),
-      {}
+      {} as Context
     )
 
     const body = JSON.parse(response.body)
@@ -285,7 +298,9 @@ describe('useRequireAuth', () => {
   })
 
   it('returns 200 if decoding JWT succeeds for netlify', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -307,7 +322,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: netlifyJWTHeaders }),
-      {}
+      {} as Context
     )
 
     const body = JSON.parse(response.body)
@@ -318,7 +333,9 @@ describe('useRequireAuth', () => {
   })
 
   it('is 200 status if decoding JWT fails for netlify', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -332,7 +349,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: invalidJWTHeaders }),
-      {}
+      {} as Context
     )
 
     const body = JSON.parse(response.body)
@@ -342,7 +359,9 @@ describe('useRequireAuth', () => {
   })
 
   it('is 200 status if decoding JWT fails for supabase', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const handlerEnrichedWithAuthentication = useRequireAuth({
       handlerFn: handler,
@@ -356,7 +375,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: invalidJWTHeaders }),
-      {}
+      {} as Context
     )
 
     const body = JSON.parse(response.body)
@@ -366,7 +385,9 @@ describe('useRequireAuth', () => {
   })
 
   it('is 500 Server Error status if handler errors', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const customHeaders = {
       'auth-provider': 'custom',
@@ -380,7 +401,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: customHeaders }),
-      {}
+      {} as Context
     )
 
     const message = JSON.parse(response.body).error
@@ -390,7 +411,9 @@ describe('useRequireAuth', () => {
   })
 
   it('enables the use of auth functions inside the handler to check that isAuthenticated blocks unauthenticated users', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     const netlifyJWTHeaders = {
       'auth-provider': 'netlify',
@@ -404,7 +427,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: netlifyJWTHeaders }),
-      {}
+      {} as Context
     )
 
     const body = JSON.parse(response.body)
@@ -414,7 +437,9 @@ describe('useRequireAuth', () => {
   })
 
   it("enables the use of auth functions inside the handler to check that requireAuth throws if the user doesn't have the required role", async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     // Note: The Bearer token JWT contains:
     // {
@@ -437,13 +462,15 @@ describe('useRequireAuth', () => {
     await expect(
       handlerEnrichedWithAuthentication(
         mockedAuthenticationEvent({ headers: netlifyJWTHeaders }),
-        {}
+        {} as Context
       )
     ).rejects.toThrow("You don't have access to do that.")
   })
 
   it('enables the use of auth functions inside the handler to check editor role', async () => {
-    const { useRequireAuth } = require('../useRequireAuth')
+    const {
+      useRequireAuth,
+    }: { useRequireAuth: UseRequireAuth } = require('../useRequireAuth')
 
     // The authorization JWT is valid and has roles in app metadata
     // {
@@ -467,7 +494,7 @@ describe('useRequireAuth', () => {
 
     const response = await handlerEnrichedWithAuthentication(
       mockedAuthenticationEvent({ headers: headersWithRoles }),
-      {}
+      {} as Context
     )
 
     const body = JSON.parse(response.body)

--- a/packages/graphql-server/src/functions/useRequireAuth.ts
+++ b/packages/graphql-server/src/functions/useRequireAuth.ts
@@ -15,10 +15,22 @@ interface Args {
     context: LambdaContext,
     ...others: any
   ) => any
-  getCurrentUser: GetCurrentUser
+  getCurrentUser?: GetCurrentUser
 }
 
-export const useRequireAuth = ({ handlerFn, getCurrentUser }: Args) => {
+// Used for type safety in our tests
+export type UseRequireAuth = (
+  args: Args
+) => (
+  event: APIGatewayEvent,
+  context: LambdaContext,
+  ...rest: any
+) => Promise<ReturnType<Args['handlerFn']>>
+
+export const useRequireAuth: UseRequireAuth = ({
+  handlerFn,
+  getCurrentUser,
+}: Args) => {
   return async (
     event: APIGatewayEvent,
     context: LambdaContext,

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodAuthContext.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodAuthContext.test.ts
@@ -5,7 +5,6 @@ import { useRedwoodAuthContext } from '../useRedwoodAuthContext'
 
 jest.mock('@redwoodjs/api', () => {
   return {
-    //@ts-expect-error jest types being silly
     ...jest.requireActual('@redwoodjs/api'),
     getAuthenticationContext: jest.fn().mockResolvedValue([
       { sub: '1', email: 'ba@zin.ga' },


### PR DESCRIPTION
Tighten up types mainly for the tests in graphql-server

I originally did this as part of my Decouple Auth PR to make it easier to spot any errors when I was rewriting auth