### PR TITLE
feat(api): support building .jsx, .tsx files

### DIFF
--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -52,7 +52,7 @@ const ignoreApiFiles = [
 ]
 
 export const findApiFiles = (cwd: string = getPaths().api.src) => {
-  const files = fg.sync('**/*.{js,ts}', {
+  const files = fg.sync('**/*.{js,ts,jsx,tsx}', {
     cwd,
     absolute: true,
     ignore: ignoreApiFiles,


### PR DESCRIPTION
If users want to use JSX in a custom function on the api side, provided they have the babel config, they should be able to. Addresses @chenkie's use case specifically 