### PR TITLE
Update installer and docs to node 18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       - run: yarn install
         working-directory: ./.github/actions/only_doc_changes
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install
         working-directory: ./tasks/check
 
@@ -56,13 +56,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
       fail-fast: true
     name: 🏗 Build, lint, test / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Remove the tsc problem matcher if not ubuntu-latest, node 16
-        if: (matrix.os == 'ubuntu-latest' && matrix.node-version == '16') == false
+      - name: Remove the tsc problem matcher if not ubuntu-latest, node 18
+        if: (matrix.os == 'ubuntu-latest' && matrix.node-version == '18') == false
         run: echo "echo "::remove-matcher owner=tsc::""
 
       - uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
     name: 🏗 Build, lint, test / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
       fail-fast: true
     name: 🌲 Tutorial E2E / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
@@ -161,7 +161,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
     name: 🌲 Tutorial E2E / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -172,7 +172,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
       fail-fast: true
     name: 👀 Smoke test / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
@@ -313,7 +313,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16]
+        node-version: [14, 16, 18]
     name: 👀 Smoke test / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-1.0/quick-start.md
+++ b/docs/versioned_docs/version-1.0/quick-start.md
@@ -2,7 +2,7 @@
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-1.0/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.0/tutorial/chapter1/prerequisites.md
@@ -26,7 +26,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.17 <=16.x"
+- node: ">=14.17 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:
@@ -50,7 +50,7 @@ Please do upgrade accordingly. Then proceed to the Redwood installation when you
 >
 > - `nvm` is a great tool for managing multiple versions of Node on one system. It takes a bit more effort to set up and learn, however. Follow the [nvm installation instructions](https://github.com/nvm-sh/nvm#installing-and-updating). (Windows users should go to [nvm-windows](https://github.com/coreybutler/nvm-windows/releases)). For **Mac** users with Homebrew installed, you can alternatively use it to [install `nvm`](https://formulae.brew.sh/formula/nvm).
 >
-> If you're confused about which of the two current Node versions to use, we recommend using the most recent LTS, which is currently [v16.x](https://nodejs.org/download/release/latest-gallium/).
+> If you're confused about which of the two current Node versions to use, we recommend using the most recent LTS, which is currently [v18.x](https://nodejs.org/download/release/latest-hydrogen/).
 
 > **Windows:** Recommended Development Setup
 >

--- a/docs/versioned_docs/version-1.1/quick-start.md
+++ b/docs/versioned_docs/version-1.1/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-1.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.1/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-1.2/quick-start.md
+++ b/docs/versioned_docs/version-1.2/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-1.2/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.2/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-1.3/quick-start.md
+++ b/docs/versioned_docs/version-1.3/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-1.3/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.3/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-1.4/quick-start.md
+++ b/docs/versioned_docs/version-1.4/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-1.4/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.4/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-1.5/quick-start.md
+++ b/docs/versioned_docs/version-1.5/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-1.5/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-1.5/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-2.0/quick-start.md
+++ b/docs/versioned_docs/version-2.0/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-2.0/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.0/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-2.1/quick-start.md
+++ b/docs/versioned_docs/version-2.1/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-2.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.1/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-2.2/quick-start.md
+++ b/docs/versioned_docs/version-2.2/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-2.2/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-2.2/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-3.0/quick-start.md
+++ b/docs/versioned_docs/version-3.0/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-3.0/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-3.0/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-3.1/quick-start.md
+++ b/docs/versioned_docs/version-3.1/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-3.1/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-3.1/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/docs/versioned_docs/version-3.2/quick-start.md
+++ b/docs/versioned_docs/version-3.2/quick-start.md
@@ -6,7 +6,7 @@ description: Redwood quick start
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](how-to/windows-development-setup.md) guide
 
 Create a Redwood project with `yarn create redwood-app`:

--- a/docs/versioned_docs/version-3.2/tutorial/chapter1/prerequisites.md
+++ b/docs/versioned_docs/version-3.2/tutorial/chapter1/prerequisites.md
@@ -30,7 +30,7 @@ If you have an existing site created with a prior version, you'll need to upgrad
 
 During installation, RedwoodJS checks if your system meets version requirements for Node and Yarn:
 
-- node: ">=14.19 <=16.x"
+- node: ">=14.19 <=18.x"
 - yarn: ">=1.15"
 
 If your system versions do not meet both requirements, _the installation bootstrap will result in an ERROR._ To check, please run the following from your terminal command line:

--- a/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/README.md
+++ b/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/README.md
@@ -21,7 +21,7 @@ In v0.38 we started supporting node 16. That means in the root package json of a
     },
     "engines": {
 -     "node": "14.x",
-+     "node": ">=14.17 <=16.x",
++     "node": ">=14.17 <=18.x",
       "yarn": "1.x"
     },
     "prisma": {

--- a/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/updateNodeEngine.ts
+++ b/packages/codemods/src/codemods/v0.38.x/updateNodeEngine/updateNodeEngine.ts
@@ -5,7 +5,7 @@ import getRootPackageJSON from '../../../lib/getRootPackageJSON'
 export const updateNodeEngine = () => {
   const [rootPackageJSON, rootPackageJSONPath] = getRootPackageJSON()
 
-  rootPackageJSON.engines.node = '>=14.17 <=16.x'
+  rootPackageJSON.engines.node = '>=14.17 <=18.x'
 
   fs.writeFileSync(
     rootPackageJSONPath,

--- a/packages/codemods/src/codemods/v0.48.x/upgradeYarn/__testfixtures__/default/input/package.json
+++ b/packages/codemods/src/codemods/v0.48.x/upgradeYarn/__testfixtures__/default/input/package.json
@@ -15,7 +15,7 @@
     "root": true
   },
   "engines": {
-    "node": ">=14.17 <=16.x",
+    "node": ">=14.17 <=18.x",
     "yarn": ">=1.15 <2"
   },
   "prisma": {

--- a/packages/codemods/src/codemods/v0.48.x/upgradeYarn/__testfixtures__/default/output/package.json
+++ b/packages/codemods/src/codemods/v0.48.x/upgradeYarn/__testfixtures__/default/output/package.json
@@ -15,7 +15,7 @@
     "root": true
   },
   "engines": {
-    "node": ">=14.17 <=16.x",
+    "node": ">=14.17 <=18.x",
     "yarn": ">=1.15 <2"
   },
   "prisma": {

--- a/packages/create-redwood-app/README.md
+++ b/packages/create-redwood-app/README.md
@@ -26,7 +26,7 @@ Want great developer experience and easy scaling? How about an integrated front-
 
 <h2>Quick Start</h2>
 
-Redwood requires Node.js >=14.x <=16.x and Yarn v1.15 (or newer).
+Redwood requires Node.js >=14.x <=18.x and Yarn v1.15 (or newer).
 ```console
 yarn create redwood-app redwood-project
 cd redwood-project

--- a/packages/create-redwood-app/template/README.md
+++ b/packages/create-redwood-app/template/README.md
@@ -4,7 +4,7 @@ Welcome to [RedwoodJS](https://redwoodjs.com)!
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=16.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=14.19.x <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](https://redwoodjs.com/docs/how-to/windows-development-setup) guide
 
 Start by installing dependencies:

--- a/packages/create-redwood-app/template/package.json
+++ b/packages/create-redwood-app/template/package.json
@@ -15,7 +15,7 @@
     "root": true
   },
   "engines": {
-    "node": ">=14.19 <=16.x",
+    "node": ">=14.19 <=18.x",
     "yarn": ">=1.15"
   },
   "prisma": {


### PR DESCRIPTION
This was a pretty straight forward find/replace. Redwood seems to work just fine with node 18, and considering that 18 is the new LTS, Redwood should support it.

Unsure how to test the installer, though I have been running my side project in node 18 just fine.