### PR TITLE
fix(ts): Undo skipLibCheck change

### DIFF
--- a/packages/create-redwood-app/template/api/tsconfig.json
+++ b/packages/create-redwood-app/template/api/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "baseUrl": "./",
     "rootDirs": [
       "./src",

--- a/packages/create-redwood-app/template/web/tsconfig.json
+++ b/packages/create-redwood-app/template/web/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "baseUrl": "./",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/web/src",


### PR DESCRIPTION
See comment from Orta here: https://github.com/redwoodjs/redwood/pull/7499#issuecomment-1428634775


**For Release Notes:**
In v4.1 we shipped with `skipLibCheck: true` in the template. If you created a new project in the last week, we recommend that you change this setting back to false in your `web/tsconfig.json` and `api/tsconfig.json`.

```diff
{
  "compilerOptions": {
    "noEmit": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,	
```

Alternatively you can just run`yarn rw setup tsconfig --force`, which will replace your existing tsconfigs with the one from the latest template on our repo.