### PR TITLE
Change to use @iarna/toml instead of toml

### DIFF
--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -26,6 +26,7 @@
     "@babel/core": "7.19.3",
     "@babel/plugin-transform-typescript": "7.19.3",
     "@babel/runtime-corejs3": "7.19.4",
+    "@iarna/toml": "2.2.5",
     "@vscode/ripgrep": "1.14.2",
     "core-js": "3.26.0",
     "cross-undici-fetch": "0.4.14",
@@ -37,7 +38,6 @@
     "jscodeshift": "0.14.0",
     "prettier": "2.7.1",
     "tasuku": "2.0.0",
-    "toml": "3.0.0",
     "typescript": "4.7.4",
     "yargs": "17.6.0"
   },

--- a/packages/codemods/src/lib/getRWPaths.ts
+++ b/packages/codemods/src/lib/getRWPaths.ts
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import path from 'path'
 
+import toml from '@iarna/toml'
 import merge from 'deepmerge'
 import findUp from 'findup-sync'
-import toml from 'toml'
 
 enum TargetEnum {
   NODE = 'node',

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -41,6 +41,7 @@
     "@graphql-codegen/typescript-operations": "2.5.4",
     "@graphql-codegen/typescript-react-apollo": "3.3.4",
     "@graphql-codegen/typescript-resolvers": "2.7.4",
+    "@iarna/toml": "2.2.5",
     "@redwoodjs/graphql-server": "3.2.0",
     "babel-plugin-graphql-tag": "3.3.0",
     "babel-plugin-polyfill-corejs3": "0.6.0",
@@ -58,7 +59,6 @@
     "string-env-interpolation": "1.0.1",
     "systeminformation": "5.12.6",
     "terminal-link": "2.1.1",
-    "toml": "3.0.0",
     "typescript": "4.7.4"
   },
   "devDependencies": {

--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -1,8 +1,8 @@
 import fs from 'fs'
 
+import toml from '@iarna/toml'
 import merge from 'deepmerge'
 import { env as envInterpolation } from 'string-env-interpolation'
-import toml from 'toml'
 
 import { getConfigPath } from './paths'
 

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.19.4",
+    "@iarna/toml": "2.2.5",
     "@prisma/internals": "4.5.0",
     "@redwoodjs/internal": "3.2.0",
     "@types/line-column": "1.0.0",
@@ -47,7 +48,6 @@
     "lodash-decorators": "6.0.1",
     "lru-cache": "6.0.0",
     "proxyquire": "2.1.3",
-    "toml": "3.0.0",
     "ts-morph": "15.1.0",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-textdocument": "1.0.7",

--- a/packages/structure/src/model/RWTOML.ts
+++ b/packages/structure/src/model/RWTOML.ts
@@ -1,4 +1,4 @@
-import { parse as parseTOML } from 'toml'
+import { JsonMap, parse as parseTOML } from '@iarna/toml'
 import { Range } from 'vscode-languageserver-types'
 
 import { FileNode } from '../ide'
@@ -19,7 +19,10 @@ export class RWTOML extends FileNode {
     return parseTOML(this.text)
   }
   @lazy() get web_includeEnvironmentVariables(): string[] | undefined {
-    return this.parsedTOML?.web?.includeEnvironmentVariables ?? []
+    return (
+      ((this.parsedTOML?.web as JsonMap)
+        ?.includeEnvironmentVariables as string[]) ?? []
+    )
   }
   *diagnostics() {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3736,7 +3736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iarna/toml@npm:^2.2.5":
+"@iarna/toml@npm:2.2.5, @iarna/toml@npm:^2.2.5":
   version: 2.2.5
   resolution: "@iarna/toml@npm:2.2.5"
   checksum: d095381ad4554aca233b7cf5a91f243ef619e5e15efd3157bc640feac320545450d14b394aebbf6f02a2047437ced778ae598d5879a995441ab7b6c0b2c2f201
@@ -6625,6 +6625,7 @@ __metadata:
     "@babel/core": 7.19.3
     "@babel/plugin-transform-typescript": 7.19.3
     "@babel/runtime-corejs3": 7.19.4
+    "@iarna/toml": 2.2.5
     "@types/babel__core": 7.1.19
     "@types/findup-sync": 4.0.2
     "@types/fs-extra": 9.0.13
@@ -6645,7 +6646,6 @@ __metadata:
     prettier: 2.7.1
     tasuku: 2.0.0
     tempy: 1.0.1
-    toml: 3.0.0
     typescript: 4.7.4
     yargs: 17.6.0
   bin:
@@ -6843,6 +6843,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": 2.5.4
     "@graphql-codegen/typescript-react-apollo": 3.3.4
     "@graphql-codegen/typescript-resolvers": 2.7.4
+    "@iarna/toml": 2.2.5
     "@redwoodjs/graphql-server": 3.2.0
     "@types/babel-plugin-tester": 9.0.5
     "@types/babel__core": 7.1.19
@@ -6868,7 +6869,6 @@ __metadata:
     string-env-interpolation: 1.0.1
     systeminformation: 5.12.6
     terminal-link: 2.1.1
-    toml: 3.0.0
     typescript: 4.7.4
   bin:
     rw-gen: ./dist/generate/generate.js
@@ -6948,6 +6948,7 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.19.3
     "@babel/runtime-corejs3": 7.19.4
+    "@iarna/toml": 2.2.5
     "@prisma/internals": 4.5.0
     "@redwoodjs/internal": 3.2.0
     "@types/fs-extra": 9.0.13
@@ -6970,7 +6971,6 @@ __metadata:
     lodash-decorators: 6.0.1
     lru-cache: 6.0.0
     proxyquire: 2.1.3
-    toml: 3.0.0
     ts-morph: 15.1.0
     typescript: 4.7.4
     vscode-languageserver: 6.1.1
@@ -29891,13 +29891,6 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
-  languageName: node
-  linkType: hard
-
-"toml@npm:3.0.0":
-  version: 3.0.0
-  resolution: "toml@npm:3.0.0"
-  checksum: 8d7ed3e700ca602e5419fca343e1c595eb7aa177745141f0761a5b20874b58ee5c878cd045c408da9d130cb2b611c639912210ba96ce2f78e443569aa8060c18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Problem**
Multiple different TOML packages are used in the framework. Is it possible to move to use a consistent TOML package?

**Motivation**
~~My own interest is that in a separate PR I wish to go from JSON to TOML but that doesn't appear to be support by `toml` but is by `@iarna/toml`.~~ `@iarna/toml` is a reasonable choice because it's more recently updated, has more active users and was not overly complex to switch to.

**Changes**
1. Updates to `structure`, `internal` and `codemods` package.json's. 
2. Update to imports to use `@iarna/toml` instead of `toml`
3. Some type casting in RWTOML.ts
