### PR TITLE
fix(gql-codegen): Prevent double wrapping of resolved types in promises

### DIFF
--- a/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
@@ -100,7 +100,7 @@ type MaybeOrArrayOfMaybe<T> = T | Maybe<T> | Maybe<T>[];
 type AllMappedModels = MaybeOrArrayOfMaybe<Todo>
 
 
-export type ResolverTypeWrapper<T> = Promise<T> | T;
+export type ResolverTypeWrapper<T> = T;
 
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs>;
 

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -237,6 +237,7 @@ function getPluginConfig(side: CodegenSide) {
     omitOperationSuffix: true,
     showUnusedMappers: false,
     customResolverFn: getResolverFnType(),
+    resolverTypeWrapperSignature: 'T', // do this to prevent double wrapping of resolved types in Promises
     mappers: prismaModels,
     avoidOptionals: {
       // We do this, so that service tests can call resolvers without doing a null check


### PR DESCRIPTION
Fixes #6495

This is a bit of a sledgehammer fix - so would love some analysis before merging this.

### What does this do?
Changes the Graphql codegen config so that it doesn't wrap ResolverTypes in a promise

Open up api/graphql.d.ts and you'll notice this difference:
```diff
- export type ResolverTypeWrapper<T> = Promise<T> | T;
+ export type ResolverTypeWrapper<T> = T;
```

See the original issue I created for more details on what error this fixes. 

The `ResolverTypeWrapper` is used to wrap all of the "types" in graphql. My shallow understanding of the issue is that something weird happens with Prisma's mapped types - but why for findMany only is a total mystery to me.