### PR TITLE
fix(Supabase): Set Supabase webPackage to 1.35.7 (from main)

### DIFF
--- a/packages/auth-providers-setup/src/supabase/setup.ts
+++ b/packages/auth-providers-setup/src/supabase/setup.ts
@@ -24,7 +24,7 @@ export const handler = async ({ rwVersion, force: forceArg }: Args) => {
     provider: 'supabase',
     authDecoderImport:
       "import { supabaseAuthDecoder as authDecoder } from '@redwoodjs/auth-providers-api'",
-    webPackages: ['@supabase/supabase-js'],
+    webPackages: ['@supabase/supabase-js@1.35.7'],
     notes: [
       'You will need to add your Supabase URL (SUPABASE_URL), public API KEY,',
       'and JWT SECRET (SUPABASE_KEY, and SUPABASE_JWT_SECRET) to your .env file.',


### PR DESCRIPTION
This change hardcodes the version supported for Supabase in the webPackages const for the Supabase provider

The latest Supabase version v2.0.4 is incompatible with the current Supabase auth setup.

For example using their Docs on using Supabase with Redwood: https://supabase.com/docs/guides/with-redwoodjs

The function `client.auth.signIn` does not exist anymore in v2.0.4

Fix: https://github.com/redwoodjs/redwood/issues/6729