### PR TITLE
setupHelpers.test.ts: Remove unused arg

### DIFF
--- a/packages/cli-helpers/src/auth/__tests__/setupHelpers.test.ts
+++ b/packages/cli-helpers/src/auth/__tests__/setupHelpers.test.ts
@@ -70,7 +70,6 @@ describe('Auth generator tests', () => {
   it('Successfully executes the handler for Netlify', async () => {
     await standardAuthHandler({
       basedir: path.join(__dirname, 'fixtures/supertokensSetup'),
-      rwVersion: '1.2.3',
       provider: 'supertokens',
       webAuthn: false,
       forceArg: false,
@@ -91,7 +90,6 @@ describe('Auth generator tests', () => {
   it('Successfully executes the handler for Netlify without prompting the user when --force is true', async () => {
     await standardAuthHandler({
       basedir: path.join(__dirname, 'fixtures/supertokensSetup'),
-      rwVersion: '1.2.3',
       provider: 'supertokens',
       webAuthn: false,
       forceArg: true,
@@ -105,7 +103,6 @@ describe('Auth generator tests', () => {
   it('Successfully executes the handler for dbAuth', async () => {
     await standardAuthHandler({
       basedir: path.join(__dirname, 'fixtures/dbAuthSetup'),
-      rwVersion: '1.2.3',
       provider: 'dbAuth',
       webAuthn: false,
       forceArg: false,


### PR DESCRIPTION
the `rwVersion` argument was removed a few days/weeks ago, but we forgot to remove it from the tests