### PR TITLE
(crwa): Add git init option

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -53,7 +53,7 @@ yarn create redwood-app <project directory> [option]
 | `--overwrite`          | Create the project even if the specified project directory isn't empty                                                  |
 | `--no-telemetry`       | Disable sending telemetry events for this create command and all Redwood CLI commands: https://telemetry.redwoodjs.com  |
 | `--yarn1`              | Use yarn 1 instead of yarn 3                                                                                            |
-| `--git-init`, `--git`  | Initialize a new git repo, disabled by default                                                   |
+| `--git-init`, `--git`  | Initialize a new git repo during the install process, disabled by default                                                   |
 
 If you run into trouble during the yarn install step, which may happen if you're developing on an external drive and in other miscellaneous scenarios, try the `--yarn1` flag:
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -53,7 +53,7 @@ yarn create redwood-app <project directory> [option]
 | `--overwrite`          | Create the project even if the specified project directory isn't empty                                                  |
 | `--no-telemetry`       | Disable sending telemetry events for this create command and all Redwood CLI commands: https://telemetry.redwoodjs.com  |
 | `--yarn1`              | Use yarn 1 instead of yarn 3                                                                                            |
-| `--git-init`, `--git`  | Initialize a new git repo during the install process, disabled by default                                                   |
+| `--git-init`, `--git`  | Initialize a git repo during the install process, disabled by default                                                   |
 
 If you run into trouble during the yarn install step, which may happen if you're developing on an external drive and in other miscellaneous scenarios, try the `--yarn1` flag:
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -53,6 +53,7 @@ yarn create redwood-app <project directory> [option]
 | `--overwrite`          | Create the project even if the specified project directory isn't empty                                                  |
 | `--no-telemetry`       | Disable sending telemetry events for this create command and all Redwood CLI commands: https://telemetry.redwoodjs.com  |
 | `--yarn1`              | Use yarn 1 instead of yarn 3                                                                                            |
+| `--git-init`, `--git`  | Initialize a new git repo, disabled by default                                                   |
 
 If you run into trouble during the yarn install step, which may happen if you're developing on an external drive and in other miscellaneous scenarios, try the `--yarn1` flag:
 

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -347,6 +347,12 @@ import { name, version } from '../package'
             onCancel: () => process.exit(1),
           })
           task.output = ctx.language
+          // Error code and exit if someone has disabled yarn install but selected JavaScript
+          if (yarnInstall === false && ctx.language === 'JavaScript') {
+            throw new Error(
+              'JavaScript transpilation requires running yarn install. Please rerun Create-Redwood-App without disabling yarn install.'
+            )
+          }
         },
         options: {
           persistentOutput: true,

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -107,7 +107,7 @@ import { name, version } from '../package'
       alias: 'git',
       default: null,
       type: 'boolean',
-      describe: 'Initialize a new git repository.',
+      describe: 'Initialize a git repository.',
     })
     .version(version)
     .parse()
@@ -344,13 +344,12 @@ import { name, version } from '../package'
             choices: ['TypeScript', 'JavaScript'],
             message: 'Select your preferred coding language',
             initial: 'TypeScript',
-            onCancel: () => process.exit(1),
           })
           task.output = ctx.language
           // Error code and exit if someone has disabled yarn install but selected JavaScript
-          if (yarnInstall === false && ctx.language === 'JavaScript') {
+          if (!yarnInstall && ctx.language === 'JavaScript') {
             throw new Error(
-              'JavaScript transpilation requires running yarn install. Please rerun Create-Redwood-App without disabling yarn install.'
+              'JavaScript transpilation requires running yarn install. Please rerun create-redwood-app without disabling yarn install.'
             )
           }
         },
@@ -364,18 +363,12 @@ import { name, version } from '../package'
         task: async (ctx, task) => {
           ctx.gitInit = await task.prompt({
             type: 'Toggle',
-            message: 'Do you want to initialize a new git repo?',
+            message: 'Do you want to initialize a git repo?',
             enabled: 'Yes',
-            disabled: 'No',
+            disabled: 'no',
             initial: 'Yes',
-            onCancel: () => process.exit(1),
           })
-          if (ctx.gitInit === true) {
-            task.output = 'Initialize a new git repo'
-          }
-          if (ctx.gitInit === false) {
-            task.output = 'Skip git setup'
-          }
+          task.output = ctx.gitInit ? 'Initialize a git repo' : 'Skip'
         },
         options: {
           persistentOutput: true,
@@ -414,11 +407,11 @@ import { name, version } from '../package'
         },
       },
       {
-        title: 'Initializing a new git repo',
-        enabled: (ctx) => gitInit === true || ctx.gitInit === true,
+        title: 'Initializing a git repo',
+        enabled: (ctx) => gitInit || ctx.gitInit,
         task: () => {
           return execa(
-            'git init && git add . && git commit -m "Initial commit" && git branch -M main',
+            'git init && git add . && git commit -m "Initial commit"',
             {
               shell: true,
               cwd: newAppDir,

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -344,6 +344,7 @@ import { name, version } from '../package'
             choices: ['TypeScript', 'JavaScript'],
             message: 'Select your preferred coding language',
             initial: 'TypeScript',
+            onCancel: () => process.exit(1),
           })
           task.output = ctx.language
         },
@@ -357,12 +358,13 @@ import { name, version } from '../package'
         task: async (ctx, task) => {
           ctx.gitInit = await task.prompt({
             type: 'Select',
-            message: 'Initialize a new git repo?',
+            message: 'Do you want to initialize a new git repo?',
             choices: ['Yes', 'No'],
             initial: 'Yes',
+            onCancel: () => process.exit(1),
           })
           if (ctx.gitInit === 'Yes') {
-            task.output = 'Setup new git repo'
+            task.output = 'Initialize a new git repo'
           }
           if (ctx.gitInit === 'No') {
             task.output = 'Skip git setup'
@@ -406,7 +408,7 @@ import { name, version } from '../package'
       },
       {
         title: 'Initializing a new git repo',
-        enabled: (ctx) => gitInit === true || ctx.gitInit === true,
+        enabled: (ctx) => gitInit === true || ctx.gitInit === 'Yes',
         task: () => {
           return execa(
             'git init && git add . && git commit -m "Initial commit" && git branch -M main',

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -357,16 +357,17 @@ import { name, version } from '../package'
         skip: () => gitInit !== null,
         task: async (ctx, task) => {
           ctx.gitInit = await task.prompt({
-            type: 'Select',
+            type: 'Toggle',
             message: 'Do you want to initialize a new git repo?',
-            choices: ['Yes', 'No'],
+            enabled: 'Yes',
+            disabled: 'No',
             initial: 'Yes',
             onCancel: () => process.exit(1),
           })
-          if (ctx.gitInit === 'Yes') {
+          if (ctx.gitInit === true) {
             task.output = 'Initialize a new git repo'
           }
-          if (ctx.gitInit === 'No') {
+          if (ctx.gitInit === false) {
             task.output = 'Skip git setup'
           }
         },
@@ -408,7 +409,7 @@ import { name, version } from '../package'
       },
       {
         title: 'Initializing a new git repo',
-        enabled: (ctx) => gitInit === true || ctx.gitInit === 'Yes',
+        enabled: (ctx) => gitInit === true || ctx.gitInit === true,
         task: () => {
           return execa(
             'git init && git add . && git commit -m "Initial commit" && git branch -M main',

--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -56,6 +56,7 @@ const createRedwoodJSApp = ({ yarn1 }) => {
         '--no-yarn-install',
         '--typescript',
         '--no-telemetry',
+        '--no-git',
         yarn1 && '--yarn1',
       ].filter(Boolean),
       {


### PR DESCRIPTION
Hi All,

Related to: https://github.com/redwoodjs/redwood/issues/3989

This PR does the following:

- Adds `--git`  and `--git-init` args to the cli installer, `--git` is just an alias for `--git-init`. By default this also enables `--no-git` and `--no-git-init`
- Adds prompt for whether the user wants to init a new git repo
- Adds ListR task for initializing a new git repo using the following command `git init && git add . && git commit -m "Initial commit" && git branch -M main`
- Adds `onCancel: () => process.exit(1)` to both the code language prompt and git init prompt so there is a cleaner cancel if the user exits the process during the prompts
- Adds an error for when the user selects JavaScript but disables yarn install which won't work

The biggest question I had was _which_ prompt style I should actually use. It could be a toggle, confirm or select.  I actually prefer the visual layout of the select prompt even though logically it is really more of a toggle prompt. Either way the code can be easily modified to use the preferred prompt style.

Prompt examples:
- https://github.com/enquirer/enquirer#toggle-prompt
- https://github.com/enquirer/enquirer#confirm-prompt
- https://github.com/enquirer/enquirer#select-prompt

