### PR TITLE
fix(auth): handle CRLFs in `yarn rw setup auth`

### DIFF
--- a/packages/cli-helpers/src/auth/__tests__/authTasks.test.ts
+++ b/packages/cli-helpers/src/auth/__tests__/authTasks.test.ts
@@ -430,6 +430,36 @@ describe('authTasks', () => {
       `)
     })
 
+    test('Legacy auth single line CRLF', () => {
+      const content = `
+        const App = () => (
+          <FatalErrorBoundary page={FatalErrorPage}>
+            <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+              <AuthProvider client={netlifyIdentity} type="netlify">
+                <RedwoodApolloProvider>
+                  <Routes />
+                </RedwoodApolloProvider>
+              </AuthProvider>
+            </RedwoodProvider>
+          </FatalErrorBoundary>
+        )
+      `.replace(/\n/g, '\r\n')
+
+      expect(removeAuthProvider(content)).toMatch(
+        `
+        const App = () => (
+          <FatalErrorBoundary page={FatalErrorPage}>
+            <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+              <RedwoodApolloProvider>
+                <Routes />
+              </RedwoodApolloProvider>
+            </RedwoodProvider>
+          </FatalErrorBoundary>
+        )
+      `.replace(/\n/g, '\r\n')
+      )
+    })
+
     test('Legacy auth multi-line', () => {
       const content = `
         const App = () => (
@@ -470,6 +500,48 @@ describe('authTasks', () => {
       `)
     })
 
+    test('Legacy auth multi-line CRLF', () => {
+      const content = `
+        const App = () => (
+          <FatalErrorBoundary page={FatalErrorPage}>
+            <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+              <AuthProvider
+                client={WebAuthnClient}
+                type="dbAuth"
+                config={{ fetchConfig: { credentials: 'include' } }}
+              >
+                <RedwoodApolloProvider
+                  graphQLClientConfig={{
+                    httpLinkConfig: { credentials: 'include' },
+                  }}
+                >
+                  <Routes />
+                </RedwoodApolloProvider>
+              </AuthProvider>
+            </RedwoodProvider>
+          </FatalErrorBoundary>
+        )
+      `.replace(/\n/g, '\r\n')
+
+      expect(removeAuthProvider(content)).toMatch(
+        `
+        const App = () => (
+          <FatalErrorBoundary page={FatalErrorPage}>
+            <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+              <RedwoodApolloProvider
+                graphQLClientConfig={{
+                  httpLinkConfig: { credentials: 'include' },
+                }}
+              >
+                <Routes />
+              </RedwoodApolloProvider>
+            </RedwoodProvider>
+          </FatalErrorBoundary>
+        )
+      `.replace(/\n/g, '\r\n')
+      )
+    })
+
     test('AuthProvider exists', () => {
       const content = `
         const App = () => (
@@ -496,6 +568,36 @@ describe('authTasks', () => {
           </FatalErrorBoundary>
         )
       `)
+    })
+
+    test('AuthProvider exists CRLF', () => {
+      const content = `
+        const App = () => (
+          <FatalErrorBoundary page={FatalErrorPage}>
+            <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+              <AuthProvider>
+                <RedwoodApolloProvider useAuth={useAuth}>
+                  <Routes />
+                </RedwoodApolloProvider>
+              </AuthProvider>
+            </RedwoodProvider>
+          </FatalErrorBoundary>
+        )
+      `.replace(/\n/g, '\r\n')
+
+      expect(removeAuthProvider(content)).toMatch(
+        `
+        const App = () => (
+          <FatalErrorBoundary page={FatalErrorPage}>
+            <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+              <RedwoodApolloProvider useAuth={useAuth}>
+                <Routes />
+              </RedwoodApolloProvider>
+            </RedwoodProvider>
+          </FatalErrorBoundary>
+        )
+      `.replace(/\n/g, '\r\n')
+      )
     })
 
     test("AuthProvider doesn't exist", () => {

--- a/packages/cli-helpers/src/auth/authTasks.ts
+++ b/packages/cli-helpers/src/auth/authTasks.ts
@@ -300,7 +300,11 @@ export const addConfigToWebApp = <
         throw new Error(`Could not find root App.${ext}`)
       }
 
-      let content = fs.readFileSync(webAppPath).toString()
+      let content = fs
+        .readFileSync(webAppPath)
+        .toString()
+        // For Windows. Replaces all CRLFs with LFs.
+        .replaceAll(/\r\n/g, '\n')
 
       if (!content.includes(AUTH_PROVIDER_HOOK_IMPORT)) {
         content = addAuthImportToApp(content)

--- a/packages/cli-helpers/src/auth/authTasks.ts
+++ b/packages/cli-helpers/src/auth/authTasks.ts
@@ -191,11 +191,15 @@ export const removeAuthProvider = (content: string) => {
         unindent = true
         // Assume the end line is indented to the same level as the start,
         // and contains just a single '>'
-        end = line.replace(/^(\s*)<Auth.*/, '$1') + '>'
+        end = line.replace(/^(\s*)<Auth.*/s, '$1') + '>'
       }
 
       // Single-line AuthProvider, or end of multi-line
-      if ((hasAuthProvider(line) && line.at(-1) === '>') || line === end) {
+      // .trimEnd() to handle CRLF
+      if (
+        (hasAuthProvider(line) && line.trimEnd().at(-1) === '>') ||
+        line.trimEnd() === end
+      ) {
         remove = false
       }
 
@@ -300,11 +304,7 @@ export const addConfigToWebApp = <
         throw new Error(`Could not find root App.${ext}`)
       }
 
-      let content = fs
-        .readFileSync(webAppPath)
-        .toString()
-        // For Windows. Replaces all CRLFs with LFs.
-        .replaceAll(/\r\n/g, '\n')
+      let content = fs.readFileSync(webAppPath, 'utf-8')
 
       if (!content.includes(AUTH_PROVIDER_HOOK_IMPORT)) {
         content = addAuthImportToApp(content)


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/7537. I've confirmed this works locally, but not sure if this's the best way to do it. @Tobbe you know more about RegExps, what do you think? We could also move the logic to the line that's actually failing:

https://github.com/redwoodjs/redwood/blob/c6a31f1da3329538ad94cd5a1847bbb780162898/packages/cli-helpers/src/auth/authTasks.ts#L226-L228