### PR TITLE
Fix typo in dbauth setup package name

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -71,7 +71,7 @@ export async function builder(yargs) {
     '@redwoodjs/auth-firebase-setup',
     '@redwoodjs/auth-azure-active-directory-setup',
     '@redwoodjs/auth-clerk-setup',
-    '@redwoodjs/auth=dbauth-setup',
+    '@redwoodjs/auth-dbauth-setup',
     '@redwoodjs/auth-supabase-setup',
     '@redwoodjs/auth-supertokens-setup',
   ]) {


### PR DESCRIPTION
The code for adding installed auth setup commands to `yarn rw setup auth` had a typo in the dbauth setup package name