### PR TITLE
[Feat(branch strategy)]: Add readme, expand milestone validation

### DIFF
--- a/tasks/release/branchStrategy/README.md
+++ b/tasks/release/branchStrategy/README.md
@@ -1,0 +1,23 @@
+# Branch Strategy
+
+Sometimes the changes introduced in a major version can't be fully vetted in a pull request.
+When this happens, we use a dual branch strategy ("main" and "next") to enable work on the major (by committing breaking changes to main) while preserving our ability to release minors and patches.
+This is a tradeoff that makes working on the major easier but releasing harder.
+The tooling in this directory tries to mitigate that, taking advantage of the branch strategy's "one-way commit flow" (from main to next).
+
+## Usage
+
+> **Note**
+>
+> Always start on the `branch-strategy-triage` branch
+
+## Reference
+
+Preface all commands with `yarn branch-strategy`
+
+| Command               | Description                                                                            |
+| :-------------------- | :------------------------------------------------------------------------------------- |
+| `triage-main`         | Triage commits from main to next                                                       |
+| `triage-next`         | Triage commits from next to the release branch                                         |
+| `find-pr`             | Find which branches a PR is in                                                         |
+| `validate-milestones` | Validate PRs' milestone (i.e., that a PR milestoned v3.5.0 is in release/minor/v3.5.0) |

--- a/tasks/release/branchStrategy/branchStrategyCLI.mjs
+++ b/tasks/release/branchStrategy/branchStrategyCLI.mjs
@@ -3,11 +3,25 @@
 
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
+import { $ } from 'zx'
 
 import * as findPRCommand from './findPRCommand.mjs'
 import * as triageMainCommand from './triageMainCommand.mjs'
 import * as triageNextCommand from './triageNextCommand.mjs'
 import * as validateMilestonesCommand from './validateMilestonesCommand.mjs'
+
+// Make sure we're on the branch-strategy-triage branch
+
+$.verbose = false
+
+const gitBranchPO = await $`git branch --show-current`
+
+if (gitBranchPO.stdout.trim() !== 'branch-strategy-triage') {
+  console.log(`Start from branch-strategy-triage`)
+  process.exit(1)
+}
+
+$.verbose = true
 
 yargs(hideBin(process.argv))
   // Config

--- a/tasks/release/branchStrategy/branchStrategyLib.mjs
+++ b/tasks/release/branchStrategy/branchStrategyLib.mjs
@@ -77,7 +77,7 @@ export async function triageCommits(commits) {
       const answer = await question(
         `Does ${chalk.bold(chalk.yellow(hash))} ${chalk.cyan(
           message
-        )} need to be cherry picked into ${this.branch}? (Y/n/o(pen)) > `
+        )} need to be cherry picked into ${this.branch}? [Y/n/o(pen)] > `
       )
 
       commit = this.cache.get(hash)

--- a/tasks/release/branchStrategy/triageNextCommand.mjs
+++ b/tasks/release/branchStrategy/triageNextCommand.mjs
@@ -19,7 +19,7 @@ import {
 } from './branchStrategyLib.mjs'
 
 export const command = 'triage-next'
-export const description = 'Triage commits from next to release'
+export const description = 'Triage commits from next to the release branch'
 
 export async function handler() {
   await updateRemotes()

--- a/tasks/release/branchStrategy/validateMilestonesCommand.mjs
+++ b/tasks/release/branchStrategy/validateMilestonesCommand.mjs
@@ -1,118 +1,153 @@
 /* eslint-env node, es2022 */
 
 import { Octokit } from 'octokit'
-import { chalk } from 'zx'
+import { $ } from 'zx'
+import { chalk, question } from 'zx'
 
 import { isCommitInBranch, getReleaseBranch } from './branchStrategyLib.mjs'
 
 export const command = 'validate-milestones'
-export const description = 'Validate PRs with the "next-release" milestone'
+export const description =
+  "Validate PRs' milestone (i.e., that a PR milestoned v3.5.0 is in release/minor/v3.5.0)"
 
-export async function handler() {
+export function builder(yargs) {
+  yargs.option('prompt', {
+    description: 'Prompt for confirmation before fixing',
+    type: 'boolean',
+    default: false,
+  })
+}
+
+export async function handler({ prompt }) {
   const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN })
-
-  const {
-    node: {
-      pullRequests: { nodes: prs },
-    },
-  } = await octokit.graphql(getNextReleasePRs)
-
-  const branch = await getReleaseBranch()
-  console.log()
 
   let {
     repository: {
-      milestones: { nodes: milestones },
+      milestones: { nodes },
     },
-  } = await octokit.graphql(getMilestoneIds)
+  } = await octokit.graphql(getPRs)
 
-  milestones = milestones.reduce((obj, { title, id }) => {
+  nodes = nodes.filter((node) => node.title !== 'chore')
+
+  if (
+    !nodes.every((milestone) => !milestone.pullRequests.pageInfo.hasNextPage)
+  ) {
+    console.log('A milestone has a next page; this script needs to be updated')
+    process.exit(1)
+  }
+
+  const prs = nodes.flatMap((milestone) => {
+    return milestone.pullRequests.nodes.map((pr) => {
+      pr.mergeCommit.message = pr.mergeCommit.message.split('\n').shift()
+
+      return {
+        ...pr,
+        milestone: milestone.title,
+      }
+    })
+  })
+
+  const milestoneTitlesToIds = nodes.reduce((obj, { title, id }) => {
     obj[title] = id
     return obj
   }, {})
 
-  for (const pr of prs) {
-    if (await isCommitInBranch(branch, pr.mergeCommit.messageHeadline)) {
-      console.log(
-        [
-          `${chalk.red('error')}: pr #${
-            pr.number
-          } should be milestoned ${chalk.green(branch.split('/')[2])}`,
-          `${chalk.blue('fixing')}: milestoning PR #${
-            pr.number
-          } to ${chalk.green(branch.split('/')[2])}`,
-        ].join('\n')
-      )
+  async function validateMilestone(pr, milestone) {
+    const hasCorrectMilestone = pr.milestone === milestone
 
-      await octokit.graphql(milestonePullRequest, {
-        pullRequestId: pr.id,
-        milestoneId: milestones[branch.split('/')[2]],
-      })
-
-      console.log(chalk.green('done'))
-      console.log()
-
-      continue
-    }
-
-    if (await isCommitInBranch('next', pr.mergeCommit.messageHeadline)) {
-      console.log(
-        `${chalk.green('ok')}: pr #${
-          pr.number
-        } should be milestoned next release`
-      )
-      console.log(chalk.green('done'))
-      console.log()
-      continue
-    }
-
+    console.log()
     console.log(
       [
-        `${chalk.red('error')}: pr #${
-          pr.number
-        } should be milestoned ${chalk.green('v4.0.0')}`,
-        `${chalk.blue('fixing')}: milestoning PR #${pr.number} to ${chalk.green(
-          'v4.0.0'
-        )}`,
+        `  #${chalk.yellow(pr.number)} ${chalk.blue(
+          pr.title
+        )} should be milestoned ${chalk.magenta(milestone)}`,
+        `  ${
+          hasCorrectMilestone ? chalk.green('ok') : chalk.red('error')
+        }: it's currently milestoned ${chalk.magenta(pr.milestone)}`,
       ].join('\n')
     )
 
-    await octokit.graphql(milestonePullRequest, {
-      pullRequestId: pr.id,
-      milestoneId: milestones['v4.0.0'],
-    })
+    if (hasCorrectMilestone) {
+      console.log(`  ${chalk.green('done')}`)
+      return
+    }
 
-    console.log(chalk.green('done'))
-    console.log()
+    let answer = 'y'
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (prompt) {
+        answer = await question('  ok to fix? [Y/n/o(pen)] > ')
+      }
+
+      if (answer === 'o' || answer === 'open') {
+        await $`open https://github.com/redwoodjs/redwood/pull/${pr.number}`
+        continue
+      }
+
+      if (answer === 'y' || answer === 'Y' || answer === '') {
+        console.log(
+          `  ${chalk.blue('fixing')}: milestoning #${chalk.yellow(
+            pr.number
+          )} ${chalk.magenta(milestone)}`
+        )
+        await octokit.graphql(milestonePullRequest, {
+          pullRequestId: pr.id,
+          milestoneId: milestoneTitlesToIds[milestone],
+        })
+      }
+
+      console.log(`  ${chalk.green('done')}`)
+
+      break
+    }
+  }
+
+  const branch = await getReleaseBranch()
+  console.log()
+
+  for (const pr of prs) {
+    console.log(chalk.dim('-'.repeat(process.stdout.columns)))
+
+    if (await isCommitInBranch(branch, pr.mergeCommit.message)) {
+      await validateMilestone(pr, branch.split('/')[2])
+      continue
+    }
+
+    if (await isCommitInBranch('next', pr.mergeCommit.message)) {
+      await validateMilestone(pr, 'next-release')
+      continue
+    }
+
+    await validateMilestone(pr, 'v4.0.0')
   }
 }
 
-const getNextReleasePRs = `
-  query GetNextReleasePRs {
-    node(id: "MI_kwDOC2M2f84Aa82f") {
-      ... on Milestone {
-        pullRequests(first: 100) {
-          nodes {
-            id
-            number
-            title
-            mergeCommit {
-              messageHeadline
-            }
-          }
-        }
-      }
-    }
-  }
-`
-
-const getMilestoneIds = `
-  query GetMilestoneIds {
+const getPRs = `
+  query GetPRs {
     repository(owner: "redwoodjs", name: "redwood") {
       milestones(first: 10, states: OPEN) {
         nodes {
           id
           title
+
+          pullRequests(first: 100) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+
+            totalCount
+
+            nodes {
+              id
+              number
+              title
+              mergeCommit {
+                message
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This updates the branch strategy tooling, mainly expanding the scope of the `validate-milestones` command to validate all "active" milestones ("next-release", "v4.0.0" and the release milestone (right now, "v3.5.0")). It also forces the user to be on the `branch-strategy-triage` branch (which I will push up to this repo) because doing triage requires committing changes to the `triage*Cache.json` files, which is unfeasible to do on main since it happens constantly.

I've added the beginnings of a readme I'll expand on later.