### PR TITLE
fix: update packages in supabase setup

### DIFF
--- a/packages/auth-providers/supabase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supabase/setup/src/setupHandler.ts
@@ -14,10 +14,10 @@ export const handler = async ({ force: forceArg }: Args) => {
     basedir: __dirname,
     forceArg,
     provider: 'supabase',
-    authDecoderImport: `import { authDecoder } from '@redwoodjs/auth-supabase-api@${version}'`,
-    apiPackages: [`@redwoodjs/auth-providers-api@${version}`],
+    authDecoderImport: `import { authDecoder } from '@redwoodjs/auth-supabase-api'`,
+    apiPackages: [`@redwoodjs/auth-supabase-api@${version}`],
     webPackages: [
-      `@redwoodjs/auth-providers-web@${version}`,
+      `@redwoodjs/auth-supabase-web@${version}`,
       '@supabase/supabase-js@1.35.7',
     ],
     notes: [


### PR DESCRIPTION
The `yarn rw setup auth supabase` command is still using the old `auth-providers-{api,web}` packages instead of the new ones exclusive to supabase.