### PR TITLE
Include experiments in telemetry payload

### DIFF
--- a/packages/internal/src/config.ts
+++ b/packages/internal/src/config.ts
@@ -73,6 +73,9 @@ export interface Config {
   notifications: {
     versionUpdates: string[]
   }
+  experiments: {
+    enabled: string[]
+  }
 }
 
 // Note that web's includeEnvironmentVariables is handled in `webpack.common.js`
@@ -111,6 +114,9 @@ const DEFAULT_CONFIG: Config = {
   },
   notifications: {
     versionUpdates: [],
+  },
+  experiments: {
+    enabled: [],
   },
 }
 

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -90,10 +90,13 @@ const getInfo = async (presets: Args = {}) => {
   const mem = await system.mem()
 
   // Must only call getConfig() once the project is setup - so not within telemetry for CRWA
+  const isCrwa = presets.command?.startsWith('create redwood-app')
+
   // Default to 'webpack' for new projects
-  const webBundler = presets.command?.startsWith('create redwood-app')
-    ? 'webpack'
-    : getConfig().web.bundler
+  const webBundler = isCrwa ? 'webpack' : getConfig().web.bundler
+  // New projects don't have any experiments going, so we default to an empty
+  // array
+  const experiments = isCrwa ? { enabled: [] } : getConfig().experiments
 
   return {
     os: info.System?.OS?.split(' ')[0],
@@ -107,6 +110,7 @@ const getInfo = async (presets: Args = {}) => {
       presets.redwoodVersion || info.npmPackages['@redwoodjs/core']?.installed,
     system: `${cpu.physicalCores}.${Math.round(mem.total / 1073741824)}`,
     webBundler,
+    experiments,
   }
 }
 


### PR DESCRIPTION
We want to be able to measure how popular our experiments are. One way to do that is to list them in `redwood.toml` and then include them in our telemetry data. This has previously been discussed in https://github.com/redwoodjs/redwood/pull/7536#issuecomment-1416549530 and other places.

First I tried this:
```toml
[web]
  title = "Redwood App"
  port = 8910
  apiUrl = "/.redwood/functions"
  includeEnvironmentVariables = []
[api]
  port = 8911
[browser]
  open = true
[notifications]
  versionUpdates = ["latest"]
experiments = ["websockets"]
```

But that will actually nest them inside `notifications`, like this
```js
notifications: {
  versionUpdates: ['latest']
  experiments: ['websockets']
}
```

To make it work we need to place it at the top of the file, before any sections are declared
```toml
experiments = ["websockets"]
[web]
  title = "Redwood App"
  port = 8910
  apiUrl = "/.redwood/functions"
  includeEnvironmentVariables = []
[api]
  port = 8911
[browser]
  open = true
[notifications]
  versionUpdates = ["latest"]
```

But since everything else is in a section it didn't feel right.

Also considered
```toml
[web]
  title = "Redwood App"
  port = 8910
  apiUrl = "/.redwood/functions"
  includeEnvironmentVariables = []
[api]
  port = 8911
[browser]
  open = true
[notifications]
  versionUpdates = ["latest"]
[tracking]
  experiments = ["websockets"]
```

That one is probably the most correct, but might not be PC enough

Could do
```toml
[web]
  title = "Redwood App"
  port = 8910
  apiUrl = "/.redwood/functions"
  includeEnvironmentVariables = []
[api]
  port = 8911
[browser]
  open = true
[notifications]
  versionUpdates = ["latest"]
[telemetry]
  experiments = ["websockets"]
```

But ultimately I settled for
```toml
[web]
  title = "Redwood App"
  port = 8910
  apiUrl = "/.redwood/functions"
  includeEnvironmentVariables = []
[api]
  port = 8911
[browser]
  open = true
[notifications]
  versionUpdates = ["latest"]
[experiments]
  enabled = ["websockets"]
```

It makes it possible to add
```toml
[experiments]
  available = ["rest", "subscriptions", "trpc"]
```
For discoverability of other experiments

And
```toml
[experiments.rest]
  basePath = '/rest'
```
For experimental specific config

What I don't like about it though, especially for my WebSockets experiment, is that people might think it's a toggle for turning the experiment on or off. But you can't really turn the WebSockets experiment off by just editing a config file. You have to remove the fastify config to turn it off. And you can't enable it by just adding it to redwood.toml. You have to run the setup command.

Happy for any kind of input on the syntax or even the general idea