### PR TITLE
fix(cli) setup tsconfig update template path

### DIFF
--- a/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
+++ b/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
@@ -18,7 +18,7 @@ export const handler = async ({ force }) => {
     ? 'main'
     : `v${installedRwVersion}`
 
-  const CRWA_TEMPLATE_URL = `https://raw.githubusercontent.com/redwoodjs/redwood/${GITHUB_VERSION_TAG}/packages/create-redwood-app/template`
+  const CRWA_TEMPLATE_URL = `https://raw.githubusercontent.com/redwoodjs/redwood/${GITHUB_VERSION_TAG}/packages/create-redwood-app/templates/ts`
 
   const tasks = new Listr(
     [


### PR DESCRIPTION
This modifies the template path of tsconfig used during `yarn rw setup tsconfig` from:
- `https://raw.githubusercontent.com/redwoodjs/redwood/v5.2.2/packages/create-redwood-app/template/web|api/tsconfig.json`
to
- `https://raw.githubusercontent.com/redwoodjs/redwood/v5.2.2/packages/create-redwood-app/templates/ts/web|api/tsconfig.json`

This change is necessary after the CRAW template was split into separate directories.