### PR TITLE
Fix premajor canary publishing when there's a major RC 

### DIFF
--- a/.github/actions/get_publish_flags/action.yml
+++ b/.github/actions/get_publish_flags/action.yml
@@ -1,0 +1,8 @@
+name: Get publish flags
+description: Get flags for canary publishing
+outputs:
+  flags:
+    description: The flags for canary publishing
+runs:
+  using: node16
+  main: get_publish_flags.mjs

--- a/.github/actions/get_publish_flags/get_publish_flags.mjs
+++ b/.github/actions/get_publish_flags/get_publish_flags.mjs
@@ -21,22 +21,17 @@ if (TAG === 'canary') {
     await $`git tag --sort="-version:refname" --list "v?.?.?" | head -n 1`
   ).stdout.trim()
 
-  console.log('Latest release:', latestRelease)
-
   // Get the major version from a string like v3.8.0
   const currentMajor = +latestRelease.match(/^v(?<currentMajor>\d)\./).groups.currentMajor
   const nextMajor = `${currentMajor + 1}.0.0`
 
-  console.log('Current major:', nextMajor)
-  console.log('Next major:', nextMajor)
+  console.log({ currentMajor, nextMajor })
 
   // Get the latest RC from NPM
   /**
    * @type {{ name: string, version: `${number}.${number}.${number}` }}
    */
   const { version: latestRC } = JSON.parse(await $`yarn npm info @redwoodjs/core@rc --fields version --json`)
-
-  console.log('latest RC:', latestRC)
 
   if (latestRC.startsWith(nextMajor)) {
     console.log('The latest rc is the same as the canary; adding an extra minor to the canary')

--- a/.github/actions/get_publish_flags/get_publish_flags.mjs
+++ b/.github/actions/get_publish_flags/get_publish_flags.mjs
@@ -1,0 +1,62 @@
+import * as core from '@actions/core'
+import { $ } from 'zx'
+
+let args = []
+
+const TAG = process.env.GITHUB_REF_NAME === 'next' ? 'next' : 'canary'
+
+console.log({
+  GITHUB_REF_NAME: process.env.GITHUB_REF_NAME,
+  TAG
+})
+
+if (TAG === 'canary') {
+  args.push('premajor')
+
+  // Returns a string like v3.8.0
+  /**
+   * @type {`v${number}.${number}.${number}`}
+   */
+  const latestRelease = (
+    await $`git tag --sort="-version:refname" --list "v?.?.?" | head -n 1`
+  ).stdout.trim()
+
+  console.log('Latest release:', latestRelease)
+
+  // Get the major version from a string like v3.8.0
+  const currentMajor = +latestRelease.match(/^v(?<currentMajor>\d)\./).groups.currentMajor
+  const nextMajor = `${currentMajor + 1}.0.0`
+
+  console.log('Current major:', nextMajor)
+  console.log('Next major:', nextMajor)
+
+  // Get the latest RC from NPM
+  /**
+   * @type {{ name: string, version: `${number}.${number}.${number}` }}
+   */
+  const { version: latestRC } = JSON.parse(await $`yarn npm info @redwoodjs/core@rc --fields version --json`)
+
+  console.log('latest RC:', latestRC)
+
+  if (latestRC.startsWith(nextMajor)) {
+    console.log('The latest rc is the same as the canary; adding an extra minor to the canary')
+
+    args.push('--rw-custom-bump')
+  }
+}
+
+args = [
+  ...args,
+  '--include-merged-tags',
+  '--canary',
+  `--preid ${TAG}`,
+  `--dist-tag ${TAG}`,
+  '--force-publish',
+  '--loglevel verbose',
+  '--no-git-reset',
+  '--yes',
+]
+
+console.log({ args })
+
+core.setOutput('flags', `${args.join(' ')}`)

--- a/.github/actions/message_slack_publishing/action.yml
+++ b/.github/actions/message_slack_publishing/action.yml
@@ -30,6 +30,7 @@ runs:
             "title": "${{ inputs.title }}",
             "status": "${{ steps.get-status-emoji.outputs.value }} ${{ inputs.status }}",
             "version": "${{ inputs.version }}"
+            "ref": "${{ github.ref }}"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -61,7 +61,7 @@ jobs:
   message-slack:
     name: 💬 Message Slack
     needs: publish-canary
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -3,7 +3,7 @@ name: 🦜 Publish Canary
 on:
   push:
     branches: [main, next]
-    # We don't want this to run when we publish a release.
+    # We don't want this to run when we publish a release
     tags-ignore: ['v**']
     # No need to run on docs-only changes
     paths-ignore: ['docs/**']
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/checkout@v3
         # `fetch-depth`—number of commits to fetch. `0` fetches all history for all branches and tags.
-        #  This is required because lerna uses tags to determine the version.
+        #  This is required because lerna uses tags to determine the version
         with:
           fetch-depth: 0
 
@@ -40,33 +40,15 @@ jobs:
       - name: 🧪 Test
         run: yarn test
 
+      - name: Get publish flags
+        id: get-publish-flags
+        uses: ./.github/actions/get_publish_flags
+
       - name: 🚢 Publish
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
 
-          TAG='canary' && [[ "$GITHUB_REF_NAME" = 'next' ]] && TAG='next'
-          echo "Publishing $TAG"
-
-          args=()
-
-          if [[ "$GITHUB_REF_NAME" = 'main' ]]; then
-            args+=(premajor)
-          fi
-
-          args+=(
-            --include-merged-tags
-            --canary
-            --exact
-            --preid "$TAG"
-            --dist-tag "$TAG"
-            --force-publish
-            --loglevel verbose
-            --no-git-reset
-            --yes
-          )
-
-          yarn lerna publish "${args[@]}"
-
+          yarn lerna publish ${{ steps.get-publish-flags.outputs.flags }}
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch
+++ b/.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch
@@ -1,0 +1,32 @@
+diff --git a/command.js b/command.js
+index 586c774f717ade45a01b7b9dd699a77a0e13f22d..ab164f152e3bff74fcfa1fa0c4502e8df977a35a 100644
+--- a/command.js
++++ b/command.js
+@@ -166,6 +166,10 @@ exports.builder = (yargs) => {
+       /* eslint-enable no-param-reassign */
+ 
+       return argv;
++    }).option("rw-custom-bump", {
++      hidden: true,
++      type: "boolean",
++      default: false,
+     });
+ };
+ 
+diff --git a/index.js b/index.js
+index 716c8764f501af5fe0e83fc38d6dfa2b994877a8..e4b24e79c2cc78e14a976ba9f07087673f5236e2 100644
+--- a/index.js
++++ b/index.js
+@@ -424,7 +424,11 @@ class PublishCommand extends Command {
+       (fallback) =>
+       ({ lastVersion = fallback, refCount, sha }) => {
+         // the next version is bumped without concern for preid or current index
+-        const nextVersion = semver.inc(lastVersion.replace(this.tagPrefix, ""), release.replace("pre", ""));
++        let nextVersion = semver.inc(lastVersion.replace(this.tagPrefix, ""), release.replace("pre", ""));
++
++        if (this.argv.rwCustomBump) {
++          nextVersion = semver.inc(nextVersion, "minor")
++        }
+ 
+         // semver.inc() starts a new prerelease at .0, git describe starts at .1
+         // and build metadata is always ignored when comparing dependency ranges

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-protocol": "3.15.3",
     "vscode-languageserver-textdocument": "1.0.8",
-    "vscode-languageserver-types": "3.17.2"
+    "vscode-languageserver-types": "3.17.2",
+    "@lerna/publish@6.4.1": "patch:@lerna/publish@npm%3A6.4.1#./.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch"
   },
   "devDependencies": {
     "@actions/core": "1.10.0",

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -189,11 +189,9 @@ function updatePackageJsonVersion(pkgPath, version, { dryRun, verbose }) {
       x.startsWith('@redwoodjs/')
     )) {
       if (verbose || dryRun) {
-        console.log(
-          ` - ${depName}: ${pkg.dependencies[depName]} => ^${version}`
-        )
+        console.log(` - ${depName}: ${pkg.dependencies[depName]} => ${version}`)
       }
-      pkg.dependencies[depName] = `^${version}`
+      pkg.dependencies[depName] = `${version}`
     }
   }
   if (pkg.devDependencies) {
@@ -202,10 +200,10 @@ function updatePackageJsonVersion(pkgPath, version, { dryRun, verbose }) {
     )) {
       if (verbose || dryRun) {
         console.log(
-          ` - ${depName}: ${pkg.devDependencies[depName]} => ^${version}`
+          ` - ${depName}: ${pkg.devDependencies[depName]} => ${version}`
         )
       }
-      pkg.devDependencies[depName] = `^${version}`
+      pkg.devDependencies[depName] = `${version}`
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4889,6 +4889,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lerna/publish@patch:@lerna/publish@npm%3A6.4.1#./.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 6.4.1
+  resolution: "@lerna/publish@patch:@lerna/publish@npm%3A6.4.1#./.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch::version=6.4.1&hash=24f641&locator=root-workspace-0b6124%40workspace%3A."
+  dependencies:
+    "@lerna/check-working-tree": 6.4.1
+    "@lerna/child-process": 6.4.1
+    "@lerna/collect-updates": 6.4.1
+    "@lerna/command": 6.4.1
+    "@lerna/describe-ref": 6.4.1
+    "@lerna/log-packed": 6.4.1
+    "@lerna/npm-conf": 6.4.1
+    "@lerna/npm-dist-tag": 6.4.1
+    "@lerna/npm-publish": 6.4.1
+    "@lerna/otplease": 6.4.1
+    "@lerna/output": 6.4.1
+    "@lerna/pack-directory": 6.4.1
+    "@lerna/prerelease-id-from-version": 6.4.1
+    "@lerna/prompt": 6.4.1
+    "@lerna/pulse-till-done": 6.4.1
+    "@lerna/run-lifecycle": 6.4.1
+    "@lerna/run-topologically": 6.4.1
+    "@lerna/validation-error": 6.4.1
+    "@lerna/version": 6.4.1
+    fs-extra: ^9.1.0
+    libnpmaccess: ^6.0.3
+    npm-package-arg: 8.1.1
+    npm-registry-fetch: ^13.3.0
+    npmlog: ^6.0.2
+    p-map: ^4.0.0
+    p-pipe: ^3.1.0
+    pacote: ^13.6.1
+    semver: ^7.3.4
+  checksum: 76cfe9636507afa87da3fb4c4963669a1a967f7d3229297b28ee3c1273d469a2355f9dbea850600e9f8e2c68f7dc912281a21ce0a55be6fe34ba355800f461e5
+  languageName: node
+  linkType: hard
+
 "@lerna/pulse-till-done@npm:6.4.1":
   version: 6.4.1
   resolution: "@lerna/pulse-till-done@npm:6.4.1"


### PR DESCRIPTION
When there's a major RC, `yarn rw upgrade -t canary` is silently broken. 

`yarn rw upgrade -t canary` does it's thing by 1) changing the versions in the package.jsons to something like `^4.0.0-canary.456`, then 2) installing. Since the verisons in the package.jsons have carets, they grab the RC instead of the canary since the RC's specifier is "higher" (4.0.0-r... > 4.0.0-c...):

```
4.0.0-canary...
4.0.0-rc...
```

I tried to solve this in a few ways, all using lerna's existing api (i.e. CLI commands like `yarn lerna version`, `yarn lerna publish`). None of them worked, and after poking around the source of lerna's publish command, I discovered that what I want to do isn't possible unless I `git tag`, which I definitely don't want to do. So I patched lerna, adding a custom flag `--rw-custom-bump`, which adds an extra minor to a premajor.

The main con of this solution is that we have to maintain it when we upgrade lerna. But I don't mind doing that, and I couldn't think of another way to solve the problem.