### PR TITLE
Add back `buildType: nixpacks` per Flightcontrol request

### DIFF
--- a/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
+++ b/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
@@ -30,6 +30,7 @@ export const flightcontrolConfig = {
           id: 'redwood-web',
           name: 'Redwood Web',
           type: 'static',
+          buildType: 'nixpacks',
           singlePageApp: true,
           installCommand:
             'yarn set version stable && NODE_ENV=development yarn install',

--- a/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
+++ b/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
@@ -32,8 +32,6 @@ export const flightcontrolConfig = {
           type: 'static',
           buildType: 'nixpacks',
           singlePageApp: true,
-          installCommand:
-            'yarn set version stable && NODE_ENV=development yarn install',
           buildCommand: 'yarn rw deploy flightcontrol web',
           outputDirectory: 'web/dist',
           envVariables: {


### PR DESCRIPTION
Following up from the [issue here ](https://github.com/redwoodjs/redwood/issues/7597#issuecomment-1424054130) where the default `flightcontrol.json` no longer works after upgrading to RedwoodJS 4. Seems like the `buildType: 'nixpacks'` option was removed in [this PR](https://github.com/redwoodjs/redwood/pull/6941) (unsure why it was - seems the [issue](https://github.com/redwoodjs/redwood/issues/6927) it was solving only needed the `postBuildCommand` be removed.

Regardless, after discussing with the Flightcontrol team, we needed to get that added back for builds to work such that the node version would be respected and not fail on the null coalescing operator that was only introduced in node 15.

tl;dr - Closes #7597 