### PR TITLE
fix(clerk): Remove privateMetadata property from getCurrentUser

### DIFF
--- a/packages/auth-providers/clerk/setup/src/templates/api/lib/auth.ts.template
+++ b/packages/auth-providers/clerk/setup/src/templates/api/lib/auth.ts.template
@@ -29,11 +29,14 @@ export const getCurrentUser = async (
 
   const { roles } = parseJWT({ decoded })
 
+  // Remove privateMetadata property from CurrentUser as it should not be accessible on the web
+  const { privateMetadata, ...userWithoutPrivateMetadata } = decoded
+
   if (roles) {
-    return { ...decoded, roles }
+    return { ...userWithoutPrivateMetadata, roles }
   }
 
-  return { ...decoded }
+  return { ...userWithoutPrivateMetadata }
 }
 
 /**


### PR DESCRIPTION
The [privateMetadata property](https://clerk.dev/docs/users/user-metadata) should not be accessible on the client side. This commit removes this property from the getCurrentUser function returned user object.