### PR TITLE
Keep prerender component tree the same as regular render tree

### DIFF
--- a/packages/internal/src/build/babelPlugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/internal/src/build/babelPlugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -62,9 +62,15 @@ export default function (
         )[0]
 
         // Remove Page imports in prerender mode (see babel-preset)
-        // This is to make sure that all the imported "Page modules" are normal imports
-        // and not asynchronous ones.
-        // But note that jest in a user's project does not enter this block, but our tests do
+        // The removed imports will be replaced further down in this file
+        // with declarations like these:
+        // const HomePage = {
+        //   name: "HomePage",
+        //   loader: () => require("./pages/HomePage/HomePage")
+        // };
+        // This is to make sure that all the imported "Page modules" are normal
+        // imports and not asynchronous ones.
+        // Note that jest in a user's project does not enter this block, but our tests do
         if (useStaticImports) {
           // Match import paths, const name could be different
 


### PR DESCRIPTION
React 18's tree diffing works differently compared to React 17.

This PR changes the logic so that we use the same code for both pre-render and regular rendering to a much greater extent. 