### PR TITLE
chore: remove private field on new packages package.json

### DIFF
--- a/packages/auth-providers-api/package.json
+++ b/packages/auth-providers-api/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@redwoodjs/auth-providers-api",
-  "private": true,
   "version": "3.2.0",
   "repository": {
     "type": "git",

--- a/packages/auth-providers-setup/package.json
+++ b/packages/auth-providers-setup/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@redwoodjs/auth-providers-setup",
-  "private": true,
   "version": "3.2.0",
   "repository": {
     "type": "git",

--- a/packages/auth-providers-web/package.json
+++ b/packages/auth-providers-web/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@redwoodjs/auth-providers-web",
-  "private": true,
   "version": "3.2.0",
   "repository": {
     "type": "git",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@redwoodjs/cli-helpers",
-  "private": true,
   "version": "3.2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
These packages were marked as private to keep canary publishing going before https://github.com/redwoodjs/redwood/pull/5985 was merged, but now that it's in main, we want these packages to be published.