### PR TITLE
Allow .mts and .mjs file extensions

### DIFF
--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -122,7 +122,7 @@ export const getBaseDirFromFile = (file: string) => {
  */
 export const resolveFile = (
   filePath: string,
-  extensions: string[] = ['.js', '.tsx', '.ts', '.jsx']
+  extensions: string[] = ['.js', '.tsx', '.ts', '.jsx', '.mjs', '.mts']
 ): string | null => {
   for (const extension of extensions) {
     const p = `${filePath}${extension}`


### PR DESCRIPTION
While working through a vite config issue related to @mdx-js/rollup, one potential solution involved changing the `vite.config` file extension to `.mts`. It seems like vite supports this extension but Redwood project-config code currently does not allow it. I'm submitting this PR in case this is a "no down side" sort of issue. If there are non-obvious ramifications that makes this not worth it, please go ahead and close. Thank you, RW team!