### PR TITLE
Render deploy: Static sites are always free

### DIFF
--- a/packages/cli/src/commands/setup/deploy/templates/render.js
+++ b/packages/cli/src/commands/setup/deploy/templates/render.js
@@ -14,7 +14,6 @@ export const RENDER_YAML = (database) => {
 services:
 - name: ${PROJECT_NAME}-web
   type: web
-  plan: free
   env: static
   buildCommand: yarn install && yarn rw deploy render web
   staticPublishPath: ./web/dist


### PR DESCRIPTION
Fixes #7195

![image](https://user-images.githubusercontent.com/30793/208165937-177dc0e0-40bd-412c-999d-9352a9d8c124.png)
https://community.render.com/t/blueprint-error-services-0-plan-no-such-plan-free-for-service-type-web/7067