### PR TITLE
Add RLS test strategy

### DIFF
--- a/packages/testing/config/jest/api/globalSetup.js
+++ b/packages/testing/config/jest/api/globalSetup.js
@@ -14,7 +14,8 @@ module.exports = async function () {
     process.env.DATABASE_URL = process.env.TEST_DATABASE_URL || cacheDirDb
 
     const command =
-      process.env.TEST_DATABASE_STRATEGY === 'reset'
+      process.env.TEST_DATABASE_STRATEGY === 'reset' ||
+      process.env.TEST_DATABASE_STRATEGY === 'rls'
         ? ['prisma', 'migrate', 'reset', '--force', '--skip-seed']
         : ['prisma', 'db', 'push', '--force-reset', '--accept-data-loss']
 

--- a/packages/testing/config/jest/api/jest.setup.js
+++ b/packages/testing/config/jest/api/jest.setup.js
@@ -78,9 +78,9 @@ const getQuoteStyle = async () => {
 }
 
 const getProjectDb = () => {
-  const { db } = require(`${apiSrcPath}/lib/db`)
+  const { db, testDb } = require(`${apiSrcPath}/lib/db`)
 
-  return db
+  return process.env.TEST_DATABASE_STRATEGY === 'rls' ? testDb : db
 }
 
 const buildScenario =


### PR DESCRIPTION
This PR adds support for an additional test strategy, `"rls"`, including the following:

* Run `prisma migrate reset` to ensure migration files are used to setup the test database.
  * Prisma does not support defining security policies using its schema, so they need to be defined by hand in one of an application's `migration.sql` files.
* Expect a DB client named `testDb` which connects to the test-database as a superuser.
  * Superusers can bypass security policies, so this client can be used to seed and teardown the test database before and after tests without the need of explicit bypass policies.

Context can be found in [this Slack thread](https://redwoodjs.slack.com/archives/G01JBDDU2CF/p1675971194750249). Use cases would be applications making use of [@dthyresson's Supabase RLS Prisma Extension](https://github.com/dthyresson/prisma-extension-supabase-rls) as well as [my RLS demo app](https://github.com/realStandal/redwood-rls-demo).

### Enabling the strategy

The strategy can be enabled by setting the `TEST_DATABASE_STRATEGY` environment variable to `"rls"`

```dotenv
TEST_DATABASE_STRATEGY=rls
```

### Creating an additional Prisma Client

The strategy will expect a Prisma Client named "testDb" to be exported from `api/src/lib/db.{js,ts}`. This should be added alongside an application's default client.

```typescript
export const testDb = new PrismaClient({
  log: emitLogLevels(['error']),
  datasources: {
    db: {
      url: process.env.TEST_ROOT_DATABASE_URL,
    },
  },
})

handlePrismaLogging({ db: testDb, logger, logLevels: ['error'] })
```

An environment variable should be added named `TEST_ROOT_DATABASE_URL` which provides access to the test database as a root user.

```dotenv
TEST_ROOT_DATABASE_URL=postgres://postgres:secret@localhost:5432/test
```
