### PR TITLE
fix(graphql-server): Display correct plugin name in error message

### DIFF
--- a/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
@@ -106,7 +106,7 @@ export const useRedwoodOpenTelemetry = (): Plugin<PluginContext> => {
             executionSpan.end()
             // eslint-disable-next-line no-console
             console.warn(
-              `Plugin "newrelic" encountered a AsyncIterator which is not supported yet, so tracing data is not available for the operation.`
+              `Plugin "RedwoodOpenTelemetry" encountered a AsyncIterator which is not supported yet, so tracing data is not available for the operation.`
             )
             return
           }

--- a/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
@@ -106,7 +106,7 @@ export const useRedwoodOpenTelemetry = (): Plugin<PluginContext> => {
             executionSpan.end()
             // eslint-disable-next-line no-console
             console.warn(
-              `Plugin "RedwoodOpenTelemetry" encountered a AsyncIterator which is not supported yet, so tracing data is not available for the operation.`
+              `Plugin "RedwoodOpenTelemetry" encountered an AsyncIterator which is not supported yet, so tracing data is not available for the operation.`
             )
             return
           }


### PR DESCRIPTION
Fixes #8270 

I had failed to update the error message when copying over the envelop plugin. This corrects that oversight. 

Comment: I'll likely produce a PR to update the envelop plugin once we've fully integrated and tested this custom/updated version in Redwood. 