### PR TITLE
Reserve h for help, and format docs

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1989,12 +1989,12 @@ yarn redwood serve [side]
 
 `yarn rw serve` is useful for debugging locally or for self-hosting—deploying a single server into a serverful environment. Since both the api and the web sides run in the same server, CORS isn't a problem.
 
-| Arguments & Options | Description                                                                    |
-| ------------------- | ------------------------------------------------------------------------------ |
-| `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web` |
-| `--port`            | What port should the server run on [default: 8911]                             |
+| Arguments & Options | Description                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web`                                                                  |
+| `--port`            | What port should the server run on [default: 8911]                                                                                              |
 | `--host`            | What host should the server run on. This defaults to the value of `web.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
-| `--socket`          | The socket the server should run. This takes precedence over port              |
+| `--socket`          | The socket the server should run. This takes precedence over port                                                                               |
 
 ### serve api
 
@@ -2006,12 +2006,12 @@ yarn rw serve api
 
 This command uses `apiUrl` in your `redwood.toml`. Use this command if you want to run just the api side on a server (e.g. running on Render).
 
-| Arguments & Options | Description                                                       |
-| ------------------- | ----------------------------------------------------------------- |
-| `--port`            | What port should the server run on [default: 8911]                |
+| Arguments & Options | Description                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--port`            | What port should the server run on [default: 8911]                                                                                              |
 | `--host`            | What host should the server run on. This defaults to the value of `api.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
-| `--socket`          | The socket the server should run. This takes precedence over port |
-| `--apiRootPath`     | The root path where your api functions are served                 |
+| `--socket`          | The socket the server should run. This takes precedence over port                                                                               |
+| `--apiRootPath`     | The root path where your api functions are served                                                                                               |
 
 For the full list of Server Configuration settings, see [this documentation](app-configuration-redwood-toml.md#api).
 If you want to format your log output, you can pipe the command to the Redwood LogFormatter:
@@ -2034,12 +2034,12 @@ This command serves the contents in `web/dist`. Use this command if you're debug
 >
 > Probably, but it can be a challenge to setup when you just want something running quickly!
 
-| Arguments & Options | Description                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------- |
-| `--port`            | What port should the server run on [default: 8911]                                    |
+| Arguments & Options | Description                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--port`            | What port should the server run on [default: 8911]                                                                                              |
 | `--host`            | What host should the server run on. This defaults to the value of `web.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
-| `--socket`          | The socket the server should run. This takes precedence over port                     |
-| `--apiHost`         | Forwards requests from the `apiUrl` (defined in `redwood.toml`) to the specified host |
+| `--socket`          | The socket the server should run. This takes precedence over port                                                                               |
+| `--apiHost`         | Forwards requests from the `apiUrl` (defined in `redwood.toml`) to the specified host                                                           |
 
 If you want to format your log output, you can pipe the command to the Redwood LogFormatter:
 

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -29,7 +29,6 @@ export const commonOptions = {
   host: {
     default: redwoodProjectConfig.web.host,
     type: 'string',
-    alias: 'h',
   },
   socket: { type: 'string' },
 } as const
@@ -43,7 +42,6 @@ export const apiCliOptions = {
   host: {
     default: redwoodProjectConfig.api.host,
     type: 'string',
-    alias: 'h',
   },
   socket: { type: 'string' },
   apiRootPath: {
@@ -64,7 +62,6 @@ export const webCliOptions = {
   host: {
     default: redwoodProjectConfig.web.host,
     type: 'string',
-    alias: 'h',
   },
   socket: { type: 'string' },
   apiHost: {

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -33,7 +33,6 @@ const argv = yargs(hideBin(process.argv))
     default: redwoodProjectConfig.api.port,
   })
   .option('host', {
-    alias: 'h',
     description: 'Host',
     type: 'string',
     default: redwoodProjectConfig.api.host,

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -30,7 +30,6 @@ export async function builder(yargs) {
           host: {
             default: redwoodProjectConfig.web.host,
             type: 'string',
-            alias: 'h',
           },
           socket: { type: 'string' },
         }),
@@ -77,7 +76,6 @@ export async function builder(yargs) {
           host: {
             default: redwoodProjectConfig.api.host,
             type: 'string',
-            alias: 'h',
           },
           socket: { type: 'string' },
           apiRootPath: {
@@ -106,7 +104,6 @@ export async function builder(yargs) {
           host: {
             default: redwoodProjectConfig.web.host,
             type: 'string',
-            alias: 'h',
           },
           socket: { type: 'string' },
           apiHost: {


### PR DESCRIPTION
#8385 introduced the `--host` option, with a `-h` alias. `-h` is probably best reserved for `--help`, so I'm removing it after discussing with @jtoar. 

Also updated the formatting of the docs for `--host` so that the table cells line up in the markdown source.