### PR TITLE
CurrentUser: Let declaration merging add `roles`

### DIFF
--- a/packages/auth/src/AuthContext.ts
+++ b/packages/auth/src/AuthContext.ts
@@ -1,7 +1,6 @@
 import React from 'react'
 
 export interface CurrentUser {
-  roles?: Array<string> | string
   [key: string]: unknown
 }
 

--- a/packages/internal/src/generate/templates/all-currentUser.d.ts.template
+++ b/packages/internal/src/generate/templates/all-currentUser.d.ts.template
@@ -3,8 +3,7 @@ import '@redwoodjs/auth'
 
 import { getCurrentUser } from '../../../api/src/lib/auth'
 
-type ThenArg<T> = T extends PromiseLike<infer U> ? U : T
-export type InferredCurrentUser = ThenArg<ReturnType<typeof getCurrentUser>>
+export type InferredCurrentUser = Awaited<ReturnType<typeof getCurrentUser>>
 
 type UndefinedRoles = {
   /**


### PR DESCRIPTION
Fixes #7359 

By not declaring `roles` on the "base" `CurrentUser` we give full flexibility to `getCurrentUser` in the user's project to define `roles` however it wants.