### PR TITLE
fix(CLI): try-catch `require.resolve` in setup auth

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -222,6 +222,11 @@ function isInstalled(module) {
 
   // Check node_modules to see if the module is there.
   // This enables testing auth setup packages with `yarn rwfw project:copy`.
-  const nodeModulesPackageJsonPath = require.resolve(`${module}/package.json`)
-  return fs.existsSync(nodeModulesPackageJsonPath)
+  // If `require.resolve` can't find the module, it throws a `MODULE_NOT_FOUND` error.
+  try {
+    require.resolve(`${module}/package.json`)
+    return true
+  } catch (e) {
+    return false
+  }
 }


### PR DESCRIPTION
@Tobbe we forgot one thing here—`require.resolve` throws if it can't find the module. I'm going to merge this one if it passes checks cause it's broken in main and the RC, but feel free to do a review or change anything you want in another PR.

For the catch block, I could've made it more specific to the `MODULE_NOT_FOUND` error code, but I don't think we want this command to blow up if it can't find the module.