### PR TITLE
fix(router): Add ts definitions to allow name a on redirect and notfound Routes

### DIFF
--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -5,7 +5,10 @@ module.exports = {
       displayName: 'code',
       setupFilesAfterEnv: ['./jest.setup.js'],
       testEnvironment: 'jest-environment-jsdom',
-      testMatch: ['**/*.test.+(ts|tsx|js)', '!**/__typetests__/*.ts'],
+      testMatch: [
+        '**/*.test.+(ts|tsx|js)',
+        '!**/__typetests__/*.+(ts|tsx|js|jsx)',
+      ],
     },
     {
       displayName: {
@@ -13,7 +16,7 @@ module.exports = {
         name: 'types',
       },
       runner: 'jest-runner-tsd',
-      testMatch: ['**/__typetests__/*.test.ts'],
+      testMatch: ['**/__typetests__/*.test.+(ts|tsx|js|jsx)'],
     },
   ],
 }

--- a/packages/router/src/__typetests__/route.test.tsx
+++ b/packages/router/src/__typetests__/route.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from 'react'
+
+import { expectType, expectError } from 'tsd-lite'
+
+import { Route } from '@redwoodjs/router'
+
+describe('<Route/>', () => {
+  /**
+   * These tests don't need an expectation,
+   * TS will do the checks as part of tsc,
+   * the expectType is just to stop TS from complaining about unused vars
+   */
+  const TestPageComponent = () => <h1>This is a Page</h1>
+
+  test('Standard props', () => {
+    const route = <Route path="/" page={TestPageComponent} name="test" />
+    expectType<JSX.Element>(route)
+  })
+
+  test('Redirect props', () => {
+    const noName = <Route path="/" redirect="/test" />
+    expectType<JSX.Element>(noName)
+
+    const withName = <Route path="/" redirect="/test" name="bazinga" />
+    expectType<JSX.Element>(withName)
+
+    expectError()
+  })
+
+  test('NotFound page', () => {
+    const standardNotFound = <Route notfound page={TestPageComponent} />
+    expectType<JSX.Element>(standardNotFound)
+
+    const notFoundWithName = (
+      <Route notfound page={TestPageComponent} name="404-guy" />
+    )
+    expectType<JSX.Element>(notFoundWithName)
+
+    // Should not be able to assign a redirect to not found
+    expectError(<Route notfound page={TestPageComponent} redirect="/test" />)
+  })
+})

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -42,12 +42,14 @@ interface RouteProps {
 interface RedirectRouteProps {
   path: string
   redirect: string
+  name?: string
 }
 
 interface NotFoundRouteProps {
   notfound: boolean
   page: PageType
   prerender?: boolean
+  name?: string
 }
 
 export type InternalRouteProps = Partial<


### PR DESCRIPTION
### Context 

As title, see original forum post from user: https://community.redwoodjs.com/t/redirect-from-splash-screen/4552/2

Note that it actually works fine, we just had inaccurate typedefs. 

Also adds a few rough typetests to cover the cases