### PR TITLE
Mention both the template file and the model on a template crash

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -62,15 +62,20 @@ export const nameVariants = (name) => {
 }
 
 export const generateTemplate = (templateFilename, { name, ...rest }) => {
-  const template = lodash.template(readFile(templateFilename).toString())
+  try {
+    const template = lodash.template(readFile(templateFilename).toString())
 
-  const renderedTemplate = template({
-    name,
-    ...nameVariants(name),
-    ...rest,
-  })
+    const renderedTemplate = template({
+      name,
+      ...nameVariants(name),
+      ...rest,
+    })
 
-  return prettify(templateFilename, renderedTemplate)
+    return prettify(templateFilename, renderedTemplate)
+  } catch (error) {
+    error.message = `Error applying template at ${templateFilename} for ${name}: ${error.message}`
+    throw error
+  }
 }
 
 export const prettify = (templateFilename, renderedTemplate) => {


### PR DESCRIPTION
As it looks like the exposed variables to templates have changed between versions, my older templates don't work anymore - the crash looks like this:

```
> yarn rw g scaffold admin/thing --tests false
⠙ Generating scaffold files...
◼ Install helper packages
⠼ Generating scaffold files...
✖ editableColumns is not defined
◼ Install helper packages
◼ Adding layout import...
◼ Adding set import...
◼ Adding scaffold routes...
◼ Adding scaffold asset imports...
◼ Generating types ...
editableColumns is not defined
```

Which wasn't too useful, so the templating fn now re-throws with templating info added to the message:

```
> yarn rw g scaffold admin/ads --tests false
Debugger attached.
Debugger attached.
Debugger attached.
⠙ Generating scaffold files...
◼ Install helper packages
◼ Adding layout import...
⠴ Generating scaffold files...
✖ Error generating template /home/orta/dev/redwoodapp/web/generators/scaffold/pages/NamePage.tsx.template for Thing: editableColumns is not defined
◼ Install helper packages
◼ Adding layout import...
◼ Adding set import...
◼ Adding scaffold routes...
◼ Adding scaffold asset imports...
◼ Generating types ...
Error generating template /home/orta/dev/redwoodapp/web/generators/scaffold/pages/NamePage.tsx.template for Thing: editableColumns is not defined
```