### PR TITLE
prerender.spec.ts: Fix TS errors

### DIFF
--- a/tasks/smoke-test/tests/prerender.spec.ts
+++ b/tasks/smoke-test/tests/prerender.spec.ts
@@ -12,6 +12,11 @@ import execa from 'execa'
 import rwServeTest from '../playwright-fixtures/rwServe.fixture'
 import type { ServeFixture } from '../playwright-fixtures/rwServe.fixture'
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
+}
+
 let noJsBrowser: BrowserContext
 rwServeTest.beforeAll(async ({ browser }: PlaywrightWorkerArgs) => {
   noJsBrowser = await browser.newContext({
@@ -26,9 +31,9 @@ rwServeTest(
     await pageWithoutJs.goto(`http://localhost:${port}/`)
 
     const cellSuccessState = await pageWithoutJs.locator('main').innerHTML()
-    expect(cellSuccessState).toMatch('Welcome to the blog!')
-    expect(cellSuccessState).toMatch('A little more about me')
-    expect(cellSuccessState).toMatch('What is the meaning of life?')
+    expect(cellSuccessState).toMatch(/Welcome to the blog!/)
+    expect(cellSuccessState).toMatch(/A little more about me/)
+    expect(cellSuccessState).toMatch(/What is the meaning of life\?/)
 
     const navTitle = await pageWithoutJs.locator('header >> h1').innerText()
     expect(navTitle).toBe('Redwood Blog')
@@ -61,11 +66,11 @@ rwServeTest(
     await pageWithoutJs.goto(`http://localhost:${port}${meaningOfLifeHref}`)
 
     const mainContent = await pageWithoutJs.locator('main').innerHTML()
-    expect(mainContent).toMatch('What is the meaning of life?')
+    expect(mainContent).toMatch(/What is the meaning of life\?/)
     // Test that nested cell content is also rendered
-    expect(mainContent).toMatch('user.two@example.com')
-    expect(mainContent).not.toMatch('Welcome to the blog!')
-    expect(mainContent).not.toMatch('A little more about me')
+    expect(mainContent).toMatch(/user\.two@example\.com/)
+    expect(mainContent).not.toMatch(/Welcome to the blog!/)
+    expect(mainContent).not.toMatch(/A little more about me/)
 
     const navTitle = await pageWithoutJs.locator('header >> h1').innerText()
     expect(navTitle).toBe('Redwood Blog')
@@ -83,7 +88,7 @@ rwServeTest(
 )
 
 rwServeTest(
-  'Check that <meta> tags are rendering the correct dynamic data',
+  'Check that meta-tags are rendering the correct dynamic data',
   async ({ port }: ServeFixture & PlaywrightTestArgs) => {
     const pageWithoutJs = await noJsBrowser.newPage()
 
@@ -114,9 +119,9 @@ rwServeTest(
     await pageWithoutJs.goto(`http://localhost:${port}`)
 
     let mainContent = await pageWithoutJs.locator('main').innerHTML()
-    expect(mainContent).toMatch('Welcome to the blog!')
-    expect(mainContent).toMatch('A little more about me')
-    expect(mainContent).toMatch('What is the meaning of life?')
+    expect(mainContent).toMatch(/Welcome to the blog!/)
+    expect(mainContent).toMatch(/A little more about me/)
+    expect(mainContent).toMatch(/What is the meaning of life\?/)
 
     await pageWithoutJs.goto(`http://localhost:${port}/`)
     const aboutMeAnchor = await pageWithoutJs.locator(
@@ -129,10 +134,12 @@ rwServeTest(
     expect(aboutMeAnchorHref).not.toEqual('')
 
     mainContent = await pageWithoutJs.locator('main').innerHTML()
-    expect(mainContent).toMatch('A little more about me')
-    expect(mainContent).not.toMatch('Welcome to the blog!')
-    expect(mainContent).not.toMatch('What is the meaning of life?')
-    expect(pageWithoutJs.url()).toMatch(aboutMeAnchorHref)
+    expect(mainContent).toMatch(/A little more about me/)
+    expect(mainContent).not.toMatch(/Welcome to the blog!/)
+    expect(mainContent).not.toMatch(/What is the meaning of life\?/)
+    expect(pageWithoutJs.url()).toMatch(
+      new RegExp(escapeRegExp(aboutMeAnchorHref))
+    )
 
     pageWithoutJs.close()
   }
@@ -181,7 +188,7 @@ rwServeTest('prerender with broken gql query', async () => {
     })
   } catch (e) {
     expect(e.message).toMatch(
-      'GQL error: Cannot query field "timestamp" on type "Post".'
+      /GQL error: Cannot query field "timestamp" on type "Post"\./
     )
   }
 
@@ -208,7 +215,7 @@ rwServeTest(
     const mainContent = await pageWithoutJs.locator('main').innerHTML()
     expect(mainContent).toMatch(/<header.*<h2.*>[\w\s?!]+<\/h2><\/header>/)
     // Test that nested cell content is also rendered
-    expect(mainContent).toMatch('class="author-cell"')
+    expect(mainContent).toMatch(/class="author-cell"/)
     expect(mainContent).toMatch(/user.(one|two)@example.com/)
 
     pageWithoutJs.close()


### PR DESCRIPTION
This PR fixes errors like these
![image](https://user-images.githubusercontent.com/30793/222978173-bd84fdb1-fbf9-4523-bdd2-eec8ef958e82.png)

Also does this change
![image](https://user-images.githubusercontent.com/30793/222978432-c563472b-ca13-4969-a0bf-9be3c1257c12.png)
![image](https://user-images.githubusercontent.com/30793/222978445-64f8789a-5146-4e18-811d-1f22ff2af0ef.png)
Because Replay strips html tags from test names. So when showing a failed test the name won't match the name in our source code, making it difficult to find
