### PR TITLE
fix cli yarn rw destroy graphiql command

### DIFF
--- a/packages/cli/src/commands/destroy/graphiql/graphiql.js
+++ b/packages/cli/src/commands/destroy/graphiql/graphiql.js
@@ -8,7 +8,7 @@ import {
   getGraphqlPath,
 } from '../../../lib'
 import c from '../../../lib/colors'
-import { getOutputPath } from '../../setup/graphiql/graphiql'
+import { getOutputPath } from '../../setup/graphiql/graphiqlHelpers'
 
 const removeGraphiqlFromGraphqlHandler = () => {
   const graphqlPath = getGraphqlPath()


### PR DESCRIPTION
Currently `yarn rw destroy graphiql` throws

```js
TypeError: (0 , _graphiql.getOutputPath) is not a function
    at Object.handler (<project_path>/node_modules/@redwoodjs/cli/dist/commands/destroy/graphiql/graphiql.js:32:44)
    at <project_path>/node_modules/yargs/build/index.cjs:1:8993
    at <project_path>/node_modules/yargs/build/index.cjs:1:4949
error Command failed with exit code 1.
```
This is because `getOutputPath` is imported from

`import { getOutputPath } from '../../setup/graphiql/graphiql`

instead of

`import { getOutputPath } from '../../setup/graphiql/graphiqlHelpers'`

I guess this broke when the graphiql setup logic was refactored.

regards