### PR TITLE
[CI]: Add Prisma resolutions to tutorial-e2e test project

### DIFF
--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -65,6 +65,24 @@ const createRedwoodJSApp = ({ yarn1 }) => {
         stdio: 'inherit',
       }
     )
+
+    // Add prisma resolutions
+    const packageJSONPath = path.join(REDWOOD_PROJECT_DIRECTORY, 'package.json')
+    const packageJSON = fs.readJSONSync(packageJSONPath)
+
+    const getVersionFrmRwPkg = (dep, pkg) => {
+      return fs.readJSONSync(
+        path.join(REDWOODJS_FRAMEWORK_PATH, 'packages', pkg, 'package.json')
+      ).dependencies[dep]
+    }
+
+    packageJSON.resolutions = {
+      prisma: getVersionFrmRwPkg('prisma', 'cli'),
+      '@prisma/client': getVersionFrmRwPkg('@prisma/client', 'api'),
+      '@prisma/internals': getVersionFrmRwPkg('@prisma/internals', 'cli'),
+    }
+
+    fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2))
   } catch (e) {
     console.error('Error: Could not create Redwood Project')
     console.error(e)


### PR DESCRIPTION
The Prisma v4.5.0 upgrade (https://github.com/redwoodjs/redwood/pull/6485) revealed a bug in the tutorial e2e CI job since the `yarn rw g scaffold` command now has an install step.

The problem is that the tutorial e2e test project uses the current stable version of Redwood (v3.2.1), which has Prisma v4.3.1. When we use rwfw to link, it adds v4.5.0 to the root package.json. Since there's now two different versions of Prisma, after the install step happens in `yarn rw g scaffold`, yarn realizes it can't hoist Prisma anymore since there's two versions (or something like that), so it installs v4.3.1 into `node_modules/@redwoodjs/cli/node_modules`.