### PR TITLE
createAuth: Allow passing a custom type string

### DIFF
--- a/packages/auth-providers/clerk/web/src/clerk.tsx
+++ b/packages/auth-providers/clerk/web/src/clerk.tsx
@@ -11,20 +11,27 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 
 type Clerk = ClerkClient | undefined | null
 
-export function createAuth(customProviderHooks?: {
+interface CustomProviderHooks {
   useCurrentUser?: () => Promise<Record<string, unknown>>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
-}) {
-  const authImplementation = createAuthImplementation()
+}
+
+interface CreateAuthArgs {
+  type?: string
+  customProviderHooks?: CustomProviderHooks
+}
+
+export function createAuth({ type, customProviderHooks }: CreateAuthArgs) {
+  const authImplementation = createAuthImplementation(type)
 
   return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createAuthImplementation() {
+function createAuthImplementation(type?: string) {
   return {
-    type: 'clerk',
+    type: type || 'clerk',
     // Using a getter here to make sure we're always returning a fresh value
     // and not creating a closure around an old (probably `undefined`) value
     // for Clerk that'll we always return, even when Clerk on the window object


### PR DESCRIPTION
# Solution variant two. This is a breaking change

## Old usage syntax. This would now break
```js
createAuth({
  useCurrentUser: async () => ({ userId: 'abc123', roles: ['admin'] }),
})
```

## New usage syntax (same as Solution variant one)
```js
createAuth({
  type: 'clerk-admin',
  customProviderHooks: {
    useCurrentUser: async () => ({ userId: 'abc123', roles: ['admin'] }),
  },
})
```

# Other solution variants
One: https://github.com/redwoodjs/redwood/pull/7686
Three: https://github.com/redwoodjs/redwood/pull/7688