### PR TITLE
feat(cli): Support for plugins

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -34,6 +34,7 @@ import * as typeCheckCommand from './commands/type-check'
 import * as upgradeCommand from './commands/upgrade'
 import { getPaths } from './lib'
 import * as updateCheck from './lib/updateCheck'
+import { loadPlugins } from './plugin'
 
 // # Setting the CWD
 //
@@ -98,54 +99,61 @@ config({
   multiline: true,
 })
 
-// # Build the CLI and run it
-yargs(hideBin(process.argv))
-  // Config
-  .scriptName('rw')
-  .middleware(
-    [
-      // We've already handled `cwd` above, but it may still be in `argv`.
-      // We don't need it anymore so let's get rid of it.
-      (argv) => {
-        delete argv.cwd
-      },
-      telemetryMiddleware,
-      updateCheck.isEnabled() && updateCheck.updateCheckMiddleware,
-    ].filter(Boolean)
-  )
-  .option('cwd', {
-    describe: 'Working directory to use (where `redwood.toml` is located)',
-  })
-  .example(
-    'yarn rw g page home /',
-    "\"Create a page component named 'Home' at path '/'\""
-  )
-  .demandCommand()
-  .strict()
+async function runYargs() {
+  // # Build the CLI yargs instance
+  const yarg = yargs(hideBin(process.argv))
+    // Config
+    .scriptName('rw')
+    .middleware(
+      [
+        // We've already handled `cwd` above, but it may still be in `argv`.
+        // We don't need it anymore so let's get rid of it.
+        (argv) => {
+          delete argv.cwd
+        },
+        telemetryMiddleware,
+        updateCheck.isEnabled() && updateCheck.updateCheckMiddleware,
+      ].filter(Boolean)
+    )
+    .option('cwd', {
+      describe: 'Working directory to use (where `redwood.toml` is located)',
+    })
+    .example(
+      'yarn rw g page home /',
+      "\"Create a page component named 'Home' at path '/'\""
+    )
+    .demandCommand()
+    .strict()
 
-  // Commands
-  .command(buildCommand)
-  .command(checkCommand)
-  .command(consoleCommand)
-  .command(dataMigrateCommand)
-  .command(deployCommand)
-  .command(destroyCommand)
-  .command(devCommand)
-  .command(execCommand)
-  .command(experimentalCommand)
-  .command(generateCommand)
-  .command(infoCommand)
-  .command(lintCommand)
-  .command(prerenderCommand)
-  .command(prismaCommand)
-  .command(recordCommand)
-  .command(serveCommand)
-  .command(setupCommand)
-  .command(storybookCommand)
-  .command(testCommand)
-  .command(tstojsCommand)
-  .command(typeCheckCommand)
-  .command(upgradeCommand)
+    // Commands (Built in or pre-plugin support)
+    .command(buildCommand)
+    .command(checkCommand)
+    .command(consoleCommand)
+    .command(dataMigrateCommand)
+    .command(deployCommand)
+    .command(destroyCommand)
+    .command(devCommand)
+    .command(execCommand)
+    .command(experimentalCommand)
+    .command(generateCommand)
+    .command(infoCommand)
+    .command(lintCommand)
+    .command(prerenderCommand)
+    .command(prismaCommand)
+    .command(recordCommand)
+    .command(serveCommand)
+    .command(setupCommand)
+    .command(storybookCommand)
+    .command(testCommand)
+    .command(tstojsCommand)
+    .command(typeCheckCommand)
+    .command(upgradeCommand)
+
+  // Load any CLI plugins
+  await loadPlugins(yarg)
 
   // Run
-  .parse()
+  yarg.parse()
+}
+
+runYargs()

--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -6,6 +6,29 @@ import fs from 'fs-extra'
 import { getPaths } from './index'
 
 /**
+ *  Installs a module into a user's project. If the module is already installed,
+ *  this function does nothing.
+ *
+ * @param {string} name The name of the module to install
+ * @param {string} version The version of the module to install
+ * @param {boolean} isDevDependency Whether to install as a devDependency or not
+ * @returns Whether the module was installed or not
+ */
+export async function installModule(name, version, isDevDependency = true) {
+  if (isModuleInstalled(name)) {
+    return false
+  }
+  await execa.command(
+    `yarn add ${isDevDependency ? '-D' : ''} ${name}@${version}`,
+    {
+      stdio: 'inherit',
+      cwd: getPaths().base,
+    }
+  )
+  return true
+}
+
+/**
  * Installs a Redwood module into a user's project keeping the version consistent with that of \@redwoodjs/cli.
  * If the module is already installed, this function does nothing.
  * If no remote version can not be found which matches the local cli version then the latest canary version will be used.

--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -1,0 +1,228 @@
+import fs from 'fs'
+import path from 'path'
+
+import chalk from 'chalk'
+
+import { getConfig, getPaths } from './lib'
+import { installModule } from './lib/packages'
+
+const PLUGIN_CACHE_FILENAME = 'command-cache.json'
+
+function validatePluginList(plugins) {
+  // Plugins should only occur once in the list
+  const pluginNames = plugins.map((p) => p.package)
+  if (plugins.length !== new Set(pluginNames).size) {
+    console.warn(
+      chalk.yellow(
+        '⚠️  Duplicate plugin names found in redwood.toml, duplicates will be ignored.'
+      )
+    )
+  }
+
+  // Plugins should be published to npm under a scope which is used as the namespace
+  const namespaces = plugins.map((p) => p.package.split('/')[0])
+  namespaces.forEach((ns) => {
+    if (!ns.includes('@')) {
+      console.warn(
+        chalk.yellow(
+          `⚠️  Plugin "${ns}" is missing a scope/namespace, it will not be loaded.`
+        )
+      )
+    }
+  })
+}
+
+export async function loadPlugins(yargs) {
+  const { plugins, autoInstall } = getConfig().cli
+
+  // TODO: Remove this when we make the full switch to a total plugin based CLI
+  // If we don't have any plugins in the toml file, add all the current @redwoodjs plugins
+  if (plugins.length === 0) {
+    // TODO: Start splitting up CLI into plugins
+    // Nothing to add here at the moment
+  }
+
+  // Validate plugin list from redwood.toml, will print warnings to the console
+  validatePluginList(plugins)
+
+  // Get a list of all unique namespaces, sorted alphabetically but with @redwoodjs first
+  // we ignore any invalid names i.e. names without an '@'
+  const namespaces = Array.from(
+    new Set([
+      ...plugins
+        .filter((p) => p.package.startsWith('@redwoodjs/'))
+        .map((p) => p.package.split('/')[0])
+        .sort((a, b) =>
+          a.package > b.package ? 1 : b.package > a.package ? -1 : 0
+        ),
+      ...plugins
+        .filter((p) => !p.package.startsWith('@redwoodjs/'))
+        .map((p) => p.package.split('/')[0])
+        .sort((a, b) =>
+          a.package > b.package ? 1 : b.package > a.package ? -1 : 0
+        ),
+    ])
+  ).filter((ns) => ns.includes('@'))
+
+  // If the user is running a help command or no command was given
+  // we want to load all plugins for observability in the help output
+  const processArgv = process.argv.slice(2).join(' ')
+  const showingRootHelp =
+    processArgv === '--help' || processArgv === '-h' || processArgv === ''
+
+  // Filter the namespaces based on the command line args to
+  // reduce the number of plugins we need to load
+  const namespacesInUse = namespaces.filter(
+    (ns) => showingRootHelp || processArgv.includes(ns)
+  )
+  if (namespacesInUse.length === 0) {
+    // If no namespace is in use we're using the default @redwoodjs namespace which
+    // is just an empty string ''
+    namespacesInUse.unshift('@redwoodjs')
+  }
+
+  // TODO: We should have some mechanism to fetch the cache from an online or precomputed
+  // source this will allow us to have a cache hit on the first run of a command
+  let pluginCommandCache = {}
+  try {
+    pluginCommandCache = JSON.parse(
+      fs.readFileSync(
+        path.join(getPaths().generated.base, PLUGIN_CACHE_FILENAME)
+      )
+    )
+  } catch (_error) {
+    // No need to log this error, it's just a cache miss
+    // console.log(error)
+  }
+
+  // We filter plugins based on the first word which depends on if a namespace is in use
+  const firstWord = process.argv[2]?.includes('@')
+    ? process.argv[3]
+    : process.argv[2]
+  const showingNamespaceHelp =
+    firstWord === '--help' || firstWord === '-h' || firstWord === undefined
+
+  for (const namespace of namespacesInUse) {
+    // Get all the plugins for this namespace
+    const namespacedPlugins = new Set(
+      plugins.filter(
+        (p) => p.package.startsWith(namespace) && (p.enabled ?? true)
+      )
+    )
+    // Do nothing if there are no enabled plugins for this namespace
+    if (namespacedPlugins.size === 0) {
+      continue
+    }
+
+    // For help output we only show the root level commands which doesn't actually need
+    // to load any plugins other than the @redwoodjs namespaced ones
+    if (showingRootHelp && namespace !== '@redwoodjs') {
+      yargs.command({
+        command: `${namespace} <command>`,
+        describe: `${namespace} plugin commands`,
+        builder: () => {},
+        handler: () => {},
+      })
+      continue
+    }
+
+    const namespacedCommands = []
+    // Load all plugins for this namespace
+    for (const namespacedPlugin of namespacedPlugins) {
+      // Check the cache to see if we can skip loading this plugin
+      // If this plugin doesn't have a command that matches the first word we can skip loading it
+      const cacheEntry = pluginCommandCache[namespacedPlugin.package]
+      if (
+        !showingNamespaceHelp &&
+        cacheEntry &&
+        !cacheEntry.includes(firstWord)
+      ) {
+        continue
+      }
+
+      let plugin
+      try {
+        plugin = await import(namespacedPlugin.package)
+      } catch (error) {
+        // TODO: Batch all missing plugins and install them in one go
+        if (error.code === 'MODULE_NOT_FOUND') {
+          if (!autoInstall) {
+            console.warn(
+              chalk.yellow(
+                `⚠️  Plugin "${namespacedPlugin.package}" cannot be loaded because it is not installed and "autoInstall" is disabled.`
+              )
+            )
+            continue
+          }
+          console.log(
+            chalk.green(`Installing plugin "${namespacedPlugin.package}"...`)
+          )
+          // Install the plugin
+          await installModule(
+            namespacedPlugin.package,
+            namespacedPlugin.version,
+            true
+          )
+          plugin = await import(namespacedPlugin.package)
+        }
+      }
+
+      if (!plugin) {
+        console.log(
+          chalk.red(`❌  Plugin "${namespacedPlugin.package}" failed to load.`)
+        )
+        continue
+      }
+
+      // Add the plugin to the cache entry
+      pluginCommandCache[namespacedPlugin.package] = []
+      for (const command of plugin.commands) {
+        // Add the first word of the command to the cache entry
+        pluginCommandCache[namespacedPlugin.package].push(
+          command.command.split(' ')[0]
+        )
+        // Add any aliases of the command to the cache entry
+        pluginCommandCache[namespacedPlugin.package].push(
+          ...(command.aliases || [])
+        )
+      }
+
+      // Add these commands to the namespace list
+      namespacedCommands.push(...plugin.commands)
+    }
+
+    // If we didn't load any commands for this namespace we can skip registering it
+    // unless we're loading all namespaces for the help output
+    if (namespacedCommands.length === 0 && !showingRootHelp) {
+      continue
+    }
+
+    // Register all commands we loaded for this namespace
+    // If the namespace is @redwoodjs, we don't need to nest the commands under a namespace
+    if (namespace === '@redwoodjs') {
+      yargs.command(namespacedCommands)
+    } else {
+      yargs.command({
+        command: `${namespace} <command>`,
+        describe: `${namespace} plugin commands`,
+        builder: (yargs) => {
+          yargs.command(namespacedCommands)
+        },
+        handler: () => {},
+      })
+    }
+  }
+
+  // Cache the plugin-command mapping to optimise loading on the next invocation
+  try {
+    fs.writeFileSync(
+      path.join(getPaths().generated.base, PLUGIN_CACHE_FILENAME),
+      JSON.stringify(pluginCommandCache)
+    )
+  } catch (_error) {
+    // console.error(error)
+    // No need to log this error, it's not critical to cache the plugin commands
+  }
+
+  return yargs
+}

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -100,6 +100,16 @@ export interface Config {
     }
     studio: StudioConfig
   }
+  cli: {
+    autoInstall: boolean
+    plugins: CLIPlugin[]
+  }
+}
+
+export interface CLIPlugin {
+  package: string
+  version: string
+  enabled?: boolean
 }
 
 // Note that web's includeEnvironmentVariables is handled in `webpack.common.js`
@@ -157,6 +167,10 @@ const DEFAULT_CONFIG: Config = {
         },
       },
     },
+  },
+  cli: {
+    autoInstall: false,
+    plugins: [],
   },
 }
 


### PR DESCRIPTION
**Problem**
We require the redwood CLI to become more pluggable. It should start to support plugins so we as a framework can write smaller individual CLI plugin packages which should be more performant and maintainable. We also need to support third party plugins so our partners and community can develop their own plugins for the redwood CLI.

**Solution**
**NOTE:** This PR does  not split up  the CLI into any packages and does not introduce any breaking changes. It merely adds the functionality to load plugins should they be present which by default they are not.

We support arbitrary npm packages that export a field `commands` which are a list of yargs command objects. These plugin packages are defined within the TOML with the following structure (the example is a valid third party package if you wish to test):
```toml
[cli]
  autoInstall = false
  [[cli.plugins]]
    package = "@joshgmw/rw-plugin-one"
    version = "0.0.3"
``` 
Packages must have a `package` and a `version` and can optionally contain an `enabled` flag which defaults to true. The `package` is the npm package name and `version` is the npm package version, semver or tag.

`autoInstall` is a flag which controls whether the CLI should attempt to automatically install any plugins which are defined in the TOML but which are not currently installed as a dev dependency. It currently defaults to `false`.

Plugin packages *must* be published under a scope such that they obtain an `@author/` prefix to the package name. This is because plugin commands are "namespaced" under the npm scope they were published under. Such that attempting to call commands from the example third party plugin above is achieved by:
```bash
yarn rw @joshgmw --help
```
This namespacing is nessecary to avoid global command name collisions. Without namespacing two plugins which have an `setup` command would conflict and yargs would only dispatch to the first `setup` which it loaded. With namespacing the task of preventing collisions belongs to plugin authors and they only need to avoid conflicts with any other plugins published under their scope.
RedwoodJS has reserved the `''` namespace so that all plugins published under `@redwoodjs/` don't need a namespace prefix, retaining their usual form of `yarn rw [command]` 

*Optimisations*
Although the goal is to support plugins we must be careful to ensure the CLI is performant - both with disk usage and process memory. A few simple optimisations have been added here:
* Namespace based plugin culling
	This means any plugin which are not from the namespace included in the invoked command are not loaded into memory. E.g. we only load plugins from `@joshgmw/` when we run `yarn rw @joshgmw [command]` as we know `@jtoar` plugins will not be needed. 
* Command based plugin culling
   It would still be non-performant to load all plugins within the same namespace. `@redwoodjs/` will likely publish multiple plugins and we do not wish to load all of them into memory to support a command which will only be performed by one of those packages. 
   To avoid this we currently cache the top level commands a plugin provides and use this cache to opportunistically skip loading them if we are sure they cannot provide the command we wish to call. This caching currently requires the plugin to have been loaded into memory at least once before so the cache entry is present. 
   Example: Assume `@joshgmw/rw-1` provides generator commands under `yarn rw @joshgmw generate [type]`  and that `@joshgmw/rw-2` provides setup commands under `yarn rw @joshgmw setup [type]`. Now assume a user runs `yarn rw @joshgmw setup coolThing`. By sampling the first command word, `setup`, and using the cache entries we can eliminate the need to load `@joshgmw/rw-1` because we know it cannot satisfy a setup command. 

Those optimisations should ensure only the dependencies of the packages which could provide the command are loaded into memory. Smaller CLI plugin packages which contain the minimal dependencies will therefore reduce memory usage. 
To reduce initial disk size we can make use of lazy-installing plugin packages. Plugins are installed as dev dependencies and plugins are known to the CLI via the TOML. This means it's possible for the CLI to know about the existence of commands which have not yet been fully installed. By selectively including only a subset of command packages as dev dependencies at the time we install a users project we can reduce the initial disk usage. The CLI plugin packages will be installed when needed. *Note*: As the cache entry for a plugin is currently only available after it is loaded for the first time we will only be able to lazy-install at the namespace level currently rather than at the individual plugin level. Providing a precomputed cache would allow full lazy-installing capabilities. 

**Next steps (in following PRs)**
1. We should start splitting up the existing CLI package into smaller CLI plugin packages based on:
	1. Usage volume - niche commands can be in a package which isn't installed in a users project at install time
	2. Scope/theme - commands with similar actions should be grouped into the same package
	3. Need - Commands that are immediately essential at dev time, like `dev`, `build` or `serve` should be grouped into a package
2. Add a CI action to precompute the cache for `@redwoodjs/` cli plugins when they change and add that to the crwa template. This would be an initial stopgap solution to an online cache entry.
3. Add helper functions to the base CLI package to assit in updating the `cli.plugins` toml entries. Commands like `add`, `remove` and `update` which assist in maintaining the plugin entries. 
4. Support some sort of online registry for users to see what packages exist and to provide an API to access data such as the cache entry.

Note: The instrumentation of the CLI using OpenTelemetry is likely to start alongside the process of introducing this plugin based architecture.