### PR TITLE
[Fix]: Ensure client is defined using Clerk auth

### DIFF
--- a/packages/auth-providers/clerk/web/src/clerk.tsx
+++ b/packages/auth-providers/clerk/web/src/clerk.tsx
@@ -2,7 +2,6 @@ import {
   SignInProps,
   SignUpProps,
   SignOutCallback,
-  Resources,
   Clerk as ClerkClient,
   GetTokenOptions,
   SignOutOptions,
@@ -26,7 +25,9 @@ export function createAuth(customProviderHooks?: {
 function createAuthImplementation() {
   return {
     type: 'clerk',
-    client: (window as any).Clerk as Clerk,
+    get client(): Clerk | undefined {
+      return (window as any).Clerk
+    },
     login: async (options?: SignInProps) => {
       const clerk = (window as any).Clerk as Clerk
       clerk?.openSignIn(options || {})
@@ -41,36 +42,6 @@ function createAuthImplementation() {
     signup: async (options?: SignUpProps) => {
       const clerk = (window as any).Clerk as Clerk
       clerk?.openSignUp(options || {})
-    },
-    restoreAuthState: async () => {
-      const clerk = (window as any).Clerk as Clerk
-      if (!clerk) {
-        // If clerk is null, we can't restore state or listen for it to
-        // happen. This behavior is somewhat undefined, which is why we
-        // instruct the user to wrap the auth provider in <ClerkLoaded> to
-        // prevent it. For now we'll just return.
-
-        if (process.env.NODE_ENV === 'development') {
-          console.log('Please wrap your auth provider with `<ClerkLoaded>`')
-        }
-
-        return
-      }
-
-      // NOTE: Clerk's API docs says session will be undefined if loading (null
-      // if loaded and confirmed unset).
-      if (!clerk || clerk.session !== undefined) {
-        return new Promise<void>((resolve) => {
-          clerk.addListener((msg: Resources) => {
-            if (msg.session !== undefined && msg.client) {
-              resolve()
-            }
-          })
-        })
-      } else {
-        // In this case, we assume everything has been restored already.
-        return
-      }
     },
     getToken: async (options?: GetTokenOptions) => {
       const clerk = (window as any).Clerk as Clerk

--- a/packages/auth-providers/clerk/web/src/clerk.tsx
+++ b/packages/auth-providers/clerk/web/src/clerk.tsx
@@ -25,6 +25,10 @@ export function createAuth(customProviderHooks?: {
 function createAuthImplementation() {
   return {
     type: 'clerk',
+    // Using a getter here to make sure we're always returning a fresh value
+    // and not creating a closure around an old (probably `undefined`) value
+    // for Clerk that'll we always return, even when Clerk on the window object
+    // eventually refreshes
     get client(): Clerk | undefined {
       return (window as any).Clerk
     },

--- a/packages/auth/src/AuthProvider/AuthProviderState.ts
+++ b/packages/auth/src/AuthProvider/AuthProviderState.ts
@@ -1,13 +1,13 @@
 import { CurrentUser } from '../AuthContext'
 
-export type AuthProviderState<TUser> = {
-  client?: any
+export type AuthProviderState<TUser, TClient = unknown> = {
   loading: boolean
   isAuthenticated: boolean
   userMetadata: null | TUser
   currentUser: null | CurrentUser
   hasError: boolean
   error?: Error
+  client?: TClient
 }
 
 export const defaultAuthProviderState: AuthProviderState<never> = {

--- a/packages/auth/src/AuthProvider/AuthProviderState.ts
+++ b/packages/auth/src/AuthProvider/AuthProviderState.ts
@@ -1,6 +1,7 @@
 import { CurrentUser } from '../AuthContext'
 
 export type AuthProviderState<TUser> = {
+  client?: any
   loading: boolean
   isAuthenticated: boolean
   userMetadata: null | TUser

--- a/packages/auth/src/AuthProvider/useReauthenticate.ts
+++ b/packages/auth/src/AuthProvider/useReauthenticate.ts
@@ -29,7 +29,10 @@ export const useReauthenticate = <TUser>(
       const userMetadata = await authImplementation.getUserMetadata()
 
       if (!userMetadata) {
-        setAuthProviderState(notAuthenticatedState)
+        setAuthProviderState({
+          ...notAuthenticatedState,
+          client: authImplementation.client,
+        })
       } else {
         await getToken()
 
@@ -41,6 +44,7 @@ export const useReauthenticate = <TUser>(
           currentUser,
           isAuthenticated: true,
           loading: false,
+          client: authImplementation.client,
         }))
       }
     } catch (e: any) {


### PR DESCRIPTION
Clerk isn't defined on the window object till Clerk has loaded, so right now, destructuring `client` from `useAuth` always returns `undefined` because it tries to access it too early. This makes it so that `client` is defined when Clerk has loaded. 

Note that https://community.redwoodjs.com/t/with-clerk-logout-triggers-a-react-error/2853 is no longer an error since in the new auth implementation, the auth provider wraps the clerk provider, so it no longer unmounts.