### PR TITLE
fix launch.json

### DIFF
--- a/__fixtures__/test-project/.vscode/launch.json
+++ b/__fixtures__/test-project/.vscode/launch.json
@@ -15,8 +15,6 @@
         "<node_internals>/**"
       ],
       "type": "node",
-      "protocol": "inspector",
-      "stopOnEntry": false,
       "localRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
       "remoteRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
       "sourceMaps": true,

--- a/packages/create-redwood-app/template/.vscode/launch.json
+++ b/packages/create-redwood-app/template/.vscode/launch.json
@@ -15,8 +15,6 @@
         "<node_internals>/**"
       ],
       "type": "node",
-      "protocol": "inspector",
-      "stopOnEntry": false,
       "localRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
       "remoteRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
       "sourceMaps": true,


### PR DESCRIPTION
There are several different files `launch.json` - PR addresses the likely most often used one at `https://github.com/redwoodjs/redwood/blob/main/packages/create-redwood-app/template/.vscode/launch.json`. 

I am proposing to remove two arguments
```
      "protocol": "inspector",
      "stopOnEntry": false,
```

The first one is illegal in the context it is being used and the second one's default value is false, so it is redundant. 

I presented this [issue](https://community.redwoodjs.com/t/protocol-inspector-inside-launch-json-is-not-allowed/4319) in Discourse hoping to elicit some comments, go nothing so far