### PR TITLE
chore(deps): bump setup of Chakra UI to V2

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
@@ -36,10 +36,10 @@ export async function handler({ force, install }) {
   const rwPaths = getPaths()
 
   const packages = [
-    '@chakra-ui/react',
-    '@emotion/react',
-    '@emotion/styled',
-    'framer-motion',
+    '@chakra-ui/react@^2',
+    '@emotion/react@^11',
+    '@emotion/styled@^11',
+    'framer-motion@^9',
   ]
 
   const tasks = new Listr(

--- a/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
@@ -36,10 +36,10 @@ export async function handler({ force, install }) {
   const rwPaths = getPaths()
 
   const packages = [
-    '@chakra-ui/react@^1',
-    '@emotion/react@^11',
-    '@emotion/styled@^11',
-    'framer-motion@^6',
+    '@chakra-ui/react',
+    '@emotion/react',
+    '@emotion/styled',
+    'framer-motion',
   ]
 
   const tasks = new Listr(


### PR DESCRIPTION
> Version 2 of Chakra UI is only compatible with React 18. If you are still needing to use React 17 or earlier, please use version 1 of Chakra UI.

see also:

- https://chakra-ui.com/getting-started
- https://github.com/redwoodjs/redwood/pull/4992#issuecomment-1235718694
- #5614