### PR TITLE
fix(crwa): revert yarn.lock in crwa template

### DIFF
--- a/packages/create-redwood-app/tests/template.test.js
+++ b/packages/create-redwood-app/tests/template.test.js
@@ -167,41 +167,24 @@ describe('JS template', () => {
 })
 
 /**
- * Used to get the directory structure of the CRWA templates for snapshot testing.
- *
- * Between CI and our branch strategy, this function has to handle some edge cases:
- *
- * - the yarn lint edge case
- *
- *   We run `yarn lint` before `yarn test` in CI.
- *   Running `yarn lint` leads to a call to `getPaths` from `@redwoodjs/internal` which creates the `.redwood` directory.
- *   That directory and its contents aren't part of the template,
- *   but will be picked up by this test and lead to a false negative without this.
- *
- * - the yarn.lock edge case
- *
- *   When we release , we add lock files to the templates to speed up yarn install.
- *   We remove these lock files after releasing.
- *   But before we release, we run all our unit tests, so these test sees an extra file and fails.
- *   While introduces a blind spot (if a lock file gets added, it won't be caught), that's the tradeoff we're making.
- *
  * @param {string} dir
  * @returns string[]
  */
 function getDirectoryStructure(dir) {
   let fileStructure = klawSync(dir)
 
-  return fileStructure
-    .filter(
-      (file) =>
-        !filePathsToIgnore.some((filePathToIgnore) =>
-          file.path.includes(filePathToIgnore)
-        )
-    )
-    .map((file) =>
-      file.path.replace(dir, '').split(path.sep).join(path.posix.sep)
-    )
-    .sort()
+  return (
+    fileStructure
+      // This filter handles an edge case in CI.
+      //
+      // We run `yarn lint` before `yarn test` in CI.
+      // Running `yarn lint` leads to a call to `getPaths` from `@redwoodjs/internal` which creates the `.redwood` directory.
+      // That directory and its contents aren't part of the template,
+      // but will be picked up by this test and lead to a false negative without this.
+      .filter((file) => !file.path.includes('.redwood'))
+      .map((file) =>
+        file.path.replace(dir, '').split(path.sep).join(path.posix.sep)
+      )
+      .sort()
+  )
 }
-
-const filePathsToIgnore = ['.redwood', 'yarn.lock']

--- a/packages/create-redwood-app/tsToJS.mjs
+++ b/packages/create-redwood-app/tsToJS.mjs
@@ -18,7 +18,6 @@ const { default: prettierConfig } = await import(
   new URL('./templates/ts/prettier.config.js', import.meta.url)
 )
 
-// Handle node_modules, .yarn/install-state.gz.
 const tsTemplateNodeModulesPath = path.join(
   TS_TEMPLATE_FILEPATH,
   'node_modules'
@@ -29,25 +28,12 @@ if (fs.existsSync(tsTemplateNodeModulesPath)) {
   fs.rmSync(tsTemplateNodeModulesPath, { recursive: true })
 }
 
-const tsTemplateYarnInstallState = path.join(
-  TS_TEMPLATE_FILEPATH,
-  '.yarn',
-  'install-state.gz'
-)
-
-if (fs.existsSync(tsTemplateYarnInstallState)) {
-  console.log('Removing .yarn/install-state.gz in TS template')
-  fs.rmSync(tsTemplateYarnInstallState, { recursive: true })
-}
-
-// Clean and copy the TS template to the JS template.
 console.log('Cleaning JS template')
 fs.rmSync(JS_TEMPLATE_FILEPATH, { recursive: true })
 
 console.log('Copying TS template to JS template')
 fs.copySync(TS_TEMPLATE_FILEPATH, JS_TEMPLATE_FILEPATH)
 
-// Find files and transform.
 const apiWebFilePaths = fg.sync('{api,web}/src/**/*.{ts,tsx}', {
   cwd: JS_TEMPLATE_FILEPATH,
   absolute: true,


### PR DESCRIPTION
Reverts https://github.com/redwoodjs/redwood/commit/20a87bc4d8cff6553169877b7c60dee9bf1d39dc and part of https://github.com/redwoodjs/redwood/commit/1d341dd8336eee010023f910b1bda39211ebe2d6, which added `yarn.lock` files to the create redwood app templates at the time of publish.

The rationale for the above change was simply:
- yarn install is the slowest part of create redwood app
- we could speed up yarn install by shipping a lock file so yarn didn't have to resolve all the versions of all the packages on a user's computer 

The problem isn't that the above idea is impossible, but that our setup with lerna publishing makes it difficult to do. It's pretty obvious in hindsight:

<img width="1136" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/0f86d656-07e1-43b5-b1b4-375c0549c140">

You can't make a lock file for packages that aren't published. The bug in my script was that the lock file gets made before the package versions are updated. So after the package versions are updated, the lock file is outdated. This means when users get a project, when they run yarn install, the lock file gets updated. This may be faster than a lock file from scratch (I'm not sure), but that's not the point. The point is now, users have a git change as soon as they run yarn install which is incorrect and annoying. So doubling back on this for now.