### PR TITLE
Fastify server: Default to localhost

### DIFF
--- a/packages/api-server/src/server.ts
+++ b/packages/api-server/src/server.ts
@@ -11,10 +11,9 @@ export const startServer = ({
   socket,
   fastify,
 }: HttpServerParams) => {
-  const host = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
   const serverPort = socket ? parseInt(socket) : port
 
-  fastify.listen({ port: serverPort, host })
+  fastify.listen({ port: serverPort })
 
   fastify.ready(() => {
     fastify.log.debug(


### PR DESCRIPTION
The table here is good for understanding the `host` options https://www.fastify.io/docs/latest/Reference/Server/#listen

I chose to just remove the option, which will use the default, which is `localhost`. If someone prefers to be more explicit about it, let me know and I'll add it in.

I needed this change for #8002 
It will also work towards making it possible to use RW in ipv6-only environments (at least it should help, more changes might be needed in other places)