### PR TITLE
Make it easier to test auth setup with rwfw project:copy

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -166,10 +166,7 @@ function getRedirectMessage(provider) {
  * @param {string} module
  */
 async function getAuthHandler(module) {
-  // Here we're reading this package's (@redwoodjs/cli) package.json.
-  // So, in a user's project, `packageJsonPath` will be something like...
-  // /Users/bob/tmp/rw-app/node_modules/@redwoodjs/cli/package.json
-  const packageJsonPath = path.resolve(__dirname, '../../../../package.json')
+  const packageJsonPath = require.resolve('@redwoodjs/cli/package.json')
   let { version } = fs.readJSONSync(packageJsonPath)
 
   if (!isInstalled(module)) {
@@ -205,7 +202,7 @@ async function getAuthHandler(module) {
 
 /**
  * Check if a user's project's package.json has a module listed as a dependency
- * or devDependency. If not, we'll also check inside node_modules
+ * or devDependency. If not, check node_modules.
  *
  * @param {string} module
  */
@@ -220,21 +217,11 @@ function isInstalled(module) {
   }
 
   if (!deps[module]) {
-    // Check node_modules to see if the module exists there (this is mainly to
-    // handle testing setup packages with rwfw project:copy)
+    // Check node_modules to see if it's there.
+    // This enables testing auth setup packages with `yarn rwfw project:copy`.
     const nodeModulesPackageJsonPath = require.resolve(`${module}/package.json`)
-
-    if (fs.existsSync(nodeModulesPackageJsonPath)) {
-      const { version: installedModuleVersion } = fs.readJSONSync(
-        nodeModulesPackageJsonPath
-      )
-
-      const cliPackageJsonPath = require.resolve('@redwoodjs/cli/package.json')
-      const { version: cliVersion } = fs.readJSONSync(cliPackageJsonPath)
-
-      return installedModuleVersion === cliVersion
-    }
+    return fs.existsSync(nodeModulesPackageJsonPath)
   }
 
-  return !!deps[module]
+  return false
 }

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -220,32 +220,19 @@ function isInstalled(module) {
   }
 
   if (!deps[module]) {
-    // Check node_modules to see if it exists there (this is mainly to handle
-    // testing setup packages with rwfw project:copy)
-    const nodeModulesPackageJsonPath = path.resolve(
-      __dirname,
-      // Back up to the project root dir node_modules
-      '../../../../../..',
-      module,
-      'package.json'
-    )
-    console.log('nodeModulesPackageJsonPath', nodeModulesPackageJsonPath)
+    // Check node_modules to see if the module exists there (this is mainly to
+    // handle testing setup packages with rwfw project:copy)
+    const nodeModulesPackageJsonPath = require.resolve(`${module}/package.json`)
 
     if (fs.existsSync(nodeModulesPackageJsonPath)) {
-      const { version: installedVersion } = fs.readJSONSync(
+      const { version: installedModuleVersion } = fs.readJSONSync(
         nodeModulesPackageJsonPath
       )
 
-      // We're in node_modules/@redwoodjs/cli/dist/commands/setup/auth/
-      // Backing up four steps takes us to node_modules/@redwoodjs/cli
-      const packageJsonPath = path.resolve(
-        __dirname,
-        '../../../../package.json'
-      )
+      const cliPackageJsonPath = require.resolve('@redwoodjs/cli/package.json')
+      const { version: cliVersion } = fs.readJSONSync(cliPackageJsonPath)
 
-      const { version } = fs.readJSONSync(packageJsonPath)
-
-      return installedVersion === version
+      return installedModuleVersion === cliVersion
     }
   }
 


### PR DESCRIPTION
When using `yarn rwfw project:copy` the latest versions of all the auth provider packages are already copied over into the target project's node_modules. So no need to try to install the setup package. In fact, if it does try to install it'll grab the latest canary version from npm, which isn't want we want if we're trying to test something new in the setup package