### PR TITLE
fix(cli): Fix port in use check when using `--fwd="--port ..."` option

### DIFF
--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -50,9 +50,8 @@ export const handler = async ({
       ...forward.matchAll(/\-\-port(\=|\s)(?<port>[^\s]*)/g),
     ]
     if (forwardedPortMatches.length) {
-      webPreferredPort = forwardedPortMatches.pop().groups.port
+      webPreferredPort = parseInt(forwardedPortMatches.pop().groups.port)
     }
-
     webAvailablePort = await getFreePort(webPreferredPort, [
       apiPreferredPort,
       apiAvailablePort,

--- a/packages/cli/src/lib/ports.js
+++ b/packages/cli/src/lib/ports.js
@@ -2,9 +2,9 @@ import portfinder from 'portfinder'
 
 /**
  * Finds a free port
- * @param  {[number]}   requestedPort Port to start searching from
- * @param  {[number[]]} excludePorts  Array of port numbers to exclude
- * @return {[number]}                 A free port equal or higher than requestedPort but not within excludePorts. If no port can be found then returns -1
+ * @param  {number}   requestedPort Port to start searching from
+ * @param  {number[]} excludePorts  Array of port numbers to exclude
+ * @return {Promise<number>}                 A free port equal or higher than requestedPort but not within excludePorts. If no port can be found then returns -1
  */
 export async function getFreePort(requestedPort, excludePorts = []) {
   try {


### PR DESCRIPTION
**Problem**
When passing in the port option to the web side of the `yarn rw dev` command using `--fwd="--port ..."` the port you specify is always reported as in use.

**Solution**
Add `parseInt` from extracted string port option.