### PR TITLE
chore: run lerna repair

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,6 @@
   "version": "3.2.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "useNx": true,
   "command": {
     "publish": {
       "verifyAccess": false

--- a/nx.json
+++ b/nx.json
@@ -19,8 +19,12 @@
     "prod": [
       "!{projectRoot}/**/*.test.{js,jsx,ts,tsx}",
       "{workspaceRoot}/babel.config.js",
-      { "runtime": "node -v" },
-      { "runtime": "node -e \"console.log(process.platform)\""}
+      {
+        "runtime": "node -v"
+      },
+      {
+        "runtime": "node -e \"console.log(process.platform)\""
+      }
     ]
   },
   "targetDefaults": {
@@ -39,5 +43,6 @@
         "^prod"
       ]
     }
-  }
+  },
+  "$schema": "./node_modules/nx/schemas/nx-schema.json"
 }


### PR DESCRIPTION
Follow up to upgrading to lerna v6 in https://github.com/redwoodjs/redwood/pull/6676, this PR has the results of running lerna's new repair command.