### PR TITLE
Update auth docs to not import global context

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -142,10 +142,9 @@ const Routes = () => {
 ## Authentication on the API Side
 
 GraphQL requests automatically receive an `Authorization` header when a user is authenticated and Redwood will decode and verify the header, making the user available (if they are logged in) in `context.currentUser`.
+`context` is a global so it's always available on your api side, like in your services.
 
 ```jsx
-import { context } from '@redwoodjs/api'
-
 console.log(context.currentUser)
 // {
 //    sub: '<netlify-id>

--- a/docs/versioned_docs/version-3.2/authentication.md
+++ b/docs/versioned_docs/version-3.2/authentication.md
@@ -142,10 +142,9 @@ const Routes = () => {
 ## Authentication on the API Side
 
 GraphQL requests automatically receive an `Authorization` header when a user is authenticated and Redwood will decode and verify the header, making the user available (if they are logged in) in `context.currentUser`.
+`context` is a global so it's always available on your api side, like in your services.
 
 ```jsx
-import { context } from '@redwoodjs/api'
-
 console.log(context.currentUser)
 // {
 //    sub: '<netlify-id>


### PR DESCRIPTION
`context` is a global and should not be imported. In fact, trying to import it from rw/api will give red squiggles