### PR TITLE
chore(ci): Update node version for telemetry check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16.20, 18]
+        node-version: [16.20.0, 18]
       fail-fast: true
     name: 🔭 Telemetry check / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
@@ -360,7 +360,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16.20, 18]
+        node-version: [16.20.0, 18]
     name: 🔭 Telemetry check / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,7 +330,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16, 18]
+        node-version: [16.20, 18]
       fail-fast: true
     name: 🔭 Telemetry check / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
@@ -360,7 +360,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [16, 18]
+        node-version: [16.20, 18]
     name: 🔭 Telemetry check / ${{ matrix.os }} / node ${{ matrix.node-version }} latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
**Problem**
After updating the engine check requirements to a minimum of `16.20` the GitHub ci node version is too low for telemetry checks to run as intended.

**Changes**
Update from `16` to `16.20.0` in the node version. 