### PR TITLE
fix(cli): Install studio package if not found

### DIFF
--- a/packages/cli/src/commands/experimental/studio.js
+++ b/packages/cli/src/commands/experimental/studio.js
@@ -1,7 +1,6 @@
-import execa from 'execa'
 import terminalLink from 'terminal-link'
 
-import { getPaths } from '../../lib'
+import { isModuleInstalled, installRedwoodModule } from '../../lib/packages'
 
 export const command = 'studio'
 export const description = 'Run the Redwood development studio'
@@ -17,28 +16,21 @@ export const builder = (yargs) => {
 
 export const handler = async () => {
   try {
+    // Check the module is installed
+    if (!isModuleInstalled('@redwoodjs/studio')) {
+      console.log(
+        'The studio package is not installed, installing it for you, this may take a moment...'
+      )
+      await installRedwoodModule('@redwoodjs/studio')
+      console.log('Studio package installed successfully.')
+    }
+
     // Import studio and start it
     const { start } = await import('@redwoodjs/studio')
     await start()
   } catch (e) {
     console.log('Cannot start the development studio')
-
-    // If we don't have the package installed, install it for the user
-    if (e.code === 'MODULE_NOT_FOUND') {
-      console.log(
-        'Installing the studio package for you, this may take a moment...'
-      )
-      await execa('yarn', ['add', '@redwoodjs/studio', '--dev'], {
-        shell: true,
-        cwd: getPaths().base,
-      })
-      console.log(
-        'Studio package installed successfully, please execute the command again.'
-      )
-    } else {
-      // Otherwise, log the error and exit
-      console.log(e)
-      process.exit(1)
-    }
+    console.log(e)
+    process.exit(1)
   }
 }

--- a/packages/cli/src/commands/experimental/studio.js
+++ b/packages/cli/src/commands/experimental/studio.js
@@ -1,7 +1,11 @@
+import execa from 'execa'
 import terminalLink from 'terminal-link'
+
+import { getPaths } from '../../lib'
 
 export const command = 'studio'
 export const description = 'Run the Redwood development studio'
+
 export const builder = (yargs) => {
   yargs.epilogue(
     `Also see the ${terminalLink(
@@ -10,13 +14,31 @@ export const builder = (yargs) => {
     )}`
   )
 }
+
 export const handler = async () => {
   try {
+    // Import studio and start it
     const { start } = await import('@redwoodjs/studio')
     await start()
   } catch (e) {
-    console.log('Error: Cannot start the development studio')
-    console.log(e)
-    process.exit(1)
+    console.log('Cannot start the development studio')
+
+    // If we don't have the package installed, install it for the user
+    if (e.code === 'MODULE_NOT_FOUND') {
+      console.log(
+        'Installing the studio package for you, this may take a moment...'
+      )
+      await execa('yarn', ['add', '@redwoodjs/studio', '--dev'], {
+        shell: true,
+        cwd: getPaths().base,
+      })
+      console.log(
+        'Studio package installed successfully, please execute the command again.'
+      )
+    } else {
+      // Otherwise, log the error and exit
+      console.log(e)
+      process.exit(1)
+    }
   }
 }

--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -1,0 +1,76 @@
+import path from 'path'
+
+import execa from 'execa'
+import fs from 'fs-extra'
+
+import { getPaths } from './index'
+
+/**
+ * Installs a Redwood module into a user's project keeping the version consistent with that of \@redwoodjs/cli.
+ * If the module is already installed, this function does nothing.
+ * If no remote version can not be found which matches the local cli version then the latest canary version will be used.
+ *
+ * @param {string} module A redwoodjs module, e.g. \@redwoodjs/web
+ */
+export async function installRedwoodModule(module) {
+  const packageJsonPath = require.resolve('@redwoodjs/cli/package.json')
+  let { version } = fs.readJSONSync(packageJsonPath)
+
+  if (!isModuleInstalled(module)) {
+    const { stdout } = await execa.command(
+      `yarn npm info ${module} --fields versions --json`
+    )
+
+    // If the version includes a plus, like '4.0.0-rc.428+dd79f1726'
+    // (all @canary, @next, and @rc packages do), get rid of everything after the plus.
+    if (version.includes('+')) {
+      version = version.split('+')[0]
+    }
+
+    const versionIsPublished = JSON.parse(stdout).versions.includes(version)
+
+    if (!versionIsPublished) {
+      // Fallback to canary. This is most likely because it's a new package
+      version = 'canary'
+    }
+
+    // We use `version` to make sure we install the same version as the rest
+    // of the RW packages
+    await execa.command(`yarn add -D ${module}@${version}`, {
+      stdio: 'inherit',
+      cwd: getPaths().base,
+    })
+  }
+}
+
+/**
+ * Check if a user's project's package.json has a module listed as a dependency
+ * or devDependency. If not, check node_modules.
+ *
+ * @param {string} module
+ */
+export function isModuleInstalled(module) {
+  const { dependencies, devDependencies } = fs.readJSONSync(
+    path.join(getPaths().base, 'package.json')
+  )
+
+  const deps = {
+    ...dependencies,
+    ...devDependencies,
+  }
+
+  if (deps[module]) {
+    return true
+  }
+
+  // Check any of the places require would look for this module.
+  // This enables testing auth setup packages with `yarn rwfw project:copy`.
+  //
+  // We can't use require.resolve here because it cahces the exception
+  // Making it impossible to require when we actually do install it...
+  return require.resolve
+    .paths(`${module}/package.json`)
+    .some((requireResolvePath) => {
+      return fs.existsSync(path.join(requireResolvePath, module))
+    })
+}

--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -64,9 +64,9 @@ export function isModuleInstalled(module) {
   }
 
   // Check any of the places require would look for this module.
-  // This enables testing auth setup packages with `yarn rwfw project:copy`.
+  // This enables testing with `yarn rwfw project:copy`.
   //
-  // We can't use require.resolve here because it cahces the exception
+  // We can't use require.resolve here because it caches the exception
   // Making it impossible to require when we actually do install it...
   return require.resolve
     .paths(`${module}/package.json`)


### PR DESCRIPTION
**Problem**
The studio package is not included by default so the CLI command fails to import and start the studio.

**Changes**
1. Automatically install the `@redwoodjs/studio` package if it is not found.