### PR TITLE
fix(vite): Respect `host`, `sourceMap` settings in redwood.toml on vite dev server

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -112,6 +112,7 @@ export default function redwoodPluginVite() {
           server: {
             open: redwoodConfig.browser.open,
             port: redwoodConfig.web.port,
+            host: redwoodConfig.web.host,
             proxy: {
               //@TODO we need to do a check for absolute urls here
               [redwoodConfig.web.apiUrl]: {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -62,13 +62,19 @@ export default function redwoodPluginVite() {
           existsSync(clientEntryPath) &&
           normalizePath(id) === normalizePath(redwoodPaths.web.html)
         ) {
-          return code.replace(
-            '</head>',
-            `<script type="module" src="/entry-client.jsx"></script>
+          return {
+            code: code.replace(
+              '</head>',
+              `<script type="module" src="/entry-client.jsx"></script>
         </head>`
-          )
+            ),
+            map: null,
+          }
         } else {
-          return code
+          return {
+            code,
+            map: null, // Returning null here preserves the original sourcemap
+          }
         }
       },
       // ---------- End Bundle injection ----------
@@ -127,6 +133,7 @@ export default function redwoodPluginVite() {
             outDir: redwoodPaths.web.dist,
             emptyOutDir: true,
             manifest: 'build-manifest.json',
+            sourcemap: redwoodConfig.web.sourceMap, // Note that this can be boolean or 'inline'
           },
           optimizeDeps: {
             esbuildOptions: {


### PR DESCRIPTION
Based on user feedback. This PR does two things:

### 1. Host is respected
The vite plugin now respects the host specified in `redwood.toml`. Note that when we specify the host to be `0.0.0.0` vite will still _print_ that its running on localhost but actually listen on all hosts, as per this doc: https://vitejs.dev/config/server-options.html#server-host

### 2. Sourcemap setting for production build is respected
If you want to generate sourcemaps for production, this is now respected. The key changes here were
a) Passing through the sourceMap option from `redwood.toml` through to Vite's build settings
b) Making sure any custom transforms, in this case the html transformer (bundle injection), preserves the original sourcemap. 

The information on this was a little hard to find, but is in the rollup documentation: https://rollupjs.org/plugin-development/#transform

> If the transformation does not move code, you can preserve existing sourcemaps by setting map to null