### PR TITLE
fix: serverless deploy template node version and deprecations

### DIFF
--- a/packages/cli/src/commands/setup/deploy/templates/serverless/api.js
+++ b/packages/cli/src/commands/setup/deploy/templates/serverless/api.js
@@ -19,7 +19,7 @@ useDotenv: true
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs18.x
   region: us-east-1 # AWS region where the service will be deployed, defaults to N. Virginia
   httpApi:          # HTTP API is used by default. To learn about the available options in API Gateway, see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html
     cors:
@@ -35,13 +35,11 @@ provider:
         - X-Amz-Security-Token
         - X-Amz-User-Agent
     payload: '1.0'
-    useProviderTags: true # https://www.serverless.com/framework/docs/deprecations/#AWS_HTTP_API_USE_PROVIDER_TAGS
   stackTags:
     source: serverless
     name: Redwood Lambda API with HTTP API Gateway
   tags:
     name: Redwood Lambda API with HTTP API Gateway
-  lambdaHashingVersion: 20201221 # https://www.serverless.com/framework/docs/deprecations/#LAMBDA_HASHING_VERSION_V2
   environment:
     # Add environment variables here, either in the form
     # VARIABLE_NAME: \${env:VARIABLE_NAME} for vars in your local environment, or

--- a/packages/cli/src/commands/setup/deploy/templates/serverless/web.js
+++ b/packages/cli/src/commands/setup/deploy/templates/serverless/web.js
@@ -26,6 +26,6 @@ constructs:
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs18.x
   region: us-east-1 # AWS region where the service will be deployed, defaults to N. Virgina
 `


### PR DESCRIPTION
The Serverless deploy setup yaml files contained 2 deprecations and were using Node.js v14. This removes deprecations and updates Node.js to v18.

Note: this does not fully resolve issues with Serverless deploy. See https://github.com/redwoodjs/deploy-target-ci/issues/826