### PR TITLE
fix(coherence): fix health check path

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
@@ -204,7 +204,7 @@ api:
   system:
     cpu: 2
     memory: 2G
-    health_check: "/health"
+    health_check: "/api/health"
 
   resources:
     - name: ${path.basename(redwoodProjectPaths.base)}-db


### PR DESCRIPTION
cc @zach-withcoherence. We didn't catch this before since GCP health checks work different from AWS