### PR TITLE
Add config for Auth Provider

### DIFF
--- a/packages/auth/src/AuthProvider/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider/AuthProvider.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode, useEffect, useState } from 'react'
 
+import { type HttpOptions } from '@apollo/client'
+
 import { AuthContextInterface, CurrentUser } from '../AuthContext'
 import type { AuthImplementation } from '../AuthImplementation'
 
@@ -18,8 +20,13 @@ import { useSignUp } from './useSignUp'
 import { useToken } from './useToken'
 import { useValidateResetToken } from './useValidateResetToken'
 
+export interface AuthProviderConfig {
+  fetchConfig?: HttpOptions
+}
+
 export interface AuthProviderProps {
   skipFetchCurrentUser?: boolean
+  config?: AuthProviderConfig
   children: ReactNode
 }
 
@@ -80,6 +87,7 @@ export function createAuthProvider<
   const AuthProvider = ({
     children,
     skipFetchCurrentUser,
+    config,
   }: AuthProviderProps) => {
     // const [hasRestoredState, setHasRestoredState] = useState(false)
 
@@ -96,7 +104,7 @@ export function createAuthProvider<
     const getCurrentUser = customProviderHooks?.useCurrentUser
       ? customProviderHooks.useCurrentUser
       : // eslint-disable-next-line react-hooks/rules-of-hooks
-        useCurrentUser(authImplementation)
+        useCurrentUser(authImplementation, config)
 
     const reauthenticate = useReauthenticate(
       authImplementation,

--- a/packages/auth/src/AuthProvider/useCurrentUser.ts
+++ b/packages/auth/src/AuthProvider/useCurrentUser.ts
@@ -2,21 +2,33 @@ import { useCallback } from 'react'
 
 import type { AuthImplementation } from '../AuthImplementation'
 
+import { AuthProviderConfig } from './AuthProvider'
 import { useToken } from './useToken'
 
-export const useCurrentUser = (authImplementation: AuthImplementation) => {
+export const useCurrentUser = (
+  authImplementation: AuthImplementation,
+  authProviderClientConfig?: AuthProviderConfig
+) => {
   const getToken = useToken(authImplementation)
 
   return useCallback(async (): Promise<Record<string, unknown>> => {
     // Always get a fresh token, rather than use the one in state
     const token = await getToken()
-    const response = await globalThis.fetch(globalThis.RWJS_API_GRAPHQL_URL, {
+
+    const fetcher =
+      authProviderClientConfig?.fetchConfig?.fetch ?? globalThis.fetch
+
+    const response = await fetcher(globalThis.RWJS_API_GRAPHQL_URL, {
+      ...(authProviderClientConfig?.fetchConfig?.fetchOptions ?? {}),
       method: 'POST',
-      credentials: 'include',
+      credentials:
+        (authProviderClientConfig?.fetchConfig
+          ?.credentials as RequestCredentials) ?? 'include',
       headers: {
         'content-type': 'application/json',
         'auth-provider': authImplementation.type,
         authorization: `Bearer ${token}`,
+        ...(authProviderClientConfig?.fetchConfig?.headers ?? {}),
       },
       body: JSON.stringify({
         query:
@@ -32,5 +44,12 @@ export const useCurrentUser = (authImplementation: AuthImplementation) => {
         `Could not fetch current user: ${response.statusText} (${response.status})`
       )
     }
-  }, [authImplementation, getToken])
+  }, [
+    authImplementation.type,
+    authProviderClientConfig?.fetchConfig?.credentials,
+    authProviderClientConfig?.fetchConfig?.fetch,
+    authProviderClientConfig?.fetchConfig?.fetchOptions,
+    authProviderClientConfig?.fetchConfig?.headers,
+    getToken,
+  ])
 }


### PR DESCRIPTION

# The issue

* The `AuthProvider` is not using the same fetch configuration as `RedwoodApolloProvider` when fetching from the graphQL API. This causes hard-to-find bugs.

* The header `Access-Control-Allow-Credentials` is always set to `include` when fetching `currentUser`:
<img width="757" alt="image" src="https://github.com/redwoodjs/redwood/assets/1438153/325e6db1-a1b1-4233-80e6-3efae84d206a">


When using token-based authentication, this might not be desired. This is not allowed and will cause a CORS error when the header `Access-Control-Allow-Origin`is set to `*`

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials

* It's not possible to send custom headers. Sometimes you want to send additional headers when fetching the current user. For example, if you're building a multi-tenant solution you might want to send the header `X-Tenant` in the request.

# The solution

As a developer, I want to be able to provide the same fetch configuration to the `AuthProvider` as I do to the `RedwoodApolloProvider`

<img width="777" alt="image" src="https://github.com/redwoodjs/redwood/assets/1438153/b3f9e894-e20a-4a60-8054-c36ceea7e667">


