### PR TITLE
chore(cli): Enable 'next' and 'experimental' tags for `rw upgrade`

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -2043,7 +2043,7 @@ A canary release is published to npm every time a PR is merged to the `main` bra
 | Option          | Description                                                                                                                                                                                                        |
 | :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dry-run, -d` | Check for outdated packages without upgrading                                                                                                                                                                      |
-| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", "experimental", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "experimental" and "rc" will force upgrade packages to the most recent release of the specified tag. |
+| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", "experimental", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "rc", "next", and "experimental". And "canary" releases include breaking changes often requiring codemods if upgrading a project. |
 
 **Example**
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -2043,7 +2043,7 @@ A canary release is published to npm every time a PR is merged to the `main` bra
 | Option          | Description                                                                                                                                                                                                        |
 | :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dry-run, -d` | Check for outdated packages without upgrading                                                                                                                                                                      |
-| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", a tag beginning with "experimental-", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "experimental-" and "rc" will force upgrade packages to the most recent release of the specified tag. |
+| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", "experimental", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "experimental" and "rc" will force upgrade packages to the most recent release of the specified tag. |
 
 **Example**
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -2043,7 +2043,7 @@ A canary release is published to npm every time a PR is merged to the `main` bra
 | Option          | Description                                                                                                                                                                                                        |
 | :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dry-run, -d` | Check for outdated packages without upgrading                                                                                                                                                                      |
-| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", "experimental", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "experimental" and "rc" will force upgrade packages to the most recent release of the specified tag. |
+| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", a tag beginning with "experimental-", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "experimental-" and "rc" will force upgrade packages to the most recent release of the specified tag. |
 
 **Example**
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -2043,7 +2043,7 @@ A canary release is published to npm every time a PR is merged to the `main` bra
 | Option          | Description                                                                                                                                                                                                        |
 | :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dry-run, -d` | Check for outdated packages without upgrading                                                                                                                                                                      |
-| `--tag, -t`     | Choices are "canary", "rc", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary" and "rc", which will force upgrade packages to the most recent release of the specified tag. |
+| `--tag, -t`     | Choices are "rc", "canary", "latest", "next", "experimental", or a specific version (e.g. "0.19.3"). WARNING: Unstable releases in the case of "canary", "experimental" and "rc" will force upgrade packages to the most recent release of the specified tag. |
 
 **Example**
 

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -30,7 +30,7 @@ export const builder = (yargs) => {
     .option('tag', {
       alias: 't',
       description:
-        '[choices: "rc", "canary", "latest", "next", "experimental", or specific-version (see example below)] WARNING: "canary", "rc" and "experimental" tags are unstable releases!',
+        '[choices: "rc", "canary", "latest", "next", a tag beginning with "experimental-", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental-" tags are unstable releases!',
       requiresArg: true,
       type: 'string',
       coerce: validateTag,
@@ -67,14 +67,15 @@ const SEMVER_REGEX =
   /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/i
 export const validateTag = (tag) => {
   const isTagValid =
-    ['rc', 'canary', 'latest', 'next', 'experimental'].includes(tag) ||
+    ['rc', 'canary', 'latest', 'next'].includes(tag) ||
+    tag.startsWith('experimental-') ||
     SEMVER_REGEX.test(tag)
 
   if (!isTagValid) {
     // Stop execution
     throw new Error(
       c.error(
-        "Invalid tag supplied. Supported values: 'rc', 'canary', 'latest', 'next', 'experimental', or valid semver version\n"
+        "Invalid tag supplied. Supported values: 'rc', 'canary', 'latest', 'next', a tag beginning with 'experimental-', or a valid semver version\n"
       )
     )
   }

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -30,7 +30,7 @@ export const builder = (yargs) => {
     .option('tag', {
       alias: 't',
       description:
-        '[choices: "rc", "canary", "latest", "next", a tag beginning with "experimental-", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental-" tags are unstable releases!',
+        '[choices: "rc", "canary", "latest", "next", "experimental", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental" are unstable releases!',
       requiresArg: true,
       type: 'string',
       coerce: validateTag,
@@ -67,15 +67,14 @@ const SEMVER_REGEX =
   /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/i
 export const validateTag = (tag) => {
   const isTagValid =
-    ['rc', 'canary', 'latest', 'next'].includes(tag) ||
-    tag.startsWith('experimental-') ||
+    ['rc', 'canary', 'latest', 'next', 'experimental'].includes(tag) ||
     SEMVER_REGEX.test(tag)
 
   if (!isTagValid) {
     // Stop execution
     throw new Error(
       c.error(
-        "Invalid tag supplied. Supported values: 'rc', 'canary', 'latest', 'next', a tag beginning with 'experimental-', or a valid semver version\n"
+        "Invalid tag supplied. Supported values: 'rc', 'canary', 'latest', 'next', 'experimental', or a valid semver version\n"
       )
     )
   }

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -67,16 +67,14 @@ const SEMVER_REGEX =
   /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/i
 export const validateTag = (tag) => {
   const isTagValid =
-    tag === 'rc' ||
-    tag === 'canary' ||
-    tag === 'latest' ||
+    ['rc', 'canary', 'latest', 'next', 'experimental'].includes(tag) ||
     SEMVER_REGEX.test(tag)
 
   if (!isTagValid) {
     // Stop execution
     throw new Error(
       c.error(
-        'Invalid tag supplied. Supported values: rc, canary, latest, or valid semver version\n'
+        "Invalid tag supplied. Supported values: 'rc', 'canary', 'latest', 'next', 'experimental', or valid semver version\n"
       )
     )
   }

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -30,7 +30,7 @@ export const builder = (yargs) => {
     .option('tag', {
       alias: 't',
       description:
-        '[choices: "rc", "canary", "latest", "next", "experimental", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental" are unstable releases!',
+        '[choices: "rc", "canary", "latest", "next", "experimental", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental" are unstable releases! And "canary" releases include breaking changes often requiring codemods if upgrading a project.',
       requiresArg: true,
       type: 'string',
       coerce: validateTag,

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -30,7 +30,7 @@ export const builder = (yargs) => {
     .option('tag', {
       alias: 't',
       description:
-        '[choices: "rc", "canary", "latest", "next", "experimental", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental" are unstable releases! And "canary" releases include breaking changes often requiring codemods if upgrading a project.',
+        '[choices: "latest", "rc", "next", "canary", "experimental", or a specific-version (see example below)] WARNING: "canary", "rc" and "experimental" are unstable releases! And "canary" releases include breaking changes often requiring codemods if upgrading a project.',
       requiresArg: true,
       type: 'string',
       coerce: validateTag,

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -30,7 +30,7 @@ export const builder = (yargs) => {
     .option('tag', {
       alias: 't',
       description:
-        '[choices: "canary", "rc", or specific-version (see example below)] WARNING: "canary" and "rc" tags are unstable releases!',
+        '[choices: "rc", "canary", "latest", "next", "experimental", or specific-version (see example below)] WARNING: "canary", "rc" and "experimental" tags are unstable releases!',
       requiresArg: true,
       type: 'string',
       coerce: validateTag,


### PR DESCRIPTION
**Problem**
We want to allow users to select the `next` and `experimental` tags when running `yarn rw upgrade --tag [tag]` but this is currently not allowed.

**Changes**
1. Add `next` and `experimental` to the allowed tags list.
2. Update the docs to reflect the updated tag options.