### PR TITLE
Allow string userId in Redwood Studio generated dbAuth header

### DIFF
--- a/packages/studio/backend/lib/authProviderEncoders/dbAuthEncoder.ts
+++ b/packages/studio/backend/lib/authProviderEncoders/dbAuthEncoder.ts
@@ -3,6 +3,10 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { SESSION_SECRET } from '../envars'
 
+const isNumeric = (id: string) => {
+  return /^\d+$/.test(id)
+}
+
 export const getDBAuthHeader = async (userId?: string) => {
   if (!userId) {
     throw new Error('Require an unique id to generate session cookie')
@@ -14,10 +18,9 @@ export const getDBAuthHeader = async (userId?: string) => {
     )
   }
 
+  const id = isNumeric(userId) ? parseInt(userId) : userId;
   const cookie = CryptoJS.AES.encrypt(
-    // ids muts be integers, so can they be uuids or cuids?
-    // why this may not work on MongoDB?
-    JSON.stringify({ id: parseInt(userId) }) + ';' + uuidv4(),
+    JSON.stringify({ id }) + ';' + uuidv4(),
     SESSION_SECRET
   ).toString()
 


### PR DESCRIPTION
## Problem
When using String type as your User's `id` field (with dbAuth), your session token would include a non-numeric `id`. However, Redwood Studio's GraphQL explorer could not generate session token with non-numeric id, it was requiring an Int.

## Solution
Allow string `id` to be used in session token creation for Redwood Studio GraphQL. Check if value is numeric and if so, use `parseInt`, otherwise use the provided string.

## Test Plan

Before (with String id):

https://user-images.githubusercontent.com/5488094/233819776-e75f7424-952c-413c-8ce9-866cc9904f7e.mov

After (with String id):

https://user-images.githubusercontent.com/5488094/233819875-6b5c2f9f-d679-451c-ac7a-40c7a1c33c57.mov

After (with Int id):

https://user-images.githubusercontent.com/5488094/233819880-cda492de-bc8e-485a-a528-cccebc9e7726.mov

