### PR TITLE
Correct link to Netlify deploy docs

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/netlify.js
+++ b/packages/cli/src/commands/setup/deploy/providers/netlify.js
@@ -19,7 +19,7 @@ const files = [
 
 const notes = [
   'You are ready to deploy to Netlify!',
-  'See: https://redwoodjs.com/docs/deploy#netlify-deploy',
+  'See: https://redwoodjs.com/docs/deploy/netlify',
 ]
 
 export const handler = async ({ force }) => {


### PR DESCRIPTION
This url is no longer correct

![image](https://user-images.githubusercontent.com/30793/208203943-54a7fa63-33f4-44d6-97f4-b60d1d80575f.png)

Switched to https://redwoodjs.com/docs/deploy/netlify instead