### PR TITLE
Add graphql-codegen/typescript-react-apollo plugin for generating react hooks

### DIFF
--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -10,6 +10,7 @@ import type {
 } from '@graphql-codegen/plugin-helpers'
 import * as typescriptPlugin from '@graphql-codegen/typescript'
 import * as typescriptOperations from '@graphql-codegen/typescript-operations'
+import * as typescriptReactApollo from '@graphql-codegen/typescript-react-apollo'
 import { CodeFileLoader } from '@graphql-tools/code-file-loader'
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
 import { loadDocuments, loadSchemaSync } from '@graphql-tools/load'
@@ -98,6 +99,11 @@ export const generateTypeDefGraphQLWeb = async () => {
       name: 'typescript-operations',
       options: {},
       codegenPlugin: typescriptOperations,
+    },
+    {
+      name: 'typescript-react-apollo',
+      options: {},
+      codegenPlugin: typescriptReactApollo,
     },
   ]
 


### PR DESCRIPTION
This plugin generates React hooks for each mutation and query in the schema, allowing for direct usage without the need to create separate GraphQL documents. This simplifies the code and saves time, in my view. I was accustomed to using this method in previous projects, and miss this feature.

Before
```
import {
  CreateContactMutation,
  CreateContactMutationVariables,
} from 'types/graphql'

const CREATE_CONTACT = gql`
  mutation CreateContactMutation($input: CreateContactInput!) {
    createContact(input: $input) {
      id
    }
  }
`

const ContactPage = () => {
  const [create] = useMutation<CreateContactMutation,
    CreateContactMutationVariables>(CREATE_CONTACT)
```


After

```
const ContactPage = () => {
  const [create] = useCreateContactMutation()
```

https://community.redwoodjs.com/t/using-codegen-plugins/3512