### PR TITLE
fix(smoke test): add babel resolution for storybook

### DIFF
--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -21,5 +21,8 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@3.3.0"
+  "packageManager": "yarn@3.3.0",
+  "resolutions": {
+    "@babel/plugin-transform-block-scoping": "7.18.9"
+  }
 }


### PR DESCRIPTION
Storybook smoke tests are failing because of https://github.com/storybookjs/storybook/issues/20382. It sounds like this'll be resolved soon, but for now I'm following the workaround in https://github.com/storybookjs/storybook/issues/20382#issuecomment-1363042761