### PR TITLE
Switch to React's isValidElement

### DIFF
--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { isValidElement } from 'react'
 
 import { ActiveRouteLoader } from './active-route-loader'
 import { useActivePageContext } from './ActivePageContext'
@@ -13,7 +13,6 @@ import {
 import { SplashPage } from './splash-page'
 import {
   flattenAll,
-  isReactElement,
   parseSearch,
   replaceParams,
   matchPath,
@@ -126,7 +125,7 @@ const InternalRoute = ({
 function isRoute(
   node: React.ReactNode
 ): node is React.ReactElement<InternalRouteProps> {
-  return isReactElement(node) && node.type === Route
+  return isValidElement(node) && node.type === Route
 }
 
 export interface RouterProps extends RouterContextProviderProps {
@@ -335,7 +334,7 @@ function analyzeRouterTree(
 
           return childWithKey
         }
-      } else if (isReactElement(child) && child.props.children) {
+      } else if (isValidElement(child) && child.props.children) {
         // We have a child element that's not a <Route ...>, and that has
         // children. It's probably a <Set>. Recurse down one level
         const nestedActive = analyzeRouterTreeInternal(child.props.children)

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -1,4 +1,4 @@
-import React, { Children, ReactElement, ReactNode } from 'react'
+import React, { Children, isValidElement, ReactNode } from 'react'
 
 /** Create a React Context with the given name. */
 export const createNamedContext = <T>(name: string, defaultValue?: T) => {
@@ -283,19 +283,11 @@ export const replaceParams = (
   return path
 }
 
-export function isReactElement(node: ReactNode): node is ReactElement {
-  return (
-    node !== undefined &&
-    node !== null &&
-    (node as ReactElement).type !== undefined
-  )
-}
-
 export function flattenAll(children: ReactNode): ReactNode[] {
   const childrenArray = Children.toArray(children)
 
   return childrenArray.flatMap((child) => {
-    if (isReactElement(child) && child.props.children) {
+    if (isValidElement(child) && child.props.children) {
       return [child, ...flattenAll(child.props.children)]
     }
 


### PR DESCRIPTION
@jtoar pointed out in #3977 that React has `isValidElement` that we can use instead of our own implementation. #3977 got closed, but I didn't want to forget about `isValidElement`, so this PR introduces just that one change