### PR TITLE
Forms: Export EmptyAsValue

### DIFF
--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -161,7 +161,7 @@ const isValueEmpty = (val: string): boolean => val === ''
  * the comments above the setCoercion function for more details)
  */
 
-type EmptyAsValue = null | 'undefined' | 0 | ''
+export type EmptyAsValue = null | 'undefined' | 0 | ''
 
 type ValueAsType =
   | 'valueAsDate'


### PR DESCRIPTION
When building custom components that you want to be compatible with existing form components it'd be nice to be able to use the same type for `emptyAs`. Right now you have to copy/paste `null | 'undefined' | 0 | ''` and hope it never changes