### PR TITLE
Fix flightcontrol deploy with new install command

### DIFF
--- a/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
+++ b/packages/cli/src/commands/setup/deploy/templates/flightcontrol.js
@@ -32,6 +32,7 @@ export const flightcontrolConfig = {
           type: 'static',
           buildType: 'nixpacks',
           singlePageApp: true,
+          installCommand: 'NODE_ENV=development yarn install --immutable',
           buildCommand: 'yarn rw deploy flightcontrol web',
           outputDirectory: 'web/dist',
           envVariables: {


### PR DESCRIPTION
This is a fix for https://github.com/redwoodjs/redwood/issues/7641, where the Redwood Web service does not deploy on Flightcontrol due to the following error:
`Unknown Syntax Error: Invalid option name ("--production=false").`

Adding the `installCommand`, based on the discussion in the linked issue, fixes the issue and results in a successful deploy.