### PR TITLE
babel-plugin-redwood-routes-auto-loader.tests.ts: Break up into separate tests

### DIFF
--- a/packages/internal/src/build/babelPlugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
+++ b/packages/internal/src/build/babelPlugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
@@ -11,13 +11,6 @@ const FIXTURE_PATH = path.resolve(
   '../../../../../../__fixtures__/example-todo-main/'
 )
 
-beforeAll(() => {
-  process.env.RWJS_CWD = FIXTURE_PATH
-})
-afterAll(() => {
-  delete process.env.RWJS_CWD
-})
-
 const transform = (filename: string) => {
   const code = fs.readFileSync(filename, 'utf-8')
   return babel.transform(code, {
@@ -27,14 +20,25 @@ const transform = (filename: string) => {
   })
 }
 
-test('page auto loader correctly imports pages', () => {
-  const result = transform(getPaths().web.routes)
+describe('page auto loader correctly imports pages', () => {
+  let result: babel.BabelFileResult | null
 
-  // Pages are automatically imported
-  expect(result.code).toContain(`const HomePage = {
+  beforeAll(() => {
+    process.env.RWJS_CWD = FIXTURE_PATH
+    result = transform(getPaths().web.routes)
+  })
+
+  afterAll(() => {
+    delete process.env.RWJS_CWD
+  })
+
+  test('Pages are automatically imported', () => {
+    expect(result?.code).toContain(`const HomePage = {
   name: "HomePage",
   loader: () => import("`)
+  })
 
-  // Already imported pages are left alone.
-  expect(result.code).toContain(`import FooPage from 'src/pages/FooPage'`)
+  test('Already imported pages are left alone.', () => {
+    expect(result?.code).toContain(`import FooPage from 'src/pages/FooPage'`)
+  })
 })


### PR DESCRIPTION
Refactor tests
Wrap tests in a `describe`, and break the one test with multiple assertions up into separate tests.