### PR TITLE
fix(CI): cancel previous `in_progress` or `queued` canaries

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -16,6 +16,9 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.value }}
     steps:
+      - name: ⏹️ Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.11.0
+
       - uses: actions/checkout@v3
         # `fetch-depth`—number of commits to fetch. `0` fetches all history for all branches and tags.
         #  This is required because lerna uses tags to determine the version.


### PR DESCRIPTION
I'd like to try using this action a bit more in our CI workflows to decongest our GitHub Actions runners. 

Sometimes things happen too fast, and irrelevant workflows are left as `in_progress` or `queued`. The main case where this happens I'm thinking of is renovate, when I squash merge a bunch of PRs that all pass CI. It could queue up 5+ canaries to be published, when it makes more sense to just do one.

So let's try this for a bit and see if it's effective; if so we can add it to other workflows.