### PR TITLE
Fix dbAuth webAuthn template (redundant type import)

### DIFF
--- a/packages/auth-providers-setup/src/dbAuth/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/auth-providers-setup/src/dbAuth/templates/api/functions/auth.webAuthn.ts.template
@@ -1,7 +1,6 @@
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 
 import { DbAuthHandler, DbAuthHandlerOptions } from '@redwoodjs/auth-providers-api'
-import type { DbAuthHandlerOptions } from '@redwoodjs/api'
 
 import { db } from 'src/lib/db'
 


### PR DESCRIPTION
Type was imported twice, and the second time from the wrong package