### PR TITLE
Remove legacy auth import

### DIFF
--- a/packages/cli-helpers/src/auth/__tests__/__snapshots__/authTasks.test.ts.snap
+++ b/packages/cli-helpers/src/auth/__tests__/__snapshots__/authTasks.test.ts.snap
@@ -286,6 +286,38 @@ export default Routes
 "
 `;
 
+exports[`authTasks Should update App.tsx for legacy apps 1`] = `
+"import netlifyIdentity from 'netlify-identity-widget'
+
+import { isBrowser } from '@redwoodjs/prerender/browserUtils'
+import { FatalErrorBoundary, RedwoodProvider } from '@redwoodjs/web'
+import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
+
+import FatalErrorPage from 'src/pages/FatalErrorPage'
+import Routes from 'src/Routes'
+
+import { AuthProvider, useAuth } from './auth'
+
+import './index.css'
+
+isBrowser && netlifyIdentity.init()
+
+const App = () => (
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <AuthProvider client={netlifyIdentity} type="netlify">
+        <RedwoodApolloProvider useAuth={useAuth}>
+          <Routes />
+        </RedwoodApolloProvider>
+      </AuthProvider>
+    </RedwoodProvider>
+  </FatalErrorBoundary>
+)
+
+export default App
+"
+`;
+
 exports[`authTasks Swapped out GraphQL client Should add auth config when app is missing RedwoodApolloProvider 1`] = `
 "import { FatalErrorBoundary, RedwoodProvider } from '@redwoodjs/web'
 

--- a/packages/cli-helpers/src/auth/__tests__/authTasks.test.ts
+++ b/packages/cli-helpers/src/auth/__tests__/authTasks.test.ts
@@ -105,6 +105,17 @@ describe('authTasks', () => {
     addConfigToRoutes().task()
   })
 
+  it('Should update App.tsx for legacy apps', () => {
+    const ctx: AuthGeneratorCtx = {
+      provider: 'clerk',
+      setupMode: 'FORCE',
+    }
+
+    mockWebAppPath = 'src/auth/__tests__/fixtures/AppWithLegacyAuth.tsx'
+
+    addConfigToWebApp().task(ctx, {} as any)
+  })
+
   describe('Components with props', () => {
     it('Should add useAuth on the same line for single line components, and separate line for multiline components', () => {
       const ctx: AuthGeneratorCtx = {

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/AppWithLegacyAuth.tsx
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/AppWithLegacyAuth.tsx
@@ -1,0 +1,27 @@
+import netlifyIdentity from 'netlify-identity-widget'
+
+import { AuthProvider } from '@redwoodjs/auth'
+import { isBrowser } from '@redwoodjs/prerender/browserUtils'
+import { FatalErrorBoundary, RedwoodProvider } from '@redwoodjs/web'
+import { RedwoodApolloProvider } from '@redwoodjs/web/apollo'
+
+import FatalErrorPage from 'src/pages/FatalErrorPage'
+import Routes from 'src/Routes'
+
+import './index.css'
+
+isBrowser && netlifyIdentity.init()
+
+const App = () => (
+  <FatalErrorBoundary page={FatalErrorPage}>
+    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <AuthProvider client={netlifyIdentity} type="netlify">
+        <RedwoodApolloProvider>
+          <Routes />
+        </RedwoodApolloProvider>
+      </AuthProvider>
+    </RedwoodProvider>
+  </FatalErrorBoundary>
+)
+
+export default App

--- a/packages/cli-helpers/src/auth/authTasks.ts
+++ b/packages/cli-helpers/src/auth/authTasks.ts
@@ -232,7 +232,7 @@ export const addConfigToWebApp = <
 >(): ListrTask<AuthGeneratorCtx, Renderer> => {
   return {
     title: 'Updating web/src/App.{js,tsx}',
-    task: (_ctx, task) => {
+    task: (ctx, task) => {
       const webAppPath = getWebAppPath()
 
       if (!fs.existsSync(webAppPath)) {
@@ -244,6 +244,14 @@ export const addConfigToWebApp = <
 
       if (!content.includes(AUTH_PROVIDER_HOOK_IMPORT)) {
         content = addAuthImportToApp(content)
+      }
+
+      if (ctx.setupMode === 'REPLACE' || ctx.setupMode === 'FORCE') {
+        // Remove legacy AuthProvider import
+        content = content.replace(
+          "import { AuthProvider } from '@redwoodjs/auth'\n",
+          ''
+        )
       }
 
       if (!hasAuthProvider(content)) {


### PR DESCRIPTION
When setup mode is FORCE or REPLACE we remove any legacy AuthProvider imports because that's in practice what we want when we replace a legacy auth provider setup