### PR TITLE
Allow other repo names than just "redwood"

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -39,11 +39,9 @@ test.only('customOrDefaultTemplatePath returns the default path if no custom tem
   })
 
   expect(output).toMatch(
-    path
-      .normalize(
-        '/packages/cli/src/commands/generate/page/templates/page.tsx.template'
-      )
-      .replace('red', '')
+    path.normalize(
+      '/packages/cli/src/commands/generate/page/templates/page.tsx.template'
+    )
   )
 })
 

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -31,7 +31,7 @@ const FooBarPage = () => {
 export default FooBarPage
 `
 
-test('customOrDefaultTemplatePath returns the default path if no custom templates exist', () => {
+test.only('customOrDefaultTemplatePath returns the default path if no custom templates exist', () => {
   const output = helpers.customOrDefaultTemplatePath({
     side: 'web',
     generator: 'page',
@@ -39,9 +39,11 @@ test('customOrDefaultTemplatePath returns the default path if no custom template
   })
 
   expect(output).toMatch(
-    path.normalize(
-      'redwood/packages/cli/src/commands/generate/page/templates/page.tsx.template'
-    )
+    path
+      .normalize(
+        '/packages/cli/src/commands/generate/page/templates/page.tsx.template'
+      )
+      .replace('red', '')
   )
 })
 

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -31,7 +31,7 @@ const FooBarPage = () => {
 export default FooBarPage
 `
 
-test.only('customOrDefaultTemplatePath returns the default path if no custom templates exist', () => {
+test('customOrDefaultTemplatePath returns the default path if no custom templates exist', () => {
   const output = helpers.customOrDefaultTemplatePath({
     side: 'web',
     generator: 'page',


### PR DESCRIPTION
This test would fail if you had the repo checked out to a folder named anything but "redwood". Just removing that part make the test pass and be more flexible with folder names. `toMatch` does a substring match, that's why this works