### PR TITLE
Separate setup vite handler, install canary version of `@redwoodjs/vite`

### DIFF
--- a/packages/cli/src/commands/setup/vite/vite.js
+++ b/packages/cli/src/commands/setup/vite/vite.js
@@ -1,20 +1,8 @@
-import fs from 'fs'
-import path from 'path'
-
-import chalk from 'chalk'
-import { Listr } from 'listr2'
-
-import { addWebPackages } from '@redwoodjs/cli-helpers'
-import { getConfigPath } from '@redwoodjs/internal/dist/paths'
-import { errorTelemetry } from '@redwoodjs/telemetry'
-
-import { getPaths, transformTSToJS, writeFile } from '../../../lib'
-import c from '../../../lib/colors'
-import { isTypeScriptProject } from '../../../lib/project'
-
 export const command = 'vite'
+
 export const description =
   '[Experimental] Configure the web side to use Vite, instead of Webpack'
+
 export const builder = (yargs) => {
   yargs.option('force', {
     alias: 'f',
@@ -36,121 +24,7 @@ export const builder = (yargs) => {
   })
 }
 
-export const handler = async ({ force, verbose, addPackage }) => {
-  const ts = isTypeScriptProject()
-  const tasks = new Listr(
-    [
-      {
-        title: 'Confirmation',
-        task: async (_ctx, task) => {
-          const confirmation = await task.prompt({
-            type: 'Confirm',
-            message: 'Vite support is experimental. Continue?',
-          })
-
-          if (!confirmation) {
-            throw new Error('User aborted')
-          }
-        },
-      },
-      {
-        title: 'Adding vite.config.js...',
-        task: () => {
-          const viteConfigPath = `${getPaths().web.base}/vite.config.${
-            ts ? 'ts' : 'js'
-          }`
-
-          const templateContent = fs.readFileSync(
-            path.resolve(__dirname, 'templates', 'vite.config.ts.template'),
-            'utf-8'
-          )
-
-          const viteConfigContent = ts
-            ? templateContent
-            : transformTSToJS(viteConfigPath, templateContent)
-
-          return writeFile(viteConfigPath, viteConfigContent, {
-            overwriteExisting: force,
-          })
-        },
-      },
-      {
-        title: 'Adding Vite bundler flag to redwood.toml...',
-        task: (_ctx, task) => {
-          const redwoodTomlPath = getConfigPath()
-          const configContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
-
-          if (!configContent.includes('bundler = vite')) {
-            // Use string replace to preserve comments and formatting
-            writeFile(
-              redwoodTomlPath,
-              configContent.replace('[web]', '[web]\n  bundler = "vite"'),
-              {
-                overwriteExisting: true, // redwood.toml always exists
-              }
-            )
-          } else {
-            task.skip('Vite bundler flag already set in redwood.toml')
-          }
-        },
-      },
-      {
-        title: 'Creating new entry point in `web/src/entry-client.jsx`...',
-        task: () => {
-          // Keep it as JSX for now
-          const entryPointFile = path.join(
-            getPaths().web.src,
-            `entry-client.jsx`
-          )
-          const content = fs
-            .readFileSync(
-              path.join(
-                getPaths().base,
-                // NOTE we're copying over the index.js before babel transform
-                'node_modules/@redwoodjs/web/src/entry/index.js'
-              ),
-              'utf-8'
-            )
-            .replace('~redwood-app-root', './App')
-
-          return writeFile(entryPointFile, content, {
-            overwriteExisting: force,
-          })
-        },
-      },
-      {
-        ...addWebPackages(['@redwoodjs/vite']),
-        title: 'Adding @redwoodjs/vite dependency...',
-        skip: () => {
-          if (!addPackage) {
-            return 'Skipping package install, you will need to add @redwoodjs/vite manaually as a dependency on the web workspace'
-          }
-        },
-      },
-      {
-        title: 'One more thing...',
-        task: (_ctx, task) => {
-          task.title = `One more thing...\n
-          ${c.green('Vite Support is still experimental!')}
-          ${c.green('Please let us know if you find bugs or quirks.')}
-          ${chalk.hex('#e8e8e8')(
-            'https://github.com/redwoodjs/redwood/issues/new'
-          )}
-        `
-        },
-      },
-    ],
-    {
-      rendererOptions: { collapse: false },
-      renderer: verbose ? 'verbose' : 'default',
-    }
-  )
-
-  try {
-    await tasks.run()
-  } catch (e) {
-    errorTelemetry(process.argv, e.message)
-    console.error(c.error(e.message))
-    process.exit(e?.exitCode || 1)
-  }
+export const handler = async (options) => {
+  const { handler } = await import('./viteHandler')
+  return handler(options)
 }

--- a/packages/cli/src/commands/setup/vite/viteHandler.js
+++ b/packages/cli/src/commands/setup/vite/viteHandler.js
@@ -12,6 +12,10 @@ import { getPaths, transformTSToJS, writeFile } from '../../../lib'
 import c from '../../../lib/colors'
 import { isTypeScriptProject } from '../../../lib/project'
 
+const { version } = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../../package.json'), 'utf-8')
+)
+
 export const handler = async ({ force, verbose, addPackage }) => {
   const ts = isTypeScriptProject()
   const tasks = new Listr(
@@ -95,7 +99,7 @@ export const handler = async ({ force, verbose, addPackage }) => {
         },
       },
       {
-        ...addWebPackages(['@redwoodjs/vite']),
+        ...addWebPackages([`@redwoodjs/vite@${version}}`]),
         title: 'Adding @redwoodjs/vite dependency...',
         skip: () => {
           if (!addPackage) {

--- a/packages/cli/src/commands/setup/vite/viteHandler.js
+++ b/packages/cli/src/commands/setup/vite/viteHandler.js
@@ -1,0 +1,132 @@
+import fs from 'fs'
+import path from 'path'
+
+import chalk from 'chalk'
+import { Listr } from 'listr2'
+
+import { addWebPackages } from '@redwoodjs/cli-helpers'
+import { getConfigPath } from '@redwoodjs/internal/dist/paths'
+import { errorTelemetry } from '@redwoodjs/telemetry'
+
+import { getPaths, transformTSToJS, writeFile } from '../../../lib'
+import c from '../../../lib/colors'
+import { isTypeScriptProject } from '../../../lib/project'
+
+export const handler = async ({ force, verbose, addPackage }) => {
+  const ts = isTypeScriptProject()
+  const tasks = new Listr(
+    [
+      {
+        title: 'Confirmation',
+        task: async (_ctx, task) => {
+          const confirmation = await task.prompt({
+            type: 'Confirm',
+            message: 'Vite support is experimental. Continue?',
+          })
+
+          if (!confirmation) {
+            throw new Error('User aborted')
+          }
+        },
+      },
+      {
+        title: 'Adding vite.config.js...',
+        task: () => {
+          const viteConfigPath = `${getPaths().web.base}/vite.config.${
+            ts ? 'ts' : 'js'
+          }`
+
+          const templateContent = fs.readFileSync(
+            path.resolve(__dirname, 'templates', 'vite.config.ts.template'),
+            'utf-8'
+          )
+
+          const viteConfigContent = ts
+            ? templateContent
+            : transformTSToJS(viteConfigPath, templateContent)
+
+          return writeFile(viteConfigPath, viteConfigContent, {
+            overwriteExisting: force,
+          })
+        },
+      },
+      {
+        title: 'Adding Vite bundler flag to redwood.toml...',
+        task: (_ctx, task) => {
+          const redwoodTomlPath = getConfigPath()
+          const configContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
+
+          if (!configContent.includes('bundler = vite')) {
+            // Use string replace to preserve comments and formatting
+            writeFile(
+              redwoodTomlPath,
+              configContent.replace('[web]', '[web]\n  bundler = "vite"'),
+              {
+                overwriteExisting: true, // redwood.toml always exists
+              }
+            )
+          } else {
+            task.skip('Vite bundler flag already set in redwood.toml')
+          }
+        },
+      },
+      {
+        title: 'Creating new entry point in `web/src/entry-client.jsx`...',
+        task: () => {
+          // Keep it as JSX for now
+          const entryPointFile = path.join(
+            getPaths().web.src,
+            `entry-client.jsx`
+          )
+          const content = fs
+            .readFileSync(
+              path.join(
+                getPaths().base,
+                // NOTE we're copying over the index.js before babel transform
+                'node_modules/@redwoodjs/web/src/entry/index.js'
+              ),
+              'utf-8'
+            )
+            .replace('~redwood-app-root', './App')
+
+          return writeFile(entryPointFile, content, {
+            overwriteExisting: force,
+          })
+        },
+      },
+      {
+        ...addWebPackages(['@redwoodjs/vite']),
+        title: 'Adding @redwoodjs/vite dependency...',
+        skip: () => {
+          if (!addPackage) {
+            return 'Skipping package install, you will need to add @redwoodjs/vite manaually as a dependency on the web workspace'
+          }
+        },
+      },
+      {
+        title: 'One more thing...',
+        task: (_ctx, task) => {
+          task.title = `One more thing...\n
+          ${c.green('Vite Support is still experimental!')}
+          ${c.green('Please let us know if you find bugs or quirks.')}
+          ${chalk.hex('#e8e8e8')(
+            'https://github.com/redwoodjs/redwood/issues/new'
+          )}
+        `
+        },
+      },
+    ],
+    {
+      rendererOptions: { collapse: false },
+      renderer: verbose ? 'verbose' : 'default',
+    }
+  )
+
+  try {
+    await tasks.run()
+  } catch (e) {
+    errorTelemetry(process.argv, e.message)
+    console.error(c.error(e.message))
+    process.exit(e?.exitCode || 1)
+  }
+}


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/6967; this PR 1) separates the handler from the rest of the  `yarn rw setup vite` command module and 2) fixes the version of `@redwoodjs/vite` installed by `yarn rw setup vite`, using the strategy `yarn rw setup auth` commands use.

More on the latter: right now, when you upgrade to canary and run `yarn rw setup vite`, it'll install version `0.0.1` of `@redwoodjs/vite` because `addWebPackages` installs the latest version of a package if no version is provided. We had this problem with the auth provider packages. The way we solved it was just being specific about which version to install by reading from the package.json, so that you always get exactly what you think you're getting.