### PR TITLE
Adds ability to delete a cache entry

### DIFF
--- a/packages/api/src/cache/__tests__/cache.test.ts
+++ b/packages/api/src/cache/__tests__/cache.test.ts
@@ -2,7 +2,7 @@ import InMemoryClient from '../clients/InMemoryClient'
 import { createCache } from '../index'
 
 describe('cache', () => {
-  it('adds a missing key to the cache', async () => {
+  it('set(): adds a missing key to the cache', async () => {
     const client = new InMemoryClient()
     const { cache } = createCache(client)
 
@@ -14,7 +14,7 @@ describe('cache', () => {
     expect(client.storage.test.value).toEqual(JSON.stringify({ foo: 'bar' }))
   })
 
-  it('finds an existing key in the cache', async () => {
+  it('get(): finds an existing key in the cache', async () => {
     const client = new InMemoryClient({
       test: { expires: 1977175194415, value: '{"foo":"bar"}' },
     })
@@ -26,5 +26,41 @@ describe('cache', () => {
 
     // returns existing cached value, not the one that was just set
     expect(result).toEqual({ foo: 'bar' })
+  })
+
+  it('delete(): deletes a key from the cache', async () => {
+    const client = new InMemoryClient({
+      test: { expires: 1977175194415, value: '{"foo":"bar"}' },
+    })
+    const { deleteCacheKey } = createCache(client)
+
+    await deleteCacheKey('test')
+
+    // returns existing cached value, not the one that was just set
+    expect(client.storage['test']).toEqual(undefined)
+  })
+
+  it('delete(): returns true if key was deleted', async () => {
+    const client = new InMemoryClient({
+      test: { expires: 1977175194415, value: '{"foo":"bar"}' },
+    })
+    const { deleteCacheKey } = createCache(client)
+
+    const result = await deleteCacheKey('test')
+
+    // returns existing cached value, not the one that was just set
+    expect(result).toEqual(true)
+  })
+
+  it('delete(): returns false if key did not exist', async () => {
+    const client = new InMemoryClient({
+      test: { expires: 1977175194415, value: '{"foo":"bar"}' },
+    })
+    const { deleteCacheKey } = createCache(client)
+
+    const result = await deleteCacheKey('foobar')
+
+    // returns existing cached value, not the one that was just set
+    expect(result).toEqual(false)
   })
 })

--- a/packages/api/src/cache/clients/BaseClient.ts
+++ b/packages/api/src/cache/clients/BaseClient.ts
@@ -16,4 +16,7 @@ export default abstract class BaseClient {
     value: unknown,
     options: { expires?: number }
   ): Promise<any> | any // types are tightened in the child classes
+
+  // Removes a value by its key
+  abstract del(key: string): any
 }

--- a/packages/api/src/cache/clients/InMemoryClient.ts
+++ b/packages/api/src/cache/clients/InMemoryClient.ts
@@ -52,6 +52,15 @@ export default class InMemoryClient extends BaseClient {
     return true
   }
 
+  async del(key: string) {
+    if (this.storage[key]) {
+      delete this.storage[key]
+      return true
+    } else {
+      return false
+    }
+  }
+
   /**
    * Special functions for testing, only available in InMemoryClient
    */

--- a/packages/api/src/cache/clients/MemcachedClient.ts
+++ b/packages/api/src/cache/clients/MemcachedClient.ts
@@ -44,4 +44,13 @@ export default class MemcachedClient extends BaseClient {
 
     return this.client?.set(key, JSON.stringify(value), options)
   }
+
+  async del(key: string) {
+    if (!this.client) {
+      await this.connect()
+    }
+
+    // memcached returns true/false natively
+    return this.client?.delete(key)
+  }
 }

--- a/packages/api/src/cache/clients/RedisClient.ts
+++ b/packages/api/src/cache/clients/RedisClient.ts
@@ -66,4 +66,18 @@ export default class RedisClient extends BaseClient {
 
     return this.client?.set(key, JSON.stringify(value), setOptions)
   }
+
+  async del(key: string) {
+    if (!this.client) {
+      await this.connect()
+    }
+
+    // Redis client returns 0 or 1, so convert to true/false
+    const result = await this.client?.del([key])
+    if (result === 1) {
+      return true
+    } else {
+      return false
+    }
+  }
 }

--- a/packages/api/src/cache/index.ts
+++ b/packages/api/src/cache/index.ts
@@ -185,8 +185,28 @@ export const createCache = (
     return cache(latestCacheKey, () => model.findMany(conditions), rest)
   }
 
+  const deleteCacheKey = async (key: CacheKey) => {
+    let result
+
+    try {
+      await Promise.race([
+        (result = client.del(key as string)),
+        wait(timeout).then(() => {
+          throw new CacheTimeoutError()
+        }),
+      ])
+
+      logger?.debug(`[Cache] DEL '${key}'`)
+      return result
+    } catch (e: any) {
+      logger?.error(`[Cache] Error DEL '${key}': ${e.message}`)
+      return false
+    }
+  }
+
   return {
     cache,
     cacheFindMany,
+    deleteCacheKey,
   }
 }


### PR DESCRIPTION
This adds the ability to delete a cache entry by its key. This will allow you to be a little more lax in your cache key names if you know you have circumstances where you bust the cache explicitly so that it can be re-built.

Consider an example where you are caching a post by its `id`. You currently have no way to bust the cache when the post itself changes in some way. But if you can manually delete the cache entry when updating or deleting a post, you are good to go:

```js
import { cache, deleteCacheKey } from 'src/lib/cache'

const post = ({ id }) => {
  return cache(`post-${id}`, () => {
    return db.post.findUnique({ where: { id } })
  })
})

const updatePost = async ({ id, input }) => {
  await deleteCacheKey(`post-${id}`)
  return db.post.update({ where: { id }, data: { input } })
})
```

Thanks for the suggestion @dthyresson!

Closes #7003