### PR TITLE
chore(deps): Add resolutions for `uuid` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "vscode-languageserver-protocol": "3.15.3",
     "vscode-languageserver-textdocument": "1.0.8",
     "vscode-languageserver-types": "3.17.2",
-    "@lerna/publish@6.4.1": "patch:@lerna/publish@npm%3A6.4.1#./.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch"
+    "@lerna/publish@6.4.1": "patch:@lerna/publish@npm%3A6.4.1#./.yarn/patches/@lerna-publish-npm-6.4.1-27e0fee593.patch",
+    "temp-write/uuid": "8.0.0",
+    "webpack-log/uuid": "8.0.0"
   },
   "devDependencies": {
     "@actions/core": "1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30509,15 +30509,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.3.2":
-  version: 3.4.0
-  resolution: "uuid@npm:3.4.0"
-  bin:
-    uuid: ./bin/uuid
-  checksum: 1c13950df865c4f506ebfe0a24023571fa80edf2e62364297a537c80af09c618299797bbf2dbac6b1f8ae5ad182ba474b89db61e0e85839683991f7e08795347
-  languageName: node
-  linkType: hard
-
 "v8-compile-cache-lib@npm:^3.0.1":
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"


### PR DESCRIPTION
**Problem**
The `temp-write@npm:4.0.0` and `webpack-log@npm:2.0.0` currently ask for the `uuid` package at `^3.3.2`. This version of that package is deprecated and results in a warning when running yarn commands. Those two packages don't seem to be actively maintained hence why they request an outdated version of `uuid`.  

See also #5682 and my comment within that issue for more links. This would close #5682 - though I didn't experience the visible warning on a new project creation anyway.

**Changes**
Add resolutions for the two packages to use `8.0.0` of `uuid`. This is the lowest version requested by any of the other dependencies and does not suffer from the deprecation warnings of `^3.3.2`. I believe it should be safe to bump up `uuid`. Any advice on required further testing beyond the framework's own tests would be welcomed. 

**Outstanding**
1. @jtoar I'm not an expert in this section. Perhaps this is not the way it is done in RW or this is not how it should be done in general. Might be a useful teachable moment for me if you don't like this?