### PR TITLE
chore(tests): increment pages found in path test

### DIFF
--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -902,7 +902,7 @@ describe('paths', () => {
 
         const pages = processPagesDir(pagesDir)
 
-        expect(pages.length).toEqual(20)
+        expect(pages.length).toEqual(21)
 
         const pageNames = [
           'AboutPage',


### PR DESCRIPTION
Looks like we forgot to increment the number of pages found in a test after adding a page in https://github.com/redwoodjs/redwood/pull/8178, but this test doesn't seem to fail in PRs, only in CI that runs against main—in actions like publish canary (see https://github.com/redwoodjs/redwood/actions/runs/4856408246/jobs/8655938165#step:8:66).