### PR TITLE
Auth: Add TS types for auth method options

### DIFF
--- a/packages/auth-providers/auth0/web/src/__tests__/auth0.test.tsx
+++ b/packages/auth-providers/auth0/web/src/__tests__/auth0.test.tsx
@@ -43,7 +43,7 @@ const auth0MockClient: Partial<Auth0Client> = {
   loginWithRedirect: async () => {
     loggedInUser = user
   },
-  logout: () => {},
+  logout: async () => {},
   getTokenSilently,
   getUser: <TUser extends User>() => {
     return new Promise<TUser | undefined>((resolve) => {

--- a/packages/auth-providers/auth0/web/src/__tests__/auth0.test.tsx
+++ b/packages/auth-providers/auth0/web/src/__tests__/auth0.test.tsx
@@ -80,7 +80,7 @@ beforeEach(() => {
 })
 
 function getAuth0Auth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/auth0/web/src/auth0.ts
+++ b/packages/auth-providers/auth0/web/src/auth0.ts
@@ -12,7 +12,7 @@ export interface Auth0User {}
 export function createAuth(
   auth0Client: Auth0Client,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/azureActiveDirectory/web/src/__tests__/azureActiveDirectory.test.tsx
+++ b/packages/auth-providers/azureActiveDirectory/web/src/__tests__/azureActiveDirectory.test.tsx
@@ -116,7 +116,7 @@ beforeEach(() => {
 })
 
 function getAzureActiveDirectoryAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/azureActiveDirectory/web/src/azureActiveDirectory.ts
+++ b/packages/auth-providers/azureActiveDirectory/web/src/azureActiveDirectory.ts
@@ -11,7 +11,7 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 export function createAuth(
   azureActiveDirectoryClient: AzureActiveDirectoryClient,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/clerk/web/src/__tests__/clerk.test.tsx
+++ b/packages/auth-providers/clerk/web/src/__tests__/clerk.test.tsx
@@ -101,7 +101,7 @@ beforeEach(() => {
 })
 
 function getClerkAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/clerk/web/src/clerk.tsx
+++ b/packages/auth-providers/clerk/web/src/clerk.tsx
@@ -12,7 +12,7 @@ import { CurrentUser, createAuthentication } from '@redwoodjs/auth'
 type Clerk = ClerkClient | undefined | null
 
 export function createAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -192,7 +192,7 @@ describe('dbAuth', () => {
     await act(
       async () =>
         await auth.resetPassword({
-          token: 'reset-token',
+          resetToken: 'reset-token',
           password: 'password',
         })
     )

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -79,7 +79,7 @@ beforeEach(() => {
 })
 
 const defaultArgs: DbAuthClientArgs & {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -189,7 +189,13 @@ describe('dbAuth', () => {
 
   it('passes through fetchOptions to resetPassword calls', async () => {
     const auth = getDbAuth().current
-    await act(async () => await auth.resetPassword({}))
+    await act(
+      async () =>
+        await auth.resetPassword({
+          token: 'reset-token',
+          password: 'password',
+        })
+    )
 
     expect(globalThis.fetch).toBeCalledWith(
       `${globalThis.RWJS_API_URL}/auth`,
@@ -201,7 +207,13 @@ describe('dbAuth', () => {
 
   it('passes through fetchOptions to signup calls', async () => {
     const auth = getDbAuth().current
-    await act(async () => await auth.signUp({}))
+    await act(
+      async () =>
+        await auth.signUp({
+          username: 'username',
+          password: 'password',
+        })
+    )
 
     expect(globalThis.fetch).toBeCalledWith(
       `${globalThis.RWJS_API_URL}/auth`,

--- a/packages/auth-providers/dbAuth/web/src/dbAuth.ts
+++ b/packages/auth-providers/dbAuth/web/src/dbAuth.ts
@@ -19,7 +19,7 @@ const TOKEN_CACHE_TIME = 5000
 export function createAuth(
   dbAuthClient: ReturnType<typeof createDbAuthClient>,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/dbAuth/web/src/dbAuth.ts
+++ b/packages/auth-providers/dbAuth/web/src/dbAuth.ts
@@ -8,7 +8,7 @@ export interface LoginAttributes {
 }
 
 export interface ResetPasswordAttributes {
-  token: string
+  resetToken: string
   password: string
 }
 

--- a/packages/auth-providers/firebase/web/src/__tests__/firebase.test.tsx
+++ b/packages/auth-providers/firebase/web/src/__tests__/firebase.test.tsx
@@ -143,7 +143,7 @@ beforeEach(() => {
 })
 
 function getFirebaseAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/firebase/web/src/firebase.ts
+++ b/packages/auth-providers/firebase/web/src/firebase.ts
@@ -77,7 +77,7 @@ const applyProviderOptions = (
 export function createAuth(
   firebaseClient: FirebaseClient,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/netlify/web/src/__tests__/netlify.test.tsx
+++ b/packages/auth-providers/netlify/web/src/__tests__/netlify.test.tsx
@@ -93,7 +93,7 @@ beforeEach(() => {
 })
 
 function getNetlifyAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/netlify/web/src/netlify.ts
+++ b/packages/auth-providers/netlify/web/src/netlify.ts
@@ -32,7 +32,8 @@ function createAuthImplementation(netlifyIdentity: NetlifyIdentity) {
   return {
     type: 'netlify',
     client: netlifyIdentity,
-    login: () => {
+    // _options: never is needed to help TS infer the TLogInOptions type
+    login: (_options: never) => {
       return new Promise<NetlifyIdentityNS.User | null>((resolve, reject) => {
         let autoClosedModal = false
         netlifyIdentity.open('login')
@@ -48,14 +49,14 @@ function createAuthImplementation(netlifyIdentity: NetlifyIdentity) {
         netlifyIdentity.on('error', reject)
       })
     },
-    logout: () => {
+    logout: (_options: never) => {
       return new Promise<void>((resolve, reject) => {
         netlifyIdentity.logout()
         netlifyIdentity.on('logout', resolve)
         netlifyIdentity.on('error', reject)
       })
     },
-    signup: () => {
+    signup: (_options: never) => {
       return new Promise<null>((resolve, reject) => {
         netlifyIdentity.open('signup')
         netlifyIdentity.on('close', () => {

--- a/packages/auth-providers/netlify/web/src/netlify.ts
+++ b/packages/auth-providers/netlify/web/src/netlify.ts
@@ -13,7 +13,7 @@ type NetlifyIdentity = typeof NetlifyIdentityNS
 export function createAuth(
   netlifyIdentity: NetlifyIdentity,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/netlify/web/src/netlify.ts
+++ b/packages/auth-providers/netlify/web/src/netlify.ts
@@ -32,7 +32,7 @@ function createAuthImplementation(netlifyIdentity: NetlifyIdentity) {
   return {
     type: 'netlify',
     client: netlifyIdentity,
-    // _options: never is needed to help TS infer the TLogInOptions type
+    // `_options: never` is needed to help TS infer the TLogInOptions type
     login: (_options: never) => {
       return new Promise<NetlifyIdentityNS.User | null>((resolve, reject) => {
         let autoClosedModal = false

--- a/packages/auth-providers/supabase/web/src/__tests__/supabase.test.tsx
+++ b/packages/auth-providers/supabase/web/src/__tests__/supabase.test.tsx
@@ -107,7 +107,7 @@ beforeEach(() => {
 })
 
 function getSupabaseAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/supabase/web/src/supabase.ts
+++ b/packages/auth-providers/supabase/web/src/supabase.ts
@@ -22,7 +22,7 @@ type SignUpOptions = {
 export function createAuth(
   supabaseClient: SupabaseClient,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/supertokens/web/src/__tests__/supertokens.test.tsx
+++ b/packages/auth-providers/supertokens/web/src/__tests__/supertokens.test.tsx
@@ -77,7 +77,7 @@ beforeEach(() => {
 })
 
 function getSuperTokensAuth(customProviderHooks?: {
-  useCurrentUser?: () => Promise<Record<string, unknown>>
+  useCurrentUser?: () => Promise<CurrentUser>
   useHasRole?: (
     currentUser: CurrentUser | null
   ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth-providers/supertokens/web/src/supertokens.ts
+++ b/packages/auth-providers/supertokens/web/src/supertokens.ts
@@ -17,7 +17,7 @@ export type SessionRecipe = {
 export function createAuth(
   superTokens: SuperTokensAuth,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth/src/AuthContext.ts
+++ b/packages/auth/src/AuthContext.ts
@@ -6,10 +6,14 @@ export interface CurrentUser {
 
 export interface AuthContextInterface<
   TUser,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
   TClient
@@ -40,9 +44,9 @@ export interface AuthContextInterface<
    * ```
    */
   userMetadata: null | TUser
-  logIn(options?: unknown): Promise<TLogIn>
-  logOut(options?: unknown): Promise<TLogOut>
-  signUp(options?: unknown): Promise<TSignUp>
+  logIn(options?: TLogInOptions): Promise<TLogIn>
+  logOut(options?: TLogOutOptions): Promise<TLogOut>
+  signUp(options?: TSignUpOptions): Promise<TSignUp>
   /**
    * Clients should always return null or string
    * It is expected that they catch any errors internally
@@ -65,7 +69,7 @@ export interface AuthContextInterface<
    */
   reauthenticate(): Promise<void>
   forgotPassword(username: string): Promise<TForgotPassword>
-  resetPassword(options?: unknown): Promise<TResetPassword>
+  resetPassword(options?: TResetPasswordOptions): Promise<TResetPassword>
   validateResetToken(resetToken: string | null): Promise<TValidateResetToken>
   /**
    * A reference to auth service provider sdk "client", which is useful if we
@@ -79,10 +83,14 @@ export interface AuthContextInterface<
 
 export function createAuthContext<
   TUser,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
   TClient
@@ -90,10 +98,14 @@ export function createAuthContext<
   return React.createContext<
     | AuthContextInterface<
         TUser,
+        TLogInOptions,
         TLogIn,
+        TLogOutOptions,
         TLogOut,
+        TSignUpOptions,
         TSignUp,
         TForgotPassword,
+        TResetPasswordOptions,
         TResetPassword,
         TValidateResetToken,
         TClient

--- a/packages/auth/src/AuthImplementation.ts
+++ b/packages/auth/src/AuthImplementation.ts
@@ -1,10 +1,14 @@
 export interface AuthImplementation<
   TUser = unknown,
   TRestoreAuth = unknown,
+  TLogInOptions = unknown,
   TLogIn = unknown,
+  TLogOutOptions = unknown,
   TLogOut = unknown,
+  TSignUpOptions = unknown,
   TSignUp = unknown,
   TForgotPassword = unknown,
+  TResetPasswordOptions = unknown,
   TResetPassword = unknown,
   TValidateResetToken = unknown,
   TClient = unknown
@@ -13,12 +17,12 @@ export interface AuthImplementation<
   client?: TClient
 
   restoreAuthState?(): Promise<TRestoreAuth>
-  login(options?: unknown): Promise<TLogIn>
-  logout(options?: unknown): Promise<TLogOut>
-  signup(options?: unknown): Promise<TSignUp>
-  getToken(options?: unknown): Promise<string | null>
+  login(options?: TLogInOptions): Promise<TLogIn>
+  logout(options?: TLogOutOptions): Promise<TLogOut>
+  signup(options?: TSignUpOptions): Promise<TSignUp>
+  getToken(): Promise<string | null>
   forgotPassword?(username: string): Promise<TForgotPassword>
-  resetPassword?(options?: unknown): Promise<TResetPassword>
+  resetPassword?(options?: TResetPasswordOptions): Promise<TResetPassword>
   validateResetToken?(token: string | null): Promise<TValidateResetToken>
   clientHasLoaded?(): boolean
 

--- a/packages/auth/src/AuthProvider/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider/AuthProvider.tsx
@@ -26,10 +26,14 @@ export interface AuthProviderProps {
 export function createAuthProvider<
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
   TClient
@@ -37,10 +41,14 @@ export function createAuthProvider<
   AuthContext: React.Context<
     | AuthContextInterface<
         TUser,
+        TLogInOptions,
         TLogIn,
+        TLogOutOptions,
         TLogOut,
+        TSignUpOptions,
         TSignUp,
         TForgotPassword,
+        TResetPasswordOptions,
         TResetPassword,
         TValidateResetToken,
         TClient
@@ -50,10 +58,14 @@ export function createAuthProvider<
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
     TValidateResetToken,
     TClient

--- a/packages/auth/src/AuthProvider/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider/AuthProvider.tsx
@@ -71,7 +71,7 @@ export function createAuthProvider<
     TClient
   >,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth/src/AuthProvider/useForgotPassword.ts
+++ b/packages/auth/src/AuthProvider/useForgotPassword.ts
@@ -5,22 +5,32 @@ import type { AuthImplementation } from '../AuthImplementation'
 export const useForgotPassword = <
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
-  TValidateResetToken
+  TValidateResetToken,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
-    TValidateResetToken
+    TValidateResetToken,
+    TClient
   >
 ) => {
   return useCallback(

--- a/packages/auth/src/AuthProvider/useLogIn.ts
+++ b/packages/auth/src/AuthProvider/useLogIn.ts
@@ -12,22 +12,32 @@ import { useReauthenticate } from './useReauthenticate'
 export const useLogIn = <
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
-  TValidateResetToken
+  TValidateResetToken,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
-    TValidateResetToken
+    TValidateResetToken,
+    TClient
   >,
   setAuthProviderState: React.Dispatch<
     React.SetStateAction<AuthProviderState<TUser>>
@@ -43,7 +53,7 @@ export const useLogIn = <
   )
 
   return useCallback(
-    async (options?: unknown) => {
+    async (options?: TLogInOptions) => {
       setAuthProviderState(defaultAuthProviderState)
       const loginResult = await authImplementation.login(options)
       await reauthenticate()

--- a/packages/auth/src/AuthProvider/useLogOut.ts
+++ b/packages/auth/src/AuthProvider/useLogOut.ts
@@ -7,29 +7,39 @@ import { AuthProviderState } from './AuthProviderState'
 export const useLogOut = <
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
-  TValidateResetToken
+  TValidateResetToken,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
-    TValidateResetToken
+    TValidateResetToken,
+    TClient
   >,
   setAuthProviderState: React.Dispatch<
     React.SetStateAction<AuthProviderState<TUser>>
   >
 ) => {
   return useCallback(
-    async (options?: unknown) => {
+    async (options?: TLogOutOptions) => {
       const logoutOutput = await authImplementation.logout(options)
 
       setAuthProviderState({

--- a/packages/auth/src/AuthProvider/useResetPassword.ts
+++ b/packages/auth/src/AuthProvider/useResetPassword.ts
@@ -5,26 +5,36 @@ import type { AuthImplementation } from '../AuthImplementation'
 export const useResetPassword = <
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
-  TValidateResetToken
+  TValidateResetToken,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
-    TValidateResetToken
+    TValidateResetToken,
+    TClient
   >
 ) => {
   return useCallback(
-    async (options?: unknown) => {
+    async (options?: TResetPasswordOptions) => {
       if (authImplementation.resetPassword) {
         return await authImplementation.resetPassword(options)
       } else {

--- a/packages/auth/src/AuthProvider/useSignUp.ts
+++ b/packages/auth/src/AuthProvider/useSignUp.ts
@@ -9,22 +9,32 @@ import { useReauthenticate } from './useReauthenticate'
 export const useSignUp = <
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
-  TValidateResetToken
+  TValidateResetToken,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
-    TValidateResetToken
+    TValidateResetToken,
+    TClient
   >,
   setAuthProviderState: React.Dispatch<
     React.SetStateAction<AuthProviderState<TUser>>
@@ -40,7 +50,7 @@ export const useSignUp = <
   )
 
   return useCallback(
-    async (options?: unknown) => {
+    async (options?: TSignUpOptions) => {
       const signupOutput = await authImplementation.signup(options)
       await reauthenticate()
       return signupOutput

--- a/packages/auth/src/AuthProvider/useValidateResetToken.ts
+++ b/packages/auth/src/AuthProvider/useValidateResetToken.ts
@@ -5,22 +5,32 @@ import type { AuthImplementation } from '../AuthImplementation'
 export const useValidateResetToken = <
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
-  TValidateResetToken
+  TValidateResetToken,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
-    TValidateResetToken
+    TValidateResetToken,
+    TClient
   >
 ) => {
   return useCallback(

--- a/packages/auth/src/__tests__/fixtures/customTestAuth.ts
+++ b/packages/auth/src/__tests__/fixtures/customTestAuth.ts
@@ -25,7 +25,7 @@ export interface CustomTestAuthClient {
 export function createCustomTestAuth(
   customTest: CustomTestAuthClient,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth/src/authFactory.ts
+++ b/packages/auth/src/authFactory.ts
@@ -6,10 +6,14 @@ import { createUseAuth } from './useAuth'
 export function createAuthentication<
   TUser,
   TRestoreAuth,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
   TClient
@@ -17,10 +21,14 @@ export function createAuthentication<
   authImplementation: AuthImplementation<
     TUser,
     TRestoreAuth,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
     TValidateResetToken,
     TClient
@@ -34,10 +42,14 @@ export function createAuthentication<
 ) {
   const AuthContext = createAuthContext<
     TUser,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
     TValidateResetToken,
     TClient

--- a/packages/auth/src/authFactory.ts
+++ b/packages/auth/src/authFactory.ts
@@ -34,7 +34,7 @@ export function createAuthentication<
     TClient
   >,
   customProviderHooks?: {
-    useCurrentUser?: () => Promise<Record<string, unknown>>
+    useCurrentUser?: () => Promise<CurrentUser>
     useHasRole?: (
       currentUser: CurrentUser | null
     ) => (rolesToCheck: string | string[]) => boolean

--- a/packages/auth/src/useAuth.ts
+++ b/packages/auth/src/useAuth.ts
@@ -4,10 +4,14 @@ import type { AuthContextInterface } from './AuthContext'
 
 export function createUseAuth<
   TUser,
+  TLogInOptions,
   TLogIn,
+  TLogOutOptions,
   TLogOut,
+  TSignUpOptions,
   TSignUp,
   TForgotPassword,
+  TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
   TClient
@@ -15,10 +19,14 @@ export function createUseAuth<
   AuthContext: React.Context<
     | AuthContextInterface<
         TUser,
+        TLogInOptions,
         TLogIn,
+        TLogOutOptions,
         TLogOut,
+        TSignUpOptions,
         TSignUp,
         TForgotPassword,
+        TResetPasswordOptions,
         TResetPassword,
         TValidateResetToken,
         TClient
@@ -28,10 +36,14 @@ export function createUseAuth<
 ) {
   const useAuth = (): AuthContextInterface<
     TUser,
+    TLogInOptions,
     TLogIn,
+    TLogOutOptions,
     TLogOut,
+    TSignUpOptions,
     TSignUp,
     TForgotPassword,
+    TResetPasswordOptions,
     TResetPassword,
     TValidateResetToken,
     TClient
@@ -50,6 +62,10 @@ export function createUseAuth<
 
 export function useNoAuth(): AuthContextInterface<
   null,
+  void,
+  void,
+  void,
+  void,
   void,
   void,
   void,
@@ -80,6 +96,10 @@ export function useNoAuth(): AuthContextInterface<
 }
 
 export type UseAuth = () => AuthContextInterface<
+  unknown,
+  unknown,
+  unknown,
+  unknown,
   unknown,
   unknown,
   unknown,

--- a/packages/router/src/router-context.tsx
+++ b/packages/router/src/router-context.tsx
@@ -12,6 +12,10 @@ type UseAuth = () => AuthContextInterface<
   unknown,
   unknown,
   unknown,
+  unknown,
+  unknown,
+  unknown,
+  unknown,
   unknown
 >
 


### PR DESCRIPTION
Provide types for the auth method options, like `options` in `logIn(options)` and `signUp(options)`

Users who were previously (probably unknowingly) passing unsupported parameters to `logIn`, `signUp` and a few more methods will now see TS type errors when trying to build their code base, requiring them to fix their code.