### PR TITLE
feat: add publish experimental workflow

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -1,0 +1,85 @@
+name: 🧪 Publish Experimental
+
+on:
+  push:
+    branches: ['experimental/*']
+    # No need to run on docs-only changes
+    paths-ignore: ['docs/**']
+
+# Cancel in-progress runs of this workflow.
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-experimental:
+    name: 🧪 Publish Experimental
+    if: github.repository == 'redwoodjs/redwood'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v3
+        # `fetch-depth`—number of commits to fetch. `0` fetches all history for all branches and tags.
+        #  This is required because lerna uses tags to determine the version.
+        with:
+          fetch-depth: 0
+
+      - name: 🧶 Set up job
+        uses: ./.github/actions/set-up-job
+
+      - name: ✅ Check constraints, dependencies, and package.json's
+        uses: ./tasks/check
+
+      - name: 🏗 Build
+        run: yarn build
+
+      - name: 🔎 Lint
+        run: yarn lint
+
+      - name: 🧪 Test
+        run: yarn test
+
+      - name: 🚢 Publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
+
+          TAG="experimental-$(basename ${{ github.ref_name }})"
+
+          echo "Publishing $TAG"
+
+          yarn lerna publish premajor --include-merged-tags \
+                                      --canary \
+                                      --exact \
+                                      --preid "$TAG" \
+                                      --dist-tag "$TAG" \
+                                      --force-publish \
+                                      --loglevel verbose \
+                                      --no-git-reset \
+                                      --yes
+
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: 🏷 Get version
+        id: get-version
+        uses: sergeysova/jq-action@v2.3.0
+        with:
+          cmd: 'jq .version packages/core/package.json -r'
+
+  message-slack:
+    name: 💬 Message Slack
+    needs: publish-experimental
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: 💬 Message Slack
+        uses: ./.github/actions/message_slack_publishing
+        with:
+          title: "🧪 Experimental Packages"
+          status: ${{ needs.publish-canary.result }}
+          version: ${{ needs.publish-canary.outputs.version }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_PACKAGE_PUBLISHING }}


### PR DESCRIPTION
This workflows publishes any branch prefixed with `experimental/`. So a branch named `experimental/ssr` would be published as `5.0.0-experimental-ssr.348` (where 348 is the number of commits to main since the last tag, or something like that). The version would track a dist tag of the same name, in this case, `experimental-ssr`.