### PR TITLE
chore: forego semver carets in canary publishing

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -53,6 +53,7 @@ jobs:
           args+=(
             --include-merged-tags
             --canary
+            --exact
             --preid "$TAG"
             --dist-tag "$TAG"
             --force-publish


### PR DESCRIPTION
Redwood's deploy target CI was failing on a version of the `next` tag. Curiously, the version it was at in main also failed if you rebuilt the `yarn.lock`, so something weird was going on. The `yarn.lock` look botched—it was installing `v3.7.1` of some of the redwood packages, not the `v3.7.1-next.*`. And there were semver carets all over the place, which our CI is supposed to catch.

The new npm code browser makes the problem clear:

<img width="520" alt="image" src="https://user-images.githubusercontent.com/32992335/208154910-8d059fcb-307d-43f1-b808-295eee2dda44.png">

Why do all the `@redwoodjs` packages have semver carets? Lerna is putting them there because we're not passing the `--exact` flag.
