### PR TITLE
fix:(webAuthn) use `globalThis`, not `process.env`

### DIFF
--- a/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
@@ -1,6 +1,6 @@
 import WebAuthnClient from '../webAuthn'
 
-process.env.RWJS_API_URL = '/.redwood/functions'
+globalThis.RWJS_API_URL = '/.redwood/functions'
 
 jest.mock('@whatwg-node/fetch', () => {
   return
@@ -81,12 +81,12 @@ describe('webAuthn', () => {
 
     expect(mockOpen).toBeCalledWith(
       'GET',
-      `${process.env.RWJS_API_URL}/auth?method=webAuthnAuthOptions`,
+      `${globalThis.RWJS_API_URL}/auth?method=webAuthnAuthOptions`,
       false
     )
     expect(mockOpen).toBeCalledWith(
       'POST',
-      `${process.env.RWJS_API_URL}/auth`,
+      `${globalThis.RWJS_API_URL}/auth`,
       false
     )
     expect(mockSend).toBeCalledWith(
@@ -122,12 +122,12 @@ describe('webAuthn', () => {
 
     expect(mockOpen).toBeCalledWith(
       'GET',
-      `${process.env.RWJS_API_URL}/auth?method=webAuthnRegOptions`,
+      `${globalThis.RWJS_API_URL}/auth?method=webAuthnRegOptions`,
       false
     )
     expect(mockOpen).toBeCalledWith(
       'POST',
-      `${process.env.RWJS_API_URL}/auth`,
+      `${globalThis.RWJS_API_URL}/auth`,
       false
     )
     expect(mockSend).toBeCalledWith(

--- a/packages/auth-providers/dbAuth/web/src/webAuthn.ts
+++ b/packages/auth-providers/dbAuth/web/src/webAuthn.ts
@@ -45,7 +45,7 @@ export default class WebAuthnClient {
   authApiUrl = ''
 
   private getAuthApiUrl() {
-    return this.authApiUrl || `${process.env.RWJS_API_URL}/auth`
+    return this.authApiUrl || `${globalThis.RWJS_API_URL}/auth`
   }
 
   setAuthApiUrl(authApiUrl?: string) {

--- a/packages/auth-providers/dbAuth/web/src/webAuthn.ts
+++ b/packages/auth-providers/dbAuth/web/src/webAuthn.ts
@@ -45,7 +45,7 @@ export default class WebAuthnClient {
   authApiUrl = ''
 
   private getAuthApiUrl() {
-    return this.authApiUrl || `${globalThis.RWJS_API_URL}/auth`
+    return this.authApiUrl || `${RWJS_API_URL}/auth`
   }
 
   setAuthApiUrl(authApiUrl?: string) {


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/7637.

There's probably some tests that need updating here.