### PR TITLE
fix: pin webAuthn, SuperTokens, comment out latter

### DIFF
--- a/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
@@ -8,10 +8,10 @@ import { functionsPath, libPath } from './setupData'
 export { extraTask } from './setupData'
 
 // required packages to install on the web side
-export const webPackages = ['@simplewebauthn/browser']
+export const webPackages = ['@simplewebauthn/browser@^6']
 
 // required packages to install on the api side
-export const apiPackages = ['@simplewebauthn/server']
+export const apiPackages = ['@simplewebauthn/server@^6']
 
 // any notes to print out when the job is done
 export const notes = [

--- a/packages/auth-providers/supertokens/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supertokens/setup/src/setupHandler.ts
@@ -18,14 +18,15 @@ export async function handler({ force: forceArg }: Args) {
       "import { authDecoder } from '@redwoodjs/auth-supertokens-api'",
     apiPackages: [
       `@redwoodjs/auth-supertokens-api@${version}`,
-      'supertokens-node',
+      'supertokens-node@^12',
     ],
     webPackages: [
       `@redwoodjs/auth-supertokens-web@${version}`,
-      'supertokens-auth-react',
+      'supertokens-auth-react@^0',
+      'supertokens-web-js@^0',
     ],
     notes: [
-      "We've implemented some of SuperToken's recipes, but do feel free",
+      "We've implemented some of SuperToken's recipes, but feel free",
       'to switch to something that better fits your needs. See https://supertokens.com/docs/guides.',
     ],
   })

--- a/packages/auth-providers/supertokens/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supertokens/setup/src/setupHandler.ts
@@ -22,8 +22,8 @@ export async function handler({ force: forceArg }: Args) {
     ],
     webPackages: [
       `@redwoodjs/auth-supertokens-web@${version}`,
-      'supertokens-auth-react@^0',
-      'supertokens-web-js@^0',
+      'supertokens-auth-react@^0.30',
+      'supertokens-web-js@^0.4',
     ],
     notes: [
       "We've implemented some of SuperToken's recipes, but feel free",

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -117,18 +117,21 @@ export async function builder(yargs) {
         handler(args)
       }
     )
-    .command(
-      'supertokens',
-      'Set up auth for for SuperTokens',
-      (yargs) => standardAuthBuilder(yargs),
-      async (args) => {
-        const handler = await getAuthHandler(
-          '@redwoodjs/auth-supertokens-setup'
-        )
-        console.log()
-        handler(args)
-      }
-    )
+  // @MARK We'll add this back when we finalize it in a v4 minor.
+  // This setup command wasn't in v3.x, so leaving it out isn't breaking.
+  //
+  // .command(
+  //   'supertokens',
+  //   'Set up auth for for SuperTokens',
+  //   (yargs) => standardAuthBuilder(yargs),
+  //   async (args) => {
+  //     const handler = await getAuthHandler(
+  //       '@redwoodjs/auth-supertokens-setup'
+  //     )
+  //     console.log()
+  //     handler(args)
+  //   }
+  // )
 }
 
 /**

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -122,7 +122,7 @@ export async function builder(yargs) {
   //
   // .command(
   //   'supertokens',
-  //   'Set up auth for for SuperTokens',
+  //   'Set up auth for SuperTokens',
   //   (yargs) => standardAuthBuilder(yargs),
   //   async (args) => {
   //     const handler = await getAuthHandler(


### PR DESCRIPTION
This PR:
- fixes setting up dbAuth with webAuthn (it was installing the latest versions of the `@simplewebauthn` packages, which are v7)
- comments out `yarn rw setup auth supertokens`, as it's not working. note that it wasn't a setup command in v3, so not shipping one in v4 isn't breaking. but we'd like to get it working soon, probably in a v4 minor

To discuss with @thedavidprice later.