### PR TITLE
fix(v5 codemod): handle errors in cell query parsing

### DIFF
--- a/packages/codemods/src/codemods/v5.x.x/detectEmptyCells/detectEmptyCells.ts
+++ b/packages/codemods/src/codemods/v5.x.x/detectEmptyCells/detectEmptyCells.ts
@@ -14,14 +14,13 @@ async function detectEmptyCells(taskContext: TaskInnerAPI) {
 
   const susceptibleCells = cellPaths.filter((cellPath) => {
     const fileContents = fileToAst(cellPath)
-
     const cellQuery = getCellGqlQuery(fileContents)
 
     if (!cellQuery) {
       return false
     }
 
-    let fields
+    let fields: ReturnType<typeof parseGqlQueryToAst>[0]['fields']
 
     try {
       fields = parseGqlQueryToAst(cellQuery)[0].fields
@@ -40,7 +39,7 @@ async function detectEmptyCells(taskContext: TaskInnerAPI) {
     return
   }
 
-  const message = []
+  const message: string[] = []
 
   if (susceptibleCells.length > 0) {
     message.push(

--- a/packages/codemods/src/codemods/v5.x.x/detectEmptyCells/detectEmptyCells.ts
+++ b/packages/codemods/src/codemods/v5.x.x/detectEmptyCells/detectEmptyCells.ts
@@ -8,38 +8,80 @@ import {
 } from '../../../lib/cells'
 
 async function detectEmptyCells(taskContext: TaskInnerAPI) {
+  const warnings: string[] = []
+
   const cellPaths = findCells()
 
   const susceptibleCells = cellPaths.filter((cellPath) => {
     const fileContents = fileToAst(cellPath)
+
     const cellQuery = getCellGqlQuery(fileContents)
 
     if (!cellQuery) {
       return false
     }
 
-    const { fields } = parseGqlQueryToAst(cellQuery)[0]
+    let fields
+
+    try {
+      fields = parseGqlQueryToAst(cellQuery)[0].fields
+    } catch (e) {
+      warnings.push(cellPath)
+      return
+    }
 
     return fields.length > 1
   })
 
-  if (susceptibleCells.length > 0) {
+  if (susceptibleCells.length === 0 && warnings.length === 0) {
     taskContext.setOutput(
+      "None of your project's Cells are susceptible to the new `isDataEmpty` behavior."
+    )
+    return
+  }
+
+  const message = []
+
+  if (susceptibleCells.length > 0) {
+    message.push(
       [
         'You have Cells that are susceptible to the new `isDataEmpty` behavior:',
         '',
         susceptibleCells.map((c) => `• ${c}`).join('\n'),
         '',
-        'The new behavior is documented in detail on the forums: https://community.redwoodjs.com/t/redwood-v5-0-0-rc-is-now-available/4715.',
-        "It's most likely what you want, but consider whether it affects you.",
-        "If you'd like to revert to the old behavior, you can override the `isDataEmpty` function.",
       ].join('\n')
     )
-  } else {
-    taskContext.setOutput(
-      "None of your project's Cells are susceptible to the new `isDataEmpty` behavior."
+  }
+
+  if (warnings.length > 0) {
+    message.push(
+      [
+        [
+          message.length > 0 && '→',
+          `The following Cell(s) could not be parsed:`,
+        ]
+          .filter(Boolean)
+          .join(' '),
+        '',
+        warnings.map((c) => `• ${c}`).join('\n'),
+        '',
+        "You'll have to audit them manually.",
+        '',
+      ].join('\n')
     )
   }
+
+  message.push(
+    [
+      'The new behavior is documented in detail on the forums: https://community.redwoodjs.com/t/redwood-v5-0-0-rc-is-now-available/4715.',
+      "It's most likely what you want, but consider whether it affects you.",
+      "If you'd like to revert to the old behavior, you can override the `isDataEmpty` function.",
+    ].join('\n')
+  )
+
+  const taskContextMethod = warnings.length > 0 ? 'setWarning' : 'setOutput'
+
+  taskContext[taskContextMethod](message.join('\n'))
 }
 
 export { detectEmptyCells }


### PR DESCRIPTION
Users with Cells that have fragments in their query like:

```js
export const QUERY = gql`
  ${MY_FRAGMENT}

  query MyQuery($id: Int!) {
    post(id: $id) {
      ...MyFragment
    }
  }
`
```

Will get the following unhelpful output from the `detect-empty-cells` codemod:

```
$ npx @redwoodjs/codemods@canary detect-empty-cells
✖ Detecting Cells susceptible to the new Empty behavior
  → Failed to detect cells susceptible to the new Empty behavior in your project 
  Syntax Error: Unexpected <EOF>.
```

Fixing the functions used to parse the Cell query is a bit non-trivial at the moment, so in the meantime we can handle the error and tell the user to manually audit the Cell so that other Cells are still processed:

<img width="916" alt="image" src="https://user-images.githubusercontent.com/32992335/235514492-b3b114cd-9396-4b06-9e88-1d06434b5be5.png">
