### PR TITLE
fix(crwa): Prevent links including "zero width space" in URL

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -106,7 +106,11 @@ async function executeCompatibilityCheck(templateDir, yarnInstall) {
           `  Please use tools like nvm or corepack to change to a compatible version.`,
           `  See: ${terminalLink(
             'Tutorial - Prerequisites',
-            'https://redwoodjs.com/docs/tutorial/chapter1/prerequisites'
+            'https://redwoodjs.com/docs/tutorial/chapter1/prerequisites',
+            {
+              fallback: () =>
+                'Tutorial - Prerequisites https://redwoodjs.com/docs/tutorial/chapter1/prerequisites',
+            }
           )}`,
         ].join('\n')
       )
@@ -125,7 +129,11 @@ async function executeCompatibilityCheck(templateDir, yarnInstall) {
         `  This may make your project incompatible with some deploy targets, especially those using AWS Lambdas.`,
         `  See: ${terminalLink(
           'Tutorial - Prerequisites',
-          'https://redwoodjs.com/docs/tutorial/chapter1/prerequisites'
+          'https://redwoodjs.com/docs/tutorial/chapter1/prerequisites',
+          {
+            fallback: () =>
+              'Tutorial - Prerequisites https://redwoodjs.com/docs/tutorial/chapter1/prerequisites',
+          }
         )}`,
       ].join('\n')
     )


### PR DESCRIPTION
Fixes #8224 

**Problem**
When using some terminals the "zero width space" is included in the URL link and causes a 404 when trying to access the link.

**Solution**
As per https://github.com/sindresorhus/terminal-link/issues/18 the solution is to add a fallback with the text formatted as we'd like it to be presented.

Using Hyper the output looks like:
![image](https://user-images.githubusercontent.com/56300765/236358808-b922e0c3-7f2a-4ff5-a022-128c5384bc21.png)
FYI: I did try `text (url)` but it picked up the `)` in the url.