### PR TITLE
chore: Cleans up server template for realtime

### DIFF
--- a/packages/cli/src/commands/experimental/templates/server.ts.template
+++ b/packages/cli/src/commands/experimental/templates/server.ts.template
@@ -1,4 +1,5 @@
 import path from 'path'
+
 import chalk from 'chalk'
 import { config } from 'dotenv-defaults'
 import Fastify from 'fastify'

--- a/packages/cli/src/commands/experimental/templates/server.ts.template
+++ b/packages/cli/src/commands/experimental/templates/server.ts.template
@@ -1,10 +1,7 @@
 import path from 'path'
-
-// import { useLiveQuery } from '@envelop/live-query'
 import chalk from 'chalk'
 import { config } from 'dotenv-defaults'
 import Fastify from 'fastify'
-import { OperationTypeNode } from 'graphql'
 
 import {
   coerceRootPath,
@@ -55,7 +52,6 @@ async function serve() {
   await fastify.register(redwoodFastifyGraphQLServer, {
     loggerConfig: {
       logger: logger,
-      options: { query: true, data: true, level: 'trace' },
     },
     graphiQLEndpoint: '/.redwood/functions/graphql',
     sdls,


### PR DESCRIPTION
With the last PR merged for realtime, I forgot to clean up the server file template so a few bits that are not needed unfortunately snuck in.

This removes:

* Operation node types not needed
* some live query comments
* whitespacing