### PR TITLE
chore: fix lint warnings forms/internal

### DIFF
--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -886,7 +886,7 @@ const INPUT_TYPES = [
   'week',
 ] as const
 
-type InputType = typeof INPUT_TYPES[number]
+type InputType = (typeof INPUT_TYPES)[number]
 
 export interface InputFieldProps
   extends Omit<FieldProps<HTMLInputElement>, 'type'>,

--- a/packages/internal/src/routes.ts
+++ b/packages/internal/src/routes.ts
@@ -17,7 +17,8 @@ export interface RouteInformation {
  */
 export function getDuplicateRoutes() {
   const duplicateRoutes: RouteInformation[] = []
-  const allRoutes: typeof RWRoute[] = getProject(getPaths().base).router.routes
+  const allRoutes: (typeof RWRoute)[] = getProject(getPaths().base).router
+    .routes
   const uniquePathNames = new Set(allRoutes.map((route) => route.name))
   uniquePathNames.forEach((name) => {
     const routesWithName = allRoutes.filter((route) => {


### PR DESCRIPTION
Seeingn some lint warnings in GitHub's "Unchanged files with check annotations" in PRs like https://github.com/redwoodjs/redwood/pull/7321; this PR runs `yarn lint --fix`