### PR TITLE
fix(v5): type `queryResult` in Cells

### DIFF
--- a/__fixtures__/test-project/README.md
+++ b/__fixtures__/test-project/README.md
@@ -4,7 +4,7 @@ Welcome to [RedwoodJS](https://redwoodjs.com)!
 
 > **Prerequisites**
 >
-> - Redwood requires [Node.js](https://nodejs.org/en/) (>=16.20 <=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
+> - Redwood requires [Node.js](https://nodejs.org/en/) (>=18.x) and [Yarn](https://yarnpkg.com/) (>=1.15)
 > - Are you on Windows? For best results, follow our [Windows development setup](https://redwoodjs.com/docs/how-to/windows-development-setup) guide
 
 Start by installing dependencies:
@@ -20,7 +20,7 @@ cd my-redwood-project
 yarn redwood dev
 ```
 
-Your browser should automatically open to http://localhost:8910 where you'll see the Welcome Page, which links out to a ton of great resources.
+Your browser should automatically open to http://localhost:8910 where you'll see the Welcome Page, which links to many great resources.
 
 > **The Redwood CLI**
 >

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -20,8 +20,5 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@3.5.0",
-  "dependencies": {
-    "glob": "10.2.2"
-  }
+  "packageManager": "yarn@3.5.0"
 }

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.21",
-    "postcss-loader": "^7.2.4",
-    "prettier-plugin-tailwindcss": "^0.2.7",
-    "tailwindcss": "^3.3.1"
+    "postcss": "^8.4.23",
+    "postcss-loader": "^7.3.0",
+    "prettier-plugin-tailwindcss": "^0.2.8",
+    "tailwindcss": "^3.3.2"
   }
 }

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -86,6 +86,7 @@ describe('CellProps mapper type', () => {
 
       expectAssignable<CellWithoutVariablesInputs>({
         customProp: 55,
+        queryResult: {},
       })
     })
   })

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -72,7 +72,6 @@ describe('CellProps mapper type', () => {
         customProp: 55,
         category: 'Dinner',
         saved: true,
-        queryResult: {},
       })
     })
 
@@ -86,7 +85,6 @@ describe('CellProps mapper type', () => {
 
       expectAssignable<CellWithoutVariablesInputs>({
         customProp: 55,
-        queryResult: {},
       })
     })
   })

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -72,6 +72,7 @@ describe('CellProps mapper type', () => {
         customProp: 55,
         category: 'Dinner',
         saved: true,
+        queryResult: {},
       })
     })
 

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -53,27 +53,23 @@ export type CellProps<
     CellPropsVariables<CellType, GQLVariables>
 >
 
-export type CellLoadingProps<TVariables extends OperationVariables = any> =
-  Partial<{
-    queryResult: Omit<
-      QueryOperationResult<any, TVariables>,
-      'loading' | 'error' | 'data'
-    >
-  }>
+export type CellLoadingProps<TVariables extends OperationVariables = any> = {
+  queryResult: Partial<
+    Omit<QueryOperationResult<any, TVariables>, 'loading' | 'error' | 'data'>
+  >
+}
 
-export type CellFailureProps<TVariables extends OperationVariables = any> =
-  Partial<{
-    queryResult: Omit<
-      QueryOperationResult<any, TVariables>,
-      'loading' | 'error' | 'data'
-    >
-    error: QueryOperationResult['error'] | Error // for tests and storybook
-    /**
-     * @see {@link https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes}
-     */
-    errorCode: string
-    updating: boolean
-  }>
+export type CellFailureProps<TVariables extends OperationVariables = any> = {
+  queryResult: Partial<
+    Omit<QueryOperationResult<any, TVariables>, 'loading' | 'error' | 'data'>
+  >
+  error?: QueryOperationResult['error'] | Error // for tests and storybook
+  /**
+   * @see {@link https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes}
+   */
+  errorCode?: string
+  updating?: boolean
+}
 
 // aka guarantee that all properties in T exist
 // This is necessary for Cells, because if it doesn't exist it'll go to Empty or Failure
@@ -106,14 +102,12 @@ export type CellSuccessData<TData = any> = Omit<Guaranteed<TData>, '__typename'>
 export type CellSuccessProps<
   TData = any,
   TVariables extends OperationVariables = any
-> = Partial<{
-  queryResult: Omit<
-    QueryOperationResult<TData, TVariables>,
-    'loading' | 'error' | 'data'
+> = {
+  queryResult: Partial<
+    Omit<QueryOperationResult<TData, TVariables>, 'loading' | 'error' | 'data'>
   >
-  updating: boolean
-}> &
-  A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
+  updating?: boolean
+} & A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
 
 /**
  * A coarse type for the `data` prop returned by `useQuery`.

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -46,21 +46,21 @@ export type CellProps<
   Omit<
     ComponentProps<CellSuccess>,
     | keyof CellPropsVariables<CellType, GQLVariables>
-    | keyof QueryOperationResult
     | keyof GQLResult
     | 'updating'
+    | 'queryResult'
   > &
     CellPropsVariables<CellType, GQLVariables>
 >
 
 export type CellLoadingProps<TVariables extends OperationVariables = any> = {
-  queryResult: Partial<
+  queryResult?: Partial<
     Omit<QueryOperationResult<any, TVariables>, 'loading' | 'error' | 'data'>
   >
 }
 
 export type CellFailureProps<TVariables extends OperationVariables = any> = {
-  queryResult: Partial<
+  queryResult?: Partial<
     Omit<QueryOperationResult<any, TVariables>, 'loading' | 'error' | 'data'>
   >
   error?: QueryOperationResult['error'] | Error // for tests and storybook
@@ -103,7 +103,7 @@ export type CellSuccessProps<
   TData = any,
   TVariables extends OperationVariables = any
 > = {
-  queryResult: Partial<
+  queryResult?: Partial<
     Omit<QueryOperationResult<TData, TVariables>, 'loading' | 'error' | 'data'>
   >
   updating?: boolean

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -104,14 +104,13 @@ export type CellSuccessData<TData = any> = Omit<Guaranteed<TData>, '__typename'>
 export type CellSuccessProps<
   TData = any,
   TVariables extends OperationVariables = any
-> = Partial<
-  Omit<
+> = Partial<{
+  queryResult: Omit<
     QueryOperationResult<TData, TVariables>,
     'loading' | 'error' | 'data'
-  > & {
-    updating: boolean
-  }
-> &
+  >
+  updating: boolean
+}> &
   A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
 
 /**

--- a/packages/web/src/components/createCell.tsx
+++ b/packages/web/src/components/createCell.tsx
@@ -54,24 +54,26 @@ export type CellProps<
 >
 
 export type CellLoadingProps<TVariables extends OperationVariables = any> =
-  Partial<
-    Omit<QueryOperationResult<any, TVariables>, 'loading' | 'error' | 'data'>
-  >
-
-export type CellFailureProps<TVariables extends OperationVariables = any> =
-  Partial<
-    Omit<
+  Partial<{
+    queryResult: Omit<
       QueryOperationResult<any, TVariables>,
       'loading' | 'error' | 'data'
-    > & {
-      error: QueryOperationResult['error'] | Error // for tests and storybook
-      /**
-       * @see {@link https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes}
-       */
-      errorCode: string
-      updating: boolean
-    }
-  >
+    >
+  }>
+
+export type CellFailureProps<TVariables extends OperationVariables = any> =
+  Partial<{
+    queryResult: Omit<
+      QueryOperationResult<any, TVariables>,
+      'loading' | 'error' | 'data'
+    >
+    error: QueryOperationResult['error'] | Error // for tests and storybook
+    /**
+     * @see {@link https://www.apollographql.com/docs/apollo-server/data/errors/#error-codes}
+     */
+    errorCode: string
+    updating: boolean
+  }>
 
 // aka guarantee that all properties in T exist
 // This is necessary for Cells, because if it doesn't exist it'll go to Empty or Failure


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/pull/7024#issuecomment-1528877742. @Tobbe works in VS Code with `yarn rwfw` going, but do you think it's this simple?

<img width="1522" alt="image" src="https://user-images.githubusercontent.com/32992335/235331046-6f19cc27-0ce1-4744-8eb7-9018eae268ee.png">
