### PR TITLE
fix(crwa): handle esbuild can't be built error

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -291,7 +291,7 @@ async function installNodeModules(newAppDir) {
         [
           "Yarn couldn't run esbuild's postinstall script.\n",
           logFile &&
-            `You can see the log file for more details here: ${RedwoodStyling.info(
+            `You can see the log file here for more details: ${RedwoodStyling.info(
               logFile
             )}\n`,
           `This is a known issue we're trying to sort out. (See ${terminalLink(


### PR DESCRIPTION
Tries to handle https://github.com/redwoodjs/redwood/issues/8164. It's not a fix, but it at least handles the error. I'll leave that issue open till it's actually solved.

TL;DR: on yarn 3 (or at least when invoking `yarn install` in a `child_process`), esbuild's postinstall script doesn't seem to work. But in debugging, we realized:
    
  1) it doesn't need to be built for this script to finish
  2) users can easily build it by running `yarn install`

(Note that I tried re-running yarn install via execa, but it didn't seem to work—there's something about running install in a `child_process` yarn doesn't like.)
    
So it feels like we should handle this error and continue. While matching on stdout is brittle, it's just a check, and if there's no match (i.e. yarn's output changes from under us—unlikely), it's not a big deal. The error will just bubble up to the user anyway, like it always has.

<img width="958" alt="image" src="https://user-images.githubusercontent.com/32992335/235245256-6cfa9e47-ca5c-403c-9cf5-9584fc32051a.png">
