### PR TITLE
fix: add missing deps to cli helpers

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -22,17 +22,26 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/core": "7.20.5",
     "@babel/runtime-corejs3": "7.20.6",
+    "@redwoodjs/internal": "3.2.0",
     "@redwoodjs/telemetry": "3.2.0",
+    "chalk": "4.1.2",
     "core-js": "3.26.1",
-    "listr2": "5.0.6"
+    "execa": "5.1.1",
+    "listr2": "5.0.6",
+    "lodash.memoize": "4.1.2",
+    "pascalcase": "1.0.0",
+    "prettier": "2.8.1",
+    "prompts": "2.4.2",
+    "terminal-link": "2.1.1"
   },
   "devDependencies": {
     "@babel/cli": "7.19.3",
-    "@babel/core": "7.20.5",
-    "@types/react": "17.0.52",
+    "@types/lodash.memoize": "4.1.7",
+    "@types/pascalcase": "1.0.1",
+    "@types/yargs": "17.0.17",
     "jest": "29.3.1",
-    "react": "17.0.2",
     "typescript": "4.7.4"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/cli-helpers/src/lib/paths.ts
+++ b/packages/cli-helpers/src/lib/paths.ts
@@ -1,4 +1,4 @@
-import { memoize } from 'lodash'
+import memoize from 'lodash.memoize'
 
 import {
   getPaths as getRedwoodPaths,

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -8,5 +8,8 @@
     "outDir": "dist"
   },
   "include": ["src"],
-  "references": [{ "path": "../telemetry" }]
+  "references": [
+    { "path": "../internal" },
+    { "path": "../telemetry" }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7024,12 +7024,21 @@ __metadata:
     "@babel/cli": 7.19.3
     "@babel/core": 7.20.5
     "@babel/runtime-corejs3": 7.20.6
+    "@redwoodjs/internal": 3.2.0
     "@redwoodjs/telemetry": 3.2.0
-    "@types/react": 17.0.52
+    "@types/lodash.memoize": 4.1.7
+    "@types/pascalcase": 1.0.1
+    "@types/yargs": 17.0.17
+    chalk: 4.1.2
     core-js: 3.26.1
+    execa: 5.1.1
     jest: 29.3.1
     listr2: 5.0.6
-    react: 17.0.2
+    lodash.memoize: 4.1.2
+    pascalcase: 1.0.0
+    prettier: 2.8.1
+    prompts: 2.4.2
+    terminal-link: 2.1.1
     typescript: 4.7.4
   languageName: unknown
   linkType: soft
@@ -9663,6 +9672,15 @@ __metadata:
   dependencies:
     "@types/lodash": "*"
   checksum: d14cb561e3db36b80bde1d6eea5b012c46c8bb7a7dadb2844bd80b209d7c324eb54ad5ca7b6e57c253593662d8fc676da430f2216aaca1c04b087d38030151ae
+  languageName: node
+  linkType: hard
+
+"@types/lodash.memoize@npm:4.1.7":
+  version: 4.1.7
+  resolution: "@types/lodash.memoize@npm:4.1.7"
+  dependencies:
+    "@types/lodash": "*"
+  checksum: 979a59dbbae968a03834fdb544dc5ddd34620a2912d5030c997a1aa919326425a900c93bc69554b2a873cf54f09b4dd2752b3a1c29ab4bffac5983113c58b1b5
   languageName: node
   linkType: hard
 
@@ -22371,7 +22389,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.memoize@npm:^4.1.2":
+"lodash.memoize@npm:4.1.2, lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
   checksum: c8713e51eccc650422716a14cece1809cfe34bc5ab5e242b7f8b4e2241c2483697b971a604252807689b9dd69bfe3a98852e19a5b89d506b000b4187a1285df8


### PR DESCRIPTION
While reviewing https://github.com/redwoodjs/redwood/pull/6956, I noticed more dependencies from `@redwoodjs/cli-helpers` that were missing. This PR adds them. If it's merged before https://github.com/redwoodjs/redwood/pull/6956, I'll remove the duped packages there (just prompts right now).

The steps behind this are:
- build the package
- search through the package's dist for all require statement
- is the required package listed in package.json's dependencies?