### PR TITLE
Fix how the setup auth command checks for published versions

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -64,9 +64,7 @@ export async function builder(yargs) {
       false,
       () => {},
       () => {
-        console.log(
-          'ethereum is no longer supported out of the box. But you can still integrate it yourself with custom auth'
-        )
+        console.log(getRedirectMessage('ethereum'))
       }
     )
     .command(
@@ -74,9 +72,7 @@ export async function builder(yargs) {
       false,
       () => {},
       () => {
-        console.log(
-          'goTrue is no longer supported out of the box. But you can still integrate it yourself with custom auth'
-        )
+        console.log(getRedirectMessage('goTrue'))
       }
     )
     .command(
@@ -84,9 +80,7 @@ export async function builder(yargs) {
       false,
       () => {},
       () => {
-        console.log(
-          'magicLink is no longer supported out of the box. But you can still integrate it yourself with custom auth'
-        )
+        console.log(getRedirectMessage('magicLink'))
       }
     )
     .command(
@@ -94,9 +88,7 @@ export async function builder(yargs) {
       false,
       () => {},
       () => {
-        console.log(
-          'nhost is no longer supported out of the box. But you can still integrate it yourself with custom auth'
-        )
+        console.log(getRedirectMessage('nhost'))
       }
     )
     .command(
@@ -104,9 +96,7 @@ export async function builder(yargs) {
       false,
       () => {},
       () => {
-        console.log(
-          'okta is no longer supported out of the box. But you can still integrate it yourself with custom auth'
-        )
+        console.log(getRedirectMessage('okta'))
       }
     )
     // Providers we support
@@ -202,6 +192,19 @@ export async function builder(yargs) {
         handler(args)
       }
     )
+}
+
+/**
+ * Get a stock message for one of our removed auth providers
+ * directing the user to the Custom Auth docs.
+ *
+ * @param {string} provider
+ */
+function getRedirectMessage(provider) {
+  return `${provider} is no longer supported out of the box. But you can still integrate it yourself with ${terminalLink(
+    'Custom Auth',
+    'https://redwoodjs.com/docs/auth/custom'
+  )}`
 }
 
 async function getAuthHandler(module) {

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -219,6 +219,12 @@ async function getAuthHandler(module) {
       `yarn npm info ${module} --fields versions --json`
     )
 
+    // If the version includes a plus, like '4.0.0-rc.428+dd79f1726'
+    // (all @canary, @next, and @rc packages do), get rid of everything after the plus.
+    if (version.includes('+')) {
+      version = version.split('+')[0]
+    }
+
     const versionIsPublished = JSON.parse(stdout).versions.includes(version)
 
     if (!versionIsPublished) {


### PR DESCRIPTION
To make a canary version, lerna adds the commit hash after the number of commits. The canary versions end up looking like `4.0.0-rc.428+dd79f1726`. When you run `yarn npm info @redwoodjs/core --fields versions`, npm doesn't divulge the `+` part, just everything before it. This leads to false positives when checking for the version.