### PR TITLE
fix(cli): Add missing toml dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.21.5",
+    "@iarna/toml": "2.2.5",
     "@prisma/internals": "4.13.0",
     "@redwoodjs/api-server": "5.0.0",
     "@redwoodjs/cli-helpers": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6950,6 +6950,7 @@ __metadata:
     "@babel/cli": 7.21.5
     "@babel/core": 7.21.5
     "@babel/runtime-corejs3": 7.21.5
+    "@iarna/toml": 2.2.5
     "@prisma/internals": 4.13.0
     "@redwoodjs/api-server": 5.0.0
     "@redwoodjs/cli-helpers": 5.0.0


### PR DESCRIPTION
**Problem**

@chenkie reports the following failure:
```
May 2 10:39:35 AM  Error: Cannot find module '@iarna/toml'
May 2 10:39:35 AM  Require stack:
May 2 10:39:35 AM  - /opt/render/project/src/node_modules/@redwoodjs/cli/dist/commands/deploy/baremetal.js
May 2 10:39:35 AM  - /opt/render/project/src/node_modules/yargs/index.cjs
May 2 10:39:35 AM  - /opt/render/project/src/node_modules/@redwoodjs/cli/dist/index.js
May 2 10:39:35 AM  - /opt/render/project/src/node_modules/@redwoodjs/cli/package.json
May 2 10:39:35 AM      at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1026:15)
May 2 10:39:35 AM      at Function.Module._load (node:internal/modules/cjs/loader:871:27)
May 2 10:39:35 AM      at Module.require (node:internal/modules/cjs/loader:1098:19)
May 2 10:39:35 AM      at require (node:internal/modules/cjs/helpers:108:18)
May 2 10:39:35 AM      at Object.<anonymous> (/opt/render/project/src/node_modules/@redwoodjs/cli/dist/commands/deploy/baremetal.js:29:36)
May 2 10:39:35 AM      at Module._compile (node:internal/modules/cjs/loader:1196:14)
May 2 10:39:35 AM      at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
May 2 10:39:35 AM      at Module.load (node:internal/modules/cjs/loader:1074:32)
May 2 10:39:35 AM      at Function.Module._load (node:internal/modules/cjs/loader:909:12)
May 2 10:39:35 AM      at Module.require (node:internal/modules/cjs/loader:1098:19) {
May 2 10:39:35 AM    code: 'MODULE_NOT_FOUND',
May 2 10:39:35 AM    requireStack: [
May 2 10:39:35 AM      '/opt/render/project/src/node_modules/@redwoodjs/cli/dist/commands/deploy/baremetal.js',
May 2 10:39:35 AM      '/opt/render/project/src/node_modules/yargs/index.cjs',
May 2 10:39:35 AM      '/opt/render/project/src/node_modules/@redwoodjs/cli/dist/index.js',
May 2 10:39:35 AM      '/opt/render/project/src/node_modules/@redwoodjs/cli/package.json'
May 2 10:39:35 AM    ]
May 2 10:39:35 AM  }
May 2 10:39:35 AM  error Command failed with exit code 1.
May 2 10:39:35 AM  info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

We require `@iarna/toml` within the CLI but we do not explicitly depend on it https://github.com/redwoodjs/redwood/blob/a6da1fd67e92b06f33d854ed509a108ad7ecd674/packages/cli/src/commands/deploy/baremetal.js#L4. It is a dependency of other redwood packages such as `structure` and `project-config`. 

**Changes**
1. Add it as an explicit dependency.

**Note**
Package size is 97.5kb (https://packagephobia.com/result?p=@iarna/toml@2.2.5)

**Ping**
@jtoar - Am I right to add this as a dependency or is there more to consider that I have not?