### PR TITLE
fix upgrade.js error message

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -190,7 +190,7 @@ async function yarnInstall({ verbose }) {
     )
   } catch (e) {
     throw new Error(
-      'Could not finish installation. Please run `yarn install --force`, before continuing'
+      'Could not finish installation. Please run `yarn install` and then `yarn dedupe`, before continuing'
     )
   }
 }


### PR DESCRIPTION
fixes #7910

--force is no longer a valid option for yarn install (as of yarn v3)