### PR TITLE
Remove old AuthProvider when FORCE or REPLACE

### DIFF
--- a/packages/cli-helpers/src/auth/__tests__/__snapshots__/authTasks.test.ts.snap
+++ b/packages/cli-helpers/src/auth/__tests__/__snapshots__/authTasks.test.ts.snap
@@ -305,7 +305,7 @@ isBrowser && netlifyIdentity.init()
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
     <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
-      <AuthProvider client={netlifyIdentity} type="netlify">
+      <AuthProvider>
         <RedwoodApolloProvider useAuth={useAuth}>
           <Routes />
         </RedwoodApolloProvider>

--- a/packages/cli-helpers/src/auth/authTasks.ts
+++ b/packages/cli-helpers/src/auth/authTasks.ts
@@ -165,17 +165,77 @@ const addAuthImportToRoutes = (content: string) => {
 
 // exported for testing
 export const hasAuthProvider = (content: string) => {
-  return /\s*<AuthProvider[\s>]/.test(content)
+  return /\s*<AuthProvider([\s>]|$)/.test(content)
+}
+
+/**
+ * Removes <AuthProvider ...> and </AuthProvider> if they exist, and un-indents
+ * the content.
+ *
+ * Exported for testing
+ */
+export const removeAuthProvider = (content: string) => {
+  let remove = false
+  let end = ''
+  let unindent = false
+
+  return content
+    .split('\n')
+    .reduce<string[]>((acc, line) => {
+      let keep = !remove
+      // Find where <AuthProvider begins and remove until it ends (to handle
+      // multi-line auth providers)
+      if (hasAuthProvider(line)) {
+        remove = true
+        keep = false
+        unindent = true
+        // Assume the end line is indented to the same level as the start,
+        // and contains just a single '>'
+        end = line.replace(/^(\s*)<Auth.*/, '$1') + '>'
+      }
+
+      // Single-line AuthProvider, or end of multi-line
+      if ((hasAuthProvider(line) && line.at(-1) === '>') || line === end) {
+        remove = false
+      }
+
+      if (/\s*<\/AuthProvider>/.test(line)) {
+        keep = false
+        unindent = false
+      }
+
+      if (keep) {
+        if (unindent) {
+          acc.push(line.replace('  ', ''))
+        } else {
+          acc.push(line)
+        }
+      }
+
+      return acc
+    }, [])
+    .join('\n')
 }
 
 /** returns the content of App.{js,tsx} with <AuthProvider> added */
-const addAuthProviderToApp = (content: string) => {
+const addAuthProviderToApp = (content: string, setupMode: AuthSetupMode) => {
+  if (setupMode === 'FORCE' || setupMode === 'REPLACE') {
+    content = removeAuthProvider(content)
+  }
+
   const match = content.match(
     /(\s+)(<RedwoodProvider.*?>)(.*)(<\/RedwoodProvider>)/s
   )
 
   if (!match) {
     throw new Error('Could not find <RedwoodProvider> in App.{js,tsx}')
+  }
+
+  // If Auth.tsx already contains exactly what we're trying to add there's no
+  // need to add it (important that this check is performed after the FORCE ||
+  // REPLACE check is made above)
+  if (/\s+<AuthProvider>/.test(content)) {
+    return content
   }
 
   const [
@@ -254,9 +314,7 @@ export const addConfigToWebApp = <
         )
       }
 
-      if (!hasAuthProvider(content)) {
-        content = addAuthProviderToApp(content)
-      }
+      content = addAuthProviderToApp(content, ctx.setupMode)
 
       if (/\s*<RedwoodApolloProvider/.test(content)) {
         if (!hasUseAuthHook('RedwoodApolloProvider', content)) {


### PR DESCRIPTION
If the setup mode is FORCE or REPLACE we remove the old AuthProvider before adding the new one (effectively replacing the old one). This also handles legacy AuthProvider configs