### PR TITLE
Enable yarn rw setup auth supertokens

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -117,21 +117,18 @@ export async function builder(yargs) {
         handler(args)
       }
     )
-  // @MARK We'll add this back when we finalize it in a v4 minor.
-  // This setup command wasn't in v3.x, so leaving it out isn't breaking.
-  //
-  // .command(
-  //   'supertokens',
-  //   'Set up auth for SuperTokens',
-  //   (yargs) => standardAuthBuilder(yargs),
-  //   async (args) => {
-  //     const handler = await getAuthHandler(
-  //       '@redwoodjs/auth-supertokens-setup'
-  //     )
-  //     console.log()
-  //     handler(args)
-  //   }
-  // )
+    .command(
+      'supertokens',
+      'Set up auth for SuperTokens',
+      (yargs) => standardAuthBuilder(yargs),
+      async (args) => {
+        const handler = await getAuthHandler(
+          '@redwoodjs/auth-supertokens-setup'
+        )
+        console.log()
+        handler(args)
+      }
+    )
 }
 
 /**


### PR DESCRIPTION
This PR enables setting up SuperTokens auth by running `yarn rw setup auth supertokens`