### PR TITLE
feat: add boilerplate `authDecoder` function to custom auth setup

### DIFF
--- a/packages/auth-providers/custom/setup/src/setupHandler.ts
+++ b/packages/auth-providers/custom/setup/src/setupHandler.ts
@@ -19,6 +19,7 @@ export async function handler({ force: forceArg }: Args) {
     basedir: __dirname,
     forceArg,
     provider: 'custom',
+    authDecoderImport: "import { authDecoder } from 'src/lib/auth'",
     webPackages: [`@redwoodjs/auth@${version}`],
     notes: [
       'Done! But you have a little more work to do:\n',

--- a/packages/auth-providers/custom/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/custom/setup/src/templates/api/lib/auth.ts.template
@@ -124,3 +124,16 @@ export const requireAuth = ({ roles }: { roles?: AllowedRoles } = {}) => {
     throw new ForbiddenError("You don't have access to do that.")
   }
 }
+
+/**
+ * The function the GraphQL handler uses the deocde the JWT.
+ */
+export const authDecoder = (token: string, type: string) => {
+  // If you change the type on the web side in the `createAuthImplementation` function,
+  // be sure to change it here too.
+  if (type !== 'custom-auth') {
+    return null
+  }
+
+  // decode token...
+}


### PR DESCRIPTION
@Tobbe this is a work in progress, but I feel like we should include a boilerplate plate `authDecoder` function in custom auth setup. It doesn't even have to do anything. But adding it and commenting it lets the user know they need this function for things to work. 

Besides what the boilerplate function should look like, the issue that the existing `standardAuthHandler` doesn't know to combine the imports from `src/lib/auth` (maybe it's not an issue—maybe it just requires a bit of custom code). Here's the generated code:

```
import { authDecoder } from 'src/lib/auth'
import { createGraphQLHandler } from '@redwoodjs/graphql-server'

import directives from 'src/directives/**/*.{js,ts}'
import sdls from 'src/graphql/**/*.sdl.{js,ts}'
import services from 'src/services/**/*.{js,ts}'

import { getCurrentUser } from 'src/lib/auth'
import { db } from 'src/lib/db'
import { logger } from 'src/lib/logger'

export const handler = createGraphQLHandler({
  authDecoder,
  getCurrentUser,
  loggerConfig: { logger, options: {} },
  directives,
  sdls,
  services,
  onException: () => {
    // Disconnect from your database with an unhandled exception.
    db.$disconnect()
  },
})
```

Ideally `import { authDecoder } from 'src/lib/auth'` should be combined with `import { getCurrentUser } from 'src/lib/auth'`. (I think the merge library Nick wrote for the CLI would work here.)

Maybe this is something we get to later though. Feels like a lot of work when other things like docs aren't done, so I'll keep my focus there.