### PR TITLE
feat: Generator rollbacks 

### DIFF
--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -4,6 +4,7 @@ import { generate as generateTypes } from '@redwoodjs/internal/dist/generate/gen
 
 import { nameVariants, transformTSToJS } from '../../../lib'
 import { isWordPluralizable } from '../../../lib/pluralHelpers'
+import { addFunctionToRollback } from '../../../lib/rollback'
 import { isPlural, singularize } from '../../../lib/rwPluralize'
 import { getSchema } from '../../../lib/schemaHelpers'
 import { yargsDefaults } from '../helpers'
@@ -185,6 +186,7 @@ export const { command, description, builder, handler } =
 
             if (projectHasSdl) {
               await generateTypes()
+              addFunctionToRollback(generateTypes)
             } else {
               task.skip(
                 `Skipping type generation: no SDL defined for "${queryFieldName}". To generate types, run 'yarn rw g sdl ${queryFieldName}'.`

--- a/packages/cli/src/commands/generate/dataMigration/dataMigration.js
+++ b/packages/cli/src/commands/generate/dataMigration/dataMigration.js
@@ -7,6 +7,7 @@ import terminalLink from 'terminal-link'
 
 import { getPaths, writeFilesTask } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import { yargsDefaults } from '../helpers'
 
 const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
@@ -75,6 +76,7 @@ export const handler = async (args) => {
   )
 
   try {
+    prepareRollbackForTasks(tasks)
     await tasks.run()
   } catch (e) {
     console.log(c.error(e.message))

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -14,6 +14,7 @@ import {
   writeFilesTask,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import { yargsDefaults } from '../helpers'
 import { templateForComponentFile } from '../helpers'
 
@@ -272,6 +273,7 @@ export const handler = async (yargs) => {
   const t = tasks({ ...yargs, webAuthn: includeWebAuthn })
 
   try {
+    prepareRollbackForTasks(t)
     await t.run()
   } catch (e) {
     console.log(c.error(e.message))

--- a/packages/cli/src/commands/generate/function/function.js
+++ b/packages/cli/src/commands/generate/function/function.js
@@ -8,6 +8,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { getPaths, transformTSToJS, writeFilesTask } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import { yargsDefaults } from '../helpers'
 import { templateForComponentFile } from '../helpers'
 
@@ -131,6 +132,7 @@ export const handler = async ({ name, force, ...rest }) => {
   )
 
   try {
+    prepareRollbackForTasks(tasks)
     await tasks.run()
 
     console.info('')

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -13,6 +13,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 import { generateTemplate, getPaths, writeFilesTask } from '../../lib'
 import c from '../../lib/colors'
 import { isTypeScriptProject } from '../../lib/project'
+import { prepareRollbackForTasks } from '../../lib/rollback'
 import { pluralize, isPlural, isSingular } from '../../lib/rwPluralize'
 
 /**
@@ -221,6 +222,7 @@ export const createYargsForComponentGeneration = ({
           }
         )
 
+        prepareRollbackForTasks(tasks)
         await tasks.run()
       } catch (e) {
         errorTelemetry(process.argv, e.message)

--- a/packages/cli/src/commands/generate/model/model.js
+++ b/packages/cli/src/commands/generate/model/model.js
@@ -5,9 +5,9 @@ import terminalLink from 'terminal-link'
 
 import { getPaths, writeFilesTask, generateTemplate } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import { verifyModelName } from '../../../lib/schemaHelpers'
 import { yargsDefaults } from '../helpers'
-
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'model.js.template')
 
 export const files = ({ name, typescript = false }) => {
@@ -61,6 +61,7 @@ export const handler = async ({ force, ...args }) => {
 
   try {
     await verifyModelName({ name: args.name })
+    prepareRollbackForTasks(tasks)
     await tasks.run()
   } catch (e) {
     console.log(c.error(e.message))

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -14,6 +14,7 @@ import {
   writeFilesTask,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import {
   createYargsForComponentGeneration,
   pathName,
@@ -247,6 +248,7 @@ export const handler = async ({
   )
 
   try {
+    prepareRollbackForTasks(tasks)
     await tasks.run()
   } catch (e) {
     errorTelemetry(process.argv, e.message)

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -26,6 +26,10 @@ import {
   nameVariants,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import {
+  prepareRollbackForTasks,
+  addFunctionToRollback,
+} from '../../../lib/rollback'
 import { pluralize, singularize } from '../../../lib/rwPluralize'
 import { getSchema, verifyModelName } from '../../../lib/schemaHelpers'
 import { yargsDefaults } from '../helpers'
@@ -656,6 +660,9 @@ const addHelperPackages = async (task) => {
   // support yet (2022-09-20)
   // TODO: Update to latest version when RW supports ESMs
   await execa('yarn', ['workspace', 'web', 'add', 'humanize-string@2.1.0'])
+  addFunctionToRollback(
+    execa('yarn', ['workspace', 'web', 'remove', 'humanize-string@2.1.0'])
+  )
 }
 
 const addSetImport = (task) => {
@@ -827,6 +834,7 @@ export const handler = async ({
       typescript,
       tailwind,
     })
+    prepareRollbackForTasks(t)
     await t.run()
   } catch (e) {
     console.log(c.error(e.message))

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -8,6 +8,7 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { getPaths, writeFilesTask } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import { yargsDefaults } from '../helpers'
 
 const TEMPLATE_PATH = path.resolve(__dirname, 'templates', 'script.js.template')
@@ -83,6 +84,7 @@ export const handler = async ({ force, ...args }) => {
   )
 
   try {
+    prepareRollbackForTasks(tasks)
     await tasks.run()
   } catch (e) {
     errorTelemetry(process.argv, e.message)

--- a/packages/cli/src/commands/generate/sdl/sdl.js
+++ b/packages/cli/src/commands/generate/sdl/sdl.js
@@ -17,6 +17,7 @@ import {
   writeFilesTask,
 } from '../../../lib'
 import c from '../../../lib/colors'
+import { prepareRollbackForTasks } from '../../../lib/rollback'
 import { pluralize } from '../../../lib/rwPluralize'
 import { getSchema, getEnum, verifyModelName } from '../../../lib/schemaHelpers'
 import { yargsDefaults } from '../helpers'
@@ -294,6 +295,7 @@ export const handler = async ({
       { rendererOptions: { collapse: false }, exitOnError: true }
     )
 
+    prepareRollbackForTasks(tasks)
     await tasks.run()
   } catch (e) {
     errorTelemetry(process.argv, e.message)

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -21,6 +21,7 @@ import {
 } from '@redwoodjs/internal/dist/paths'
 
 import c from './colors'
+import { addFileToRollback } from './rollback'
 import { pluralize, singularize } from './rwPluralize'
 
 export const asyncForEach = async (array, callback) => {
@@ -135,6 +136,8 @@ export const writeFile = (
   if (!overwriteExisting && fs.existsSync(target)) {
     throw new Error(`${target} already exists.`)
   }
+
+  addFileToRollback(target)
 
   const filename = path.basename(target)
   const targetDir = target.replace(filename, '')

--- a/packages/cli/src/lib/rollback.js
+++ b/packages/cli/src/lib/rollback.js
@@ -1,0 +1,59 @@
+import fs from 'fs'
+
+let rollback = []
+
+export function addFunctionToRollback(func, atEnd = false) {
+  const step = { type: 'func', func: func }
+  if (atEnd) {
+    rollback.unshift(step)
+  } else {
+    rollback.push(step)
+  }
+}
+
+export function addFileToRollback(path, atEnd = false) {
+  const step = {
+    type: 'file',
+    path: path,
+    content: fs.existsSync(path) ? fs.readFileSync(path) : null,
+  }
+  if (atEnd) {
+    rollback.unshift(step)
+  } else {
+    rollback.push(step)
+  }
+}
+
+export async function executeRollback(ctx, task) {
+  task.title = 'Reverting generator actions...'
+  while (rollback.length > 0) {
+    const step = rollback.pop()
+    switch (step.type) {
+      case 'func':
+        await step.func()
+        break
+      case 'file':
+        if (step.content === null) {
+          fs.unlinkSync(step.path)
+        } else {
+          fs.writeFileSync(step.path, step.content)
+        }
+        break
+      default:
+        // TODO: Telemetry error.
+        break
+    }
+  }
+  task.title = `Reverted because: ${task.task.message.error}`
+}
+
+export function resetRollback() {
+  rollback.length = 0
+}
+
+export function prepareRollbackForTasks(tasks) {
+  resetRollback()
+  tasks.tasks?.forEach((task) => {
+    task.tasks.rollback = executeRollback
+  })
+}


### PR DESCRIPTION
Would close #82 

**Problem**
If any error occurs during the generators then the actions already performed are not undone. This can leave a users project in a broken state. It is also more obvious to a user that the command failed if it rolls back its actions.

**Changes**
Adds a small library file which holds an object stack, these objects are used to either undo a file change or invoke a function during a rollback. 

Minor changes within `lib/index.js` file to ensure that when files are changed a corresponding rollback entry is added.

Only minor changes, if any, are needed within the actual generator tasks. An initial reset of the rollback stack is needed before the tasks are run. Then any additional non-file changes (of which there are few) require adding a function call to the rollback stack - a function is exported from `lib/rollback.js` to allow this. 

During the initial setup the `listr2` tasks are modified to add a rollback function which executes processing of the rollback stack when an error occurs during the `listr2` task.

**Outstanding**

1. Testing to ensure the rollback's undo each generator
2. General discussions around approach