### PR TITLE
feat(CI): cancel in-progress runs

### DIFF
--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-test-project-fixture:
     name: Check test project fixture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: ⚙️ CI
 on:
   pull_request
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,12 @@ on:
   schedule:
     - cron: '42 5 * * 3'
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: 🔬 Analyze

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -8,6 +8,12 @@ on:
     # No need to run on docs-only changes
     paths-ignore: ['docs/**']
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-canary:
     name: 🦜 Publish Canary
@@ -16,9 +22,6 @@ jobs:
     outputs:
       version: ${{ steps.get-version.outputs.value }}
     steps:
-      - name: ⏹️ Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - uses: actions/checkout@v3
         # `fetch-depth`—number of commits to fetch. `0` fetches all history for all branches and tags.
         #  This is required because lerna uses tags to determine the version

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -8,6 +8,12 @@ on:
     # No need to run on docs-only changes
     paths-ignore: ['docs/**']
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-git-tags:
     name: 🏷 Check git tags
@@ -95,7 +101,7 @@ jobs:
   message-slack:
     name: 💬 Message Slack
     needs: publish-release-candidate
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   require-release-label:
     name: 🏷 Require release label

--- a/.github/workflows/update-all-contributors.yml
+++ b/.github/workflows/update-all-contributors.yml
@@ -7,6 +7,12 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-all-contributors:
     name: Update all contributors


### PR DESCRIPTION
In https://github.com/redwoodjs/redwood/pull/7323 I added https://github.com/styfle/cancel-workflow-action to the publish canary workflow. It worked exactly as intended, and as I was looking into adding it to other workflows, it seems that in the last few days that action has been scheduled for deprecation in favor of GitHub Action's native [concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow) feature, which does the same thing.