### PR TITLE
docs(roles): Update using roles to limit a private route

### DIFF
--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -134,8 +134,6 @@ becomes...
 
 Sets can take a `private` prop which makes all Routes inside that Set require authentication. When a user isn't authenticated and attempts to visit one of the Routes in the private Set, they'll be redirected to the Route passed as the Set's `unauthenticated` prop. The originally-requested Route's path is added to the query string as a `redirectTo` param. This lets you send the user to the page they originally requested once they're logged-in.
 
-For more fine-grained control, you can specify `roles` (which takes a string for a single role or an array of roles), and the router will check to see that the user is authorized before giving them access to the Route. If they're not, it'll redirect them in the same way as above.
-
 Here's an example of how you'd use a private set:
 
 ```jsx title="Routes.js"
@@ -157,6 +155,32 @@ Here's the same example again, but now using `<Private>`
   <Private unauthenticated="home">
     <Route path="/admin" page={AdminPage} name="admin" />
   </Private>
+</Router>
+```
+
+For more fine-grained control, you can specify `roles` (which takes a string for a single role or an array of roles), and the router will check to see that the current user is authorized before giving them access to the Route. If they're not, they will be redirected to the page specified in the `unauthenticated` prop, such as a "forbidden" page. Read more about Role-based Access Control in Redwood [here](how-to/role-based-access-control.md).
+
+To protect `Private` routes for access by a single role:
+
+```jsx title="Routes.js"
+<Router>
+  <Private unauthenticated="forbidden" roles="admin">
+    <Route path="/admin/users" page={UsersPage} name="users" />
+  </Private>
+
+  <Route path="/forbidden" page={ForbiddenPage} name="forbidden" />
+</Router>
+```
+
+To protect `Private` routes for access by multiple roles:
+
+```jsx title="Routes.js"
+<Router>
+  <Private unauthenticated="forbidden" roles={['admin', 'editor', 'publisher']}>
+    <Route path="/admin/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />
+  </Private>
+
+  <Route path="/forbidden" page={ForbiddenPage} name="forbidden" />
 </Router>
 ```
 


### PR DESCRIPTION
Update docs in Router's `private` Set section to include more information and code examples on using roles.

closes https://github.com/redwoodjs/redwood/issues/5997 