### PR TITLE
fix(coherence): correct doc links, add commas to template

### DIFF
--- a/docs/docs/deploy/coherence.md
+++ b/docs/docs/deploy/coherence.md
@@ -13,7 +13,7 @@ description: Serverful deploys on GCP or AWS via Coherence's full-lifecycle envi
 
 ## Coherence Prerequisites
 
-To deploy to Coherence, your Redwood project needs to be hosted on GitHub and you must have an [AWS](tbd) or [GCP](tbd) account.
+To deploy to Coherence, your Redwood project needs to be hosted on GitHub and you must have an [AWS](https://docs.withcoherence.com/docs/overview/aws-deep-dive) or [GCP](https://docs.withcoherence.com/docs/overview/gcp-deep-dive) account.
 
 ## Coherence Deploy
 

--- a/docs/docs/deploy/coherence.md
+++ b/docs/docs/deploy/coherence.md
@@ -13,7 +13,7 @@ description: Serverful deploys on GCP or AWS via Coherence's full-lifecycle envi
 
 ## Coherence Prerequisites
 
-To deploy to Coherence, your Redwood project needs to be hosted on GitHub and you must have an [AWS](https://docs.withcoherence.com/docs/tutorials/creating-an-app-on-aws) or [GCP](https://docs.withcoherence.com/docs/tutorials/creating-an-app-on-gcp) account.
+To deploy to Coherence, your Redwood project needs to be hosted on GitHub and you must have an [AWS](tbd) or [GCP](tbd) account.
 
 ## Coherence Deploy
 

--- a/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
@@ -209,8 +209,9 @@ api:
       type: database
       ${db === 'postgres' ? 'adapter: postgresql' : ''}
 
-  # If you use data migrations, add "&&", "yarn", "rw" "data-migrate" "up".
   migration: ["yarn", "rw", "prisma", "migrate", "deploy"]
+  # If you use data migrations, swap the above for the following:
+  # migration: ["yarn", "rw", "prisma", "migrate", "deploy", "&&", "yarn", "rw", "data-migrate", "up"]
 
 web:
   type: frontend

--- a/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
@@ -92,8 +92,12 @@ async function getCoherenceConfigFileContent() {
 
   if (!SUPPORTED_DATABASES.includes(db)) {
     throw new Error(
-      `Coherence doesn't support the "${db}" provider. To proceed, switch to one of the following: ` +
-        SUPPORTED_DATABASES.join(', ')
+      [
+        `Coherence doesn't support the "${db}" provider in your Prisma schema.`,
+        `To proceed, switch to one of the following: ${SUPPORTED_DATABASES.join(
+          ', '
+        )}.`,
+      ].join('\n')
     )
   }
 

--- a/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
@@ -209,9 +209,9 @@ api:
       type: database
       ${db === 'postgres' ? 'adapter: postgresql' : ''}
 
-  migration: ["yarn", "rw", "prisma", "migrate", "deploy"]
-  # If you use data migrations, swap the above for the following:
+  # If you use data migrations, use the following instead:
   # migration: ["yarn", "rw", "prisma", "migrate", "deploy", "&&", "yarn", "rw", "data-migrate", "up"]
+  migration: ["yarn", "rw", "prisma", "migrate", "deploy"]
 
 web:
   type: frontend


### PR DESCRIPTION
A few small fixes for Coherence in v5.2.0. The doc change is the more important one and can be fixed without a patch. Made the links placeholders; waiting to hear back for the right ones.