### PR TITLE
fix(codemods): make react do install, add update node engines

### DIFF
--- a/packages/codemods/src/codemods/v5.x.x/checkReactRoot/checkReactRoot.ts
+++ b/packages/codemods/src/codemods/v5.x.x/checkReactRoot/checkReactRoot.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { load } from 'cheerio'
+import execa from 'execa'
 
 import getRWPaths from '../../../lib/getRWPaths'
 
@@ -33,4 +34,36 @@ export function checkReactRoot() {
   reactRoot.text('')
 
   fs.writeFileSync(indexHTMLFilepath, indexHTML.html())
+}
+
+export function updateReactDeps() {
+  const redwoodProjectPaths = getRWPaths()
+
+  const webPackageJSONPath = path.join(
+    redwoodProjectPaths.web.base,
+    'package.json'
+  )
+
+  const webPackageJSON = JSON.parse(
+    fs.readFileSync(webPackageJSONPath, 'utf-8')
+  )
+
+  const latestReactVersion = '18.2.0'
+
+  for (const requiredReactDep of ['react', 'react-dom']) {
+    if (!Object.hasOwn(webPackageJSON.dependencies, requiredReactDep)) {
+      throw new Error(
+        `Couldn't find ${requiredReactDep} in web/package.json dependencies`
+      )
+    }
+
+    webPackageJSON.dependencies[requiredReactDep] = latestReactVersion
+  }
+
+  fs.writeFileSync(webPackageJSONPath, JSON.stringify(webPackageJSON, null, 2))
+
+  execa.commandSync('yarn install', {
+    cwd: redwoodProjectPaths.base,
+    stdio: 'inherit',
+  })
 }

--- a/packages/codemods/src/codemods/v5.x.x/checkReactRoot/checkReactRoot.yargs.ts
+++ b/packages/codemods/src/codemods/v5.x.x/checkReactRoot/checkReactRoot.yargs.ts
@@ -1,13 +1,19 @@
 import task, { TaskInnerAPI } from 'tasuku'
 
-import { checkReactRoot } from './checkReactRoot'
+import { checkReactRoot, updateReactDeps } from './checkReactRoot'
 
 export const command = 'check-react-root'
+
 export const description = '(v5.x.x->v5.x.x) Converts world to bazinga'
 
 export const handler = () => {
-  task('Check React Root', ({ setOutput }: TaskInnerAPI) => {
+  task('Check react root', ({ setOutput }: TaskInnerAPI) => {
     checkReactRoot()
+    setOutput('All done!')
+  })
+
+  task('Update react deps', ({ setOutput }: TaskInnerAPI) => {
+    updateReactDeps()
     setOutput('All done!')
   })
 }

--- a/packages/codemods/src/codemods/v5.x.x/updateNodeEngines/README.md
+++ b/packages/codemods/src/codemods/v5.x.x/updateNodeEngines/README.md
@@ -1,0 +1,4 @@
+# Update Node Engines
+
+<!-- Practice README-driven development by explaining what your codemod does:
+     https://tom.preston-werner.com/2010/08/23/readme-driven-development.html -->

--- a/packages/codemods/src/codemods/v5.x.x/updateNodeEngines/updateNodeEngines.ts
+++ b/packages/codemods/src/codemods/v5.x.x/updateNodeEngines/updateNodeEngines.ts
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+
+import getRWPaths from '../../../lib/getRWPaths'
+
+async function updateNodeEngines() {
+  const packageJSONPath = path.join(getRWPaths().base, 'package.json')
+  const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'))
+
+  packageJSON.engines.node = '=18.x'
+
+  fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2))
+}
+
+export { updateNodeEngines }

--- a/packages/codemods/src/codemods/v5.x.x/updateNodeEngines/updateNodeEngines.yargs.ts
+++ b/packages/codemods/src/codemods/v5.x.x/updateNodeEngines/updateNodeEngines.yargs.ts
@@ -1,0 +1,18 @@
+import task from 'tasuku'
+
+import { updateNodeEngines } from './updateNodeEngines'
+
+export const command = 'update-node-engines'
+
+export const description =
+  '(v5.x.x->v5.x.x) Changes the structure of your Redwood Project'
+
+export const handler = () => {
+  task('Update Node Engines', async ({ setError }: TaskInnerApi) => {
+    try {
+      await updateNodeEngines()
+    } catch (e: any) {
+      setError('Failed to codemod your project \n' + e?.message)
+    }
+  })
+}


### PR DESCRIPTION
This PR updates the check-react-root codemod to also update the version of react dependnecies in web/package.json and run yarn install. It also adds an update-node-engines codemod that updates the value of engines.node in a package.json to the new v5 value.