### PR TITLE
fix: set node linker to node_modules

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -244,6 +244,10 @@ async function installNodeModules(newAppDir) {
   const yarnInstallSubprocess = execa('yarn install', {
     shell: true,
     cwd: newAppDir,
+    // For yarn 3 users, so that esbuild's postinstall script doesn't fail.
+    env: {
+      YARN_NODE_LINKER: 'node-modules',
+    },
   })
 
   try {


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/8164. For whatever reason, esbuild's postinstall script seems to complete when yarn's `nodeLinker` is `'node-modules'`. I didn't realize till just now that you could use env vars to configure yarn. I tried it locally and it actually works! Going to merge this in and test in canary.