### PR TITLE
chore(cli): Add builder epilogue to experimental commands

### DIFF
--- a/packages/cli/src/commands/experimental/setupOpentelemetry.js
+++ b/packages/cli/src/commands/experimental/setupOpentelemetry.js
@@ -1,3 +1,5 @@
+import { getEpilogue } from './util'
+
 export const command = 'setup-opentelemetry'
 
 export const description = 'Setup OpenTelemetry within the API side'
@@ -5,18 +7,20 @@ export const description = 'Setup OpenTelemetry within the API side'
 export const EXPERIMENTAL_TOPIC_ID = 4772
 
 export const builder = (yargs) => {
-  yargs.option('force', {
-    alias: 'f',
-    default: false,
-    description: 'Overwrite existing configuration',
-    type: 'boolean',
-  })
-  yargs.option('verbose', {
-    alias: 'v',
-    default: false,
-    description: 'Print more logs',
-    type: 'boolean',
-  })
+  yargs
+    .option('force', {
+      alias: 'f',
+      default: false,
+      description: 'Overwrite existing configuration',
+      type: 'boolean',
+    })
+    .option('verbose', {
+      alias: 'v',
+      default: false,
+      description: 'Print more logs',
+      type: 'boolean',
+    })
+    .epilogue(getEpilogue(command, description, EXPERIMENTAL_TOPIC_ID, true))
 }
 
 export const handler = async (options) => {

--- a/packages/cli/src/commands/experimental/studio.js
+++ b/packages/cli/src/commands/experimental/studio.js
@@ -1,4 +1,4 @@
-import terminalLink from 'terminal-link'
+import { getEpilogue } from './util'
 
 export const command = 'studio'
 export const description = 'Run the Redwood development studio'
@@ -11,12 +11,7 @@ export function builder(yargs) {
       default: true,
       description: 'Open the studio in your browser',
     })
-    .epilogue(
-      `Also see the ${terminalLink(
-        'Redwood CLI Reference',
-        'https://redwoodjs.com/docs/cli-commands#studio'
-      )}`
-    )
+    .epilogue(getEpilogue(command, description, EXPERIMENTAL_TOPIC_ID, true))
 }
 
 export async function handler(options) {


### PR DESCRIPTION
In #8268 I forgot to add the epilogues to the builders, this corrects that. 