### PR TITLE
fix: add back webAuthn export path

### DIFF
--- a/packages/auth-providers-web/package.json
+++ b/packages/auth-providers-web/package.json
@@ -10,7 +10,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "webAuthn"
   ],
   "scripts": {
     "build": "yarn build:js && yarn build:types",

--- a/packages/auth-providers-web/webAuthn/index.js
+++ b/packages/auth-providers-web/webAuthn/index.js
@@ -1,0 +1,2 @@
+/* eslint-env es6, commonjs */
+module.exports = require('../dist/dbAuth/webAuthn')

--- a/packages/auth-providers-web/webAuthn/package.json
+++ b/packages/auth-providers-web/webAuthn/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./index.js",
+  "types": "../dist/dbAuth/webAuthn.d.ts"
+}


### PR DESCRIPTION
If you set up dbAuth with webAuthn, the `web/src/auth.ts` file looks like:

```ts
import { createDbAuth } from '@redwoodjs/auth-providers-web'
import WebAuthnClient from '@redwoodjs/auth-providers-web/webAuthn'

export const { AuthProvider, useAuth } = createDbAuth(WebAuthnClient)
```

Right now the import on line 2 errors out because there's no directory structure for it. There used to be in the old implementation (see the links below). This PR adds it back.

- https://github.com/redwoodjs/redwood/blob/next/packages/auth/webAuthn/index.js
- https://github.com/redwoodjs/redwood/blob/next/packages/auth/webAuthn/package.json
- https://github.com/redwoodjs/redwood/blob/next/packages/auth/package.json#L14