### PR TITLE
fix(studio): split file into handler, add toml step

### DIFF
--- a/packages/cli/src/commands/experimental/studio.js
+++ b/packages/cli/src/commands/experimental/studio.js
@@ -1,11 +1,9 @@
 import terminalLink from 'terminal-link'
 
-import { isModuleInstalled, installRedwoodModule } from '../../lib/packages'
-
 export const command = 'studio'
 export const description = 'Run the Redwood development studio'
 
-export const builder = (yargs) => {
+export function builder(yargs) {
   yargs.epilogue(
     `Also see the ${terminalLink(
       'Redwood CLI Reference',
@@ -14,23 +12,7 @@ export const builder = (yargs) => {
   )
 }
 
-export const handler = async () => {
-  try {
-    // Check the module is installed
-    if (!isModuleInstalled('@redwoodjs/studio')) {
-      console.log(
-        'The studio package is not installed, installing it for you, this may take a moment...'
-      )
-      await installRedwoodModule('@redwoodjs/studio')
-      console.log('Studio package installed successfully.')
-    }
-
-    // Import studio and start it
-    const { start } = await import('@redwoodjs/studio')
-    await start()
-  } catch (e) {
-    console.log('Cannot start the development studio')
-    console.log(e)
-    process.exit(1)
-  }
+export async function handler(options) {
+  const { handler } = await import('./studioHandler')
+  return handler(options)
 }

--- a/packages/cli/src/commands/experimental/studioHandler.js
+++ b/packages/cli/src/commands/experimental/studioHandler.js
@@ -1,0 +1,46 @@
+import fs from 'fs'
+
+import { getConfigPath } from '@redwoodjs/project-config'
+
+import { writeFile } from '../../lib'
+import { isModuleInstalled, installRedwoodModule } from '../../lib/packages'
+
+export const handler = async () => {
+  try {
+    // Check the module is installed
+    if (!isModuleInstalled('@redwoodjs/studio')) {
+      console.log(
+        'The studio package is not installed, installing it for you, this may take a moment...'
+      )
+      await installRedwoodModule('@redwoodjs/studio')
+      console.log('Studio package installed successfully.')
+
+      console.log('Adding config to redwood.toml...')
+      const redwoodTomlPath = getConfigPath()
+      const configContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
+
+      if (!configContent.includes('[experimental.studio]')) {
+        // Use string replace to preserve comments and formatting
+        writeFile(
+          redwoodTomlPath,
+          configContent.concat(`\n[experimental.studio]\n  enabled = true\n`),
+          {
+            overwriteExisting: true, // redwood.toml always exists
+          }
+        )
+      } else {
+        console.log(
+          `The [experimental.studio] config block already exists in your 'redwood.toml' file.`
+        )
+      }
+    }
+
+    // Import studio and start it
+    const { start } = await import('@redwoodjs/studio')
+    await start()
+  } catch (e) {
+    console.log('Cannot start the development studio')
+    console.log(e)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
This PR splits the studio command into two files, studio and studioHandler, and adds a step to the studioHandler that adds toml config. Per pairing with @thedavidprice 