### PR TITLE
fix: have scaffold set titleTo and buttonTo depend on getTemplateStrings

### DIFF
--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -694,11 +694,12 @@ const addSetImport = (task) => {
 }
 
 const addScaffoldSetToRouter = async (model, path) => {
+  const templateNames = getTemplateStrings(model, path)
   const nameVars = nameVariants(model)
   const title = nameVars.pluralPascalName
-  const titleTo = nameVars.pluralCamelName
+  const titleTo = templateNames.pluralRouteName
   const buttonLabel = `New ${nameVars.singularPascalName}`
-  const buttonTo = `new${nameVars.singularPascalName}`
+  const buttonTo = templateNames.newRouteName
 
   return addRoutesToRouterTask(
     await routes({ model, path }),


### PR DESCRIPTION
Implement a fix for this issue: https://github.com/redwoodjs/redwood/issues/6654

Gitpod snapshot: https://gitpod.io#snapshot/e0161d70-2435-435a-a229-0578ef51a48b

Steps to reproduce:

1. Open [starter repo](https://github.com/redwoodjs/gitpod-starter) in Gitpod
2. `yarn rw g scaffold admin/UserExample`
3. Navigate to `admin/user-examples`
4. See the following error:
![Screen Shot 2022-11-05 at 9 52 18 PM](https://user-images.githubusercontent.com/20568385/200154838-7abca1fb-e3e8-47cd-8f8e-65af2b0d0a1d.png)

**Solution description**:
Generate `titleTo` and `buttonTo` in the same way that scaffold route names are generated, with the function `getTemplateStrings()`