### PR TITLE
Backports tutorial updates to versioned docs 3.1 and 3.2

### DIFF
--- a/docs/versioned_docs/version-3.1/tutorial/chapter2/routing-params.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter2/routing-params.md
@@ -515,6 +515,7 @@ export const Success = ({ article, id, rand }) => {
 
 ```tsx
 interface Props extends CellSuccessProps<ArticleQuery> {
+  id: number
   rand: number
 }
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter5/first-story.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter5/first-story.md
@@ -146,7 +146,7 @@ export default { title: 'Components/Article' }
 </TabItem>
 </Tabs>
 
-As soon as you save the change the stories Storybook should refresh and show the updates:
+As soon as you save the change the stories Storybook should refresh and may show an error: there's no longer a "Generated" story to show! In the tree on the left, expand "Article" and the "Full" version should show right away. Click on "Summary" to see the difference:
 
 ![image](https://user-images.githubusercontent.com/300/153311838-595b8b38-d899-4d7b-891b-a492f0c8f2e2.png)
 
@@ -231,6 +231,8 @@ export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
 
 </TabItem>
 </Tabs>
+
+Check out the story to see the new summary view:
 
 ![image](https://user-images.githubusercontent.com/300/153312022-1cfbf696-b2cb-4fca-b640-4111643fb396.png)
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter5/first-test.md
@@ -4,13 +4,13 @@ So if Storybook is the first phase of creating/updating a component, phase two m
 
 If you've never done any kind of testing before this may be a little hard to follow. We've got a great document [all about testing](../../testing.md) (including some philosophy, for those so inclined) if you want a good overview of testing in general. We even build a super-simple test runner from scratch in plain Javascript to take some of the mystery out of how this all works!
 
-First let's run the existing suite to see if we broke anything:
+If you still have the test process running from the previous page then then you can just press `a` to run **a**ll tests. If you stopped your test process, you can start it again with:
 
 ```bash
 yarn rw test
 ```
 
-Well that didn't take long! Can you guess what we broke?
+Can you guess what broke in this test?
 
 ![image](https://user-images.githubusercontent.com/300/153312402-dd7f08bc-e23d-4acc-8202-cdfc9798a911.png)
 
@@ -79,6 +79,7 @@ Okay, let's do this:
 ```jsx title="web/src/components/ArticlesCell.test.js"
 // highlight-next-line
 import { render, screen, within } from '@redwoodjs/testing'
+
 import { Loading, Empty, Failure, Success } from './ArticlesCell'
 import { standard } from './ArticlesCell.mock'
 
@@ -127,6 +128,7 @@ describe('ArticlesCell', () => {
 ```tsx title="web/src/components/ArticlesCell.test.tsx"
 // highlight-next-line
 import { render, screen, within } from '@redwoodjs/testing'
+
 import { Loading, Empty, Failure, Success } from './ArticlesCell'
 import { standard } from './ArticlesCell.mock'
 
@@ -178,42 +180,40 @@ This loops through each article in our `standard()` mock and for each one:
 const truncatedBody = article.body.substring(0, 10)
 ```
 
-Create a variable `truncatedBody` containing the first 10 characters of the post body
+Create a variable `truncatedBody` containing the first 10 characters of the post body.
 
 ```javascript
 const matchedBody = screen.getByText(truncatedBody, { exact: false })
 ```
 
-Search through the rendered HTML on the screen and find the HTML element that contains the truncated body (note the `{ exact: false }` here, as normally the exact text, and only that text, would need to be present, but in this case there's probably more than just the 10 characters)
+Search through the rendered HTML on the screen and find the HTML element that contains the truncated body (note the `{ exact: false }` here, as normally the exact text, and only that text, would need to be present, but in this case there's probably more than just the 10 characters).
 
 ```javascript
 const ellipsis = within(matchedBody).getByText('...', { exact: false })
 ```
 
-Within the HTML element that was found in the previous line, find `...`, again without an exact match
+Within the HTML element that was found in the previous line, find `...`, again without an exact match.
 
 ```javascript
 expect(screen.getByText(article.title)).toBeInTheDocument()
 ```
 
-Find the title of the article in the page
+Find the title of the article in the page.
 
 ```javascript
 expect(screen.queryByText(article.body)).not.toBeInTheDocument()
 ```
-When trying to find the *full* text of the body, it should *not* be present
+When trying to find the *full* text of the body, it should *not* be present.
 
 ```javascript
 expect(matchedBody).toBeInTheDocument()
 ```
-Assert that the truncated text is present
+Assert that the truncated text is .
 
 ```javascript
 expect(ellipsis).toBeInTheDocument()
 ```
-Assert that the ellipsis is present
-
-As soon as you saved that test file the test should have run and passed! Press `a` to run the whole suite if you want to make sure nothing else broke. Remember to press `o` to go back to only testing changes again. (There's nothing wrong with running the full test suite each time, but it will take longer than only testing the things that have changed since the last time you committed your code.)
+Assert that the ellipsis is present.
 
 :::info What's the difference between `getByText()` and `queryByText()`?
 
@@ -221,11 +221,13 @@ As soon as you saved that test file the test should have run and passed! Press `
 
 :::
 
-To double check that we're testing what we think we're testing, open up `ArticlesCell.js` and remove the `summary={true}` prop (or set it to `false`) and the test should fail: now the full body of the post *is* on the page and `expect(screen.queryByText(article.body)).not.toBeInTheDocument()` *is* in the document! Make sure to put the `summary={true}` back before we continue.
+As soon as you saved that test file the test should have run and passed! Press `a` to run the whole suite if you want to make sure nothing else broke. Remember to press `o` to go back to only testing changes again. (There's nothing wrong with running the full test suite each time, but it will take longer than only testing the things that have changed since the last time you committed your code.)
+
+To double check that we're testing what we think we're testing, open up `ArticlesCell.js` and remove the `summary={true}` prop (or set it to `false`) and the test should fail: now the full body of the post *is* on the page and the expectation in our test `expect(screen.queryByText(article.body)).not.toBeInTheDocument()` fails because the full body *is* in the document! Make sure to put the `summary={true}` back before we continue.
 
 ### What's the Deal with Mocks?
 
-Mocks are used when you want to define the data that would normally be returned by GraphQL. In cells, a GraphQL call goes out (the query defined by **QUERY**) and returned to the **Success** component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
+Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
 
 :::info If the server is being mocked, how do we test the api-side code?
 
@@ -387,9 +389,9 @@ You can have as many mocks as you want, just import the names of the ones you ne
 
 ### Testing Article
 
-Our test suite is passing again but it's a trick! We never added a test for the actual `summary` functionality that we added to the `Article` component. We tested that `ArticlesCell` requests that `Article` return a summary, but what it means to render a summary is knowledge that only `Article` contains.
+Our test suite is passing again but it's a trick! We never added a test for the actual `summary` functionality that we added to the `Article` component. We tested that `ArticlesCell` renders (that eventually render an `Article`) include a summary, but what it means to render a summary is knowledge that only `Article` contains.
 
-When you get into the flow of building your app it can be very easy to overlook testing functionality like this. Wasn't it Winston Churchill who said "a thorough test suite requires eternal vigilance"? Techniques like [Test Driven Development](https://en.wikipedia.org/wiki/Test-driven_development) (TDD) were established to help combat this tendency—write the test first, watch it fail, then write the code to make the test pass so that you know every line of real code you write is backed by a test. What we're doing is affectionately known as [Development Driven Testing](https://medium.com/table-xi/development-driven-testing-673d3959dac2). You'll probably settle somewhere in the middle but one maxim is always true—some tests are better than no tests.
+When you get into the flow of building your app it can be very easy to overlook testing functionality like this. Wasn't it Winston Churchill who said "a thorough test suite requires eternal vigilance"? Techniques like [Test Driven Development](https://en.wikipedia.org/wiki/Test-driven_development) (TDD) were established to help combat this tendency: when you want to write a new feature, write the test first, watch it fail, then write the code to make the test pass so that you know every line of real code you write is backed by a test. What we're doing is affectionately known as [Development Driven Testing](https://medium.com/table-xi/development-driven-testing-673d3959dac2). You'll probably settle somewhere in the middle but one maxim is always true: some tests are better than no tests.
 
 The summary functionality in `Article` is pretty simple, but there are a couple of different ways we could test it:
 
@@ -398,15 +400,16 @@ The summary functionality in `Article` is pretty simple, but there are a couple 
 
 In this case `truncate()` "belongs to" `Article` and the outside world really shouldn't need to worry about it or know that it exists. If we came to a point in development where another component needed to truncate text then that would be a perfect time to move this function to a shared location and import it into both components that need it. `truncate()` could then have its own dedicated test. But for now let's keep our separation of concerns and test the one thing that's "public" about this component—the result of the render.
 
-In this case let's just test that the output matches an exact string. You could spin yourself in circles trying to refactor the code to make it absolutely bulletproof to code changes breaking the tests, but will you ever actually need that level of flexibility? It's always a trade-off!
+In this case let's just test that the output matches an exact string. Since the knowledge of how long to make the summary is contained in `Article` itself, at this point it feels okay to have the test tightly coupled to the render result of this particular component. (`ArticlesCell` itself didn't know about how long to truncate, just that *something* was shortening the text.) You could spin yourself in circles trying to refactor the code to make it absolutely bulletproof to code changes breaking the tests, but will you ever actually need that level of flexibility? It's always a trade-off!
 
-We'll move the sample post data to a constant and then use it in both the existing test (which tests that not passing the `summary` prop at all results in the full body being rendered) and our new test that checks for the summary version being rendered:
+We'll move the sample article data in the test to a constant and then use it in both the existing test (which tests that not passing the `summary` prop at all results in the full body being rendered) and our new test that checks for the summary version being rendered:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/Article/Article.test.js"
 import { render, screen } from '@redwoodjs/testing'
+
 import Article from './Article'
 
 // highlight-start
@@ -449,6 +452,7 @@ describe('Article', () => {
 
 ```jsx title="web/src/components/Article/Article.test.tsx"
 import { render, screen } from '@redwoodjs/testing'
+
 import Article from './Article'
 
 // highlight-start

--- a/docs/versioned_docs/version-3.1/tutorial/chapter5/testing.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter5/testing.md
@@ -1,6 +1,6 @@
 # Introduction to Testing
 
-Let's run the test suite to make sure everything is working as expected (you can keep the dev server running and start this in a second terminal window):
+Let's run the test suite to make sure everything is working as expected (you can keep the dev server running and start this in a new terminal window):
 
 ```bash
 yarn rw test

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/comment-form.md
@@ -93,7 +93,7 @@ const CommentForm = () => {
         </Label>
         <TextField
           name="name"
-          className="block w-full p-1 border rounded text-xs "
+          className="block w-full p-1 border rounded text-xs"
           validation={{ required: true }}
         />
 
@@ -368,7 +368,7 @@ import type {
   CreateCommentMutationVariables,
 } from 'types/graphql'
 // highlight-end
-  
+
 export const generated = () => {
   // highlight-start
   mockGraphQLMutation<CreateCommentMutation, CreateCommentMutationVariables>(
@@ -398,6 +398,12 @@ export default { title: 'Components/CommentForm' }
 </TabItem>
 </Tabs>
 
+:::info
+
+If you still get an error, try reloading the Storybook tab in the browser.
+
+:::
+
 To use `mockGraphQLMutation` you call it with the name of the mutation you want to intercept and then the function that will handle the interception and return a response. The arguments passed to that function give us some flexibility in how we handle the response.
 
 In our case we want the `variables` that were passed to the mutation (the `name` and `body`) as well as the context object (abbreviated as `ctx`) so that we can add a delay to simulate a round trip to the server. This will let us test that the **Submit** button is disabled for that one second and you can't submit a second comment while the first one is still being saved.
@@ -421,9 +427,10 @@ So let's use `Article` as the cleaning house for where all these disparate parts
 
 ```jsx title="web/src/components/Article/Article.js"
 import { Link, routes } from '@redwoodjs/router'
-import CommentsCell from 'src/components/CommentsCell'
+
 // highlight-next-line
 import CommentForm from 'src/components/CommentForm'
+import CommentsCell from 'src/components/CommentsCell'
 
 const truncate = (text, length) => {
   return text.substring(0, length) + '...'
@@ -463,9 +470,10 @@ export default Article
 
 ```tsx title="web/src/components/Article/Article.tsx"
 import { Link, routes } from '@redwoodjs/router'
-import CommentsCell from 'src/components/CommentsCell'
+
 // highlight-next-line
 import CommentForm from 'src/components/CommentForm'
+import CommentsCell from 'src/components/CommentsCell'
 
 import type { Post } from 'types/graphql'
 
@@ -663,7 +671,7 @@ Now fill out the comment form and submit! And...nothing happened! Believe it or 
 
 ![image](https://user-images.githubusercontent.com/300/153930645-c5233fb5-ad7f-4a03-8707-3cd6164bb277.png)
 
-Yay! It would have been nicer if that comment appeared as soon as we submitted the comment, so maybe that's a half-yay? Also, the text boxes stayed filled with our name/messages which isn't ideal. But, we can fix both of those! One involves telling the GraphQL client (Apollo) that we created a new record and, if it would be so kind, to try the query again that gets the comments for this page, and we'll fix the other by just removing the form from the page completely when a new comment is submitted.
+Yay! It would have been nicer if that comment appeared as soon as we submitted the comment, so maybe that's a half-yay? Also, the text boxes stayed filled with our name/messages (before we reloaded the page) which isn't ideal. But, we can fix both of those. One involves telling the GraphQL client (Apollo) that we created a new record and, if it would be so kind, to try the query again that gets the comments for this page, and we'll fix the other by just removing the form from the page completely when a new comment is submitted.
 
 ### GraphQL Query Caching
 
@@ -684,6 +692,7 @@ import {
   Submit,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
+
 // highlight-next-line
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 
@@ -713,6 +722,7 @@ import {
   Submit,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
+
 // highlight-next-line
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 
@@ -740,6 +750,9 @@ We'll make use of good old fashioned React state to keep track of whether a comm
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/CommentForm/CommentForm.js"
+// highlight-next-line
+import { useState } from 'react'
+
 import {
   Form,
   FormError,
@@ -751,9 +764,8 @@ import {
 import { useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast } from '@redwoodjs/web/toast'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
-// highlight-next-line
-import { useState } from 'react'
 
 const CREATE = gql`
   mutation CreateCommentMutation($input: CreateCommentInput!) {
@@ -835,6 +847,9 @@ export default CommentForm
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/components/CommentForm/CommentForm.tsx"
+// highlight-next-line
+import { useState } from 'react'
+
 import {
   Form,
   FormError,
@@ -842,14 +857,12 @@ import {
   TextField,
   TextAreaField,
   Submit,
-  SubmitHandler,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast } from '@redwoodjs/web/toast'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
-// highlight-next-line
-import { useState } from 'react'
 
 const CREATE = gql`
   mutation CreateCommentMutation($input: CreateCommentInput!) {
@@ -948,8 +961,8 @@ We used `hidden` to just hide the form and "Leave a comment" title completely fr
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/layouts/BlogLayout/BlogLayout.js"
-import { Link, routes } from '@redwoodjs/router'
 import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from '@redwoodjs/router'
 // highlight-next-line
 import { Toaster } from '@redwoodjs/web/toast'
 
@@ -1111,7 +1124,7 @@ So it looks like we're just about done here! Try going back to the homepage and 
 
 All posts have the same comments! **WHAT HAVE WE DONE??**
 
-Remember our foreshadowing callout a few pages back, wondering if our `comments()` service which only returns *all* comments could come back to bite us? It finally has: when we get the comments for a post we're not actually getting them for only that post. We're ignoring the `postId` completely and just returning *all* comments in the database! Turns out the old axiom is true: computers only do exactly what you tell them to do. :(
+Remember our foreshadowing callout a few pages back, wondering if our `comments()` service which only returns *all* comments could come back to bite us? It finally has: when we get the comments for a post we're not actually getting them for only that post. We're ignoring the `postId` completely and just returning *all* comments in the database! Turns out the old axiom is true: computers only do exactly what you tell them to do.
 
 Let's fix it!
 
@@ -1476,7 +1489,7 @@ scenario(
 </TabItem>
 </Tabs>
 
-Okay, open up the actual `comments.js` service and we'll update it to accept the `postId` argument and use it as an option to `findMany()`:
+Okay, open up the actual `comments.js` service and we'll update it to accept the `postId` argument and use it as an option to `findMany()` (be sure to update the `comments()` function [with an "s"] and not the unused `comment()` function):
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -1532,7 +1545,13 @@ type Query {
 
 Now if you try refreshing the real site in dev mode you'll see an error where the comments should be displayed:
 
-![image](https://user-images.githubusercontent.com/300/153936065-159eb06e-4c9e-43db-a07e-a4d17332276c.png)
+![image](https://user-images.githubusercontent.com/300/198095941-bbd07ede-2006-422a-8635-ea8fe57dd403.png)
+
+For security reasons we don't show the internal error message here, but if you check the terminal window where `yarn rw dev` is running you'll see the real message:
+
+```text
+Field "comments" argument "postId" of type "Int!" is required, but it was not provided.
+```
 
 And yep, it's complaining about `postId` not being present—exactly what we want!
 
@@ -1648,7 +1667,7 @@ export const QUERY = gql`
 
 Where does this magical `$postId` come from? Redwood is nice enough to automatically provide it to you since you passed it in as a prop when you called the component!
 
-Try going to a couple of different blog posts and you should see only comments associated to the proper posts (including the one we created in the console!). You can add a comment to each blog post individually and they'll stick to their proper owners:
+Try going to a couple of different blog posts and you should see only comments associated to the proper posts (including the one we created in the console). You can add a comment to each blog post individually and they'll stick to their proper owners:
 
 ![image](https://user-images.githubusercontent.com/300/100954162-de24f680-34c8-11eb-817b-0a7ad802f28b.png)
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/comments-schema.md
@@ -551,7 +551,7 @@ describe('comments', () => {
 </TabItem>
 </Tabs>
 
-What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it.
+What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
 :::info In the section on mocks you said relying on data in the database for testing was dumb?
 
@@ -729,7 +729,7 @@ The test created by the service generator simply checks to make sure the same nu
 
 #### Testing createComment()
 
-Let's add our first service test by making sure that `createComment()` actually stores a new comment in the database. When creating a comment we're not as worried about existing data in the database so let's create a new scenario which only contains a post—the post we'll be linking the new comment to through the comment's `postId` field:
+Let's add our first service test by making sure that `createComment()` actually stores a new comment in the database. When creating a comment we're not as worried about existing data in the database so let's create a new scenario which only contains a post—the post we'll be linking the new comment to through the comment's `postId` field. You can create multiple scenarios and then say which one you want pre-loaded into the database at the time the test is run. We'll let the `standard` scenario stay as-is and make a new one with a new set of data:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -870,7 +870,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that post…connect…id-Voodoo?! Can't we simply pass the Post's ID directly here?
+:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -900,7 +900,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the Javascript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right *now*, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? posts.bark? Really?
+:::info What's up with the names for scenario data? `posts.bark`? Really?
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -918,13 +918,15 @@ Okay, our comments service is feeling pretty solid now that we have our tests in
 
 :::info Mocks vs. Scenarios
 
-Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that "mock" is a synonym for "fake", as in this-is-fake-data-not-really-in-the-database (so that we can create stories and tests in isolation without the api side getting involved). Whereas a scenario is real data in the database, it's just pre-set to some known state that we can rely on.
+Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 
-Maybe a [mnemonic](https://www.mnemonicgenerator.com/?words=M%20W%20S%20A) would help? **M**ocks **W**eb **S**cenarios **A**PI:
+Maybe a [mnemonic](https://www.mnemonicgenerator.com/?words=M%20W%20S%20A) would help?
 
-* Mothers Worshipped Slimy Aprons
+**M**ocks : **W**eb :: **S**cenarios : **A**PI:
+
+* Mysterious Weasels Scratched Armor
 * Minesweepers Wrecked Subliminal Attorneys
-* Masked Widows Squeezed Apricots
+* Martian Warriors Squeezed Apricots
 
 Maybe not...
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/multiple-comments.md
@@ -30,14 +30,6 @@ Let's generate a **CommentsCell**:
 yarn rw g cell Comments
 ```
 
-:::caution What's with these errors and warnings after generating this cell?
-
-Redwood will try to generate types to go along with your cell. However, we haven't generated an SDL file for the Comment model yet, so types can't be created. This is safe to ignore for now as we're building out our UI in Storybook. 
-
-You may also see some red squiggles in your IDE: same thing, types couldn't be generated.
-
-:::
-
 Storybook updates with a new **CommentsCell** under the **Cells** folder, and it's actually showing something:
 
 ![image](https://user-images.githubusercontent.com/300/153477642-0d5a15a5-f96f-485a-b8b0-dbc1c4515279.png)
@@ -189,9 +181,9 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info
+:::info What's this `standard` thing?
 
-What's this `standard` thing? Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in Javascript!
+Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in Javascript!
 
 :::
 
@@ -322,7 +314,7 @@ export default Article
 
 If we are *not* showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the CommentsCell cause an actual GraphQL request? How does this work?
+:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
 
 Redwood has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 
@@ -419,6 +411,7 @@ The default `CommentsCell.test.{js,tsx}` actually tests every state for us, albe
 
 ```jsx title="web/src/components/CommentsCell/CommentsCell.test.js"
 import { render } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -454,6 +447,7 @@ describe('CommentsCell', () => {
 
 ```tsx title="web/src/components/CommentsCell/CommentsCell.test.tsx"
 import { render } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -497,6 +491,7 @@ But in this case we can do a little more to make sure `CommentsCell` is doing wh
 ```jsx title="web/src/components/CommentsCell/CommentsCell.test.js"
 // highlight-next-line
 import { render, screen } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -539,6 +534,7 @@ describe('CommentsCell', () => {
 ```tsx title="web/src/components/CommentsCell/CommentsCell.test.tsx"
 // highlight-next-line
 import { render, screen } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -578,22 +574,25 @@ describe('CommentsCell', () => {
 </TabItem>
 </Tabs>
 
-We're looping through each `comment` from the mock, the same mock used by Storybook, so that even if we add more later, we're covered. You may find yourself writing a test and saying "just test that there are 3 comments," which will work today, but months from now when you add more comments to the mock to try some different iterations in Storybook, that test will start failing. Avoid hardcoding data like this into your test when you can derive it from your mocked data!
+We're looping through each `comment` from the mock, the same mock used by Storybook, so that even if we add more later, we're covered. You may find yourself writing a test and saying "just test that there are two total comments," which will work today, but months from now when you add more comments to the mock to try some different iterations in Storybook, that test will start failing. Avoid hardcoding data like this, especially [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)), into your test when you can derive it from your mocked data!
 
 #### Testing Article
 
-The functionality we added to `Article` says to show the comments for the post if we are *not* showing the summary. We've got a test for both the "full" and "summary" renders already. Generally you want your tests to be testing "one thing" so let's add two additional tests for our new functionality:
+The functionality we added to `Article` says to show the comments for the post if we are *not* showing the summary. We've got a test for both the "full" and "summary" renders already. Generally you want a test to be testing "one thing," like whether the body of the article is present, and another test for whether the comments are displaying. If you find that you're using "and" in your test description (like "renders a blog post and its comments") that's a good sign that it should probably be split into two separate tests.
+
+Let's add two additional tests for our new functionality:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/Article/Article.test.js"
-// highlight-next-line
+// highlight-start
 import { render, screen, waitFor } from '@redwoodjs/testing'
 
-import Article from './Article'
-// highlight-next-line
 import { standard } from 'src/components/CommentsCell/CommentsCell.mock'
+// highlight-end
+
+import Article from './Article'
 
 const ARTICLE = {
   id: 1,
@@ -649,12 +648,13 @@ describe('Article', () => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/Article/Article.test.tsx"
-// highlight-next-line
+// highlight-start
 import { render, screen, waitFor } from '@redwoodjs/testing'
 
-import Article from './Article'
-// highlight-next-line
 import { standard } from 'src/components/CommentsCell/CommentsCell.mock'
+// highlight-end
+
+import Article from './Article'
 
 const ARTICLE = {
   id: 1,

--- a/docs/versioned_docs/version-3.1/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter6/the-redwood-way.md
@@ -105,7 +105,10 @@ export const generated = () => {
   // highlight-end
 }
 
-export default { title: 'Components/Comment' }
+export default {
+  title: 'Components/Comment',
+  component: Comment,
+}
 ```
 
 </TabItem>
@@ -128,7 +131,10 @@ export const generated = () => {
   // highlight-end
 }
 
-export default { title: 'Components/Comment' }
+export default {
+  title: 'Components/Comment',
+  component: Comment,
+}
 ```
 
 </TabItem>
@@ -236,6 +242,7 @@ Let's add a sample comment to the test and check that the various parts are bein
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/Comment.test.js"
+// highlight-next-line
 import { render, screen } from '@redwoodjs/testing'
 
 import Comment from './Comment'
@@ -265,6 +272,7 @@ describe('Comment', () => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/Comment.test.tsx"
+// highlight-next-line
 import { render, screen } from '@redwoodjs/testing'
 
 import Comment from './Comment'
@@ -294,6 +302,12 @@ describe('Comment', () => {
 </Tabs>
 
 Here we're testing for both elements of the output `createdAt` timestamp: the actual text that's output (similar to how we tested for an article's truncated body) but also that the element that wraps that text is a `<time>` tag and that it contains a `datetime` attribute with the raw value of `comment.createdAt`. This might seem like overkill but the point of the `datetime` attribute is to provide a machine-readable timestamp that the browser could (theoretically) hook into and do stuff with. This makes sure that we preserve that ability.
+
+If your tests aren't already running in another terminal window, you can start them now:
+
+```bash
+yarn rw test
+```
 
 :::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
 

--- a/docs/versioned_docs/version-3.1/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter7/api-side-currentuser.md
@@ -1,0 +1,743 @@
+# Accessing currentUser in the API side
+
+As our blog has evolved into a multi-million dollar enterprise, we find ourselves so busy counting our money that we no longer have the time to write actual blog posts! Let's hire some authors to write them for us.
+
+What do we need to change to allow multiple users to create posts? Well, for one, we'll need to start associating a blog post to the author that wrote it so we can give them credit. We'll also want to display the name of the author when reading an article. Finally, we'll want to limit the list of blog posts that an author has access to edit to only their own: Alice shouldn't be able to make changes to Bob's articles.
+
+## Associating a Post to a User
+
+Let's introduce a relationship between a `Post` and a `User`, AKA a foreign key. This is considered a one-to-many relationship (one `User` has many `Post`s), similar to the relationship we created earlier between a `Post` and its associated `Comment`s. Here's what our new schema will look like:
+
+```
+┌─────────────────────┐       ┌───────────┐
+│        User         │       │  Post     │
+├─────────────────────┤       ├───────────┤
+│ id                  │───┐   │ id        │
+│ name                │   │   │ title     │
+│ email               │   │   │ body      │
+│ hashedPassword      │   └──<│ userId    │
+│ ...                 │       │ createdAt │
+└─────────────────────┘       └───────────┘
+```
+
+Making data changes like this will start becoming second nature soon:
+
+1. Add the new relationship the `schema.prisma` file
+2. Migrate the database
+3. Generate/update SDLs and Services
+
+### Add the New Relationship to the Schema
+
+First we'll add the new `userId` field to `Post` and the relation to `User`:
+
+```javascript title=api/db/schema.prisma
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  body      String
+  comments  Comment[]
+  // highlight-start
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  // highlight-end
+  createdAt DateTime @default(now())
+}
+
+model User {
+  id                  Int @id @default(autoincrement())
+  name                String?
+  email               String @unique
+  hashedPassword      String
+  salt                String
+  resetToken          String?
+  resetTokenExpiresAt DateTime?
+  roles               String @default("moderator")
+  // highlight-next-line
+  posts               Post[]
+}
+```
+
+### Migrate the Database
+
+Next, migrate the database to apply the changes (when given the option, name the migration something like "add userId to post"):
+
+```
+yarn rw prisma migrate dev
+```
+
+Whoops!
+
+<img width="584" alt="image" src="https://user-images.githubusercontent.com/300/192899337-9cc1167b-e6da-42d4-83dc-d2a6c0cd1179.png" />
+
+Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
+
+:::caution Why don't we just set `@default(1)` in the schema?
+
+This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
+
+:::
+
+Since we're in development, let's just blow away the database and start over:
+
+```
+yarn rw prisma migrate reset
+```
+
+:::info Database Seeds
+
+If you started the second half the tutorial from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
+
+```javascript title=scripts/seed.js
+{
+  id: 1,
+  name: 'John Doe',
+  title: 'Welcome to the blog!',
+  body:
+    "I'm baby single- origin coffee kickstarter lo - fi paleo skateboard.Tumblr hashtag austin whatever DIY plaid knausgaard fanny pack messenger bag blog next level woke.Ethical bitters fixie freegan,helvetica pitchfork 90's tbh chillwave mustache godard subway tile ramps art party. Hammock sustainable twee yr bushwick disrupt unicorn, before they sold out direct trade chicharrones etsy polaroid hoodie. Gentrify offal hoodie fingerstache.",
+  // highlight-next-line
+  userId: 1,
+},
+```
+
+Now run `yarn rw prisma migrate reset` and and...you'll get a different error. But that's okay, read on...
+
+:::
+
+We've got an error here because running a database `reset` doesn't also apply pending migrations. So we're trying to set a `userId` where one doesn't exist in the database (it does exist in Prisma generated client libs though, so it thinks that there *should* be one, even if it doesn't exist in the database yet).
+
+It may feel like we're stuck, but note that the database did reset successfully, it's just the seed that failed. So now let's migrate the database to add the new `userId` to `Post`, and then re-run the seed to populate the database, naming it something like "add userId to post":
+
+```
+yarn rw prisma migrate dev
+```
+
+And then the seed:
+
+```
+yarn rw prisma db seed
+```
+
+:::info
+
+If you didn't start your codebase from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) then you'll now have no users or posts in the database. Go ahead and create a user by going to [http://localhost:8910/signup](http://localhost:8910/signup) but don't create any posts yet! Change the user's role to be "admin", either by using the console introduced in the [previous page](/docs/canary/tutorial/chapter7/rbac#changing-roles-on-a-user) or by [opening Prisma Studio](/docs/canary/tutorial/chapter2/getting-dynamic#prisma-studio) and changing it directly in the database.
+
+:::
+
+### Add Fields to the SDL and Service
+
+Let's think about where we want to show our new relationship. For now, probably just on the homepage and article page: we'll display the author of the post next to the title. That means we'll want to access the user from the post in a GraphQL query something like this:
+
+```graphql
+post {
+  id
+  title
+  body
+  createdAt
+  user {
+    name
+  }
+}
+```
+
+To enable this we'll need to make two modifications on the api side:
+
+1. Add the `user` field to the `posts` SDL
+2. Add a **relation resolver** for the `user` in the `posts` service
+
+#### Add User to Posts SDL
+
+```javascript title=api/src/graphql/posts.sdl.js
+  type Post {
+    id: Int!
+    title: String!
+    body: String!
+    createdAt: DateTime!
+    // highlight-next-line
+    user: User!
+  }
+```
+
+:::info What about the mutations?
+
+We did *not* add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
+
+:::
+
+Here we're using `User!` with an exclamation point because we know that every `Post` will have an associated user to it—this field will never be `null`.
+
+#### Add User Relation Resolver
+
+This one is a little tricker: we need to add a "lookup" in the `posts` service, so that it knows how to get the associated user. When we generated the `comments` SDL and service we got this **relation resolver** created for us. We could re-run the service generator for `Post` but that could blow away changes we made to this file. Our only option would be to include the `--force` flag since the file already exists, which will write over everything. In this case we'll just add the resolver manually:
+
+```javascript title=api/src/services/posts/posts.js
+import { db } from 'src/lib/db'
+
+export const posts = () => {
+  return db.post.findMany()
+}
+
+export const post = ({ id }) => {
+  return db.post.findUnique({
+    where: { id },
+  })
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: input,
+  })
+}
+
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return db.post.delete({
+    where: { id },
+  })
+}
+
+// highlight-start
+export const Post = {
+  user: (_obj, { root }) =>
+    db.post.findFirst({ where: { id: root.id } }).user(),
+}
+// highlight-end
+```
+
+This can be non-intuitive so let's step through it. First, declare a variable with the same name as the model this service is for: `Post` for the `posts` service. Now, set that to an object containing keys that are the same as the fields that are going to be looked up, in this case `user`. When GraphQL invokes this function it passes a couple of arguments, one of which is `root` which is the object that was resolved to start with, in this case the `post` in our GraphQL query:
+
+```graphql
+post {   <- root
+  id
+  title
+  body
+  createdAt
+  user {
+    name
+  }
+}
+```
+
+That post will already be retreived from the database, and so we know its `id`. `root` is that object, so can simply call `.id` on it to get that property. Now we know everything we need to to make a `findFirst()` query in Prisma, giving it the `id` of the record we already found, but returning the `user` associated to that record, rather than the `post` itself.
+
+We could also write this resolver as follows:
+
+```javascript
+export const Post = {
+  user: (_obj, { root }) =>
+    db.user.findFirst({ where: { id: root.userId } }),
+}
+```
+
+Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
+
+:::info Prisma and the N+1 Problem
+
+If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an *additional* query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
+
+There have been several attempts to work around this issue. A simple one that includes no extra dependencies is to remove this field resolver and simply include `user` data along with any `post` you retrieve from the database:
+
+```javascript
+export const post = ({ id }) => {
+  return db.post.findUnique({
+    where: { id },
+    include: {
+      user: true
+    }
+  })
+}
+```
+
+This may or may not work for you: you are incurring the overhead of always returning user data, even if that data wasn't requested in the GraphQL query. In addition, this breaks further nesting of queries: what if you wanted to return the user for this post, and a list of all the other posts IDs that they created?
+
+```graphql
+post {
+  id
+  title
+  body
+  createdAt
+  user {
+    name
+    posts {
+      id
+    }
+  }
+}
+```
+
+This query would now fail because you only have `post.user` available, not `post.user.posts`.
+
+The Redwood team is actively looking into more elegant solutions to the N+1 problem, so stay tuned!
+
+:::
+
+## Displaying the Author
+
+In order to get the author info we'll need to update our Cell queries to pull the user's name.
+
+There are two places where we publicly present a post:
+
+1. The homepage
+2. A single article page
+
+Let's update their respective Cells to include the name of the user that created the post:
+
+```jsx title=web/src/components/ArticlesCell/ArticlesCell.js
+export const QUERY = gql`
+  query ArticlesQuery {
+    articles: posts {
+      id
+      title
+      body
+      createdAt
+      // highlight-start
+      user {
+        name
+      }
+      // highlight-end
+    }
+  }
+`
+```
+
+```jsx title=web/src/components/ArticleCell/ArticleCell.js
+export const QUERY = gql`
+  query ArticleQuery($id: Int!) {
+    article: post(id: $id) {
+      id
+      title
+      body
+      createdAt
+      // highlight-start
+      user {
+        name
+      }
+      // highlight-end
+    }
+  }
+`
+```
+
+And then update the display component that shows an Article:
+
+```jsx title=web/src/components/Article/Article.js
+import { Link, routes } from '@redwoodjs/router'
+
+const Article = ({ article }) => {
+  return (
+    <article>
+      <header>
+        <h2 className="text-xl text-blue-700 font-semibold">
+          <Link to={routes.article({ id: article.id })}>{article.title}</Link>
+          // highlight-start
+          <span className="ml-2 text-gray-400 font-normal">
+            by {article.user.name}
+          </span>
+          // highlight-end
+        </h2>
+      </header>
+
+      <div className="mt-2 text-gray-900 font-light">{article.body}</div>
+    </article>
+  )
+}
+
+export default Article
+```
+
+Depending on whether you started from the Redwood Tutorial repo or not, you may not have any posts to actually display. Let's add some! However, before we can do that with our posts admin/scaffold, we'll need to actually associate a user to the post they created. Remember that we don't allow setting the `userId` via GraphQL, which is what the scaffolds use when creating/editing records. But that's okay, we want this to only happen in the service anyway, which is where we're heading now.
+
+## Accessing `currentUser` on the API side
+
+There's a magical variable named `context` that's available within any of your service functions. It contains the context in which the service function is being called. One property available on this context is the user that's logged in (*if* someone is logged in). It's the same `currentUser` that is available on the web side:
+
+```javascript title=api/src/service/posts/posts.js
+export const createPost = ({ input }) => {
+  return db.post.create({
+    // highlight-next-line
+    data: { ...input, userId: context.currentUser.id }
+  })
+}
+```
+
+So `context.currentUser` will always be around if you need access to the user that made this request. We'll take their user `id` and appened it the rest of the incoming data from the scaffold form when creating a new post. Let's try it out!
+
+You should be able to create a post via the admin now:
+
+<img width="937" alt="image" src="https://user-images.githubusercontent.com/300/193152401-d98b488e-dd71-475a-a78c-6cd5233e5bee.png" />
+
+And going back to the hompage should actually start showing posts and their authors!
+
+<img width="937" alt="image" src="https://user-images.githubusercontent.com/300/193152524-2715e49d-a1c3-43a1-b968-84a4f8ae3846.png" />
+
+## Only Show a User Their Posts in Admin
+
+Right now any admin that visits `/admin/posts` can still see all posts, not only their own. Let's change that.
+
+Since we know we have access to `context.currentUser` we can sprinkle it throughout our posts service to limit what's returned to only those posts that the currently logged in user owns:
+
+```javascript title=api/src/services/posts/posts.js
+import { db } from 'src/lib/db'
+
+export const posts = () => {
+  // highlight-next-line
+  return db.post.findMany({ where: { userId: context.currentUser.id } })
+}
+
+export const post = ({ id }) => {
+  // highlight-start
+  return db.post.findFirst({
+    where: { id, userId: context.currentUser.id },
+  })
+  // highlight-end
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: { ...input, userId: context.currentUser.id },
+  })
+}
+
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return db.post.delete({
+    where: { id },
+  })
+}
+
+export const Post = {
+  user: (_obj, { root }) =>
+    db.post.findFirst({ where: { id: root.id } }).user(),
+}
+```
+
+:::info Prisma's `findUnique()` vs. `findFirst()`
+
+Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` *in addition* to `userId`.
+
+:::
+
+These changes make sure that a user can only see a list of their own posts, or the detail for a single post that they own.
+
+What about `updatePost` and `deletePost`? They aren't limited to just the `currentUser`, which would let anyone update or delete a post if they made a manual GraphQL call! That's not good. We'll deal with those [a little later](#update-and-delete).
+
+But there's a problem with the updates we just made: doesn't the homepage also use the `posts` service to display all the articles for the homepage? This code update would limit the homepage to only showing a logged in user's own posts and no one else! And what happens if someone who is *not* logged in goes to the homepage? ERROR.
+
+How can we return one list of posts in the admin, and a different list of posts for the homepage?
+
+## An AdminPosts Service
+
+We could go down the road of adding variables in the GraphQL queries, along with checks in the existing `posts` service, that return a different list of posts whether you're on the homepage or in the admin. But this complexity adds a lot of surface area to test and some fragility if someone goes in there in the future—they have to be very careful not to add a new condition or negate an existing one and accidentally expose your admin functionality to exploits.
+
+What if we created *new* GraphQL queries for the admin views of posts? They would have automatic security checks thanks to `@requireAdmin`, no custom code required. These new queries will be used in the admin posts pages, and the original, simple `posts` service will be used for the homepage and article detail page.
+
+There are several steps we'll need to complete:
+
+1. Create a new `adminPosts` SDL that defines the types
+2. Create a new `adminPosts` service
+3. Update the posts admin GraphQL queries to pull from `adminPosts` instead of `posts`
+
+### Create the `adminPosts` SDL
+
+Let's keep the existing `posts.sdl.js` and make that the "public" interface. Duplicate that SDL, naming it `adminPosts.sdl.js`, and modify it like so:
+
+```javascript title=api/src/graphql/adminPosts.sdl.js
+export const schema = gql`
+  type Query {
+    adminPosts: [Post!]! @requireAuth(roles: ["admin"])
+    adminPost(id: Int!): Post @requireAuth(roles: ["admin"])
+  }
+
+  input CreatePostInput {
+    title: String!
+    body: String!
+  }
+
+  input UpdatePostInput {
+    title: String
+    body: String
+  }
+
+  type Mutation {
+    createPost(input: CreatePostInput!): Post! @requireAuth(roles: ["admin"])
+    updatePost(id: Int!, input: UpdatePostInput!): Post! @requireAuth(roles: ["admin"])
+    deletePost(id: Int!): Post! @requireAuth(roles: ["admin"])
+  }
+`
+```
+
+```javascript title=api/src/graphql/posts.sdl.js
+export const schema = gql`
+  type Post {
+    id: Int!
+    title: String!
+    body: String!
+    createdAt: DateTime!
+    user: User!
+  }
+
+  type Query {
+    posts: [Post!]! @skipAuth
+    post(id: Int!): Post @skipAuth
+  }
+`
+```
+
+So we keep a single type of `Post` since the data contained within it is the same, and either SDL file will return this same data type. We can remove the mutations from the `posts` SDL since the general public will not need to access those. We move create, update and delete mutations to the new `adminPosts` SDL, and rename the two queries from `posts` to `adminPosts` and `post` to `adminPost`. In case you didn't know: every query/mutation must have a unique name across your entire application!
+
+In `adminPosts` we've updated the queries to use `@requireAuth` instead of `@skipAuth`. Now that we have dedicated queries for our admin pages, we can lock them down to only allow access when authenticated.
+
+### Create the `adminPosts` Service
+
+Next let's create an `adminPosts` service. We'll need to move our create/update/delete mutations to it, as the name of the SDL needs to match the name of the service:
+
+```javascript title=api/src/services/adminPosts/adminPosts.js
+import { db } from 'src/lib/db'
+
+export const adminPosts = () => {
+  return db.post.findMany({ where: { userId: context.currentUser.id } })
+}
+
+export const adminPost = ({ id }) => {
+  return db.post.findFirst({
+    where: { id, userId: context.currentUser.id },
+  })
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: { ...input, userId: context.currentUser.id },
+  })
+}
+
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return db.post.delete({
+    where: { id },
+  })
+}
+```
+
+(Again, don't forget the change from `findUnique()` to `findFirst()`.) And update `posts` to remove some of the functions that live in `adminPosts` now:
+
+```javascript title=api/src/services/posts/posts.js
+import { db } from 'src/lib/db'
+
+export const posts = () => {
+  return db.post.findMany()
+}
+
+export const post = ({ id }) => {
+  return db.post.findUnique({ where: { id } })
+}
+
+export const Post = {
+  user: (_obj, { root }) =>
+    db.post.findFirst({ where: { id: root.id } }).user(),
+}
+```
+
+We've removed the `userId` lookup in the `posts` service so we're back to returning every post (for `posts`) or a single post (regardless of who owns it, in `post`).
+
+Note that we kept the relation resolver here `Post.user`, and there's none in `adminPosts`: since the queries and mutations from both SDLs still return a `Post`, we'll want to keep that relation resolver with the service that matches that original SDL by name: `graphql/posts.sdl.js` => `services/posts/posts.js`.
+
+### Update the GraphQL Queries
+
+Finally, we'll need to update several of the scaffold components to use the new `adminPosts` and `adminPost` queries (we'll limit the code snippets below to just the changes to save some room, this page is getting long enough!):
+
+```javascript title=web/src/components/Post/EditPostCell/EditPostCell.js
+export const QUERY = gql`
+  query FindPostById($id: Int!) {
+    // highlight-next-line
+    post: adminPost(id: $id) {
+      id
+      title
+      body
+      createdAt
+    }
+  }
+`
+```
+
+```jsx title=web/src/components/Post/PostCell/PostCell.js
+export const QUERY = gql`
+  query FindPostById($id: Int!) {
+    // highlight-next-line
+    post: adminPost(id: $id) {
+      id
+      title
+      body
+      createdAt
+    }
+  }
+`
+```
+
+```jsx title=web/src/components/Post/PostsCell/PostsCell.js
+export const QUERY = gql`
+  query POSTS {
+    // highlight-next-line
+    posts: adminPosts {
+      id
+      title
+      body
+      createdAt
+    }
+  }
+`
+```
+
+If we didn't use the `posts: adminPosts` syntax, we would need to rename the argument coming into the `Success` component below to `adminPosts`. This syntax renames the result of the query to `posts` and then nothing else below needs to change!
+
+We don't need to make any changes to the "public" views (like `ArticleCell` and `ArticlesCell`) since those will continue to use the original `posts` and `post` queries, and their respective resolvers.
+
+## Update and Delete
+
+Okay, let's take care of `updatePost` and `deletePost` now. Why couldn't we just do this?
+
+```javascript
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    // highlight-next-line
+    where: { id, userId: context.currentUser.id },
+  })
+}
+```
+
+Because like `findUnique()`, Prisma only wants to update records based on fields with unique indexes, in this case that's just `id`. So we need to keep this to just an `id`. But how do we verify that the user is only updating/deleting a record that they own?
+
+We could select the record first, make sure the user owns it, and only then let the `update()` commence:
+
+```javascript
+// highlight-next-line
+import { ForbiddenError } from '@redwoodjs/graphql-server'
+
+// highlight-start
+export const updatePost = async ({ id, input }) => {
+  if (await adminPost({ id })) {
+    return true
+  } else {
+    throw new ForbiddenError("You don't have access to this post")
+  }
+  // highlight-end
+
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+```
+
+We're using the `adminPost()` service function, rather than making another call to the database (note that we had to async/await it to make sure we have the post before continuing). Composing services like this is something Redwood was designed to encourage: services' functions act as resolvers for GraphQL, but they're also just plain JS functions and can be called wherever you need. And the reasons why you'd want to do this are clearly demonstrated here: `adminPost()` already limits the found record to be only one owned by the logged in user, so that logic is already encapsulated here, and we can be sure that any time an admin wants to do something with a single post, it runs through this code and uses the same logic every time.
+
+This works, but we'll need to do the same thing in `deletePost`. Let's extract that check for the post existence into a function:
+
+```javascript
+// highlight-start
+const verifyOwnership = async (id) {
+  if (await adminPost({ id })) {
+    return true
+  } else {
+    throw new ForbiddenError("You don't have access to this post")
+  }
+}
+// highlight-end
+
+export const updatePost = async ({ id, input }) => {
+  // highlight-next-line
+  await verifyOwnership(id)
+
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+```
+
+Simple! Our final `adminPosts` service ends up looking like:
+
+```javascript
+import { ForbiddenError } from '@redwoodjs/graphql-server'
+
+import { db } from 'src/lib/db'
+
+const validateOwnership = async ({ id }) => {
+  if (await adminPost({ id })) {
+    return true
+  } else {
+    throw new ForbiddenError("You don't have access to this post")
+  }
+}
+
+export const adminPosts = () => {
+  return db.post.findMany({ where: { userId: context.currentUser.id } })
+}
+
+export const adminPost = ({ id }) => {
+  return db.post.findFirst({
+    where: { id, userId: context.currentUser.id },
+  })
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: { ...input, userId: context.currentUser.id },
+  })
+}
+
+export const updatePost = async ({ id, input }) => {
+  await validateOwnership({ id })
+
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = async ({ id }) => {
+  await validateOwnership({ id })
+
+  return db.post.delete({
+    where: { id },
+  })
+}
+
+```
+
+## Wrapping Up
+
+Whew! Let's try several different scenarios (this is the kind of thing that the QA team lives for), making sure everything is working as expected:
+
+* A logged out user *should* see all posts on the homepage
+* A logged out user *should* be able to see the detail for a single post
+* A logged out user *should not* be able to go to /admin/posts
+* A logged out user *should not* see moderation controls next to comments
+* A logged in admin user *should* see all articles on the homepage (not just their own)
+* A logged in admin user *should* be able to go to /admin/posts
+* A logged in admin user *should* be able to create a new post
+* A logged in admin user *should not* be able to see anyone else's posts in /admin/posts
+* A logged in admin user *should not* see moderation controls next to comments (unless you modified that behavior at the end of the last page)
+* A logged in moderator user *should* see moderation controls next to comments
+* A logged in moderator user *should not* be able to access /admin/posts
+
+In fact, you could write some new tests to make sure this functionality doesn't mistakenly change in the future. The quickest would probably be to create `adminPosts.scenarios.js` and `adminPosts.test.js` files to go with the new service and verify that you are only returned the posts owned by a given user. You can [mock currentUser](/docs/testing#mockcurrentuser-on-the-api-side) to simulate someone being logged in or not, with different roles. You could add tests for the Cells we modified above, but the data they get is dependent on what's returned from the service, so as long as you have the service itself covered you should be okay. The 100% coverage folks would argue otherwise, but while they're still busy writing tests we're out cruising in our new yacht thanks to all the revenue from our newly launched (with *reasonable* test coverage) features!
+
+Did it work? Great! Did something go wrong? Can someone see too much, or too little? Double check that all of your GraphQL queries are updated and you've saved changes in all the opened files.

--- a/docs/versioned_docs/version-3.1/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter7/rbac.md
@@ -1,10 +1,10 @@
 # Role-Based Access Control (RBAC)
 
-Imagine a few weeks in the future of our blog when every post hits the front page of the New York Times and we're getting hundreds of comments a day. We can't be expected to come up with quality content each day *and* moderate the endless stream of (mostly well-meaning) comments! We're going to need help. Let's hire a comment moderator to remove obvious spam and bad intentioned posts and help make the internet a better place.
+Imagine a few weeks in the future of our blog when every post hits the front page of the New York Times and we're getting hundreds of comments a day. We can't be expected to come up with quality content each day *and* moderate the endless stream of (mostly well-meaning) comments! We're going to need help. Let's hire a comment moderator to remove obvious spam and any comments that don't heap praise on our writing ability. You know, to help make the internet a better place.
 
 We already have a login system for our blog, but right now it's all-or-nothing: you either get access to create blog posts, or you don't. In this case our comment moderator(s) will need logins so that we know who they are, but we're not going to let them create new blog posts. We need some kind of role that we can give to our two kinds of users so we can distinguish them from one another.
 
-Enter role-based access control, thankfully shortened to the common phrase **RBAC**. Authentication says who the person is, authorization says what they can do. "Access control" is another way to say authorization. Currently the blog has the lowest common denominator of authorization: if they are logged in, they can do everything. Let's add a "less than everything, but more than nothing" level.
+Enter **role-based access control**, thankfully shortened to the common phrase **RBAC**. Authentication says who the person is, authorization says what they can do. "Access control" is another way to say authorization. Currently the blog has the lowest common denominator of authorization: if they are logged in, they can do everything. Let's add a "less than everything, but more than nothing" level.
 
 ### Defining Roles
 
@@ -65,7 +65,7 @@ And you can name it something like "add roles to user".
 
 If we log in and try to go the posts admin page at [http://localhost:8910/admin/posts](http://localhost:8910/admin/posts) everything works the same as it used to: we're not actually checking for the existence of any roles yet so that makes sense. In reality we'd only want users with the `admin` role to have access to the admin pages, but our existing user just became a `moderator` because of our default role. This is a great opportunity to actually setup a role check and see if we lose access to the admin!
 
-Before we do that, we'll need to make sure that the web side has access to the roles on `currentUser`. Take a look at `api/src/lib/auth.js`. Remember when we had to add `email` to the list of fields being included in Part 1? We need to add `roles` as well:
+Before we do that, we'll need to make sure that the web side has access to the roles on `currentUser`. Take a look at `api/src/lib/auth.js`. Remember when we had to add `email` to the list of fields being included? We need to add `roles` as well:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -191,7 +191,7 @@ The easiest way to prevent access to an entire URL is via the Router. The `<Priv
 </TabItem>
 </Tabs>
 
-Now if you reload the posts admin you should get redirected to the homepage.
+Now if you browse to [http://localhost:8910/admin/posts](http://localhost:8910/admin/posts) you should get redirected to the homepage. So far so good.
 
 ### Changing Roles on a User
 
@@ -230,7 +230,7 @@ Which should return the new content of the user:
 
 :::caution
 
-If that doesn't work for you maybe your user doesn't have an `id` of `1`! Run `db.user.findMany()` first and then get the `id` of the user you want to update.
+If you re-used the same console session from the previous section, you'll need to quit it and start it again for it to know about the new Prisma data structure. If you still can't get the update to work, maybe your user doesn't have an `id` of `1`! Run `db.user.findMany()` first and then get the `id` of the user you want to update.
 
 :::
 
@@ -404,6 +404,7 @@ And due to the nice encapsulation of our **Comment** component we can make all t
 import { useAuth } from '@redwoodjs/auth'
 // highlight-start
 import { useMutation } from '@redwoodjs/web'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 // highlight-end
 
@@ -478,6 +479,7 @@ export default Comment
 import { useAuth } from '@redwoodjs/auth'
 // highlight-start
 import { useMutation } from '@redwoodjs/web'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 // highlight-end
 
@@ -620,34 +622,31 @@ import Comment from './Comment'
 // highlight-next-line
 export const defaultView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        // highlight-next-line
+        postId: 1
+      }}
+    />
   )
 }
 
 // highlight-start
 export const moderatorView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 // highlight-end
@@ -664,34 +663,31 @@ import Comment from './Comment'
 // highlight-next-line
 export const defaultView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        // highlight-next-line
+        postId: 1,
+      }}
+    />
   )
 }
 
 // highlight-start
 export const moderatorView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 // highlight-end
@@ -711,22 +707,22 @@ The **moderatorView** story needs to have a user available that has the moderato
 export const moderatorView = () => {
   // highlight-start
   mockCurrentUser({
+    id: 1,
+    email: 'moderator@moderator.com',
     roles: 'moderator',
   })
   // highlight-end
 
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 ```
@@ -738,24 +734,22 @@ export const moderatorView = () => {
 export const moderatorView = () => {
   // highlight-start
   mockCurrentUser({
-    roles: 'moderator',
     id: 1,
     email: 'moderator@moderator.com',
+    roles: 'moderator',
   })
   // highlight-end
 
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 ```
@@ -785,6 +779,7 @@ We can use the same `mockCurrentUser()` function in our Jest tests as well. Let'
 ```jsx title="web/src/components/Comment/Comment.test.js"
 // highlight-next-line
 import { render, screen, waitFor } from '@redwoodjs/testing'
+
 import Comment from './Comment'
 
 // highlight-start
@@ -821,7 +816,11 @@ describe('Comment', () => {
   })
 
   it('renders a delete button if the user is a moderator', async () => {
-    mockCurrentUser({ roles: 'moderator' })
+    mockCurrentUser({
+      id: 1,
+      email: 'moderator@moderator.com',
+      roles: 'moderator',
+    })
     render(<Comment comment={COMMENT} />)
 
     await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
@@ -876,9 +875,9 @@ describe('Comment', () => {
 
   it('renders a delete button if the user is a moderator', async () => {
     mockCurrentUser({
-      roles: 'moderator',
       id: 1,
       email: 'moderator@moderator.com',
+      roles: 'moderator',
     })
 
     render(<Comment comment={COMMENT} />)
@@ -894,7 +893,9 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-Before the test suite will work we'll need to stop and re-start the test server: when adding a field to the database (`roles` on `User` in this case) we need to restart the test runner so that it can apply the schema changes to our test database. So press `q` or `Ctrl-C` in your test runner if it's still running, then:
+:::caution Seeing errors in your test suite?
+
+We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 
 ```bash
 yarn rw test
@@ -902,11 +903,13 @@ yarn rw test
 
 The suite should automatically run the tests for `Comment` and `CommentCell` at the very least, and maybe a few more if you haven't committed your code to git in a while.
 
+:::
+
 :::info
 
 This isn't the most robust test that's ever been written: what if the sample text of the comment itself had the word "Delete" in it? Whoops! But you get the idea—find some meaningful difference in each possible render state of a component and write a test that verifies its presence (or lack of presence).
 
-Think of each conditional in your component as another branch you need to have a test for. In the worst case, each conditional adds ^2 possible render states. If you have three conditionals that's eight possible combinations of output and to be safe you'll want to test them all. When you get yourself into this scenario it's a good sign that it's time to refactor and simplify your component. Maybe into subcomponents where each is responsible for just one of those conditional outputs? You'll still need the same number of total tests, but each component and its test is now operating in isolation and making sure it does one thing, and does it well. This has benefits for your mental model of the codebase as well.
+Think of each conditional in your component as another branch you need to have a test for. In the worst case, each conditional adds 2<sup>n</sup> possible render states. If you have three conditionals that's 2<sup>3</sup> (eight) possible combinations of output and to be safe you'll want to test them all. When you get yourself into this scenario it's a good sign that it's time to refactor and simplify your component. Maybe into subcomponents where each is responsible for just one of those conditional outputs? You'll still need the same number of total tests, but each component and its test is now operating in isolation and making sure it does one thing, and does it well. This has benefits for your mental model of the codebase as well.
 
 It's like finally organizing that junk drawer in the kitchen—you still have the same number of things when you're done, but each thing is in its own space and therefore easier to remember where it lives and makes it easier to find next time.
 
@@ -1076,9 +1079,9 @@ This check only prevents access to `deleteComment` via GraphQL. What if you're c
 <TabItem value="js" label="JavaScript">
 
 ```javascript title="api/src/services/comments/comments.js"
-import { db } from 'src/lib/db'
 // highlight-next-line
 import { requireAuth } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 // ...
 
@@ -1095,9 +1098,9 @@ export const deleteComment = ({ id }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```ts title="api/src/services/comments/comments.ts"
-import { db } from 'src/lib/db'
 // highlight-next-line
 import { requireAuth } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 // ...
 
@@ -1120,10 +1123,12 @@ We'll need a test to go along with that functionality. How do we test `requireAu
 
 ```javascript title="api/src/services/comments/comments.test.js"
 // highlight-next-line
-import { comments, createComment, deleteComment } from './comments'
-import { db } from 'src/lib/db'
-// highlight-next-line
 import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
+
+import { db } from 'src/lib/db'
+
+// highlight-next-line
+import { comments, createComment, deleteComment } from './comments'
 
 describe('comments', () => {
   scenario(
@@ -1200,10 +1205,12 @@ describe('comments', () => {
 
 ```ts title="api/src/services/comments/comments.test.ts"
 // highlight-next-line
-import { comments, createComment, deleteComment } from './comments'
-import { db } from 'src/lib/db'
-// highlight-next-line
 import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
+
+import { db } from 'src/lib/db'
+
+// highlight-next-line
+import { comments, createComment, deleteComment } from './comments'
 
 import type { PostOnlyScenario, StandardScenario } from './comments.scenarios'
 

--- a/docs/versioned_docs/version-3.2/tutorial/chapter5/first-story.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter5/first-story.md
@@ -146,7 +146,7 @@ export default { title: 'Components/Article' }
 </TabItem>
 </Tabs>
 
-As soon as you save the change the stories Storybook should refresh and show the updates:
+As soon as you save the change the stories Storybook should refresh and may show an error: there's no longer a "Generated" story to show! In the tree on the left, expand "Article" and the "Full" version should show right away. Click on "Summary" to see the difference:
 
 ![image](https://user-images.githubusercontent.com/300/153311838-595b8b38-d899-4d7b-891b-a492f0c8f2e2.png)
 
@@ -231,6 +231,8 @@ export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
 
 </TabItem>
 </Tabs>
+
+Check out the story to see the new summary view:
 
 ![image](https://user-images.githubusercontent.com/300/153312022-1cfbf696-b2cb-4fca-b640-4111643fb396.png)
 

--- a/docs/versioned_docs/version-3.2/tutorial/chapter5/first-test.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter5/first-test.md
@@ -4,13 +4,13 @@ So if Storybook is the first phase of creating/updating a component, phase two m
 
 If you've never done any kind of testing before this may be a little hard to follow. We've got a great document [all about testing](../../testing.md) (including some philosophy, for those so inclined) if you want a good overview of testing in general. We even build a super-simple test runner from scratch in plain Javascript to take some of the mystery out of how this all works!
 
-First let's run the existing suite to see if we broke anything:
+If you still have the test process running from the previous page then then you can just press `a` to run **a**ll tests. If you stopped your test process, you can start it again with:
 
 ```bash
 yarn rw test
 ```
 
-Well that didn't take long! Can you guess what we broke?
+Can you guess what broke in this test?
 
 ![image](https://user-images.githubusercontent.com/300/153312402-dd7f08bc-e23d-4acc-8202-cdfc9798a911.png)
 
@@ -79,6 +79,7 @@ Okay, let's do this:
 ```jsx title="web/src/components/ArticlesCell.test.js"
 // highlight-next-line
 import { render, screen, within } from '@redwoodjs/testing'
+
 import { Loading, Empty, Failure, Success } from './ArticlesCell'
 import { standard } from './ArticlesCell.mock'
 
@@ -127,6 +128,7 @@ describe('ArticlesCell', () => {
 ```tsx title="web/src/components/ArticlesCell.test.tsx"
 // highlight-next-line
 import { render, screen, within } from '@redwoodjs/testing'
+
 import { Loading, Empty, Failure, Success } from './ArticlesCell'
 import { standard } from './ArticlesCell.mock'
 
@@ -178,42 +180,40 @@ This loops through each article in our `standard()` mock and for each one:
 const truncatedBody = article.body.substring(0, 10)
 ```
 
-Create a variable `truncatedBody` containing the first 10 characters of the post body
+Create a variable `truncatedBody` containing the first 10 characters of the post body.
 
 ```javascript
 const matchedBody = screen.getByText(truncatedBody, { exact: false })
 ```
 
-Search through the rendered HTML on the screen and find the HTML element that contains the truncated body (note the `{ exact: false }` here, as normally the exact text, and only that text, would need to be present, but in this case there's probably more than just the 10 characters)
+Search through the rendered HTML on the screen and find the HTML element that contains the truncated body (note the `{ exact: false }` here, as normally the exact text, and only that text, would need to be present, but in this case there's probably more than just the 10 characters).
 
 ```javascript
 const ellipsis = within(matchedBody).getByText('...', { exact: false })
 ```
 
-Within the HTML element that was found in the previous line, find `...`, again without an exact match
+Within the HTML element that was found in the previous line, find `...`, again without an exact match.
 
 ```javascript
 expect(screen.getByText(article.title)).toBeInTheDocument()
 ```
 
-Find the title of the article in the page
+Find the title of the article in the page.
 
 ```javascript
 expect(screen.queryByText(article.body)).not.toBeInTheDocument()
 ```
-When trying to find the *full* text of the body, it should *not* be present
+When trying to find the *full* text of the body, it should *not* be present.
 
 ```javascript
 expect(matchedBody).toBeInTheDocument()
 ```
-Assert that the truncated text is present
+Assert that the truncated text is .
 
 ```javascript
 expect(ellipsis).toBeInTheDocument()
 ```
-Assert that the ellipsis is present
-
-As soon as you saved that test file the test should have run and passed! Press `a` to run the whole suite if you want to make sure nothing else broke. Remember to press `o` to go back to only testing changes again. (There's nothing wrong with running the full test suite each time, but it will take longer than only testing the things that have changed since the last time you committed your code.)
+Assert that the ellipsis is present.
 
 :::info What's the difference between `getByText()` and `queryByText()`?
 
@@ -221,11 +221,13 @@ As soon as you saved that test file the test should have run and passed! Press `
 
 :::
 
-To double check that we're testing what we think we're testing, open up `ArticlesCell.js` and remove the `summary={true}` prop (or set it to `false`) and the test should fail: now the full body of the post *is* on the page and `expect(screen.queryByText(article.body)).not.toBeInTheDocument()` *is* in the document! Make sure to put the `summary={true}` back before we continue.
+As soon as you saved that test file the test should have run and passed! Press `a` to run the whole suite if you want to make sure nothing else broke. Remember to press `o` to go back to only testing changes again. (There's nothing wrong with running the full test suite each time, but it will take longer than only testing the things that have changed since the last time you committed your code.)
+
+To double check that we're testing what we think we're testing, open up `ArticlesCell.js` and remove the `summary={true}` prop (or set it to `false`) and the test should fail: now the full body of the post *is* on the page and the expectation in our test `expect(screen.queryByText(article.body)).not.toBeInTheDocument()` fails because the full body *is* in the document! Make sure to put the `summary={true}` back before we continue.
 
 ### What's the Deal with Mocks?
 
-Mocks are used when you want to define the data that would normally be returned by GraphQL. In cells, a GraphQL call goes out (the query defined by **QUERY**) and returned to the **Success** component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
+Did you wonder where the articles were coming from in our test? Was it the development database? Nope: that data came from a **Mock**. That's the `ArticlesCell.mock.js` file that lives next to your component, test and stories files. Mocks are used when you want to define the data that would normally be returned by GraphQL in your Storybook stories or tests. In cells, a GraphQL call goes out (the query defined by the variable `QUERY` at the top of the file) and returned to the `Success` component. We don't want to have to run the api-side server and have real data in the database just for Storybook or our tests, so Redwood intercepts those GraphQL calls and returns the data from the mock instead.
 
 :::info If the server is being mocked, how do we test the api-side code?
 
@@ -387,9 +389,9 @@ You can have as many mocks as you want, just import the names of the ones you ne
 
 ### Testing Article
 
-Our test suite is passing again but it's a trick! We never added a test for the actual `summary` functionality that we added to the `Article` component. We tested that `ArticlesCell` requests that `Article` return a summary, but what it means to render a summary is knowledge that only `Article` contains.
+Our test suite is passing again but it's a trick! We never added a test for the actual `summary` functionality that we added to the `Article` component. We tested that `ArticlesCell` renders (that eventually render an `Article`) include a summary, but what it means to render a summary is knowledge that only `Article` contains.
 
-When you get into the flow of building your app it can be very easy to overlook testing functionality like this. Wasn't it Winston Churchill who said "a thorough test suite requires eternal vigilance"? Techniques like [Test Driven Development](https://en.wikipedia.org/wiki/Test-driven_development) (TDD) were established to help combat this tendency—write the test first, watch it fail, then write the code to make the test pass so that you know every line of real code you write is backed by a test. What we're doing is affectionately known as [Development Driven Testing](https://medium.com/table-xi/development-driven-testing-673d3959dac2). You'll probably settle somewhere in the middle but one maxim is always true—some tests are better than no tests.
+When you get into the flow of building your app it can be very easy to overlook testing functionality like this. Wasn't it Winston Churchill who said "a thorough test suite requires eternal vigilance"? Techniques like [Test Driven Development](https://en.wikipedia.org/wiki/Test-driven_development) (TDD) were established to help combat this tendency: when you want to write a new feature, write the test first, watch it fail, then write the code to make the test pass so that you know every line of real code you write is backed by a test. What we're doing is affectionately known as [Development Driven Testing](https://medium.com/table-xi/development-driven-testing-673d3959dac2). You'll probably settle somewhere in the middle but one maxim is always true: some tests are better than no tests.
 
 The summary functionality in `Article` is pretty simple, but there are a couple of different ways we could test it:
 
@@ -398,15 +400,16 @@ The summary functionality in `Article` is pretty simple, but there are a couple 
 
 In this case `truncate()` "belongs to" `Article` and the outside world really shouldn't need to worry about it or know that it exists. If we came to a point in development where another component needed to truncate text then that would be a perfect time to move this function to a shared location and import it into both components that need it. `truncate()` could then have its own dedicated test. But for now let's keep our separation of concerns and test the one thing that's "public" about this component—the result of the render.
 
-In this case let's just test that the output matches an exact string. You could spin yourself in circles trying to refactor the code to make it absolutely bulletproof to code changes breaking the tests, but will you ever actually need that level of flexibility? It's always a trade-off!
+In this case let's just test that the output matches an exact string. Since the knowledge of how long to make the summary is contained in `Article` itself, at this point it feels okay to have the test tightly coupled to the render result of this particular component. (`ArticlesCell` itself didn't know about how long to truncate, just that *something* was shortening the text.) You could spin yourself in circles trying to refactor the code to make it absolutely bulletproof to code changes breaking the tests, but will you ever actually need that level of flexibility? It's always a trade-off!
 
-We'll move the sample post data to a constant and then use it in both the existing test (which tests that not passing the `summary` prop at all results in the full body being rendered) and our new test that checks for the summary version being rendered:
+We'll move the sample article data in the test to a constant and then use it in both the existing test (which tests that not passing the `summary` prop at all results in the full body being rendered) and our new test that checks for the summary version being rendered:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/Article/Article.test.js"
 import { render, screen } from '@redwoodjs/testing'
+
 import Article from './Article'
 
 // highlight-start
@@ -449,6 +452,7 @@ describe('Article', () => {
 
 ```jsx title="web/src/components/Article/Article.test.tsx"
 import { render, screen } from '@redwoodjs/testing'
+
 import Article from './Article'
 
 // highlight-start

--- a/docs/versioned_docs/version-3.2/tutorial/chapter5/testing.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter5/testing.md
@@ -1,6 +1,6 @@
 # Introduction to Testing
 
-Let's run the test suite to make sure everything is working as expected (you can keep the dev server running and start this in a second terminal window):
+Let's run the test suite to make sure everything is working as expected (you can keep the dev server running and start this in a new terminal window):
 
 ```bash
 yarn rw test

--- a/docs/versioned_docs/version-3.2/tutorial/chapter6/comment-form.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter6/comment-form.md
@@ -93,7 +93,7 @@ const CommentForm = () => {
         </Label>
         <TextField
           name="name"
-          className="block w-full p-1 border rounded text-xs "
+          className="block w-full p-1 border rounded text-xs"
           validation={{ required: true }}
         />
 
@@ -368,7 +368,7 @@ import type {
   CreateCommentMutationVariables,
 } from 'types/graphql'
 // highlight-end
-  
+
 export const generated = () => {
   // highlight-start
   mockGraphQLMutation<CreateCommentMutation, CreateCommentMutationVariables>(
@@ -398,6 +398,12 @@ export default { title: 'Components/CommentForm' }
 </TabItem>
 </Tabs>
 
+:::info
+
+If you still get an error, try reloading the Storybook tab in the browser.
+
+:::
+
 To use `mockGraphQLMutation` you call it with the name of the mutation you want to intercept and then the function that will handle the interception and return a response. The arguments passed to that function give us some flexibility in how we handle the response.
 
 In our case we want the `variables` that were passed to the mutation (the `name` and `body`) as well as the context object (abbreviated as `ctx`) so that we can add a delay to simulate a round trip to the server. This will let us test that the **Submit** button is disabled for that one second and you can't submit a second comment while the first one is still being saved.
@@ -421,9 +427,10 @@ So let's use `Article` as the cleaning house for where all these disparate parts
 
 ```jsx title="web/src/components/Article/Article.js"
 import { Link, routes } from '@redwoodjs/router'
-import CommentsCell from 'src/components/CommentsCell'
+
 // highlight-next-line
 import CommentForm from 'src/components/CommentForm'
+import CommentsCell from 'src/components/CommentsCell'
 
 const truncate = (text, length) => {
   return text.substring(0, length) + '...'
@@ -463,9 +470,10 @@ export default Article
 
 ```tsx title="web/src/components/Article/Article.tsx"
 import { Link, routes } from '@redwoodjs/router'
-import CommentsCell from 'src/components/CommentsCell'
+
 // highlight-next-line
 import CommentForm from 'src/components/CommentForm'
+import CommentsCell from 'src/components/CommentsCell'
 
 import type { Post } from 'types/graphql'
 
@@ -663,7 +671,7 @@ Now fill out the comment form and submit! And...nothing happened! Believe it or 
 
 ![image](https://user-images.githubusercontent.com/300/153930645-c5233fb5-ad7f-4a03-8707-3cd6164bb277.png)
 
-Yay! It would have been nicer if that comment appeared as soon as we submitted the comment, so maybe that's a half-yay? Also, the text boxes stayed filled with our name/messages which isn't ideal. But, we can fix both of those! One involves telling the GraphQL client (Apollo) that we created a new record and, if it would be so kind, to try the query again that gets the comments for this page, and we'll fix the other by just removing the form from the page completely when a new comment is submitted.
+Yay! It would have been nicer if that comment appeared as soon as we submitted the comment, so maybe that's a half-yay? Also, the text boxes stayed filled with our name/messages (before we reloaded the page) which isn't ideal. But, we can fix both of those. One involves telling the GraphQL client (Apollo) that we created a new record and, if it would be so kind, to try the query again that gets the comments for this page, and we'll fix the other by just removing the form from the page completely when a new comment is submitted.
 
 ### GraphQL Query Caching
 
@@ -684,6 +692,7 @@ import {
   Submit,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
+
 // highlight-next-line
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 
@@ -713,6 +722,7 @@ import {
   Submit,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
+
 // highlight-next-line
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 
@@ -740,6 +750,9 @@ We'll make use of good old fashioned React state to keep track of whether a comm
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/CommentForm/CommentForm.js"
+// highlight-next-line
+import { useState } from 'react'
+
 import {
   Form,
   FormError,
@@ -751,9 +764,8 @@ import {
 import { useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast } from '@redwoodjs/web/toast'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
-// highlight-next-line
-import { useState } from 'react'
 
 const CREATE = gql`
   mutation CreateCommentMutation($input: CreateCommentInput!) {
@@ -835,6 +847,9 @@ export default CommentForm
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/components/CommentForm/CommentForm.tsx"
+// highlight-next-line
+import { useState } from 'react'
+
 import {
   Form,
   FormError,
@@ -842,14 +857,12 @@ import {
   TextField,
   TextAreaField,
   Submit,
-  SubmitHandler,
 } from '@redwoodjs/forms'
 import { useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast } from '@redwoodjs/web/toast'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
-// highlight-next-line
-import { useState } from 'react'
 
 const CREATE = gql`
   mutation CreateCommentMutation($input: CreateCommentInput!) {
@@ -948,8 +961,8 @@ We used `hidden` to just hide the form and "Leave a comment" title completely fr
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/layouts/BlogLayout/BlogLayout.js"
-import { Link, routes } from '@redwoodjs/router'
 import { useAuth } from '@redwoodjs/auth'
+import { Link, routes } from '@redwoodjs/router'
 // highlight-next-line
 import { Toaster } from '@redwoodjs/web/toast'
 
@@ -1111,7 +1124,7 @@ So it looks like we're just about done here! Try going back to the homepage and 
 
 All posts have the same comments! **WHAT HAVE WE DONE??**
 
-Remember our foreshadowing callout a few pages back, wondering if our `comments()` service which only returns *all* comments could come back to bite us? It finally has: when we get the comments for a post we're not actually getting them for only that post. We're ignoring the `postId` completely and just returning *all* comments in the database! Turns out the old axiom is true: computers only do exactly what you tell them to do. :(
+Remember our foreshadowing callout a few pages back, wondering if our `comments()` service which only returns *all* comments could come back to bite us? It finally has: when we get the comments for a post we're not actually getting them for only that post. We're ignoring the `postId` completely and just returning *all* comments in the database! Turns out the old axiom is true: computers only do exactly what you tell them to do.
 
 Let's fix it!
 
@@ -1476,7 +1489,7 @@ scenario(
 </TabItem>
 </Tabs>
 
-Okay, open up the actual `comments.js` service and we'll update it to accept the `postId` argument and use it as an option to `findMany()`:
+Okay, open up the actual `comments.js` service and we'll update it to accept the `postId` argument and use it as an option to `findMany()` (be sure to update the `comments()` function [with an "s"] and not the unused `comment()` function):
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -1532,7 +1545,13 @@ type Query {
 
 Now if you try refreshing the real site in dev mode you'll see an error where the comments should be displayed:
 
-![image](https://user-images.githubusercontent.com/300/153936065-159eb06e-4c9e-43db-a07e-a4d17332276c.png)
+![image](https://user-images.githubusercontent.com/300/198095941-bbd07ede-2006-422a-8635-ea8fe57dd403.png)
+
+For security reasons we don't show the internal error message here, but if you check the terminal window where `yarn rw dev` is running you'll see the real message:
+
+```text
+Field "comments" argument "postId" of type "Int!" is required, but it was not provided.
+```
 
 And yep, it's complaining about `postId` not being present—exactly what we want!
 
@@ -1648,7 +1667,7 @@ export const QUERY = gql`
 
 Where does this magical `$postId` come from? Redwood is nice enough to automatically provide it to you since you passed it in as a prop when you called the component!
 
-Try going to a couple of different blog posts and you should see only comments associated to the proper posts (including the one we created in the console!). You can add a comment to each blog post individually and they'll stick to their proper owners:
+Try going to a couple of different blog posts and you should see only comments associated to the proper posts (including the one we created in the console). You can add a comment to each blog post individually and they'll stick to their proper owners:
 
 ![image](https://user-images.githubusercontent.com/300/100954162-de24f680-34c8-11eb-817b-0a7ad802f28b.png)
 

--- a/docs/versioned_docs/version-3.2/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter6/comments-schema.md
@@ -551,7 +551,7 @@ describe('comments', () => {
 </TabItem>
 </Tabs>
 
-What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it.
+What is this `scenario()` function? That's made available by Redwood that mostly acts like Jest's built-in `it()` and `test()` functions, but with one important difference: it pre-seeds a test database with data that is then passed to you in the `scenario` argument. You can count on this data existing in the database and being reset between tests in case you make changes to it. You can create the data structure for any and all models defined in `schema.prisma`, not just comments (the file happens to be named that because it's the ones that will load when running `comments.test.js`).
 
 :::info In the section on mocks you said relying on data in the database for testing was dumb?
 
@@ -729,7 +729,7 @@ The test created by the service generator simply checks to make sure the same nu
 
 #### Testing createComment()
 
-Let's add our first service test by making sure that `createComment()` actually stores a new comment in the database. When creating a comment we're not as worried about existing data in the database so let's create a new scenario which only contains a post—the post we'll be linking the new comment to through the comment's `postId` field:
+Let's add our first service test by making sure that `createComment()` actually stores a new comment in the database. When creating a comment we're not as worried about existing data in the database so let's create a new scenario which only contains a post—the post we'll be linking the new comment to through the comment's `postId` field. You can create multiple scenarios and then say which one you want pre-loaded into the database at the time the test is run. We'll let the `standard` scenario stay as-is and make a new one with a new set of data:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -870,7 +870,7 @@ We pass an optional first argument to `scenario()` which is the named scenario t
 
 We were able to use the `id` of the post that we created in our scenario because the scenarios contain the actual database data after being inserted, not just the few fields we defined in the scenario itself. In addition to `id` we could access `createdAt` which is defaulted to `now()` in the database.
 
-:::info What's that post…connect…id-Voodoo?! Can't we simply pass the Post's ID directly here?
+:::info What's that `post: { connect: { id } }` nested structure? Can't we simply pass the Post's ID directly here?
 
 What you're looking at is the [connect syntax](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#connect-an-existing-record), which is a Prisma
 core concept. And yes, we could simply pass `postId: scenario.post.bark.id` instead – as a so-called "unchecked" input. But as the name implies, the connect syntax is king
@@ -900,7 +900,7 @@ in case we wanted to allow both ways – which Prisma generally allows, however 
 
 We'll test that all the fields we give to the `createComment()` function are actually created in the database, and for good measure just make sure that `createdAt` is set to a non-null value. We could test that the actual timestamp is correct, but that involves freezing the Javascript Date object so that no matter how long the test takes, you can still compare the value to `new Date` which is right *now*, down to the millisecond. While possible, it's beyond the scope of our easy, breezy tutorial since it gets [very gnarly](https://codewithhugo.com/mocking-the-current-date-in-jest-tests/)!
 
-:::info What's up with the names for scenario data? posts.bark? Really?
+:::info What's up with the names for scenario data? `posts.bark`? Really?
 
 This makes reasoning about your tests much nicer! Which of these would you rather work with:
 
@@ -918,13 +918,15 @@ Okay, our comments service is feeling pretty solid now that we have our tests in
 
 :::info Mocks vs. Scenarios
 
-Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that "mock" is a synonym for "fake", as in this-is-fake-data-not-really-in-the-database (so that we can create stories and tests in isolation without the api side getting involved). Whereas a scenario is real data in the database, it's just pre-set to some known state that we can rely on.
+Mocks are used on the web site and scenarios are used on the api side. It might be helpful to remember that **mock** is a synonym for "fake", as in "this is fake data not really in the database" (so that we can create stories and tests in isolation without the api side getting involved). Whereas a **scenario** is real data in the database, it's just pre-set to some known state that we can rely on.
 
-Maybe a [mnemonic](https://www.mnemonicgenerator.com/?words=M%20W%20S%20A) would help? **M**ocks **W**eb **S**cenarios **A**PI:
+Maybe a [mnemonic](https://www.mnemonicgenerator.com/?words=M%20W%20S%20A) would help?
 
-* Mothers Worshipped Slimy Aprons
+**M**ocks : **W**eb :: **S**cenarios : **A**PI:
+
+* Mysterious Weasels Scratched Armor
 * Minesweepers Wrecked Subliminal Attorneys
-* Masked Widows Squeezed Apricots
+* Martian Warriors Squeezed Apricots
 
 Maybe not...
 

--- a/docs/versioned_docs/version-3.2/tutorial/chapter6/multiple-comments.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter6/multiple-comments.md
@@ -30,14 +30,6 @@ Let's generate a **CommentsCell**:
 yarn rw g cell Comments
 ```
 
-:::caution What's with these errors and warnings after generating this cell?
-
-Redwood will try to generate types to go along with your cell. However, we haven't generated an SDL file for the Comment model yet, so types can't be created. This is safe to ignore for now as we're building out our UI in Storybook. 
-
-You may also see some red squiggles in your IDE: same thing, types couldn't be generated.
-
-:::
-
 Storybook updates with a new **CommentsCell** under the **Cells** folder, and it's actually showing something:
 
 ![image](https://user-images.githubusercontent.com/300/153477642-0d5a15a5-f96f-485a-b8b0-dbc1c4515279.png)
@@ -189,9 +181,9 @@ export const standard = () => ({
 </TabItem>
 </Tabs>
 
-:::info
+:::info What's this `standard` thing?
 
-What's this `standard` thing? Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in Javascript!
+Think of it as the standard, default mock if you don't do anything else. We would have loved to use the name "default" but that's already a reserved word in Javascript!
 
 :::
 
@@ -322,7 +314,7 @@ export default Article
 
 If we are *not* showing the summary, then we'll show the comments. Take a look at the **Full** and **Summary** stories in Storybook and you should see comments on one and not on the other.
 
-:::info Shouldn't the CommentsCell cause an actual GraphQL request? How does this work?
+:::info Shouldn't the `CommentsCell` cause an actual GraphQL request? How does this work?
 
 Redwood has added some functionality around Storybook so that if you're testing a component that itself isn't a Cell (like the `Article` component) but that renders a cell (like `CommentsCell`), then it will mock the GraphQL and use the `standard` mock that goes along with that Cell. Pretty cool, huh?
 
@@ -419,6 +411,7 @@ The default `CommentsCell.test.{js,tsx}` actually tests every state for us, albe
 
 ```jsx title="web/src/components/CommentsCell/CommentsCell.test.js"
 import { render } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -454,6 +447,7 @@ describe('CommentsCell', () => {
 
 ```tsx title="web/src/components/CommentsCell/CommentsCell.test.tsx"
 import { render } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -497,6 +491,7 @@ But in this case we can do a little more to make sure `CommentsCell` is doing wh
 ```jsx title="web/src/components/CommentsCell/CommentsCell.test.js"
 // highlight-next-line
 import { render, screen } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -539,6 +534,7 @@ describe('CommentsCell', () => {
 ```tsx title="web/src/components/CommentsCell/CommentsCell.test.tsx"
 // highlight-next-line
 import { render, screen } from '@redwoodjs/testing/web'
+
 import { Loading, Empty, Failure, Success } from './CommentsCell'
 import { standard } from './CommentsCell.mock'
 
@@ -578,22 +574,25 @@ describe('CommentsCell', () => {
 </TabItem>
 </Tabs>
 
-We're looping through each `comment` from the mock, the same mock used by Storybook, so that even if we add more later, we're covered. You may find yourself writing a test and saying "just test that there are 3 comments," which will work today, but months from now when you add more comments to the mock to try some different iterations in Storybook, that test will start failing. Avoid hardcoding data like this into your test when you can derive it from your mocked data!
+We're looping through each `comment` from the mock, the same mock used by Storybook, so that even if we add more later, we're covered. You may find yourself writing a test and saying "just test that there are two total comments," which will work today, but months from now when you add more comments to the mock to try some different iterations in Storybook, that test will start failing. Avoid hardcoding data like this, especially [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)), into your test when you can derive it from your mocked data!
 
 #### Testing Article
 
-The functionality we added to `Article` says to show the comments for the post if we are *not* showing the summary. We've got a test for both the "full" and "summary" renders already. Generally you want your tests to be testing "one thing" so let's add two additional tests for our new functionality:
+The functionality we added to `Article` says to show the comments for the post if we are *not* showing the summary. We've got a test for both the "full" and "summary" renders already. Generally you want a test to be testing "one thing," like whether the body of the article is present, and another test for whether the comments are displaying. If you find that you're using "and" in your test description (like "renders a blog post and its comments") that's a good sign that it should probably be split into two separate tests.
+
+Let's add two additional tests for our new functionality:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/Article/Article.test.js"
-// highlight-next-line
+// highlight-start
 import { render, screen, waitFor } from '@redwoodjs/testing'
 
-import Article from './Article'
-// highlight-next-line
 import { standard } from 'src/components/CommentsCell/CommentsCell.mock'
+// highlight-end
+
+import Article from './Article'
 
 const ARTICLE = {
   id: 1,
@@ -649,12 +648,13 @@ describe('Article', () => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/Article/Article.test.tsx"
-// highlight-next-line
+// highlight-start
 import { render, screen, waitFor } from '@redwoodjs/testing'
 
-import Article from './Article'
-// highlight-next-line
 import { standard } from 'src/components/CommentsCell/CommentsCell.mock'
+// highlight-end
+
+import Article from './Article'
 
 const ARTICLE = {
   id: 1,

--- a/docs/versioned_docs/version-3.2/tutorial/chapter6/the-redwood-way.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter6/the-redwood-way.md
@@ -105,7 +105,10 @@ export const generated = () => {
   // highlight-end
 }
 
-export default { title: 'Components/Comment' }
+export default {
+  title: 'Components/Comment',
+  component: Comment,
+}
 ```
 
 </TabItem>
@@ -128,7 +131,10 @@ export const generated = () => {
   // highlight-end
 }
 
-export default { title: 'Components/Comment' }
+export default {
+  title: 'Components/Comment',
+  component: Comment,
+}
 ```
 
 </TabItem>
@@ -236,6 +242,7 @@ Let's add a sample comment to the test and check that the various parts are bein
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/Comment.test.js"
+// highlight-next-line
 import { render, screen } from '@redwoodjs/testing'
 
 import Comment from './Comment'
@@ -265,6 +272,7 @@ describe('Comment', () => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/Comment.test.tsx"
+// highlight-next-line
 import { render, screen } from '@redwoodjs/testing'
 
 import Comment from './Comment'
@@ -294,6 +302,12 @@ describe('Comment', () => {
 </Tabs>
 
 Here we're testing for both elements of the output `createdAt` timestamp: the actual text that's output (similar to how we tested for an article's truncated body) but also that the element that wraps that text is a `<time>` tag and that it contains a `datetime` attribute with the raw value of `comment.createdAt`. This might seem like overkill but the point of the `datetime` attribute is to provide a machine-readable timestamp that the browser could (theoretically) hook into and do stuff with. This makes sure that we preserve that ability.
+
+If your tests aren't already running in another terminal window, you can start them now:
+
+```bash
+yarn rw test
+```
 
 :::info What happens if we change the formatted output of the timestamp? Wouldn't we have to change the test?
 

--- a/docs/versioned_docs/version-3.2/tutorial/chapter7/api-side-currentuser.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter7/api-side-currentuser.md
@@ -1,0 +1,743 @@
+# Accessing currentUser in the API side
+
+As our blog has evolved into a multi-million dollar enterprise, we find ourselves so busy counting our money that we no longer have the time to write actual blog posts! Let's hire some authors to write them for us.
+
+What do we need to change to allow multiple users to create posts? Well, for one, we'll need to start associating a blog post to the author that wrote it so we can give them credit. We'll also want to display the name of the author when reading an article. Finally, we'll want to limit the list of blog posts that an author has access to edit to only their own: Alice shouldn't be able to make changes to Bob's articles.
+
+## Associating a Post to a User
+
+Let's introduce a relationship between a `Post` and a `User`, AKA a foreign key. This is considered a one-to-many relationship (one `User` has many `Post`s), similar to the relationship we created earlier between a `Post` and its associated `Comment`s. Here's what our new schema will look like:
+
+```
+┌─────────────────────┐       ┌───────────┐
+│        User         │       │  Post     │
+├─────────────────────┤       ├───────────┤
+│ id                  │───┐   │ id        │
+│ name                │   │   │ title     │
+│ email               │   │   │ body      │
+│ hashedPassword      │   └──<│ userId    │
+│ ...                 │       │ createdAt │
+└─────────────────────┘       └───────────┘
+```
+
+Making data changes like this will start becoming second nature soon:
+
+1. Add the new relationship the `schema.prisma` file
+2. Migrate the database
+3. Generate/update SDLs and Services
+
+### Add the New Relationship to the Schema
+
+First we'll add the new `userId` field to `Post` and the relation to `User`:
+
+```javascript title=api/db/schema.prisma
+model Post {
+  id        Int      @id @default(autoincrement())
+  title     String
+  body      String
+  comments  Comment[]
+  // highlight-start
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  // highlight-end
+  createdAt DateTime @default(now())
+}
+
+model User {
+  id                  Int @id @default(autoincrement())
+  name                String?
+  email               String @unique
+  hashedPassword      String
+  salt                String
+  resetToken          String?
+  resetTokenExpiresAt DateTime?
+  roles               String @default("moderator")
+  // highlight-next-line
+  posts               Post[]
+}
+```
+
+### Migrate the Database
+
+Next, migrate the database to apply the changes (when given the option, name the migration something like "add userId to post"):
+
+```
+yarn rw prisma migrate dev
+```
+
+Whoops!
+
+<img width="584" alt="image" src="https://user-images.githubusercontent.com/300/192899337-9cc1167b-e6da-42d4-83dc-d2a6c0cd1179.png" />
+
+Similar to what happened when we added `roles` to `User`, We made `userId` a required field, but we already have several posts in our development database. Since we don't have a default value for `userId` defined, it's impossible to add this column to the database.
+
+:::caution Why don't we just set `@default(1)` in the schema?
+
+This would get us past this problem, but could cause hard-to-track-down bugs in the future: if you ever forget to assign a `post` to a `user`, rather than fail it'll happily just set `userId` to `1`, which may or may not even exist some day! It's best to take the extra time to do things The Right Way and avoid the quick hacks to get past an annoyance like this. Your future self will thank you!
+
+:::
+
+Since we're in development, let's just blow away the database and start over:
+
+```
+yarn rw prisma migrate reset
+```
+
+:::info Database Seeds
+
+If you started the second half the tutorial from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) you'll get an error after resetting the database—Prisma attempts to seed the database with a user and some posts to get you started, but the posts in that seed do not have the new required `userId` field! Open up `scripts/seed.js` and edit each post to add `userId: 1` to each:
+
+```javascript title=scripts/seed.js
+{
+  id: 1,
+  name: 'John Doe',
+  title: 'Welcome to the blog!',
+  body:
+    "I'm baby single- origin coffee kickstarter lo - fi paleo skateboard.Tumblr hashtag austin whatever DIY plaid knausgaard fanny pack messenger bag blog next level woke.Ethical bitters fixie freegan,helvetica pitchfork 90's tbh chillwave mustache godard subway tile ramps art party. Hammock sustainable twee yr bushwick disrupt unicorn, before they sold out direct trade chicharrones etsy polaroid hoodie. Gentrify offal hoodie fingerstache.",
+  // highlight-next-line
+  userId: 1,
+},
+```
+
+Now run `yarn rw prisma migrate reset` and and...you'll get a different error. But that's okay, read on...
+
+:::
+
+We've got an error here because running a database `reset` doesn't also apply pending migrations. So we're trying to set a `userId` where one doesn't exist in the database (it does exist in Prisma generated client libs though, so it thinks that there *should* be one, even if it doesn't exist in the database yet).
+
+It may feel like we're stuck, but note that the database did reset successfully, it's just the seed that failed. So now let's migrate the database to add the new `userId` to `Post`, and then re-run the seed to populate the database, naming it something like "add userId to post":
+
+```
+yarn rw prisma migrate dev
+```
+
+And then the seed:
+
+```
+yarn rw prisma db seed
+```
+
+:::info
+
+If you didn't start your codebase from the [Redwood Tutorial repo](https://github.com/redwoodjs/redwood-tutorial) then you'll now have no users or posts in the database. Go ahead and create a user by going to [http://localhost:8910/signup](http://localhost:8910/signup) but don't create any posts yet! Change the user's role to be "admin", either by using the console introduced in the [previous page](/docs/canary/tutorial/chapter7/rbac#changing-roles-on-a-user) or by [opening Prisma Studio](/docs/canary/tutorial/chapter2/getting-dynamic#prisma-studio) and changing it directly in the database.
+
+:::
+
+### Add Fields to the SDL and Service
+
+Let's think about where we want to show our new relationship. For now, probably just on the homepage and article page: we'll display the author of the post next to the title. That means we'll want to access the user from the post in a GraphQL query something like this:
+
+```graphql
+post {
+  id
+  title
+  body
+  createdAt
+  user {
+    name
+  }
+}
+```
+
+To enable this we'll need to make two modifications on the api side:
+
+1. Add the `user` field to the `posts` SDL
+2. Add a **relation resolver** for the `user` in the `posts` service
+
+#### Add User to Posts SDL
+
+```javascript title=api/src/graphql/posts.sdl.js
+  type Post {
+    id: Int!
+    title: String!
+    body: String!
+    createdAt: DateTime!
+    // highlight-next-line
+    user: User!
+  }
+```
+
+:::info What about the mutations?
+
+We did *not* add `user` or `userId` to the `CreatePostInput` or `UpdatePostInput` types. Although we want to set a user on each newly created post, we don't want just anyone to do that via a GraphQL call! You could easily create or edit a post and assign it to someone else by just modifying the GraphQL payload. We'll save assigning the user to just the service, so it can't be manipulated by the outside world.
+
+:::
+
+Here we're using `User!` with an exclamation point because we know that every `Post` will have an associated user to it—this field will never be `null`.
+
+#### Add User Relation Resolver
+
+This one is a little tricker: we need to add a "lookup" in the `posts` service, so that it knows how to get the associated user. When we generated the `comments` SDL and service we got this **relation resolver** created for us. We could re-run the service generator for `Post` but that could blow away changes we made to this file. Our only option would be to include the `--force` flag since the file already exists, which will write over everything. In this case we'll just add the resolver manually:
+
+```javascript title=api/src/services/posts/posts.js
+import { db } from 'src/lib/db'
+
+export const posts = () => {
+  return db.post.findMany()
+}
+
+export const post = ({ id }) => {
+  return db.post.findUnique({
+    where: { id },
+  })
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: input,
+  })
+}
+
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return db.post.delete({
+    where: { id },
+  })
+}
+
+// highlight-start
+export const Post = {
+  user: (_obj, { root }) =>
+    db.post.findFirst({ where: { id: root.id } }).user(),
+}
+// highlight-end
+```
+
+This can be non-intuitive so let's step through it. First, declare a variable with the same name as the model this service is for: `Post` for the `posts` service. Now, set that to an object containing keys that are the same as the fields that are going to be looked up, in this case `user`. When GraphQL invokes this function it passes a couple of arguments, one of which is `root` which is the object that was resolved to start with, in this case the `post` in our GraphQL query:
+
+```graphql
+post {   <- root
+  id
+  title
+  body
+  createdAt
+  user {
+    name
+  }
+}
+```
+
+That post will already be retreived from the database, and so we know its `id`. `root` is that object, so can simply call `.id` on it to get that property. Now we know everything we need to to make a `findFirst()` query in Prisma, giving it the `id` of the record we already found, but returning the `user` associated to that record, rather than the `post` itself.
+
+We could also write this resolver as follows:
+
+```javascript
+export const Post = {
+  user: (_obj, { root }) =>
+    db.user.findFirst({ where: { id: root.userId } }),
+}
+```
+
+Note that if you keep the relation resolver above, but also included a `user` property in the post(s) returned from `posts` and `post`, this field resolver will still be invoked and whatever is returned will override any `user` property that exists already. Why? That's just how GraphQL works—resolvers, if they are present for a named field, will always be invoked and their return value used, even if the `root` already contains that data.
+
+:::info Prisma and the N+1 Problem
+
+If you have any experience with database design and retrieval you may have noticed this method presents a less than ideal solution: for every post that's found, you need to perform an *additional* query just to get the user data associated with that `post`, also known as the [N+1 problem](https://medium.com/the-marcy-lab-school/what-is-the-n-1-problem-in-graphql-dd4921cb3c1a). This is just due to the nature of GraphQL queries: each resolver function really only knows about its own parent object, nothing about potential children.
+
+There have been several attempts to work around this issue. A simple one that includes no extra dependencies is to remove this field resolver and simply include `user` data along with any `post` you retrieve from the database:
+
+```javascript
+export const post = ({ id }) => {
+  return db.post.findUnique({
+    where: { id },
+    include: {
+      user: true
+    }
+  })
+}
+```
+
+This may or may not work for you: you are incurring the overhead of always returning user data, even if that data wasn't requested in the GraphQL query. In addition, this breaks further nesting of queries: what if you wanted to return the user for this post, and a list of all the other posts IDs that they created?
+
+```graphql
+post {
+  id
+  title
+  body
+  createdAt
+  user {
+    name
+    posts {
+      id
+    }
+  }
+}
+```
+
+This query would now fail because you only have `post.user` available, not `post.user.posts`.
+
+The Redwood team is actively looking into more elegant solutions to the N+1 problem, so stay tuned!
+
+:::
+
+## Displaying the Author
+
+In order to get the author info we'll need to update our Cell queries to pull the user's name.
+
+There are two places where we publicly present a post:
+
+1. The homepage
+2. A single article page
+
+Let's update their respective Cells to include the name of the user that created the post:
+
+```jsx title=web/src/components/ArticlesCell/ArticlesCell.js
+export const QUERY = gql`
+  query ArticlesQuery {
+    articles: posts {
+      id
+      title
+      body
+      createdAt
+      // highlight-start
+      user {
+        name
+      }
+      // highlight-end
+    }
+  }
+`
+```
+
+```jsx title=web/src/components/ArticleCell/ArticleCell.js
+export const QUERY = gql`
+  query ArticleQuery($id: Int!) {
+    article: post(id: $id) {
+      id
+      title
+      body
+      createdAt
+      // highlight-start
+      user {
+        name
+      }
+      // highlight-end
+    }
+  }
+`
+```
+
+And then update the display component that shows an Article:
+
+```jsx title=web/src/components/Article/Article.js
+import { Link, routes } from '@redwoodjs/router'
+
+const Article = ({ article }) => {
+  return (
+    <article>
+      <header>
+        <h2 className="text-xl text-blue-700 font-semibold">
+          <Link to={routes.article({ id: article.id })}>{article.title}</Link>
+          // highlight-start
+          <span className="ml-2 text-gray-400 font-normal">
+            by {article.user.name}
+          </span>
+          // highlight-end
+        </h2>
+      </header>
+
+      <div className="mt-2 text-gray-900 font-light">{article.body}</div>
+    </article>
+  )
+}
+
+export default Article
+```
+
+Depending on whether you started from the Redwood Tutorial repo or not, you may not have any posts to actually display. Let's add some! However, before we can do that with our posts admin/scaffold, we'll need to actually associate a user to the post they created. Remember that we don't allow setting the `userId` via GraphQL, which is what the scaffolds use when creating/editing records. But that's okay, we want this to only happen in the service anyway, which is where we're heading now.
+
+## Accessing `currentUser` on the API side
+
+There's a magical variable named `context` that's available within any of your service functions. It contains the context in which the service function is being called. One property available on this context is the user that's logged in (*if* someone is logged in). It's the same `currentUser` that is available on the web side:
+
+```javascript title=api/src/service/posts/posts.js
+export const createPost = ({ input }) => {
+  return db.post.create({
+    // highlight-next-line
+    data: { ...input, userId: context.currentUser.id }
+  })
+}
+```
+
+So `context.currentUser` will always be around if you need access to the user that made this request. We'll take their user `id` and appened it the rest of the incoming data from the scaffold form when creating a new post. Let's try it out!
+
+You should be able to create a post via the admin now:
+
+<img width="937" alt="image" src="https://user-images.githubusercontent.com/300/193152401-d98b488e-dd71-475a-a78c-6cd5233e5bee.png" />
+
+And going back to the hompage should actually start showing posts and their authors!
+
+<img width="937" alt="image" src="https://user-images.githubusercontent.com/300/193152524-2715e49d-a1c3-43a1-b968-84a4f8ae3846.png" />
+
+## Only Show a User Their Posts in Admin
+
+Right now any admin that visits `/admin/posts` can still see all posts, not only their own. Let's change that.
+
+Since we know we have access to `context.currentUser` we can sprinkle it throughout our posts service to limit what's returned to only those posts that the currently logged in user owns:
+
+```javascript title=api/src/services/posts/posts.js
+import { db } from 'src/lib/db'
+
+export const posts = () => {
+  // highlight-next-line
+  return db.post.findMany({ where: { userId: context.currentUser.id } })
+}
+
+export const post = ({ id }) => {
+  // highlight-start
+  return db.post.findFirst({
+    where: { id, userId: context.currentUser.id },
+  })
+  // highlight-end
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: { ...input, userId: context.currentUser.id },
+  })
+}
+
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return db.post.delete({
+    where: { id },
+  })
+}
+
+export const Post = {
+  user: (_obj, { root }) =>
+    db.post.findFirst({ where: { id: root.id } }).user(),
+}
+```
+
+:::info Prisma's `findUnique()` vs. `findFirst()`
+
+Note that we switched from `findUnique()` to `findFirst()` here. Prisma's `findUnique()` requires that any attributes in the `where` clause have unique indexes, which `id` does, but `userId` does not. So we need to switch to the `findFirst()` function which allows you to put whatever you want in the `where`, which may return more than one record, but Prisma will only return the first of that set. In this case we know there'll always only be one, because we're selecting by `id` *in addition* to `userId`.
+
+:::
+
+These changes make sure that a user can only see a list of their own posts, or the detail for a single post that they own.
+
+What about `updatePost` and `deletePost`? They aren't limited to just the `currentUser`, which would let anyone update or delete a post if they made a manual GraphQL call! That's not good. We'll deal with those [a little later](#update-and-delete).
+
+But there's a problem with the updates we just made: doesn't the homepage also use the `posts` service to display all the articles for the homepage? This code update would limit the homepage to only showing a logged in user's own posts and no one else! And what happens if someone who is *not* logged in goes to the homepage? ERROR.
+
+How can we return one list of posts in the admin, and a different list of posts for the homepage?
+
+## An AdminPosts Service
+
+We could go down the road of adding variables in the GraphQL queries, along with checks in the existing `posts` service, that return a different list of posts whether you're on the homepage or in the admin. But this complexity adds a lot of surface area to test and some fragility if someone goes in there in the future—they have to be very careful not to add a new condition or negate an existing one and accidentally expose your admin functionality to exploits.
+
+What if we created *new* GraphQL queries for the admin views of posts? They would have automatic security checks thanks to `@requireAdmin`, no custom code required. These new queries will be used in the admin posts pages, and the original, simple `posts` service will be used for the homepage and article detail page.
+
+There are several steps we'll need to complete:
+
+1. Create a new `adminPosts` SDL that defines the types
+2. Create a new `adminPosts` service
+3. Update the posts admin GraphQL queries to pull from `adminPosts` instead of `posts`
+
+### Create the `adminPosts` SDL
+
+Let's keep the existing `posts.sdl.js` and make that the "public" interface. Duplicate that SDL, naming it `adminPosts.sdl.js`, and modify it like so:
+
+```javascript title=api/src/graphql/adminPosts.sdl.js
+export const schema = gql`
+  type Query {
+    adminPosts: [Post!]! @requireAuth(roles: ["admin"])
+    adminPost(id: Int!): Post @requireAuth(roles: ["admin"])
+  }
+
+  input CreatePostInput {
+    title: String!
+    body: String!
+  }
+
+  input UpdatePostInput {
+    title: String
+    body: String
+  }
+
+  type Mutation {
+    createPost(input: CreatePostInput!): Post! @requireAuth(roles: ["admin"])
+    updatePost(id: Int!, input: UpdatePostInput!): Post! @requireAuth(roles: ["admin"])
+    deletePost(id: Int!): Post! @requireAuth(roles: ["admin"])
+  }
+`
+```
+
+```javascript title=api/src/graphql/posts.sdl.js
+export const schema = gql`
+  type Post {
+    id: Int!
+    title: String!
+    body: String!
+    createdAt: DateTime!
+    user: User!
+  }
+
+  type Query {
+    posts: [Post!]! @skipAuth
+    post(id: Int!): Post @skipAuth
+  }
+`
+```
+
+So we keep a single type of `Post` since the data contained within it is the same, and either SDL file will return this same data type. We can remove the mutations from the `posts` SDL since the general public will not need to access those. We move create, update and delete mutations to the new `adminPosts` SDL, and rename the two queries from `posts` to `adminPosts` and `post` to `adminPost`. In case you didn't know: every query/mutation must have a unique name across your entire application!
+
+In `adminPosts` we've updated the queries to use `@requireAuth` instead of `@skipAuth`. Now that we have dedicated queries for our admin pages, we can lock them down to only allow access when authenticated.
+
+### Create the `adminPosts` Service
+
+Next let's create an `adminPosts` service. We'll need to move our create/update/delete mutations to it, as the name of the SDL needs to match the name of the service:
+
+```javascript title=api/src/services/adminPosts/adminPosts.js
+import { db } from 'src/lib/db'
+
+export const adminPosts = () => {
+  return db.post.findMany({ where: { userId: context.currentUser.id } })
+}
+
+export const adminPost = ({ id }) => {
+  return db.post.findFirst({
+    where: { id, userId: context.currentUser.id },
+  })
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: { ...input, userId: context.currentUser.id },
+  })
+}
+
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = ({ id }) => {
+  return db.post.delete({
+    where: { id },
+  })
+}
+```
+
+(Again, don't forget the change from `findUnique()` to `findFirst()`.) And update `posts` to remove some of the functions that live in `adminPosts` now:
+
+```javascript title=api/src/services/posts/posts.js
+import { db } from 'src/lib/db'
+
+export const posts = () => {
+  return db.post.findMany()
+}
+
+export const post = ({ id }) => {
+  return db.post.findUnique({ where: { id } })
+}
+
+export const Post = {
+  user: (_obj, { root }) =>
+    db.post.findFirst({ where: { id: root.id } }).user(),
+}
+```
+
+We've removed the `userId` lookup in the `posts` service so we're back to returning every post (for `posts`) or a single post (regardless of who owns it, in `post`).
+
+Note that we kept the relation resolver here `Post.user`, and there's none in `adminPosts`: since the queries and mutations from both SDLs still return a `Post`, we'll want to keep that relation resolver with the service that matches that original SDL by name: `graphql/posts.sdl.js` => `services/posts/posts.js`.
+
+### Update the GraphQL Queries
+
+Finally, we'll need to update several of the scaffold components to use the new `adminPosts` and `adminPost` queries (we'll limit the code snippets below to just the changes to save some room, this page is getting long enough!):
+
+```javascript title=web/src/components/Post/EditPostCell/EditPostCell.js
+export const QUERY = gql`
+  query FindPostById($id: Int!) {
+    // highlight-next-line
+    post: adminPost(id: $id) {
+      id
+      title
+      body
+      createdAt
+    }
+  }
+`
+```
+
+```jsx title=web/src/components/Post/PostCell/PostCell.js
+export const QUERY = gql`
+  query FindPostById($id: Int!) {
+    // highlight-next-line
+    post: adminPost(id: $id) {
+      id
+      title
+      body
+      createdAt
+    }
+  }
+`
+```
+
+```jsx title=web/src/components/Post/PostsCell/PostsCell.js
+export const QUERY = gql`
+  query POSTS {
+    // highlight-next-line
+    posts: adminPosts {
+      id
+      title
+      body
+      createdAt
+    }
+  }
+`
+```
+
+If we didn't use the `posts: adminPosts` syntax, we would need to rename the argument coming into the `Success` component below to `adminPosts`. This syntax renames the result of the query to `posts` and then nothing else below needs to change!
+
+We don't need to make any changes to the "public" views (like `ArticleCell` and `ArticlesCell`) since those will continue to use the original `posts` and `post` queries, and their respective resolvers.
+
+## Update and Delete
+
+Okay, let's take care of `updatePost` and `deletePost` now. Why couldn't we just do this?
+
+```javascript
+export const updatePost = ({ id, input }) => {
+  return db.post.update({
+    data: input,
+    // highlight-next-line
+    where: { id, userId: context.currentUser.id },
+  })
+}
+```
+
+Because like `findUnique()`, Prisma only wants to update records based on fields with unique indexes, in this case that's just `id`. So we need to keep this to just an `id`. But how do we verify that the user is only updating/deleting a record that they own?
+
+We could select the record first, make sure the user owns it, and only then let the `update()` commence:
+
+```javascript
+// highlight-next-line
+import { ForbiddenError } from '@redwoodjs/graphql-server'
+
+// highlight-start
+export const updatePost = async ({ id, input }) => {
+  if (await adminPost({ id })) {
+    return true
+  } else {
+    throw new ForbiddenError("You don't have access to this post")
+  }
+  // highlight-end
+
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+```
+
+We're using the `adminPost()` service function, rather than making another call to the database (note that we had to async/await it to make sure we have the post before continuing). Composing services like this is something Redwood was designed to encourage: services' functions act as resolvers for GraphQL, but they're also just plain JS functions and can be called wherever you need. And the reasons why you'd want to do this are clearly demonstrated here: `adminPost()` already limits the found record to be only one owned by the logged in user, so that logic is already encapsulated here, and we can be sure that any time an admin wants to do something with a single post, it runs through this code and uses the same logic every time.
+
+This works, but we'll need to do the same thing in `deletePost`. Let's extract that check for the post existence into a function:
+
+```javascript
+// highlight-start
+const verifyOwnership = async (id) {
+  if (await adminPost({ id })) {
+    return true
+  } else {
+    throw new ForbiddenError("You don't have access to this post")
+  }
+}
+// highlight-end
+
+export const updatePost = async ({ id, input }) => {
+  // highlight-next-line
+  await verifyOwnership(id)
+
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+```
+
+Simple! Our final `adminPosts` service ends up looking like:
+
+```javascript
+import { ForbiddenError } from '@redwoodjs/graphql-server'
+
+import { db } from 'src/lib/db'
+
+const validateOwnership = async ({ id }) => {
+  if (await adminPost({ id })) {
+    return true
+  } else {
+    throw new ForbiddenError("You don't have access to this post")
+  }
+}
+
+export const adminPosts = () => {
+  return db.post.findMany({ where: { userId: context.currentUser.id } })
+}
+
+export const adminPost = ({ id }) => {
+  return db.post.findFirst({
+    where: { id, userId: context.currentUser.id },
+  })
+}
+
+export const createPost = ({ input }) => {
+  return db.post.create({
+    data: { ...input, userId: context.currentUser.id },
+  })
+}
+
+export const updatePost = async ({ id, input }) => {
+  await validateOwnership({ id })
+
+  return db.post.update({
+    data: input,
+    where: { id },
+  })
+}
+
+export const deletePost = async ({ id }) => {
+  await validateOwnership({ id })
+
+  return db.post.delete({
+    where: { id },
+  })
+}
+
+```
+
+## Wrapping Up
+
+Whew! Let's try several different scenarios (this is the kind of thing that the QA team lives for), making sure everything is working as expected:
+
+* A logged out user *should* see all posts on the homepage
+* A logged out user *should* be able to see the detail for a single post
+* A logged out user *should not* be able to go to /admin/posts
+* A logged out user *should not* see moderation controls next to comments
+* A logged in admin user *should* see all articles on the homepage (not just their own)
+* A logged in admin user *should* be able to go to /admin/posts
+* A logged in admin user *should* be able to create a new post
+* A logged in admin user *should not* be able to see anyone else's posts in /admin/posts
+* A logged in admin user *should not* see moderation controls next to comments (unless you modified that behavior at the end of the last page)
+* A logged in moderator user *should* see moderation controls next to comments
+* A logged in moderator user *should not* be able to access /admin/posts
+
+In fact, you could write some new tests to make sure this functionality doesn't mistakenly change in the future. The quickest would probably be to create `adminPosts.scenarios.js` and `adminPosts.test.js` files to go with the new service and verify that you are only returned the posts owned by a given user. You can [mock currentUser](/docs/testing#mockcurrentuser-on-the-api-side) to simulate someone being logged in or not, with different roles. You could add tests for the Cells we modified above, but the data they get is dependent on what's returned from the service, so as long as you have the service itself covered you should be okay. The 100% coverage folks would argue otherwise, but while they're still busy writing tests we're out cruising in our new yacht thanks to all the revenue from our newly launched (with *reasonable* test coverage) features!
+
+Did it work? Great! Did something go wrong? Can someone see too much, or too little? Double check that all of your GraphQL queries are updated and you've saved changes in all the opened files.

--- a/docs/versioned_docs/version-3.2/tutorial/chapter7/rbac.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter7/rbac.md
@@ -1,10 +1,10 @@
 # Role-Based Access Control (RBAC)
 
-Imagine a few weeks in the future of our blog when every post hits the front page of the New York Times and we're getting hundreds of comments a day. We can't be expected to come up with quality content each day *and* moderate the endless stream of (mostly well-meaning) comments! We're going to need help. Let's hire a comment moderator to remove obvious spam and bad intentioned posts and help make the internet a better place.
+Imagine a few weeks in the future of our blog when every post hits the front page of the New York Times and we're getting hundreds of comments a day. We can't be expected to come up with quality content each day *and* moderate the endless stream of (mostly well-meaning) comments! We're going to need help. Let's hire a comment moderator to remove obvious spam and any comments that don't heap praise on our writing ability. You know, to help make the internet a better place.
 
 We already have a login system for our blog, but right now it's all-or-nothing: you either get access to create blog posts, or you don't. In this case our comment moderator(s) will need logins so that we know who they are, but we're not going to let them create new blog posts. We need some kind of role that we can give to our two kinds of users so we can distinguish them from one another.
 
-Enter role-based access control, thankfully shortened to the common phrase **RBAC**. Authentication says who the person is, authorization says what they can do. "Access control" is another way to say authorization. Currently the blog has the lowest common denominator of authorization: if they are logged in, they can do everything. Let's add a "less than everything, but more than nothing" level.
+Enter **role-based access control**, thankfully shortened to the common phrase **RBAC**. Authentication says who the person is, authorization says what they can do. "Access control" is another way to say authorization. Currently the blog has the lowest common denominator of authorization: if they are logged in, they can do everything. Let's add a "less than everything, but more than nothing" level.
 
 ### Defining Roles
 
@@ -65,7 +65,7 @@ And you can name it something like "add roles to user".
 
 If we log in and try to go the posts admin page at [http://localhost:8910/admin/posts](http://localhost:8910/admin/posts) everything works the same as it used to: we're not actually checking for the existence of any roles yet so that makes sense. In reality we'd only want users with the `admin` role to have access to the admin pages, but our existing user just became a `moderator` because of our default role. This is a great opportunity to actually setup a role check and see if we lose access to the admin!
 
-Before we do that, we'll need to make sure that the web side has access to the roles on `currentUser`. Take a look at `api/src/lib/auth.js`. Remember when we had to add `email` to the list of fields being included in Part 1? We need to add `roles` as well:
+Before we do that, we'll need to make sure that the web side has access to the roles on `currentUser`. Take a look at `api/src/lib/auth.js`. Remember when we had to add `email` to the list of fields being included? We need to add `roles` as well:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -191,7 +191,7 @@ The easiest way to prevent access to an entire URL is via the Router. The `<Priv
 </TabItem>
 </Tabs>
 
-Now if you reload the posts admin you should get redirected to the homepage.
+Now if you browse to [http://localhost:8910/admin/posts](http://localhost:8910/admin/posts) you should get redirected to the homepage. So far so good.
 
 ### Changing Roles on a User
 
@@ -230,7 +230,7 @@ Which should return the new content of the user:
 
 :::caution
 
-If that doesn't work for you maybe your user doesn't have an `id` of `1`! Run `db.user.findMany()` first and then get the `id` of the user you want to update.
+If you re-used the same console session from the previous section, you'll need to quit it and start it again for it to know about the new Prisma data structure. If you still can't get the update to work, maybe your user doesn't have an `id` of `1`! Run `db.user.findMany()` first and then get the `id` of the user you want to update.
 
 :::
 
@@ -404,6 +404,7 @@ And due to the nice encapsulation of our **Comment** component we can make all t
 import { useAuth } from '@redwoodjs/auth'
 // highlight-start
 import { useMutation } from '@redwoodjs/web'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 // highlight-end
 
@@ -478,6 +479,7 @@ export default Comment
 import { useAuth } from '@redwoodjs/auth'
 // highlight-start
 import { useMutation } from '@redwoodjs/web'
+
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 // highlight-end
 
@@ -620,34 +622,31 @@ import Comment from './Comment'
 // highlight-next-line
 export const defaultView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        // highlight-next-line
+        postId: 1
+      }}
+    />
   )
 }
 
 // highlight-start
 export const moderatorView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 // highlight-end
@@ -664,34 +663,31 @@ import Comment from './Comment'
 // highlight-next-line
 export const defaultView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        // highlight-next-line
+        postId: 1,
+      }}
+    />
   )
 }
 
 // highlight-start
 export const moderatorView = () => {
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 // highlight-end
@@ -711,22 +707,22 @@ The **moderatorView** story needs to have a user available that has the moderato
 export const moderatorView = () => {
   // highlight-start
   mockCurrentUser({
+    id: 1,
+    email: 'moderator@moderator.com',
     roles: 'moderator',
   })
   // highlight-end
 
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 ```
@@ -738,24 +734,22 @@ export const moderatorView = () => {
 export const moderatorView = () => {
   // highlight-start
   mockCurrentUser({
-    roles: 'moderator',
     id: 1,
     email: 'moderator@moderator.com',
+    roles: 'moderator',
   })
   // highlight-end
 
   return (
-    <div className="m-4">
-      <Comment
-        comment={{
-          id: 1,
-          name: 'Rob Cameron',
-          body: 'This is the first comment!',
-          createdAt: '2020-01-01T12:34:56Z',
-          postId: 1,
-        }}
-      />
-    </div>
+    <Comment
+      comment={{
+        id: 1,
+        name: 'Rob Cameron',
+        body: 'This is the first comment!',
+        createdAt: '2020-01-01T12:34:56Z',
+        postId: 1,
+      }}
+    />
   )
 }
 ```
@@ -785,6 +779,7 @@ We can use the same `mockCurrentUser()` function in our Jest tests as well. Let'
 ```jsx title="web/src/components/Comment/Comment.test.js"
 // highlight-next-line
 import { render, screen, waitFor } from '@redwoodjs/testing'
+
 import Comment from './Comment'
 
 // highlight-start
@@ -821,7 +816,11 @@ describe('Comment', () => {
   })
 
   it('renders a delete button if the user is a moderator', async () => {
-    mockCurrentUser({ roles: 'moderator' })
+    mockCurrentUser({
+      id: 1,
+      email: 'moderator@moderator.com',
+      roles: 'moderator',
+    })
     render(<Comment comment={COMMENT} />)
 
     await waitFor(() => expect(screen.getByText('Delete')).toBeInTheDocument())
@@ -876,9 +875,9 @@ describe('Comment', () => {
 
   it('renders a delete button if the user is a moderator', async () => {
     mockCurrentUser({
-      roles: 'moderator',
       id: 1,
       email: 'moderator@moderator.com',
+      roles: 'moderator',
     })
 
     render(<Comment comment={COMMENT} />)
@@ -894,7 +893,9 @@ describe('Comment', () => {
 
 We moved the default `comment` object to a constant `COMMENT` and then used that in all tests. We also needed to add `waitFor()` since the `hasRole()` check in the Comment itself actually executes some GraphQL calls behind the scenes to figure out who the user is. The test suite makes mocked GraphQL calls, but they're still asynchronous and need to be waited for. If you don't wait, then `currentUser` will be `null` when the test starts, and Jest will be happy with that result. But we won't—we need to wait for the actual value from the GraphQL call.
 
-Before the test suite will work we'll need to stop and re-start the test server: when adding a field to the database (`roles` on `User` in this case) we need to restart the test runner so that it can apply the schema changes to our test database. So press `q` or `Ctrl-C` in your test runner if it's still running, then:
+:::caution Seeing errors in your test suite?
+
+We added fields to the database and sometimes the test runner doesn't realize this. You may need to restart it to get the test database migrated to match what's in `schema.prisma`. Press `q` or `Ctrl-C` in your test runner if it's still running, then:
 
 ```bash
 yarn rw test
@@ -902,11 +903,13 @@ yarn rw test
 
 The suite should automatically run the tests for `Comment` and `CommentCell` at the very least, and maybe a few more if you haven't committed your code to git in a while.
 
+:::
+
 :::info
 
 This isn't the most robust test that's ever been written: what if the sample text of the comment itself had the word "Delete" in it? Whoops! But you get the idea—find some meaningful difference in each possible render state of a component and write a test that verifies its presence (or lack of presence).
 
-Think of each conditional in your component as another branch you need to have a test for. In the worst case, each conditional adds ^2 possible render states. If you have three conditionals that's eight possible combinations of output and to be safe you'll want to test them all. When you get yourself into this scenario it's a good sign that it's time to refactor and simplify your component. Maybe into subcomponents where each is responsible for just one of those conditional outputs? You'll still need the same number of total tests, but each component and its test is now operating in isolation and making sure it does one thing, and does it well. This has benefits for your mental model of the codebase as well.
+Think of each conditional in your component as another branch you need to have a test for. In the worst case, each conditional adds 2<sup>n</sup> possible render states. If you have three conditionals that's 2<sup>3</sup> (eight) possible combinations of output and to be safe you'll want to test them all. When you get yourself into this scenario it's a good sign that it's time to refactor and simplify your component. Maybe into subcomponents where each is responsible for just one of those conditional outputs? You'll still need the same number of total tests, but each component and its test is now operating in isolation and making sure it does one thing, and does it well. This has benefits for your mental model of the codebase as well.
 
 It's like finally organizing that junk drawer in the kitchen—you still have the same number of things when you're done, but each thing is in its own space and therefore easier to remember where it lives and makes it easier to find next time.
 
@@ -1076,9 +1079,9 @@ This check only prevents access to `deleteComment` via GraphQL. What if you're c
 <TabItem value="js" label="JavaScript">
 
 ```javascript title="api/src/services/comments/comments.js"
-import { db } from 'src/lib/db'
 // highlight-next-line
 import { requireAuth } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 // ...
 
@@ -1095,9 +1098,9 @@ export const deleteComment = ({ id }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```ts title="api/src/services/comments/comments.ts"
-import { db } from 'src/lib/db'
 // highlight-next-line
 import { requireAuth } from 'src/lib/auth'
+import { db } from 'src/lib/db'
 
 // ...
 
@@ -1120,10 +1123,12 @@ We'll need a test to go along with that functionality. How do we test `requireAu
 
 ```javascript title="api/src/services/comments/comments.test.js"
 // highlight-next-line
-import { comments, createComment, deleteComment } from './comments'
-import { db } from 'src/lib/db'
-// highlight-next-line
 import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
+
+import { db } from 'src/lib/db'
+
+// highlight-next-line
+import { comments, createComment, deleteComment } from './comments'
 
 describe('comments', () => {
   scenario(
@@ -1200,10 +1205,12 @@ describe('comments', () => {
 
 ```ts title="api/src/services/comments/comments.test.ts"
 // highlight-next-line
-import { comments, createComment, deleteComment } from './comments'
-import { db } from 'src/lib/db'
-// highlight-next-line
 import { AuthenticationError, ForbiddenError } from '@redwoodjs/graphql-server'
+
+import { db } from 'src/lib/db'
+
+// highlight-next-line
+import { comments, createComment, deleteComment } from './comments'
 
 import type { PostOnlyScenario, StandardScenario } from './comments.scenarios'
 


### PR DESCRIPTION
@jtoar here it is! I didn't include 3.0 because we didn't introduce the new ScaffoldLayout until 3.1 and the tutorial makes mention of that. I didn't want to try and diff the NEW stuff against the old PostsLayout junk. Plus anyone that's coming to the tutorial is probably only viewing the latest release version anyway.