### PR TITLE
Docs: Fix missing groupId attribute in Tags tag.

### DIFF
--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -1560,7 +1560,7 @@ We get that error message at the top saying something went wrong in plain Englis
 
 This just scratches the surface of what Service Validations can do. You can perform more complex validations, including combining multiple directives in a single call. What if we had a model representing a `Car`, and users could submit them to us for sale on our exclusive car shopping site. How do we make sure we only get the cream of the crop of motorized vehicles? Service validations would allow us to be very particular about the values someone would be allowed to submit, all without any custom checks, just built-in `validate()` calls:
 
-<Tabs>
+<Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```js

--- a/docs/docs/tutorial/chapter6/comments-schema.md
+++ b/docs/docs/tutorial/chapter6/comments-schema.md
@@ -567,7 +567,7 @@ That being said, if you really wanted to you could use Jest's [mocking utilities
 
 Where does that data come from? Take a look at the `comments.scenarios.{js,ts}` file which is next door:
 
-<Tabs>
+<Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```javascript title="api/src/services/comments.scenarios.js"

--- a/docs/versioned_docs/version-3.8/tutorial/chapter3/saving-data.md
+++ b/docs/versioned_docs/version-3.8/tutorial/chapter3/saving-data.md
@@ -1560,7 +1560,7 @@ We get that error message at the top saying something went wrong in plain Englis
 
 This just scratches the surface of what Service Validations can do. You can perform more complex validations, including combining multiple directives in a single call. What if we had a model representing a `Car`, and users could submit them to us for sale on our exclusive car shopping site. How do we make sure we only get the cream of the crop of motorized vehicles? Service validations would allow us to be very particular about the values someone would be allowed to submit, all without any custom checks, just built-in `validate()` calls:
 
-<Tabs>
+<Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```js

--- a/docs/versioned_docs/version-3.8/tutorial/chapter6/comments-schema.md
+++ b/docs/versioned_docs/version-3.8/tutorial/chapter6/comments-schema.md
@@ -567,7 +567,7 @@ That being said, if you really wanted to you could use Jest's [mocking utilities
 
 Where does that data come from? Take a look at the `comments.scenarios.{js,ts}` file which is next door:
 
-<Tabs>
+<Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```javascript title="api/src/services/comments.scenarios.js"


### PR DESCRIPTION
Because of this, even if we choose TypeScript tab, JavaScript is shown in some code-blocks.

In this PR, I edited current and 3.8, and I made PR to `next` branch because `main` doesn't have `versioned_docs/versione-3.8` .
I don't know the regulation about PR and backport-rule of versioned docs(this is my first PR to redwood), so if I have to do more, please tell me.