### PR TITLE
fix(clerk): make `useAuth`'s `loading` prop track the Clerk client

### DIFF
--- a/packages/auth/src/AuthProvider/useReauthenticate.ts
+++ b/packages/auth/src/AuthProvider/useReauthenticate.ts
@@ -24,6 +24,12 @@ export const useReauthenticate = <TUser>(
 ) => {
   const getToken = useToken(authImplementation)
 
+  const { type, client } = authImplementation
+
+  if (type === 'clerk') {
+    notAuthenticatedState.loading = client === undefined
+  }
+
   return useCallback(async () => {
     try {
       const userMetadata = await authImplementation.getUserMetadata()
@@ -31,7 +37,7 @@ export const useReauthenticate = <TUser>(
       if (!userMetadata) {
         setAuthProviderState({
           ...notAuthenticatedState,
-          client: authImplementation.client,
+          client,
         })
       } else {
         await getToken()
@@ -56,6 +62,7 @@ export const useReauthenticate = <TUser>(
     }
   }, [
     authImplementation,
+    client,
     getToken,
     setAuthProviderState,
     skipFetchCurrentUser,


### PR DESCRIPTION
I think something like this is the fix for https://community.redwoodjs.com/t/redwood-v4-0-and-clerk-dev-cannot-render-component-as-a-sessions-already-exists-redirecting-to-the-home-url/4567/11.

The gist of the problem is in the "try" part of the try-catch block in `useReauthenticate` here:

https://github.com/redwoodjs/redwood/blob/28131990be27d2136d32df4e29e558e656c9c197/packages/auth/src/AuthProvider/useReauthenticate.ts#L28-L36

Here's `notAuthenticatedState` for completeness:

https://github.com/redwoodjs/redwood/blob/28131990be27d2136d32df4e29e558e656c9c197/packages/auth/src/AuthProvider/useReauthenticate.ts#L9-L15

What this means is that if we can't get `userMetadata`, we consider the auth provider to have loaded. `loading` is `false`. But this isn't how Clerk works. Clerk isn't finished loading until the client is on window object (_I think_).

The work-in-progress fix in this PR is simple, maybe too simple? It doesn't use React APIs. If we want to use React APIs, we should reach for Clerk's `useAuth` hook and destructure out the `isLoaded` prop. But that would require changing the API of `createAuthImplementation` et. al a bit (_I think_—we could just add custom logic to `useReauthenticate` since we officially support Clerk, but this would kind of go against all the work we did to decouple auth in the first place).

There's a couple more changes I'd like to make in this fix:
- [ ] I'm not sure that we need `ClerkLoaded` at all in the web/src/auth.tsx template; I think it may actually be bad because it blocks rendering of its children till Clerk has loaded. Ideally the `AuthProvider` should handle that so the Router can display the `whileLoadingAuth` component
- [ ] it sounds like Clerk's `useAuth` hook is newer and more recommended than it's useUser `hook`; maybe we should go with that?

  See https://clerk.dev/docs/reference/clerk-react/useauth:
  > This new hook should be used instead of:
  > - useSession() , to access getToken() or the sessionId
  > - useUser() , to access getToken() for integrations
  > - useClerk() , to access signOut()
