### PR TITLE
Use webpack for prod building even when vite is enabled in RW apps

### DIFF
--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -7,12 +7,11 @@ import rimraf from 'rimraf'
 import terminalLink from 'terminal-link'
 
 import { buildApi } from '@redwoodjs/internal/dist/build/api'
-import { buildWeb } from '@redwoodjs/internal/dist/build/web'
 import { loadAndValidateSdls } from '@redwoodjs/internal/dist/validateSchema'
 import { detectPrerenderRoutes } from '@redwoodjs/prerender/detection'
 import { timedTelemetry, errorTelemetry } from '@redwoodjs/telemetry'
 
-import { getPaths, getConfig } from '../lib'
+import { getPaths } from '../lib'
 import c from '../lib/colors'
 import { generatePrismaCommand } from '../lib/generatePrismaClient'
 
@@ -86,32 +85,24 @@ export const handler = async ({
     },
     side.includes('web') && {
       // Clean web/dist before building
-      // Vite handles this internally
       title: 'Cleaning Web...',
       task: () => {
         return rimraf(rwjsPaths.web.dist)
       },
-      enabled: getConfig().web.bundler !== 'vite',
     },
     side.includes('web') && {
       title: 'Building Web...',
       task: async () => {
-        if (getConfig().web.bundler === 'vite') {
-          await buildWeb({
-            verbose,
-          })
-        } else {
-          await execa(
-            `yarn cross-env NODE_ENV=production webpack --config ${require.resolve(
-              '@redwoodjs/core/config/webpack.production.js'
-            )}`,
-            {
-              stdio: verbose ? 'inherit' : 'pipe',
-              shell: true,
-              cwd: rwjsPaths.web.base,
-            }
-          )
-        }
+        await execa(
+          `yarn cross-env NODE_ENV=production webpack --config ${require.resolve(
+            '@redwoodjs/core/config/webpack.production.js'
+          )}`,
+          {
+            stdio: verbose ? 'inherit' : 'pipe',
+            shell: true,
+            cwd: rwjsPaths.web.base,
+          }
+        )
 
         console.log('Creating 200.html...')
 

--- a/packages/internal/src/build/web.ts
+++ b/packages/internal/src/build/web.ts
@@ -43,29 +43,3 @@ export const prebuildWebFiles = (srcFiles: string[], flags?: Flags) => {
     return dstPath
   })
 }
-
-interface BuildOptions {
-  verbose?: boolean
-}
-
-/**
- *
- * Builds the web side with Vite
- * Note that the webpack versoin is triggered via the webpack CLI
- *
- */
-export const buildWeb = async ({ verbose }: BuildOptions) => {
-  // @NOTE: Using dynamic import, because vite is still opt-in
-  const { build } = await import('vite')
-  const viteConfig = getPaths().web.viteConfig
-
-  if (!viteConfig) {
-    throw new Error('Could not locate your web/vite.config.{js,ts} file')
-  }
-
-  return build({
-    configFile: viteConfig,
-    envFile: false,
-    logLevel: verbose ? 'info' : 'warn',
-  })
-}


### PR DESCRIPTION
This PR will have RW projects always use WebPack when building for production to make prerendering work.

Fixes #8036 