### PR TITLE
fix(vite): import default from `vite-plugin-commonjs`

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -32,7 +32,7 @@
     "buffer": "6.0.3",
     "core-js": "3.30.2",
     "vite": "4.3.5",
-    "vite-plugin-commonjs": "0.7.0",
+    "vite-plugin-commonjs": "0.6.2",
     "vite-plugin-environment": "1.1.3",
     "vite-plugin-html": "3.2.0"
   },

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -18,8 +18,6 @@ import { getConfig, getPaths } from '@redwoodjs/project-config'
 
 const readFile = promisify(fsReadFile)
 
-// Using require, because plugin has TS errors
-
 /**
  * Preconfigured vite plugin, with required config for Redwood apps.
  */

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -18,7 +18,7 @@ import { getConfig, getPaths } from '@redwoodjs/project-config'
 const readFile = promisify(fsReadFile)
 
 // Using require, because plugin has TS errors
-const commonjs = require('vite-plugin-commonjs')
+const { default: commonjs } = require('vite-plugin-commonjs')
 
 /**
  * Preconfigured vite plugin, with required config for Redwood apps.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -9,6 +9,7 @@ import {
   transformWithEsbuild,
   UserConfig,
 } from 'vite'
+import commonjs from 'vite-plugin-commonjs'
 import EnvironmentPlugin from 'vite-plugin-environment'
 import { createHtmlPlugin } from 'vite-plugin-html'
 
@@ -18,7 +19,6 @@ import { getConfig, getPaths } from '@redwoodjs/project-config'
 const readFile = promisify(fsReadFile)
 
 // Using require, because plugin has TS errors
-const { default: commonjs } = require('vite-plugin-commonjs')
 
 /**
  * Preconfigured vite plugin, with required config for Redwood apps.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -9,7 +9,6 @@ import {
   transformWithEsbuild,
   UserConfig,
 } from 'vite'
-import commonjs from 'vite-plugin-commonjs'
 import EnvironmentPlugin from 'vite-plugin-environment'
 import { createHtmlPlugin } from 'vite-plugin-html'
 
@@ -17,6 +16,9 @@ import { getWebSideDefaultBabelConfig } from '@redwoodjs/internal/dist/build/bab
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 
 const readFile = promisify(fsReadFile)
+
+// Using require, because plugin has TS errors
+const commonjs = require('vite-plugin-commonjs')
 
 /**
  * Preconfigured vite plugin, with required config for Redwood apps.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,7 +7499,7 @@ __metadata:
     jest: 29.5.0
     typescript: 5.0.4
     vite: 4.3.5
-    vite-plugin-commonjs: 0.7.0
+    vite-plugin-commonjs: 0.6.2
     vite-plugin-environment: 1.1.3
     vite-plugin-html: 3.2.0
   bin:
@@ -11034,7 +11034,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:8.8.2, acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0, acorn@npm:^8.8.1, acorn@npm:^8.8.2":
+"acorn@npm:8.8.2, acorn@npm:^8.0.4, acorn@npm:^8.1.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0, acorn@npm:^8.8.1":
   version: 8.8.2
   resolution: "acorn@npm:8.8.2"
   bin:
@@ -17233,7 +17233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:3.2.12, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9":
+"fast-glob@npm:3.2.12, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.9, fast-glob@npm:~3.2.11":
   version: 3.2.12
   resolution: "fast-glob@npm:3.2.12"
   dependencies:
@@ -31845,25 +31845,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-commonjs@npm:0.7.0":
-  version: 0.7.0
-  resolution: "vite-plugin-commonjs@npm:0.7.0"
+"vite-plugin-commonjs@npm:0.6.2":
+  version: 0.6.2
+  resolution: "vite-plugin-commonjs@npm:0.6.2"
   dependencies:
-    acorn: ^8.8.2
-    fast-glob: ^3.2.12
-    vite-plugin-dynamic-import: ^1.3.2
-  checksum: bac062401fd95707d3138718c2c1aaed1a1976a4753f10a83c5e86662d9ef872ea8b049b93f279520811fafae781de3cfa531f119840417240887c72df31b6c3
-  languageName: node
-  linkType: hard
-
-"vite-plugin-dynamic-import@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "vite-plugin-dynamic-import@npm:1.3.2"
-  dependencies:
-    acorn: ^8.8.2
-    es-module-lexer: ^1.2.1
-    fast-glob: ^3.2.12
-  checksum: 2a6f476fc91088e5ae2a67b0ddab7fadd0bc99709fe6094f9b894c9acc52f9f1de3fa584c0039a8d8605c4fc06e4eced035a88c4329bb47e4eb05399b3b1c663
+    fast-glob: ~3.2.11
+  checksum: 498623f609702fc36afdb08ec1261f8bc6acb5eb80746671229301fd1db3b9409aeab8465df3bfc4f12c1c0da6f15d38711d3265577db3017352d31d58e08bd4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes https://community.redwoodjs.com/t/redwood-v5-0-0-upgrade-guide/4715/23.