### PR TITLE
fix(api): Improve `auth-provider` header determination

### DIFF
--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -6,13 +6,16 @@ import type { Decoded } from './parseJWT'
 export type { Decoded }
 
 // This is shared by `@redwoodjs/web`
-const AUTH_PROVIDER_HEADER = 'Auth-Provider'
+const AUTH_PROVIDER_HEADER = 'auth-provider'
 
 export const getAuthProviderHeader = (event: APIGatewayProxyEvent) => {
-  return (
-    event?.headers[AUTH_PROVIDER_HEADER] ??
-    event?.headers[AUTH_PROVIDER_HEADER.toLowerCase()]
+  const authProviderKey = Object.keys(event?.headers ?? {}).find(
+    (key) => key.toLowerCase() === AUTH_PROVIDER_HEADER
   )
+  if (authProviderKey) {
+    return event?.headers[authProviderKey]
+  }
+  return undefined
 }
 
 export interface AuthorizationHeader {


### PR DESCRIPTION
**Problem**
See #8367 and #8368 for context.

**Solution**
Check for a key in a case insensitive manner rather than check for individual known key casings.

@jtoar Any reason we would avoid doing this?