### PR TITLE
[Fix]: Rebuild test-project fixture by passing `--no-git`

### DIFF
--- a/tasks/test-project/test-project
+++ b/tasks/test-project/test-project
@@ -149,7 +149,7 @@ const createProject = async () => {
   // We create a ts project and convert using ts-to-js at the end if typescript flag is false
   return execa(
     cmd,
-    ['--no-yarn-install', '--typescript', '--overwrite'],
+    ['--no-yarn-install', '--typescript', '--overwrite', '--no-git'],
     getExecaOptions(RW_FRAMEWORKPATH)
   )
 }


### PR DESCRIPTION
Follow up to adding a git init feature to CRWA https://github.com/redwoodjs/redwood/pull/6805. 