### PR TITLE
fix(babel-vite): Also transform jsx Cell files

### DIFF
--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -107,7 +107,7 @@ export const getWebSideOverrides = (
 ) => {
   const overrides = [
     {
-      test: /.+Cell.(js|tsx)$/,
+      test: /.+Cell.(js|tsx|jsx)$/,
       plugins: [require('../babelPlugins/babel-plugin-redwood-cell').default],
     },
     // Automatically import files in `./web/src/pages/*` in to


### PR DESCRIPTION
### What's the problem?
If you had a cell named like this `MyCell.jsx` the babel transform wouldn't pick it up, because we were only looking for `js` or `tsx` files. 

### Fix
Just add `jsx` to the list of extensions to match against