### PR TITLE
fix: auth provider names in setup auth

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -65,15 +65,15 @@ export async function builder(yargs) {
     .command(setupAuthOktaCommand)
 
   for (const module of [
-    '@redwoodjs/auth0-setup',
+    '@redwoodjs/auth-auth0-setup',
     '@redwoodjs/auth-custom-setup',
     '@redwoodjs/auth-netlify-setup',
     '@redwoodjs/auth-firebase-setup',
-    '@redwoodjs/azure-active-directory-setup',
-    '@redwoodjs/clerk-setup',
-    '@redwoodjs/dbauth-setup',
+    '@redwoodjs/auth-azure-active-directory-setup',
+    '@redwoodjs/auth-clerk-setup',
+    '@redwoodjs/auth=dbauth-setup',
     '@redwoodjs/auth-supabase-setup',
-    '@redwoodjs/supertokens-setup',
+    '@redwoodjs/auth-supertokens-setup',
   ]) {
     let commandModule
 


### PR DESCRIPTION
I forgot to update the auth provider names in the setup command in https://github.com/redwoodjs/redwood/pull/7019.