### PR TITLE
createAuth: Allow passing a custom type string

### DIFF
--- a/packages/auth-providers/clerk/web/src/clerk.tsx
+++ b/packages/auth-providers/clerk/web/src/clerk.tsx
@@ -11,20 +11,26 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 
 type Clerk = ClerkClient | undefined | null
 
-export function createAuth(customProviderHooks?: {
+interface CreateAuthArgs {
+  type?: string
   useCurrentUser?: () => Promise<Record<string, unknown>>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean
-}) {
-  const authImplementation = createAuthImplementation()
-
-  return createAuthentication(authImplementation, customProviderHooks)
 }
 
-function createAuthImplementation() {
+export function createAuth(args: CreateAuthArgs) {
+  const authImplementation = createAuthImplementation(args.type)
+
+  return createAuthentication(authImplementation, {
+    useCurrentUser: args.useCurrentUser,
+    useHasRole: args.useHasRole,
+  })
+}
+
+function createAuthImplementation(type?: string) {
   return {
-    type: 'clerk',
+    type: type || 'clerk',
     // Using a getter here to make sure we're always returning a fresh value
     // and not creating a closure around an old (probably `undefined`) value
     // for Clerk that'll we always return, even when Clerk on the window object


### PR DESCRIPTION
# Solution variant three

## Old usage syntax
```js
createAuth({
  useCurrentUser: async () => ({ userId: 'abc123', roles: ['admin'] }),
})
```

## New usage syntax
```js
createAuth({
  type: 'clerk-admin',
  useCurrentUser: async () => ({ userId: 'abc123', roles: ['admin'] }),
})
```

# Other solution variants
One: https://github.com/redwoodjs/redwood/pull/7686
Two: https://github.com/redwoodjs/redwood/pull/7687