### PR TITLE
Fix WebAuthn when event body is base64 encoded (like when deploying to Vercel)

### DIFF
--- a/packages/auth-providers-api/src/dbAuth/DbAuthHandler.ts
+++ b/packages/auth-providers-api/src/dbAuth/DbAuthHandler.ts
@@ -7,6 +7,10 @@ import type {
   VerifiedRegistrationResponse,
   VerifiedAuthenticationResponse,
 } from '@simplewebauthn/server'
+import type {
+  AuthenticationCredentialJSON,
+  RegistrationCredentialJSON,
+} from '@simplewebauthn/typescript-types'
 import type { APIGatewayProxyEvent, Context as LambdaContext } from 'aws-lambda'
 import base64url from 'base64url'
 import CryptoJS from 'crypto-js'
@@ -230,12 +234,13 @@ export type AuthMethodNames =
   | 'webAuthnAuthOptions'
   | 'webAuthnAuthenticate'
 
-type Params = {
-  username?: string
-  password?: string
-  method: AuthMethodNames
-  [key: string]: any
-}
+type Params = AuthenticationCredentialJSON &
+  RegistrationCredentialJSON & {
+    username?: string
+    password?: string
+    method: AuthMethodNames
+    [key: string]: any
+  }
 
 interface DbAuthSession<TIdType> {
   id: TIdType
@@ -689,9 +694,8 @@ export class DbAuthHandler<
       throw new DbAuthError.WebAuthnError('WebAuthn is not enabled')
     }
 
-    const jsonBody = JSON.parse(this.event.body as string)
     const credential = await this.dbCredentialAccessor.findFirst({
-      where: { id: jsonBody.rawId },
+      where: { id: this.params.rawId },
     })
 
     if (!credential) {
@@ -708,7 +712,7 @@ export class DbAuthHandler<
     let verification: VerifiedAuthenticationResponse
     try {
       const opts: VerifyAuthenticationResponseOpts = {
-        credential: jsonBody,
+        credential: this.params,
         expectedChallenge: user[this.options.authFields.challenge as string],
         expectedOrigin: webAuthnOptions.origin,
         expectedRPID: webAuthnOptions.domain,
@@ -756,7 +760,7 @@ export class DbAuthHandler<
     // get the regular `login` cookies
     const [, loginHeaders] = this._loginResponse(user)
     const cookies = [
-      this._webAuthnCookie(jsonBody.rawId, this.webAuthnExpiresDate),
+      this._webAuthnCookie(this.params.rawId, this.webAuthnExpiresDate),
       loginHeaders['set-cookie'],
     ].flat()
 
@@ -881,12 +885,11 @@ export class DbAuthHandler<
     }
 
     const user = await this._getCurrentUser()
-    const jsonBody = JSON.parse(this.event.body as string)
 
     let verification: VerifiedRegistrationResponse
     try {
       const options: VerifyRegistrationResponseOpts = {
-        credential: jsonBody,
+        credential: this.params,
         expectedChallenge: user[this.options.authFields.challenge as string],
         expectedOrigin: this.options.webAuthn.origin,
         expectedRPID: this.options.webAuthn.domain,
@@ -919,8 +922,10 @@ export class DbAuthHandler<
               user[this.options.authFields.id],
             [this.options.webAuthn.credentialFields.publicKey]:
               credentialPublicKey,
-            [this.options.webAuthn.credentialFields.transports]:
-              jsonBody.transports ? JSON.stringify(jsonBody.transports) : null,
+            [this.options.webAuthn.credentialFields.transports]: this.params
+              .transports
+              ? JSON.stringify(this.params.transports)
+              : null,
             [this.options.webAuthn.credentialFields.counter]: counter,
           },
         })

--- a/packages/auth-providers-api/src/dbAuth/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers-api/src/dbAuth/__tests__/DbAuthHandler.test.js
@@ -1821,6 +1821,35 @@ describe('dbAuth', () => {
       expect(credential.transports).toEqual('["internal"]')
       expect(credential.counter).toEqual(0)
     })
+
+    it('works if event body is base64 encoded', async () => {
+      const user = await createDbUser({
+        webAuthnChallenge: 'HuGPrQqK7f53NLwMZMst_DL9Dig2BBivDYWWpawIPVM',
+      })
+      event = {
+        headers: {
+          'Content-Type': 'application/json',
+          cookie: encryptToCookie(
+            JSON.stringify({ id: user.id }) + ';' + 'token'
+          ),
+        },
+        body: Buffer.from(
+          `{"method":"webAuthnRegister","id":"GqjZOuYYppObBDeVknbrcBLkaa9imS5EJJwtCV740asUz24sdAmGFg","rawId":"GqjZOuYYppObBDeVknbrcBLkaa9imS5EJJwtCV740asUz24sdAmGFg","response":{"attestationObject":"o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVisSZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAAK3OAAI1vMYKZIsLJfHwVQMAKBqo2TrmGKaTmwQ3lZJ263AS5GmvYpkuRCScLQle-NGrFM9uLHQJhhalAQIDJiABIVggGIipTQt-gcoDPOpW6Zje_Av9C0-jWb2R2PBmXJJL-c8iWCC76wxo3uzG8cPqb0A8Vij-dqMbrEytEHjuFOtiQ2dt8A","clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiSHVHUHJRcUs3ZjUzTkx3TVpNc3RfREw5RGlnMkJCaXZEWVdXcGF3SVBWTSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODkxMCIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9"},"type":"public-key","clientExtensionResults":{},"transports":["internal"]}`,
+          'utf8'
+        ),
+      }
+      const dbAuth = new DbAuthHandler(event, context, options)
+
+      await dbAuth.webAuthnRegister()
+
+      const credential = db.userCredential.findFirst({
+        where: { userId: user.id },
+      })
+
+      expect(credential.id).toEqual(
+        'GqjZOuYYppObBDeVknbrcBLkaa9imS5EJJwtCV740asUz24sdAmGFg'
+      )
+    })
   })
 
   describe('_validateOptions', () => {


### PR DESCRIPTION
If this could be a 3.2.2 that'd be awesome. Otherwise can wait for 3.3.0.

Closes #6756