### PR TITLE
[CI]: Fix and rebuild test project fixture

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -24,10 +24,10 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.12",
+    "autoprefixer": "^10.4.13",
     "postcss": "^8.4.18",
     "postcss-loader": "^7.0.1",
     "prettier-plugin-tailwindcss": "^0.1.13",
-    "tailwindcss": "^3.1.8"
+    "tailwindcss": "^3.2.1"
   }
 }

--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -514,7 +514,8 @@ async function apiTasks(outputPath, { verbose, linkWithLatestFwBuild }) {
       {
         title: 'Scaffolding post',
         task: async () => {
-          return generateScaffold('post')
+          await generateScaffold('post')
+          await execa(`yarn rwfw project:copy`, [], execaOptions)
         },
       },
       {


### PR DESCRIPTION
@virtuoushub reported that rebuilding the test project fixture with `yarn build:test-project --rebuild-fixture` on https://github.com/redwoodjs/redwood/pull/4992 was broken. Turns out it was also broken on main, I think for reasons similar to https://github.com/redwoodjs/redwood/pull/6772. This PR adds a step to recopy the framework code after generating the scaffold, and rebuilds the text project fixture cause it works now.