### PR TITLE
fix(rw-dev): with vite

### DIFF
--- a/packages/vite/bins/rw-vite-dev.mjs
+++ b/packages/vite/bins/rw-vite-dev.mjs
@@ -1,8 +1,8 @@
 import { createServer } from 'vite'
 
-import { getPaths } from '@redwoodjs/project-config'
+import projectConfig from '@redwoodjs/project-config'
 
-const rwPaths = getPaths()
+const rwPaths = projectConfig.getPaths()
 
 const startDevServer = async () => {
   const configFile = rwPaths.web.viteConfig


### PR DESCRIPTION
### What? 
Recent changes to split out internal into project-config broke the RW vite dev handler, with the error:

```
web | file:///Users/dac09/Projects/nodeconf-rw-recipe/node_modules/@redwoodjs/vite/bins/rw-vite-dev.mjs:3
web | import { getPaths } from '@redwoodjs/project-config'
web |          ^^^^^^^^
web | SyntaxError: Named export 'getPaths' not found. The requested module '@redwoodjs/project-config' is a CommonJS module, which may not support all module.exports as named exports.
web | CommonJS modules can always be imported via the default export, for example using:
web | import pkg from '@redwoodjs/project-config';
web | const { getPaths } = pkg;
```

This PR fixes it according to the suggestion in the error 