### PR TITLE
Rename create auth functions

### DIFF
--- a/__fixtures__/test-project/web/src/auth.ts
+++ b/__fixtures__/test-project/web/src/auth.ts
@@ -1,5 +1,5 @@
-import { createDbAuthClient, createDbAuth } from '@redwoodjs/auth-dbauth-web'
+import { createDbAuthClient, createAuth } from '@redwoodjs/auth-dbauth-web'
 
 const dbAuthClient = createDbAuthClient()
 
-export const { AuthProvider, useAuth } = createDbAuth(dbAuthClient)
+export const { AuthProvider, useAuth } = createAuth(dbAuthClient)

--- a/docs/docs/auth/firebase.md
+++ b/docs/docs/auth/firebase.md
@@ -22,7 +22,7 @@ We're using [Firebase Google Sign-In](https://firebase.google.com/docs/auth/web/
 import * as firebaseAuth from '@firebase/auth'
 import { initializeApp, getApp, getApps } from 'firebase/app'
 
-import { createFirebaseAuth } from '@redwoodjs/auth-providers-web'
+import { createAuth } from '@redwoodjs/auth-providers-web'
 
 const firebaseConfig = {
   apiKey: process.env.FIREBASE_API_KEY,
@@ -50,7 +50,7 @@ export const firebaseClient = {
   firebaseApp,
 }
 
-export const { AuthProvider, useAuth } = createFirebaseAuth(firebaseClient)
+export const { AuthProvider, useAuth } = createAuth(firebaseClient)
 ```
 
 ## Usage

--- a/packages/auth-providers/auth0/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/auth0/setup/src/templates/web/auth.ts.template
@@ -1,6 +1,6 @@
 import { Auth0Client } from '@auth0/auth0-spa-js'
 
-import { createAuth0Auth } from '@redwoodjs/auth-auth0-web'
+import { createAuth } from '@redwoodjs/auth-auth0-web'
 
 const auth0 = new Auth0Client({
   domain: process.env.AUTH0_DOMAIN || '',
@@ -21,4 +21,4 @@ const auth0 = new Auth0Client({
   // useRefreshTokens: true,
 })
 
-export const { AuthProvider, useAuth } = createAuth0Auth(auth0)
+export const { AuthProvider, useAuth } = createAuth(auth0)

--- a/packages/auth-providers/auth0/web/src/__tests__/auth0.test.tsx
+++ b/packages/auth-providers/auth0/web/src/__tests__/auth0.test.tsx
@@ -8,7 +8,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createAuth0Auth } from '../auth0'
+import { createAuth } from '../auth0'
 
 const user: User = {
   sub: 'unique_user_id',
@@ -85,7 +85,7 @@ function getAuth0Auth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createAuth0Auth(
+  const { useAuth, AuthProvider } = createAuth(
     auth0MockClient as Auth0Client,
     customProviderHooks
   )

--- a/packages/auth-providers/auth0/web/src/auth0.ts
+++ b/packages/auth-providers/auth0/web/src/auth0.ts
@@ -9,7 +9,7 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 // TODO: Map out this user properly.
 export interface Auth0User {}
 
-export function createAuth0Auth(
+export function createAuth(
   auth0Client: Auth0Client,
   customProviderHooks?: {
     useCurrentUser?: () => Promise<Record<string, unknown>>
@@ -18,12 +18,12 @@ export function createAuth0Auth(
     ) => (rolesToCheck: string | string[]) => boolean
   }
 ) {
-  const authImplementation = createAuth0AuthImplementation(auth0Client)
+  const authImplementation = createAuthImplementation(auth0Client)
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createAuth0AuthImplementation(auth0Client: Auth0Client) {
+function createAuthImplementation(auth0Client: Auth0Client) {
   return {
     type: 'auth0',
     client: auth0Client,

--- a/packages/auth-providers/auth0/web/src/index.ts
+++ b/packages/auth-providers/auth0/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createAuth0Auth } from './auth0'
+export { createAuth } from './auth0'

--- a/packages/auth-providers/azureActiveDirectory/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/azureActiveDirectory/setup/src/templates/web/auth.ts.template
@@ -1,6 +1,6 @@
 import { PublicClientApplication } from '@azure/msal-browser'
 
-import { createAzureActiveDirectoryAuth } from '@redwoodjs/azure-active-directory-web'
+import { createAuth } from '@redwoodjs/azure-active-directory-web'
 
 const azureActiveDirectoryClient = new PublicClientApplication({
   auth: {
@@ -12,6 +12,4 @@ const azureActiveDirectoryClient = new PublicClientApplication({
   },
 })
 
-export const { AuthProvider, useAuth } = createAzureActiveDirectoryAuth(
-  azureActiveDirectoryClient
-)
+export const { AuthProvider, useAuth } = createAuth(azureActiveDirectoryClient)

--- a/packages/auth-providers/azureActiveDirectory/web/src/__tests__/azureActiveDirectory.test.tsx
+++ b/packages/auth-providers/azureActiveDirectory/web/src/__tests__/azureActiveDirectory.test.tsx
@@ -7,7 +7,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createAzureActiveDirectoryAuth } from '../azureActiveDirectory'
+import { createAuth } from '../azureActiveDirectory'
 
 const user: AccountInfo = {
   name: 'John',
@@ -120,7 +120,7 @@ function getAzureActiveDirectoryAuth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createAzureActiveDirectoryAuth(
+  const { useAuth, AuthProvider } = createAuth(
     azureActiveDirectoryMockClient as AzureActiveDirectoryClient,
     customProviderHooks
   )

--- a/packages/auth-providers/azureActiveDirectory/web/src/azureActiveDirectory.ts
+++ b/packages/auth-providers/azureActiveDirectory/web/src/azureActiveDirectory.ts
@@ -7,7 +7,7 @@ import type {
 
 import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 
-export function createAzureActiveDirectoryAuth(
+export function createAuth(
   azureActiveDirectoryClient: AzureActiveDirectoryClient,
   customProviderHooks?: {
     useCurrentUser?: () => Promise<Record<string, unknown>>
@@ -16,14 +16,14 @@ export function createAzureActiveDirectoryAuth(
     ) => (rolesToCheck: string | string[]) => boolean
   }
 ) {
-  const authImplementation = createAzureActiveDirectoryAuthImplementation(
+  const authImplementation = createAuthImplementation(
     azureActiveDirectoryClient
   )
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createAzureActiveDirectoryAuthImplementation(
+function createAuthImplementation(
   azureActiveDirectoryClient: AzureActiveDirectoryClient
 ) {
   return {

--- a/packages/auth-providers/azureActiveDirectory/web/src/index.ts
+++ b/packages/auth-providers/azureActiveDirectory/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createAzureActiveDirectoryAuth } from './azureActiveDirectory'
+export { createAuth } from './azureActiveDirectory'

--- a/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
+++ b/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 
 import { ClerkLoaded, ClerkProvider, useUser } from '@clerk/clerk-react'
 
-import { createClerkAuth } from '@redwoodjs/auth-clerk-web'
+import { createAuth } from '@redwoodjs/auth-clerk-web'
 import { navigate } from '@redwoodjs/router'
 
 // You can set user roles in a "roles" array on the public metadata in Clerk.
@@ -14,7 +14,7 @@ import { navigate } from '@redwoodjs/router'
 // Lastly, be sure to add the key "CLERK_FRONTEND_API_URL" in your app's redwood.toml
 // [web] config "includeEnvironmentVariables" setting.
 
-export const { AuthProvider: ClerkRwAuthProvider, useAuth } = createClerkAuth()
+export const { AuthProvider: ClerkRwAuthProvider, useAuth } = createAuth()
 
 interface Props {
   children: React.ReactNode

--- a/packages/auth-providers/clerk/web/src/__tests__/clerk.test.tsx
+++ b/packages/auth-providers/clerk/web/src/__tests__/clerk.test.tsx
@@ -8,7 +8,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createClerkAuth } from '../clerk'
+import { createAuth } from '../clerk'
 
 const user: Partial<UserResource> = {
   id: 'unique_user_id',
@@ -106,7 +106,7 @@ function getClerkAuth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createClerkAuth(customProviderHooks)
+  const { useAuth, AuthProvider } = createAuth(customProviderHooks)
   const { result } = renderHook(() => useAuth(), {
     wrapper: AuthProvider,
   })

--- a/packages/auth-providers/clerk/web/src/clerk.tsx
+++ b/packages/auth-providers/clerk/web/src/clerk.tsx
@@ -12,18 +12,18 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 
 type Clerk = ClerkClient | undefined | null
 
-export function createClerkAuth(customProviderHooks?: {
+export function createAuth(customProviderHooks?: {
   useCurrentUser?: () => Promise<Record<string, unknown>>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const authImplementation = createClerkAuthImplementation()
+  const authImplementation = createAuthImplementation()
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createClerkAuthImplementation() {
+function createAuthImplementation() {
   return {
     type: 'clerk',
     client: (window as any).Clerk as Clerk,

--- a/packages/auth-providers/clerk/web/src/index.ts
+++ b/packages/auth-providers/clerk/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createClerkAuth } from './clerk'
+export { createAuth } from './clerk'

--- a/packages/auth-providers/custom/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/custom/setup/src/templates/web/auth.ts.template
@@ -1,9 +1,8 @@
 import { createAuthentication } from '@redwoodjs/auth'
 
-// If you're integrating with an auth service provider you should delete this
-// interface
-// Instead you should import the type from their auth client sdk
-export interface CustomAuthClient {
+// If you're integrating with an auth service provider you should delete this interface.
+// Instead you should import the type from their auth client sdk.
+export interface AuthClient {
   login: () => User
   logout: () => void
   signup: () => User
@@ -11,9 +10,8 @@ export interface CustomAuthClient {
   getUserMetadata: () => User | null
 }
 
-// If you're integrating with an auth service provider you should delete this
-// interface
-// This type should be inferred from the general interface above
+// If you're integrating with an auth service provider you should delete this interface.
+// This type should be inferred from the general interface above.
 interface User {
   // The name of the id variable will vary depending on what auth service
   // provider you're integrating with. Another common name is `sub`
@@ -23,8 +21,7 @@ interface User {
   roles: string[]
 }
 
-// If you're integrating with an auth service provider you should delete this
-// interface
+// If you're integrating with an auth service provider you should delete this interface
 // This type should be inferred from the general interface above
 export interface ValidateResetTokenResponse {
   error?: string
@@ -32,7 +29,7 @@ export interface ValidateResetTokenResponse {
 }
 
 // Replace this with the auth service provider client sdk
-const customClient = {
+const client = {
   login: () => ({
     id: 'unique-user-id',
     email: 'email@example.com',
@@ -52,8 +49,8 @@ const customClient = {
   }),
 }
 
-function createCustomAuth() {
-  const authImplementation = createCustomAuthImplementation(customClient)
+function createAuth() {
+  const authImplementation = createAuthImplementation(client)
 
   // You can pass custom provider hooks here if you need to as a second
   // argument. See the Redwood framework source code for how that's used
@@ -64,14 +61,14 @@ function createCustomAuth() {
 // the shape of this object (i.e. keep all the key names) but change all the
 // values/functions to use methods from the auth service provider client sdk
 // you're integrating with
-function createCustomAuthImplementation(customClient: CustomAuthClient) {
+function createAuthImplementation(client: AuthClient) {
   return {
     type: 'custom-auth',
-    client: customClient,
-    login: async () => customClient.login(),
-    logout: async () => customClient.logout(),
-    signup: async () => customClient.signup(),
-    getToken: async () => customClient.getToken(),
+    client,
+    login: async () => client.login(),
+    logout: async () => client.logout(),
+    signup: async () => client.signup(),
+    getToken: async () => client.getToken(),
     /**
      * Actual user metadata might look something like this
      * {
@@ -88,8 +85,8 @@ function createCustomAuthImplementation(customClient: CustomAuthClient) {
      *   "updated_at": "2016-05-15T19:53:12.368652374-07:00"
      * }
      */
-    getUserMetadata: async () => customClient.getUserMetadata(),
+    getUserMetadata: async () => client.getUserMetadata(),
   }
 }
 
-export const { AuthProvider, useAuth } = createCustomAuth()
+export const { AuthProvider, useAuth } = createAuth()

--- a/packages/auth-providers/dbAuth/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/web/auth.ts.template
@@ -1,5 +1,5 @@
-import { createDbAuthClient, createDbAuth } from '@redwoodjs/auth-dbauth-web'
+import { createDbAuthClient, createAuth } from '@redwoodjs/auth-dbauth-web'
 
 const dbAuthClient = createDbAuthClient()
 
-export const { AuthProvider, useAuth } = createDbAuth(dbAuthClient)
+export const { AuthProvider, useAuth } = createAuth(dbAuthClient)

--- a/packages/auth-providers/dbAuth/setup/src/templates/web/auth.webAuthn.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/web/auth.webAuthn.ts.template
@@ -1,6 +1,6 @@
-import { createDbAuthClient, createDbAuth } from '@redwoodjs/auth-dbauth-web'
+import { createDbAuthClient, createAuth } from '@redwoodjs/auth-dbauth-web'
 import WebAuthnClient from '@redwoodjs/auth-dbauth-web/webAuthn'
 
 const dbAuthClient = createDbAuthClient({ webAuthn: new WebAuthnClient() })
 
-export const { AuthProvider, useAuth } = createDbAuth(new WebAuthnClient())
+export const { AuthProvider, useAuth } = createAuth(new WebAuthnClient())

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createDbAuthClient, DbAuthClientArgs, createDbAuth } from '../dbAuth'
+import { createDbAuthClient, DbAuthClientArgs, createAuth } from '../dbAuth'
 
 process.env.RWJS_API_URL = '/.redwood/functions'
 process.env.RWJS_API_GRAPHQL_URL = '/.redwood/functions/graphql'
@@ -89,7 +89,7 @@ const defaultArgs: DbAuthClientArgs & {
 
 function getDbAuth(args = defaultArgs) {
   const dbAuthClient = createDbAuthClient(args)
-  const { useAuth, AuthProvider } = createDbAuth(dbAuthClient, {
+  const { useAuth, AuthProvider } = createAuth(dbAuthClient, {
     useHasRole: args.useHasRole,
     useCurrentUser: args.useCurrentUser,
   })

--- a/packages/auth-providers/dbAuth/web/src/dbAuth.ts
+++ b/packages/auth-providers/dbAuth/web/src/dbAuth.ts
@@ -16,7 +16,7 @@ export type SignupAttributes = Record<string, unknown> & LoginAttributes
 
 const TOKEN_CACHE_TIME = 5000
 
-export function createDbAuth(
+export function createAuth(
   dbAuthClient: ReturnType<typeof createDbAuthClient>,
   customProviderHooks?: {
     useCurrentUser?: () => Promise<Record<string, unknown>>

--- a/packages/auth-providers/firebase/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/firebase/setup/src/templates/web/auth.ts.template
@@ -1,7 +1,7 @@
 import * as firebaseAuth from 'firebase/auth'
 import { initializeApp, getApp, getApps } from 'firebase/app'
 
-import { createFirebaseAuth } from '@redwoodjs/auth-firebase-web'
+import { createAuth } from '@redwoodjs/auth-firebase-web'
 
 const firebaseConfig = {
   apiKey: process.env.FIREBASE_API_KEY,
@@ -29,4 +29,4 @@ export const firebaseClient = {
   firebaseApp, // optional
 }
 
-export const { AuthProvider, useAuth } = createFirebaseAuth(firebaseClient)
+export const { AuthProvider, useAuth } = createAuth(firebaseClient)

--- a/packages/auth-providers/firebase/web/src/__tests__/firebase.test.tsx
+++ b/packages/auth-providers/firebase/web/src/__tests__/firebase.test.tsx
@@ -4,7 +4,7 @@ import { User, OperationType, OAuthProvider, Auth } from 'firebase/auth'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createFirebaseAuth, FirebaseClient } from '../firebase'
+import { createAuth, FirebaseClient } from '../firebase'
 
 const user: User = {
   uid: 'unique_user_id',
@@ -148,7 +148,7 @@ function getFirebaseAuth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createFirebaseAuth(
+  const { useAuth, AuthProvider } = createAuth(
     firebaseMockClient as FirebaseClient,
     customProviderHooks
   )

--- a/packages/auth-providers/firebase/web/src/firebase.ts
+++ b/packages/auth-providers/firebase/web/src/firebase.ts
@@ -74,7 +74,7 @@ const applyProviderOptions = (
   return provider
 }
 
-export function createFirebaseAuth(
+export function createAuth(
   firebaseClient: FirebaseClient,
   customProviderHooks?: {
     useCurrentUser?: () => Promise<Record<string, unknown>>
@@ -83,7 +83,7 @@ export function createFirebaseAuth(
     ) => (rolesToCheck: string | string[]) => boolean
   }
 ) {
-  const authImplementation = createFirebaseAuthImplementation(firebaseClient)
+  const authImplementation = createAuthImplementation(firebaseClient)
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
@@ -93,7 +93,7 @@ export interface FirebaseClient {
   firebaseApp?: FirebaseApp
 }
 
-function createFirebaseAuthImplementation({
+function createAuthImplementation({
   firebaseAuth,
   firebaseApp,
 }: FirebaseClient) {

--- a/packages/auth-providers/firebase/web/src/index.ts
+++ b/packages/auth-providers/firebase/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createFirebaseAuth } from './firebase'
+export { createAuth } from './firebase'

--- a/packages/auth-providers/netlify/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/netlify/setup/src/templates/web/auth.ts.template
@@ -1,8 +1,8 @@
 import netlifyIdentity from 'netlify-identity-widget'
 
-import { createNetlifyAuth } from '@redwoodjs/auth-netlify-web'
+import { createAuth } from '@redwoodjs/auth-netlify-web'
 import { isBrowser } from '@redwoodjs/prerender/browserUtils'
 
 isBrowser && netlifyIdentity.init()
 
-export const { AuthProvider, useAuth } = createNetlifyAuth(netlifyIdentity)
+export const { AuthProvider, useAuth } = createAuth(netlifyIdentity)

--- a/packages/auth-providers/netlify/web/src/__tests__/netlify.test.tsx
+++ b/packages/auth-providers/netlify/web/src/__tests__/netlify.test.tsx
@@ -3,7 +3,7 @@ import * as NetlifyIdentityNS from 'netlify-identity-widget'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createNetlifyAuth } from '../netlify'
+import { createAuth } from '../netlify'
 
 type NetlifyIdentity = typeof NetlifyIdentityNS
 type User = NetlifyIdentityNS.User
@@ -98,7 +98,7 @@ function getNetlifyAuth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createNetlifyAuth(
+  const { useAuth, AuthProvider } = createAuth(
     netlifyIdentityMockClient as NetlifyIdentity,
     customProviderHooks
   )

--- a/packages/auth-providers/netlify/web/src/index.ts
+++ b/packages/auth-providers/netlify/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createNetlifyAuth } from './netlify'
+export { createAuth } from './netlify'

--- a/packages/auth-providers/netlify/web/src/netlify.ts
+++ b/packages/auth-providers/netlify/web/src/netlify.ts
@@ -10,7 +10,7 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 
 type NetlifyIdentity = typeof NetlifyIdentityNS
 
-export function createNetlifyAuth(
+export function createAuth(
   netlifyIdentity: NetlifyIdentity,
   customProviderHooks?: {
     useCurrentUser?: () => Promise<Record<string, unknown>>
@@ -19,7 +19,7 @@ export function createNetlifyAuth(
     ) => (rolesToCheck: string | string[]) => boolean
   }
 ) {
-  const authImplementation = createNetlifyAuthImplementation(netlifyIdentity)
+  const authImplementation = createAuthImplementation(netlifyIdentity)
 
   // TODO: Add this when this is a separate package. For now it'll have to be
   // done in the user's app
@@ -28,7 +28,7 @@ export function createNetlifyAuth(
   return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createNetlifyAuthImplementation(netlifyIdentity: NetlifyIdentity) {
+function createAuthImplementation(netlifyIdentity: NetlifyIdentity) {
   return {
     type: 'netlify',
     client: netlifyIdentity,

--- a/packages/auth-providers/supabase/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/supabase/setup/src/templates/web/auth.ts.template
@@ -1,10 +1,10 @@
 import { createClient } from '@supabase/supabase-js'
 
-import { createSupabaseAuth } from '@redwoodjs/auth-supabase-web'
+import { createAuth } from '@redwoodjs/auth-supabase-web'
 
 const supabaseClient = createClient(
   process.env.SUPABASE_URL || '',
   process.env.SUPABASE_KEY || ''
 )
 
-export const { AuthProvider, useAuth } = createSupabaseAuth(supabaseClient)
+export const { AuthProvider, useAuth } = createAuth(supabaseClient)

--- a/packages/auth-providers/supabase/web/src/__tests__/supabase.test.tsx
+++ b/packages/auth-providers/supabase/web/src/__tests__/supabase.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 
 import { CurrentUser } from '@redwoodjs/auth'
 
-import { createSupabaseAuth } from '../supabase'
+import { createAuth } from '../supabase'
 
 const user: Partial<User> = {
   id: 'unique_user_id',
@@ -112,7 +112,7 @@ function getSupabaseAuth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createSupabaseAuth(
+  const { useAuth, AuthProvider } = createAuth(
     supabaseMockClient as SupabaseClient,
     customProviderHooks
   )

--- a/packages/auth-providers/supabase/web/src/index.ts
+++ b/packages/auth-providers/supabase/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createSupabaseAuth } from './supabase'
+export { createAuth } from './supabase'

--- a/packages/auth-providers/supabase/web/src/supabase.ts
+++ b/packages/auth-providers/supabase/web/src/supabase.ts
@@ -19,7 +19,7 @@ type SignUpOptions = {
   redirectTo?: string
 }
 
-export function createSupabaseAuth(
+export function createAuth(
   supabaseClient: SupabaseClient,
   customProviderHooks?: {
     useCurrentUser?: () => Promise<Record<string, unknown>>
@@ -28,12 +28,12 @@ export function createSupabaseAuth(
     ) => (rolesToCheck: string | string[]) => boolean
   }
 ) {
-  const authImplementation = createSupabaseAuthImplementation(supabaseClient)
+  const authImplementation = createAuthImplementation(supabaseClient)
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createSupabaseAuthImplementation(supabaseClient: SupabaseClient) {
+function createAuthImplementation(supabaseClient: SupabaseClient) {
   return {
     type: 'supabase',
     client: supabaseClient,

--- a/packages/auth-providers/supertokens/setup/src/templates/web/auth.ts.template
+++ b/packages/auth-providers/supertokens/setup/src/templates/web/auth.ts.template
@@ -1,4 +1,4 @@
-import { createSuperTokensAuth } from '@redwoodjs/auth-supertokens-web'
+import { createAuth } from '@redwoodjs/auth-supertokens-web'
 import { isBrowser } from '@redwoodjs/prerender/browserUtils'
 
 import SuperTokens from 'supertokens-auth-react'
@@ -39,5 +39,4 @@ isBrowser &&
     ],
   })
 
-export const { AuthProvider, useAuth } =
-  createSuperTokensAuth(superTokensClient)
+export const { AuthProvider, useAuth } = createAuth(superTokensClient)

--- a/packages/auth-providers/supertokens/web/src/__tests__/supertokens.test.tsx
+++ b/packages/auth-providers/supertokens/web/src/__tests__/supertokens.test.tsx
@@ -3,7 +3,7 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import { CurrentUser } from '@redwoodjs/auth'
 
 import {
-  createSuperTokensAuth,
+  createAuth,
   SuperTokensUser,
   AuthRecipe,
   SessionRecipe,
@@ -87,7 +87,7 @@ function getSuperTokensAuth(customProviderHooks?: {
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
 }) {
-  const { useAuth, AuthProvider } = createSuperTokensAuth(
+  const { useAuth, AuthProvider } = createAuth(
     superTokensMockClient as SuperTokensAuth,
     customProviderHooks
   )

--- a/packages/auth-providers/supertokens/web/src/index.ts
+++ b/packages/auth-providers/supertokens/web/src/index.ts
@@ -1,1 +1,1 @@
-export { createSuperTokensAuth } from './supertokens'
+export { createAuth } from './supertokens'

--- a/packages/auth-providers/supertokens/web/src/supertokens.ts
+++ b/packages/auth-providers/supertokens/web/src/supertokens.ts
@@ -16,7 +16,7 @@ export type AuthRecipe = {
   redirectToAuth: (input: 'signin' | 'signup') => void
 }
 
-export function createSuperTokensAuth(
+export function createAuth(
   superTokens: {
     authRecipe: AuthRecipe
     sessionRecipe: SessionRecipe
@@ -28,7 +28,7 @@ export function createSuperTokensAuth(
     ) => (rolesToCheck: string | string[]) => boolean
   }
 ) {
-  const authImplementation = createSuperTokensAuthImplementation(superTokens)
+  const authImplementation = createAuthImplementation(superTokens)
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
@@ -38,7 +38,7 @@ export interface SuperTokensAuth {
   sessionRecipe: SessionRecipe
 }
 
-function createSuperTokensAuthImplementation(superTokens: SuperTokensAuth) {
+function createAuthImplementation(superTokens: SuperTokensAuth) {
   return {
     type: 'supertokens',
     login: async () => superTokens.authRecipe.redirectToAuth('signin'),

--- a/packages/cli-helpers/src/auth/__tests__/__snapshots__/addAuthConfig.test.ts.snap
+++ b/packages/cli-helpers/src/auth/__tests__/__snapshots__/addAuthConfig.test.ts.snap
@@ -194,9 +194,9 @@ export default App
 `;
 
 exports[`Should update App.{js,tsx}, Routes.{js,tsx} and add auth.ts Matches Auth0 Snapshot 2`] = `
-"import { createDbAuth } from '@redwoodjs/auth-providers-web'
+"import { createAuth } from '@redwoodjs/auth-providers-web'
 
-export const { AuthProvider, useAuth } = createDbAuth()
+export const { AuthProvider, useAuth } = createAuth()
 "
 `;
 
@@ -254,9 +254,9 @@ export default App
 `;
 
 exports[`Should update App.{js,tsx}, Routes.{js,tsx} and add auth.ts Matches Clerk Snapshot 2`] = `
-"import { createDbAuth } from '@redwoodjs/auth-providers-web'
+"import { createAuth } from '@redwoodjs/auth-providers-web'
 
-export const { AuthProvider, useAuth } = createDbAuth()
+export const { AuthProvider, useAuth } = createAuth()
 "
 `;
 

--- a/packages/cli-helpers/src/auth/__tests__/__snapshots__/addAuthConfig.test.ts.snap
+++ b/packages/cli-helpers/src/auth/__tests__/__snapshots__/addAuthConfig.test.ts.snap
@@ -194,7 +194,7 @@ export default App
 `;
 
 exports[`Should update App.{js,tsx}, Routes.{js,tsx} and add auth.ts Matches Auth0 Snapshot 2`] = `
-"import { createAuth } from '@redwoodjs/auth-providers-web'
+"import { createAuth } from '@redwoodjs/auth-dbauth-web'
 
 export const { AuthProvider, useAuth } = createAuth()
 "
@@ -254,7 +254,7 @@ export default App
 `;
 
 exports[`Should update App.{js,tsx}, Routes.{js,tsx} and add auth.ts Matches Clerk Snapshot 2`] = `
-"import { createAuth } from '@redwoodjs/auth-providers-web'
+"import { createAuth } from '@redwoodjs/auth-dbauth-web'
 
 export const { AuthProvider, useAuth } = createAuth()
 "

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.ts.template
@@ -1,3 +1,3 @@
-import { createAuth } from '@redwoodjs/auth-providers-web'
+import { createAuth } from '@redwoodjs/auth-dbauth-web'
 
 export const { AuthProvider, useAuth } = createAuth()

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.ts.template
@@ -1,3 +1,3 @@
-import { createDbAuth } from '@redwoodjs/auth-providers-web'
+import { createAuth } from '@redwoodjs/auth-providers-web'
 
-export const { AuthProvider, useAuth } = createDbAuth()
+export const { AuthProvider, useAuth } = createAuth()

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.webAuthn.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.webAuthn.ts.template
@@ -1,4 +1,4 @@
-import { createDbAuth } from '@redwoodjs/auth-providers-web'
+import { createAuth } from '@redwoodjs/auth-providers-web'
 import WebAuthnClient from '@redwoodjs/auth-providers-web/dbAuth/webAuthn'
 
-export const { AuthProvider, useAuth } = createDbAuth(WebAuthnClient)
+export const { AuthProvider, useAuth } = createAuth(WebAuthnClient)

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.webAuthn.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/web/auth.webAuthn.ts.template
@@ -1,4 +1,4 @@
-import { createAuth } from '@redwoodjs/auth-providers-web'
-import WebAuthnClient from '@redwoodjs/auth-providers-web/dbAuth/webAuthn'
+import { createAuth } from '@redwoodjs/auth-dbauth-web'
+import WebAuthnClient from '@redwoodjs/auth-dbauth-web/webAuthn'
 
 export const { AuthProvider, useAuth } = createAuth(WebAuthnClient)

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/supertokensSetup/templates/web/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/supertokensSetup/templates/web/auth.ts.template
@@ -1,4 +1,4 @@
-import { createSuperTokensAuth } from '@redwoodjs/auth-providers'
+import { createAuth } from '@redwoodjs/auth-providers'
 import { isBrowser } from '@redwoodjs/prerender/browserUtils'
 
 import SuperTokens from 'supertokens-auth-react'
@@ -40,4 +40,4 @@ isBrowser &&
   })
 
 export const { AuthProvider, useAuth } =
-  createSuperTokensAuth(superTokensClient)
+  createAuth(superTokensClient)

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/supertokensSetup/templates/web/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/supertokensSetup/templates/web/auth.ts.template
@@ -1,4 +1,4 @@
-import { createAuth } from '@redwoodjs/auth-providers'
+import { createAuth } from '@redwoodjs/auth-supertokens-web'
 import { isBrowser } from '@redwoodjs/prerender/browserUtils'
 
 import SuperTokens from 'supertokens-auth-react'
@@ -39,5 +39,4 @@ isBrowser &&
     ],
   })
 
-export const { AuthProvider, useAuth } =
-  createAuth(superTokensClient)
+export const { AuthProvider, useAuth } = createAuth(superTokensClient)


### PR DESCRIPTION
All of the auth providers export a `create${provider}Auth` function from their web package. This is mostly an artifact of when they were all exported from the `@redwoodjs-auth-web` package where they had to be differentiated from each other. The api packages have already dropped provider-specific naming: they just export a generically named `authDecoder` function across the board. This PR renames all the `create${provider}Auth` to just `createAuth`.