### PR TITLE
fix(Supabase): Set Supabase webPackage to 1.35.7

### DIFF
--- a/packages/cli/src/commands/setup/auth/providers/supabase.js
+++ b/packages/cli/src/commands/setup/auth/providers/supabase.js
@@ -12,7 +12,7 @@ export const config = {
 }
 
 // required packages to install
-export const webPackages = ['@supabase/supabase-js']
+export const webPackages = ['@supabase/supabase-js@1.35.7']
 export const apiPackages = []
 
 // any notes to print out when the job is done


### PR DESCRIPTION
This should not be merged into `main`!

A hotfix branch needs to be created off of tag v3.2.0 and a hotfix such as v3.2.1 should be released.

# Description

This change hardcodes the version supported for Supabase in the webPackages const for the Supabase provider

The latest Supabase version v2.0.4 is incompatible with the current Supabase auth setup.

For example using their Docs on using Supabase with Redwood: https://supabase.com/docs/guides/with-redwoodjs

The function `client.auth.signIn` does not exist anymore in v2.0.4

Fix: https://github.com/redwoodjs/redwood/issues/6729