### PR TITLE
chore(tui): Avoid reactive drawing for non-tty

### DIFF
--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -216,6 +216,12 @@ export class RedwoodTUI {
       throw new Error('TUI has no reactive content')
     }
 
+    // Only draw once if the TUI is not a TTY
+    if (!this.outStream.isTTY) {
+      this.drawReactive(true)
+      return
+    }
+
     if (!this.manager.isHooked) {
       // Take control of the terminal
       this.manager.hook()
@@ -234,6 +240,12 @@ export class RedwoodTUI {
    * @param clear If true, the last drawn content will be cleared
    */
   stopReactive(clear = false) {
+    // If the TUI is not a TTY, draw one last time and return
+    if (!this.outStream.isTTY) {
+      this.drawReactive(true)
+      return
+    }
+
     if (this.manager.isHooked) {
       // Stop the draw loop
       this.isReactive = false


### PR DESCRIPTION
**Problem**
In non-tty environments like CI the TUI reactive components don't overwrite themselves and instead produce a bazillion lines.

**Changes**
1. For non-tty only draw the reactive component once at the start and once at the end.