### PR TITLE
fix: dedupe redwoodjs packages

### DIFF
--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -28,12 +28,14 @@ export async function handler({ webauthn, force: forceArg }: Args) {
     authDecoderImport:
       "import { authDecoder } from '@redwoodjs/auth-dbauth-api'",
     webAuthn,
-    webPackages: webAuthn
-      ? webAuthnWebPackages
-      : [`@redwoodjs/auth-dbauth-web@${version}`],
-    apiPackages: webAuthn
-      ? webAuthnApiPackages
-      : [`@redwoodjs/auth-dbauth-api@${version}`],
+    webPackages: [
+      `@redwoodjs/auth-dbauth-web@${version}`,
+      ...(webAuthn ? webAuthnWebPackages : []),
+    ],
+    apiPackages: [
+      `@redwoodjs/auth-dbauth-api@${version}`,
+      ...(webAuthn ? webAuthnApiPackages : []),
+    ],
     extraTask: webAuthn ? webAuthnExtraTask : extraTask,
     notes: webAuthn ? webAuthnNotes : notes,
   })

--- a/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
@@ -8,16 +8,10 @@ import { functionsPath, libPath } from './setupData'
 export { extraTask } from './setupData'
 
 // required packages to install on the web side
-export const webPackages = [
-  '@redwoodjs/auth-dbauth-web',
-  '@simplewebauthn/browser',
-]
+export const webPackages = ['@simplewebauthn/browser']
 
 // required packages to install on the api side
-export const apiPackages = [
-  '@redwoodjs/auth-dbauth-api',
-  '@simplewebauthn/server',
-]
+export const apiPackages = ['@simplewebauthn/server']
 
 // any notes to print out when the job is done
 export const notes = [


### PR DESCRIPTION
If you setup dbAuth with webAuthn, you get the wrong versions of the corresponding web and api packages.