### PR TITLE
fix(deploy): try-catch attempt to read `redwood.toml` in `makeMergedSchema`

### DIFF
--- a/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema/makeMergedSchema.ts
@@ -104,7 +104,18 @@ const mapFieldsToService = ({
           context: unknown,
           info: unknown
         ) => {
-          if (getConfig().experimental.opentelemetry.enabled) {
+          // In serverless deploys like Netilfy and Vercel, the redwood.toml file may not be present,
+          // so we need to try-catch the attempt here to read it
+          let experimentalOpenTelemetryEnabled = false
+
+          try {
+            experimentalOpenTelemetryEnabled =
+              getConfig().experimental.opentelemetry.enabled
+          } catch (e) {
+            // Swallow the error for now
+          }
+
+          if (experimentalOpenTelemetryEnabled) {
             return wrapWithOpenTelemetry(
               services[name],
               args,


### PR DESCRIPTION
Deploy target CI is down for Netlify and Vercel with the error:

```
Error: Could not find a "redwood.toml" file, are you sure you're in a Redwood project?
    at getConfigPath (/var/task/node_modules/@redwoodjs/project-config/dist/configPath.js:20:11)
    at getConfig (/var/task/node_modules/@redwoodjs/project-config/dist/config.js:91:63)
    at Object.posts (/var/task/node_modules/@redwoodjs/graphql-server/dist/makeMergedSchema/makeMergedSchema.js:69:44)
    at useRedwoodDirectiveValidatorResolver (/var/task/node_modules/@redwoodjs/graphql-server/dist/plugins/useRedwoodDirective.js:108:22)
    at field.resolve (/var/task/node_modules/@envelop/on-resolve/cjs/index.js:33:48)
    at async field.resolve (/var/task/node_modules/@envelop/on-resolve/cjs/index.js:33:42)
    at async field.resolve (/var/task/node_modules/@envelop/on-resolve/cjs/index.js:33:42)
    at async Promise.all (index 0)
    at async promiseForObject (/var/task/node_modules/@graphql-tools/executor/cjs/execution/promiseForObject.js:14:28)
    at async /var/task/node_modules/@envelop/core/cjs/orchestrator.js:376:27
```

This is because these deploy environments bundle the functions they're given to deploy and don't seem to include the `redwood.toml` file. While we figure out how to include the toml file or debate whether or not it should be, we can at least try-catch the attempt to read it and proceed with a default value for experimental OpenTelemetry if it's not there.