### PR TITLE
fix(CLI): add env var to Supabase notes, Azure alias

### DIFF
--- a/packages/auth-providers/supabase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/supabase/setup/src/setupHandler.ts
@@ -26,6 +26,7 @@ export const handler = async ({ force: forceArg }: Args) => {
       '```bash title=".env"',
       'SUPABASE_URL="..."',
       'SUPABASE_KEY="..."',
+      'SUPABASE_JWT_SECRET="..."',
       '```',
       '',
       "You can find their values on your Supabase app's dashboard.",

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -39,7 +39,7 @@ export async function builder(yargs) {
       }
     )
     .command(
-      'azure-active-directory',
+      ['azure-active-directory', 'azureActiveDirectory'],
       'Set up auth for Azure Active Directory',
       (yargs) => standardAuthBuilder(yargs),
       async (args) => {


### PR DESCRIPTION
- The notes output by setup Supabase were missing an env var
- Azure used to be invoked as `yarn rw setup auth azureActiveDirectory`. Since we keep redirects around for the other setup commands, may as well keep this one around as an alias, though the official help will still show `azure-active-directory`