### PR TITLE
cli generate helpers.js: Fix formatting warnings

### DIFF
--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -143,7 +143,9 @@ export const yargsDefaults = {
 
 export const validateName = (name) => {
   if (name.match(/^\W/)) {
-    throw new Error('The <name> argument must start with a letter, number or underscore.')
+    throw new Error(
+      'The <name> argument must start with a letter, number or underscore.'
+    )
   }
 }
 


### PR DESCRIPTION
Getting rid of unrelated warnings on other PRs
![image](https://user-images.githubusercontent.com/30793/208951007-7080507e-6c7b-4d19-8dcc-3c444563eadc.png)
