### PR TITLE
Setup auth: No return on missing modules

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -81,11 +81,9 @@ export async function builder(yargs) {
       commandModule = await import(module)
     } catch (e) {
       // Since these are plugins, it's ok if they can't be imported because they're not installed.
-      if (e.code === 'MODULE_NOT_FOUND') {
-        return
+      if (e.code !== 'MODULE_NOT_FOUND') {
+        throw e
       }
-
-      throw e
     }
 
     if (commandModule) {


### PR DESCRIPTION
Throw an error if the error code is anything but MODULE_NOT_FOUND