### PR TITLE
fix(CLI): use `require.resolve.paths` to avoid `require.resolve` cache

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -220,13 +220,14 @@ function isInstalled(module) {
     return true
   }
 
-  // Check node_modules to see if the module is there.
+  // Check any of the places require would look for this module.
   // This enables testing auth setup packages with `yarn rwfw project:copy`.
-  // If `require.resolve` can't find the module, it throws a `MODULE_NOT_FOUND` error.
-  try {
-    require.resolve(`${module}/package.json`)
-    return true
-  } catch (e) {
-    return false
-  }
+  //
+  // We can't use require.resolve here because it cahces the exception
+  // Making it impossible to require when we actually do install it...
+  return require.resolve
+    .paths(`${module}/package.json`)
+    .some((requireResolvePath) => {
+      return fs.existsSync(path.join(requireResolvePath, module))
+    })
 }


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/7494. There seems to be a bug or at least undocumented behavior where `require.resolve` caches even modules it can't find. 

So `require.resolve` and `require` in general cache modules. You can see them all at `require.cache`, and if you want to delete one of them, you just use `delete`:

```js
delete require.cache[require.resolve(module)]
```

The issue we're having is that `require.resolve` seems to cache even exceptions... Which isn't a problem in and of itself, except for that we can't seem to delete them from the cache because `require.resolve` throws...

```ts
try {
  require.resolve("@redwoodjs/auth-auth0-setup/package.json")
  // This throws, not installed
} catch (e) {
  // Can't delete it from the cache because you need require.resolve to do that...
  //
  // delete require.cache[require.resolve("@redwoodjs/auth-auth0-setup/package.json")]
}
``` 

To be clear, I'm not entirely sure `require.resolve` is caching the exception. All I know is that it's not working the way I thought it would. So, all I can think of doing right now is using `fs.existsSync` in tandem with the paths returned by `require.resolve.paths(module)` to get a list of paths `require.resolve` would look for the module in.