### PR TITLE
Export underlying cache client with Service Cache functions

### DIFF
--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -748,6 +748,31 @@ In our example above you could cache the GraphQL query for the most popular prod
 
 As of this writing, Redwood ships with clients for the two most popular cache backends: [Memcached](https://memcached.org/) and [Redis](https://redis.io/). Service caching wraps each of these in an adapter, which makes it easy to add more clients in the future. If you're interested in adding an adapter for your favorite cache client, [open a issue](https://github.com/redwoodjs/redwood/issues) and tell us about it! Instructions for getting started with the code are [below](#creating-your-own-client).
 
+::: info
+
+If you need to access functionality in your cache client that the `cache()` and `cacheFindMany()` functions do not handle, you can always get access to the underlying raw client library and use it however you want:
+
+```javascript
+// api/src/lib/cache.js
+export const { cache, cacheFindMany, cacheClient } = createCache(client)
+
+// api/src/services/posts/posts.js
+import { cacheClient } from 'src/lib/cache'
+
+export const updatePost = async ({ id, input }) => {
+  const post = await db.post.update({
+    data: input,
+    where: { id },
+  })
+  // highlight-next-line
+  await cacheClient.MSET(`post-${id}`, JSON.stringify(post), `blogpost-${id}`, JSON.stringify(post))
+
+  return post
+}
+```
+
+:::
+
 ### What Can Be Cached
 
 The service cache mechanism can only store strings, so whatever data you want to cache needs to be able to survive a round trip through `JSON.stringify()` and `JSON.parse()`. That means that if you have a real `Date` instance, you'd need to re-initialize it as a `Date`, because it's going to return from the cache as a string like `"2022-08-24T17:50:05.679Z"`.

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -753,10 +753,6 @@ As of this writing, Redwood ships with clients for the two most popular cache ba
 If you need to access functionality in your cache client that the `cache()` and `cacheFindMany()` functions do not handle, you can always get access to the underlying raw client library and use it however you want:
 
 ```javascript
-// api/src/lib/cache.js
-export const { cache, cacheFindMany, cacheClient } = createCache(client)
-
-// api/src/services/posts/posts.js
 import { cacheClient } from 'src/lib/cache'
 
 export const updatePost = async ({ id, input }) => {

--- a/packages/api/src/cache/__tests__/shared.test.ts
+++ b/packages/api/src/cache/__tests__/shared.test.ts
@@ -1,4 +1,13 @@
-import { formatCacheKey } from '../index'
+import { createCache, formatCacheKey, InMemoryClient } from '../index'
+
+describe('exports', () => {
+  it('exports the client that was passed in', () => {
+    const client = new InMemoryClient()
+    const { cacheClient } = createCache(client)
+
+    expect(cacheClient).toEqual(client)
+  })
+})
 
 describe('formatCacheKey', () => {
   it('creates a key from a string', () => {

--- a/packages/api/src/cache/index.ts
+++ b/packages/api/src/cache/index.ts
@@ -188,5 +188,6 @@ export const createCache = (
   return {
     cache,
     cacheFindMany,
+    cacheClient: client,
   }
 }

--- a/packages/cli/src/commands/setup/cache/templates/memcached.ts.template
+++ b/packages/cli/src/commands/setup/cache/templates/memcached.ts.template
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV === 'test') {
   }
 }
 
-export const { cache, cacheFindMany } = createCache(client, {
+export const { cache, cacheFindMany, cacheClient } = createCache(client, {
   logger,
   timeout: 500,
 })

--- a/packages/cli/src/commands/setup/cache/templates/redis.ts.template
+++ b/packages/cli/src/commands/setup/cache/templates/redis.ts.template
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'test') {
   }
 }
 
-export const { cache, cacheFindMany } = createCache(client, {
+export const { cache, cacheFindMany, cacheClient } = createCache(client, {
   logger,
   timeout: 500,
 })


### PR DESCRIPTION
Provides access to the underlying cache client in case you want to do something fancy that `cache()` and `cacheFindMany()` do not do.

Closes #7004 