### PR TITLE
fix(forms): disable webpack-dev-server overlay

### DIFF
--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -86,6 +86,8 @@ const baseConfig = merge(webpackConfig('development'), {
     // `runtimeErrors` became true by default in webpack-dev-server v4.15.0 and interferes with <FormError />.
     client: {
       overlay: {
+        errors: true,
+        warnings: false,
         runtimeErrors: false,
       },
     },

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -83,6 +83,12 @@ const getProxyConfig = () => {
 /** @type {import('webpack').Configuration} */
 const baseConfig = merge(webpackConfig('development'), {
   devServer: {
+    // `runtimeErrors` became true by default in webpack-dev-server v4.15.0 and interferes with <FormError />.
+    client: {
+      overlay: {
+        runtimeErrors: false,
+      },
+    },
     // https://webpack.js.org/configuration/dev-server/
     // note: docs not yet updated for webpack-dev-server v4
     devMiddleware: {

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -86,8 +86,6 @@ const baseConfig = merge(webpackConfig('development'), {
     // `runtimeErrors` became true by default in webpack-dev-server v4.15.0 and interferes with <FormError />.
     client: {
       overlay: {
-        errors: true,
-        warnings: false,
         runtimeErrors: false,
       },
     },


### PR DESCRIPTION
Fixes https://community.redwoodjs.com/t/tutorial-email-server-validation-shows-a-runtime-error-coming-from-apollo/4883.

The issue has nothing to do with `@apollo/client`; it's `webpack-dev-server` v4.15.0 which added and enabled the `runtimeErrors` overlay which interferes with our form error handling.

See:
- https://github.com/redwoodjs/redwood/pull/8245
- https://github.com/webpack/webpack-dev-server/pull/4849
- https://github.com/webpack/webpack.js.org/commit/5873fcc08126bc60e83b3d0fb0d02e62d891f8e7