### PR TITLE
chore(cli): Consistent use of util functions within experimental commands

### DIFF
--- a/packages/cli/src/commands/experimental/setupInngestHandler.js
+++ b/packages/cli/src/commands/experimental/setupInngestHandler.js
@@ -7,7 +7,7 @@ import { getPaths } from '../../lib'
 import c from '../../lib/colors'
 
 import { command, description, EXPERIMENTAL_TOPIC_ID } from './setupInngest'
-import { getTaskEpilogue } from './util'
+import { printTaskEpilogue } from './util'
 
 export const handler = async ({ force }) => {
   const tasks = new Listr([
@@ -35,7 +35,7 @@ export const handler = async ({ force }) => {
     },
     {
       task: () => {
-        getTaskEpilogue(command, description, EXPERIMENTAL_TOPIC_ID)
+        printTaskEpilogue(command, description, EXPERIMENTAL_TOPIC_ID)
       },
     },
   ])

--- a/packages/cli/src/commands/experimental/setupOpentelemetry.js
+++ b/packages/cli/src/commands/experimental/setupOpentelemetry.js
@@ -2,6 +2,8 @@ export const command = 'setup-opentelemetry'
 
 export const description = 'Setup OpenTelemetry within the API side'
 
+export const EXPERIMENTAL_TOPIC_ID = 4772
+
 export const builder = (yargs) => {
   yargs.option('force', {
     alias: 'f',

--- a/packages/cli/src/commands/experimental/setupOpentelemetryHandler.js
+++ b/packages/cli/src/commands/experimental/setupOpentelemetryHandler.js
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import chalk from 'chalk'
 import execa from 'execa'
 import { Listr } from 'listr2'
 
@@ -12,6 +11,13 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 import { getPaths, transformTSToJS, writeFile } from '../../lib'
 import c from '../../lib/colors'
 import { isTypeScriptProject } from '../../lib/project'
+
+import {
+  command,
+  description,
+  EXPERIMENTAL_TOPIC_ID,
+} from './setupOpentelemetry'
+import { printTaskEpilogue } from './util'
 
 export const handler = async ({ force, verbose }) => {
   const ts = isTypeScriptProject()
@@ -154,33 +160,8 @@ export const handler = async ({ force, verbose }) => {
       ...opentelemetryTasks,
       ...prismaTasks,
       {
-        title: 'One more thing...',
-        task: (_ctx, task) => {
-          console.log(
-            `${chalk.hex('#ff845e')(
-              `------------------------------------------------------------------\n 🧪 ${chalk.green(
-                'Experimental Feature'
-              )} 🧪\n------------------------------------------------------------------`
-            )}`
-          )
-          console.log(
-            `Studio is an experimental feature, please find documentation and links to provide feedback at:\n -> https://community.redwoodjs.com/t/redwood-studio-experimental/4771`
-          )
-          console.log(
-            `${chalk.hex('#ff845e')(
-              '------------------------------------------------------------------'
-            )}\n`
-          )
-
-          task.title = `One more thing...\n
-          ${c.green('OpenTelemetry Support is still experimental!')}
-          ${c.green(
-            'Please let us know if you find bugs or quirks or if you have any feedback!'
-          )}
-          ${chalk.hex('#e8e8e8')(
-            'https://community.redwoodjs.com/t/opentelemetry-support-experimental/4772'
-          )}
-        `
+        task: () => {
+          printTaskEpilogue(command, description, EXPERIMENTAL_TOPIC_ID)
         },
       },
     ],

--- a/packages/cli/src/commands/experimental/studio.js
+++ b/packages/cli/src/commands/experimental/studio.js
@@ -3,6 +3,8 @@ import terminalLink from 'terminal-link'
 export const command = 'studio'
 export const description = 'Run the Redwood development studio'
 
+export const EXPERIMENTAL_TOPIC_ID = 4771
+
 export function builder(yargs) {
   yargs.epilogue(
     `Also see the ${terminalLink(

--- a/packages/cli/src/commands/experimental/studioHandler.js
+++ b/packages/cli/src/commands/experimental/studioHandler.js
@@ -5,7 +5,11 @@ import { getConfigPath } from '@redwoodjs/project-config'
 import { writeFile } from '../../lib'
 import { isModuleInstalled, installRedwoodModule } from '../../lib/packages'
 
+import { command, description, EXPERIMENTAL_TOPIC_ID } from './studio'
+import { printTaskEpilogue } from './util'
+
 export const handler = async () => {
+  printTaskEpilogue(command, description, EXPERIMENTAL_TOPIC_ID)
   try {
     // Check the module is installed
     if (!isModuleInstalled('@redwoodjs/studio')) {

--- a/packages/cli/src/commands/experimental/util.js
+++ b/packages/cli/src/commands/experimental/util.js
@@ -21,7 +21,7 @@ export const getEpilogue = (
     isTerminal
   )}`
 
-export const getTaskEpilogue = (command, description, topicId) => {
+export const printTaskEpilogue = (command, description, topicId) => {
   console.log(
     `${chalk.hex('#ff845e')(
       `------------------------------------------------------------------\n 🧪 ${chalk.green(

--- a/packages/studio/backend/index.ts
+++ b/packages/studio/backend/index.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import Fastify from 'fastify'
 import type { FastifyInstance } from 'fastify'
 import open from 'open'
@@ -64,21 +63,6 @@ export const start = async () => {
 
   fastify.listen({ port: PORT, host: HOST })
   fastify.ready(() => {
-    console.log(
-      `${chalk.hex('#ff845e')(
-        `------------------------------------------------------------------\n 🧪 ${chalk.green(
-          'Experimental Feature'
-        )} 🧪\n------------------------------------------------------------------`
-      )}`
-    )
-    console.log(
-      `Studio is an experimental feature, please find documentation and links to provide feedback at:\n -> https://community.redwoodjs.com/t/redwood-studio-experimental/4771`
-    )
-    console.log(
-      `${chalk.hex('#ff845e')(
-        '------------------------------------------------------------------'
-      )}\n`
-    )
     console.log(`Studio API listening on ${HOST}:${PORT}`)
     open(`http://${HOST}:${PORT}`)
   })

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -32,7 +32,6 @@
     "@redwoodjs/internal": "5.0.0",
     "@redwoodjs/project-config": "5.0.0",
     "ansi-colors": "4.1.3",
-    "chalk": "4.1.2",
     "chokidar": "3.5.3",
     "core-js": "3.30.2",
     "crypto-js": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7405,7 +7405,6 @@ __metadata:
     "@types/yargs": 17.0.24
     ansi-colors: 4.1.3
     aws-lambda: 1.0.7
-    chalk: 4.1.2
     chokidar: 3.5.3
     core-js: 3.30.2
     crypto-js: 4.1.1


### PR DESCRIPTION
Just tidies things up so that all the current experimental commands use the utility functions recently introduced. 

@dthyresson I renamed `getTaskEpilogue` to `printTaskEpilogue` just to be a bit more explicit that it's going to print them. 