### PR TITLE
fix(canary): add back api server for yarn rw dev

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "@babel/runtime-corejs3": "7.21.5",
     "@iarna/toml": "2.2.5",
     "@prisma/internals": "4.14.0",
+    "@redwoodjs/api-server": "5.0.0",
     "@redwoodjs/cli-helpers": "5.0.0",
     "@redwoodjs/fastify": "5.0.0",
     "@redwoodjs/internal": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6387,7 +6387,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redwoodjs/api-server@workspace:packages/api-server":
+"@redwoodjs/api-server@5.0.0, @redwoodjs/api-server@workspace:packages/api-server":
   version: 0.0.0-use.local
   resolution: "@redwoodjs/api-server@workspace:packages/api-server"
   dependencies:
@@ -6956,6 +6956,7 @@ __metadata:
     "@babel/runtime-corejs3": 7.21.5
     "@iarna/toml": 2.2.5
     "@prisma/internals": 4.14.0
+    "@redwoodjs/api-server": 5.0.0
     "@redwoodjs/cli-helpers": 5.0.0
     "@redwoodjs/fastify": 5.0.0
     "@redwoodjs/internal": 5.0.0


### PR DESCRIPTION
> **Note**
>
> This is only in canary and doesn't require releasing a patch.

If you upgrade to `6.0.0-canary.168` canary and run `yarn rw dev` you'll get:

```
api | node:internal/modules/cjs/loader:1078
api |   throw err;
api |   ^
api | 
api | Error: Cannot find module '@redwoodjs/api-server/package.json'
api | Require stack:
api | - /Users/dom/prjcts/redwood/redwood-app/node_modules/@redwoodjs/core/dist/bins/rw-log-formatter.js
api |     at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
api |     at Function.resolve (node:internal/modules/cjs/helpers:116:19)
api |     at Object.<anonymous> (/Users/dom/prjcts/redwood/redwood-app/node_modules/@redwoodjs/core/dist/bins/rw-log-formatter.js:5:65)
api |     at Module._compile (node:internal/modules/cjs/loader:1254:14)
api |     at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
api |     at Module.load (node:internal/modules/cjs/loader:1117:32)
api |     at Module._load (node:internal/modules/cjs/loader:958:12)
api |     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
api |     at node:internal/main/run_main_module:23:47 {
api |   code: 'MODULE_NOT_FOUND',
api |   requireStack: [
api |     '/Users/dom/prjcts/redwood/redwood-app/node_modules/@redwoodjs/core/dist/bins/rw-log-formatter.js'
api |   ]
api | }
```

This is because I removed the api-server package from the CLI's dependencies. I replaced it with `@redwoodjs/fastify` in https://github.com/redwoodjs/redwood/pull/8119 but I missed the fact that there's this bin here the CLI also needs that api-server exports. To fix canary, this PR adds api-server back.

The reason this wasn't caught in CI is that `yarn rwfw` adds all redwood packages to a project, so it's hard to detect if a required one is missing.