### PR TITLE
fix(Clerk): call reauthenticate before navigating

### DIFF
--- a/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
+++ b/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
@@ -1,27 +1,24 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 
-import { ClerkProvider, useUser } from '@clerk/clerk-react'
+import { ClerkProvider } from '@clerk/clerk-react'
 
 import { createAuth } from '@redwoodjs/auth-clerk-web'
 import { navigate } from '@redwoodjs/router'
 
 export const { AuthProvider: ClerkRwAuthProvider, useAuth } = createAuth()
 
-interface Props {
-  children: React.ReactNode
-}
-
-const ClerkStatusUpdater = () => {
-  const { isSignedIn, user, isLoaded } = useUser()
+const ClerkProviderWrapper = ({ children, clerkOptions}) => {
   const { reauthenticate } = useAuth()
 
-  useEffect(() => {
-    if (isLoaded) {
-      reauthenticate()
-    }
-  }, [isSignedIn, user, reauthenticate, isLoaded])
+  return (
+    <ClerkProvider {...clerkOptions} navigate={(to) => reauthenticate().then(() => navigate(to))}>
+      {children}
+    </ClerkProvider>
+  )
+}
 
-  return null
+interface Props {
+  children: React.ReactNode
 }
 
 export const AuthProvider = ({ children }: Props) => {
@@ -38,11 +35,8 @@ export const AuthProvider = ({ children }: Props) => {
     : { frontendApi }
 
   return (
-    <ClerkProvider {...clerkOptions} navigate={(to) => navigate(to)}>
-      <ClerkRwAuthProvider>
-        {children}
-        <ClerkStatusUpdater />
-      </ClerkRwAuthProvider>
-    </ClerkProvider>
+    <ClerkRwAuthProvider>
+      <ClerkProviderWrapper clerkOptions={clerkOptions}>{children}</ClerkProviderWrapper>
+    </ClerkRwAuthProvider>
   )
 }

--- a/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
+++ b/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
@@ -20,11 +20,18 @@ const ClerkStatusUpdater = () => {
   return null
 }
 
+type ClerkOptions =
+  | { publishableKey: string; frontendApi?: never }
+  | { publishableKey?: never; frontendApi: string }
+
 interface Props {
   children: React.ReactNode
 }
 
-const ClerkProviderWrapper = ({ children, clerkOptions }: Props) => {
+const ClerkProviderWrapper = ({
+  children,
+  clerkOptions,
+}: Props & { clerkOptions: ClerkOptions }) => {
   const { reauthenticate } = useAuth()
 
   return (
@@ -42,10 +49,6 @@ export const AuthProvider = ({ children }: Props) => {
   const publishableKey = process.env.CLERK_PUBLISHABLE_KEY
   const frontendApi =
     process.env.CLERK_FRONTEND_API_URL || process.env.CLERK_FRONTEND_API
-
-  type ClerkOptions =
-    | { publishableKey: string; frontendApi?: never }
-    | { publishableKey?: never; frontendApi: string }
 
   const clerkOptions: ClerkOptions = publishableKey
     ? { publishableKey }

--- a/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
+++ b/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
@@ -7,6 +7,19 @@ import { navigate } from '@redwoodjs/router'
 
 export const { AuthProvider: ClerkRwAuthProvider, useAuth } = createAuth()
 
+const ClerkStatusUpdater = () => {
+  const { isSignedIn, user, isLoaded } = useUser()
+  const { reauthenticate } = useAuth()
+
+  useEffect(() => {
+    if (isLoaded) {
+      reauthenticate()
+    }
+  }, [isSignedIn, user, reauthenticate, isLoaded])
+
+  return null
+}
+
 const ClerkProviderWrapper = ({ children, clerkOptions }) => {
   const { reauthenticate } = useAuth()
 
@@ -16,6 +29,7 @@ const ClerkProviderWrapper = ({ children, clerkOptions }) => {
       navigate={(to) => reauthenticate().then(() => navigate(to))}
     >
       {children}
+      <ClerkStatusUpdater />
     </ClerkProvider>
   )
 }

--- a/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
+++ b/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
@@ -7,11 +7,14 @@ import { navigate } from '@redwoodjs/router'
 
 export const { AuthProvider: ClerkRwAuthProvider, useAuth } = createAuth()
 
-const ClerkProviderWrapper = ({ children, clerkOptions}) => {
+const ClerkProviderWrapper = ({ children, clerkOptions }) => {
   const { reauthenticate } = useAuth()
 
   return (
-    <ClerkProvider {...clerkOptions} navigate={(to) => reauthenticate().then(() => navigate(to))}>
+    <ClerkProvider
+      {...clerkOptions}
+      navigate={(to) => reauthenticate().then(() => navigate(to))}
+    >
       {children}
     </ClerkProvider>
   )
@@ -36,7 +39,9 @@ export const AuthProvider = ({ children }: Props) => {
 
   return (
     <ClerkRwAuthProvider>
-      <ClerkProviderWrapper clerkOptions={clerkOptions}>{children}</ClerkProviderWrapper>
+      <ClerkProviderWrapper clerkOptions={clerkOptions}>
+        {children}
+      </ClerkProviderWrapper>
     </ClerkRwAuthProvider>
   )
 }

--- a/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
+++ b/packages/auth-providers/clerk/setup/src/templates/web/auth.tsx.template
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
-import { ClerkProvider } from '@clerk/clerk-react'
+import { ClerkProvider, useUser } from '@clerk/clerk-react'
 
 import { createAuth } from '@redwoodjs/auth-clerk-web'
 import { navigate } from '@redwoodjs/router'
@@ -20,7 +20,11 @@ const ClerkStatusUpdater = () => {
   return null
 }
 
-const ClerkProviderWrapper = ({ children, clerkOptions }) => {
+interface Props {
+  children: React.ReactNode
+}
+
+const ClerkProviderWrapper = ({ children, clerkOptions }: Props) => {
   const { reauthenticate } = useAuth()
 
   return (
@@ -32,10 +36,6 @@ const ClerkProviderWrapper = ({ children, clerkOptions }) => {
       <ClerkStatusUpdater />
     </ClerkProvider>
   )
-}
-
-interface Props {
-  children: React.ReactNode
 }
 
 export const AuthProvider = ({ children }: Props) => {


### PR DESCRIPTION
Our Clerk set up is broken right now. See this topic on the forums for details:

- https://community.redwoodjs.com/t/clerk-the-signup-and-signin-components-cannot-render-when-a-user-is-already-signed-in-unless-the-application-allows-multiple-sessions-since-a-user-is-signed-in-and-this-application-only-allows-a-single-session/4694

This is a fix suggested by the Clerk team. We may iterate on it still, but it's already been broken for some time and I don't want there to be more broken projects.

This doesn't help existing projects. I'm working on a codemod for that.