### PR TITLE
fix(cli): Handle importing optional setup auth commands

### DIFF
--- a/packages/auth-providers/azureActiveDirectory/setup/src/__tests__/setup.test.ts
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/__tests__/setup.test.ts
@@ -9,7 +9,7 @@ jest.mock('@redwoodjs/telemetry', () => {
 })
 
 test('standard exports', () => {
-  expect(command).toEqual('azureActiveDirectory')
+  expect(command).toEqual('azure-active-directory')
   expect(description).toMatch(/Azure Active Directory/)
   expect(typeof builder).toEqual('function')
   expect(typeof handler).toEqual('function')

--- a/packages/auth-providers/azureActiveDirectory/setup/src/setup.ts
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/setup.ts
@@ -5,9 +5,10 @@ import {
   standardAuthHandler,
 } from '@redwoodjs/cli-helpers'
 
-export const command = 'azureActiveDirectory'
+export const command = 'azure-active-directory'
 export const description =
   'Generate an auth configuration for Azure Active Directory'
+
 export const builder = (yargs: yargs.Argv) => {
   return standardAuthBuilder(yargs)
 }

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -20,17 +20,6 @@ export async function builder(yargs) {
     setupAuthSupabaseCommand,
     setupAuthSupertokensCommand,
   } = await import('@redwoodjs/auth-providers-setup')
-  const { setupAuthAuth0Command } = await import('@redwoodjs/auth-auth0-setup')
-  const { setupAuthAzureActiveDirectoryCommand } = await import(
-    '@redwoodjs/auth-azure-active-directory-setup'
-  )
-  const { setupAuthCustomCommand } = await import(
-    '@redwoodjs/auth-custom-setup'
-  )
-  const { setupAuthNetlifyCommand } = await import(
-    '@redwoodjs/auth-netlify-setup'
-  )
-
   // Don't forget to update test-project setup if you change something here
   const printExperimentalWarning = async (argv, yargs) => {
     if (!argv.warn) {
@@ -64,7 +53,7 @@ export async function builder(yargs) {
     }
   }
 
-  yargs
+  const setupAuthCommand = yargs
     .middleware([printExperimentalWarning])
     .demandCommand()
     .epilogue(
@@ -73,18 +62,45 @@ export async function builder(yargs) {
         'https://redwoodjs.com/docs/cli-commands#setup-auth'
       )}`
     )
-    .command(setupAuthAuth0Command)
-    .command(setupAuthAzureActiveDirectoryCommand)
+
     .command(setupAuthClerkCommand)
-    .command(setupAuthCustomCommand)
     .command(setupAuthDbAuthCommand)
     .command(setupAuthEthereumCommand)
     .command(setupAuthFirebaseCommand)
     .command(setupAuthGoTrueCommand)
     .command(setupAuthMagicLinkCommand)
-    .command(setupAuthNetlifyCommand)
     .command(setupAuthNhostCommand)
     .command(setupAuthOktaCommand)
     .command(setupAuthSupabaseCommand)
     .command(setupAuthSupertokensCommand)
+
+  async function addSetupCommand(module, namedExport) {
+    let commandModule
+
+    try {
+      commandModule = await import(module)
+    } catch (e) {
+      // Since these are plugins, it's ok if they can't be imported because they're not installed.
+      if (e.code === 'MODULE_NOT_FOUND') {
+        return
+      }
+      throw e
+    }
+
+    if (commandModule) {
+      setupAuthCommand.command(commandModule[namedExport])
+    }
+  }
+
+  for (const [module, namedExport] of [
+    ['@redwoodjs/auth-auth0-setup', 'setupAuthAuth0Command'],
+    [
+      '@redwoodjs/auth-azure-active-directory-setup',
+      'setupAuthAzureActiveDirectoryCommand ',
+    ],
+    ['@redwoodjs/auth-custom-setup', 'setupAuthCustomCommand'],
+    ['@redwoodjs/auth-netlify-setup', 'setupAuthNetlifyCommand'],
+  ]) {
+    await addSetupCommand(module, namedExport)
+  }
 }

--- a/tasks/framework-tools/lib/framework.mjs
+++ b/tasks/framework-tools/lib/framework.mjs
@@ -19,11 +19,13 @@ export const REDWOOD_PACKAGES_PATH = path.resolve(
 /**
  * A list of the `@redwoodjs` package.json files that are published to npm
  * and installed into a Redwood Project.
+ *
+ * The reason there's more logic here than seems necessary is because we have package.json files
+ * like packages/web/toast/package.json that aren't real packages, but just entry points.
  */
 export function frameworkPkgJsonFiles() {
-  return fg.sync('**/package.json', {
+  let pkgJsonFiles = fg.sync('**/package.json', {
     cwd: REDWOOD_PACKAGES_PATH,
-    deep: 2, // Only the top-level-packages.
     ignore: [
       '**/node_modules/**',
       '**/create-redwood-app/**',
@@ -31,6 +33,21 @@ export function frameworkPkgJsonFiles() {
     ],
     absolute: true,
   })
+
+  for (const pkgJsonFile of pkgJsonFiles) {
+    try {
+      JSON.parse(fs.readFileSync(pkgJsonFile))
+    } catch (e) {
+      throw new Error(pkgJsonFile + ' is not a valid package.json file.')
+    }
+  }
+
+  pkgJsonFiles = pkgJsonFiles.filter((pkgJsonFile) => {
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonFile))
+    return !!pkgJson.name
+  })
+
+  return pkgJsonFiles
 }
 
 /**
@@ -40,14 +57,7 @@ export function frameworkDependencies(packages = frameworkPkgJsonFiles()) {
   const dependencies = {}
 
   for (const packageJsonPath of packages) {
-    let packageJson
-    try {
-      packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
-    } catch (e) {
-      throw new Error(
-        packageJsonPath + ' is not a valid package.json file.' + e
-      )
-    }
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
 
     for (const [name, version] of Object.entries(
       packageJson?.dependencies ?? {}
@@ -80,23 +90,40 @@ export async function frameworkPackagesFiles(
 ) {
   const fileList = {}
   for (const packageFile of packages) {
-    let packageJson
-
-    try {
-      packageJson = JSON.parse(fs.readFileSync(packageFile))
-    } catch (e) {
-      throw new Error(packageFile + ' is not a valid package.json file.')
-    }
-
-    if (!packageJson.name) {
-      continue
-    }
+    const packageJson = JSON.parse(fs.readFileSync(packageFile))
 
     fileList[packageJson.name] = await packlist({
       path: path.dirname(packageFile),
     })
   }
   return fileList
+}
+
+export function frameworkPackagesNamesToPaths(
+  packages = frameworkPkgJsonFiles()
+) {
+  const packageNamesToPaths = packages.reduce(
+    (packageNamesToPaths, packageFile) => {
+      let packageJson
+
+      try {
+        packageJson = JSON.parse(fs.readFileSync(packageFile))
+      } catch (e) {
+        throw new Error(packageFile + ' is not a valid package.json file.')
+      }
+
+      if (!packageJson.name) {
+        return packageNamesToPaths
+      }
+
+      packageNamesToPaths[packageJson.name] = path.dirname(packageFile)
+
+      return packageNamesToPaths
+    },
+    {}
+  )
+
+  return packageNamesToPaths
 }
 
 /**

--- a/tasks/framework-tools/lib/framework.mjs
+++ b/tasks/framework-tools/lib/framework.mjs
@@ -99,33 +99,6 @@ export async function frameworkPackagesFiles(
   return fileList
 }
 
-export function frameworkPackagesNamesToPaths(
-  packages = frameworkPkgJsonFiles()
-) {
-  const packageNamesToPaths = packages.reduce(
-    (packageNamesToPaths, packageFile) => {
-      let packageJson
-
-      try {
-        packageJson = JSON.parse(fs.readFileSync(packageFile))
-      } catch (e) {
-        throw new Error(packageFile + ' is not a valid package.json file.')
-      }
-
-      if (!packageJson.name) {
-        return packageNamesToPaths
-      }
-
-      packageNamesToPaths[packageJson.name] = path.dirname(packageFile)
-
-      return packageNamesToPaths
-    },
-    {}
-  )
-
-  return packageNamesToPaths
-}
-
 /**
  * Returns execute files for `@redwoodjs` packages.
  **/

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -13,7 +13,7 @@ import {
   frameworkPkgJsonFiles,
   frameworkPackagesFiles,
   frameworkPackagesBins,
-  REDWOOD_PACKAGES_PATH,
+  packageJsonName,
 } from './framework.mjs'
 
 /**
@@ -99,8 +99,18 @@ export async function copyFrameworkFilesToProject(
 ) {
   // Loop over every package, delete all existing files, copy over the new files,
   // and fix binaries.
-  packages = await frameworkPackagesFiles(packages)
-  for (const [packageName, files] of Object.entries(packages)) {
+  const packagesFiles = await frameworkPackagesFiles(packages)
+
+  const packageNamesToPaths = packages.reduce(
+    (packageNamesToPaths, packagePath) => {
+      packageNamesToPaths[packageJsonName(packagePath)] =
+        path.dirname(packagePath)
+      return packageNamesToPaths
+    },
+    {}
+  )
+
+  for (const [packageName, files] of Object.entries(packagesFiles)) {
     const packageDstPath = path.join(projectPath, 'node_modules', packageName)
     console.log(
       terminalLink(packageName, 'file://' + packageDstPath),
@@ -110,11 +120,7 @@ export async function copyFrameworkFilesToProject(
     rimraf.sync(packageDstPath)
 
     for (const file of files) {
-      const src = path.join(
-        REDWOOD_PACKAGES_PATH,
-        packageName.replace('@redwoodjs', ''),
-        file
-      )
+      const src = path.join(packageNamesToPaths[packageName], file)
       const dst = path.join(packageDstPath, file)
       fs.mkdirSync(path.dirname(dst), { recursive: true })
       fs.copyFileSync(src, dst)


### PR DESCRIPTION
We're starting to move the auth providers out of the `auth-provider-*` packages. See...

- https://github.com/redwoodjs/redwood/pull/6922
- https://github.com/redwoodjs/redwood/pull/6982
- https://github.com/redwoodjs/redwood/pull/6987

This PR adds basic import handling to the setup auth command so that it doesn't break when the auth setup commands are fully removed as CLI dependencies. This could be a preliminary version of plugins where the set of plugins available is hardcoded. But this is mostly just to keep things from breaking for now.