### PR TITLE
fix(cli plugins): don't load all redwoodjs plugins

### DIFF
--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -133,7 +133,7 @@ export async function loadPlugins(yargs) {
 
     // If we didn't find any plugins to satisfy the first word we load all plugins so yargs can give
     // an appropriate help message
-    if (namespacePluginsToLoad.length === 0) {
+    if (namespacePluginsToLoad.length === 0 && namespace !== '@redwoodjs') {
       namespacePluginsToLoad.push(...namespacePlugins)
     }
 


### PR DESCRIPTION
Redwood version: `6.0.0-canary.322+300c35876`.

Quick fix to https://github.com/redwoodjs/redwood/pull/8454. @Josh-Walker-GM, feel free to redo this, but I'm going to merge this one as a temporary fix for the time being. Right now, canary will try to install the `@redwoodjs/cli-storybook` package no matter which `rw` command you run:

https://github.com/redwoodjs/redwood/assets/32992335/0b13bda5-cc54-40e2-91af-8d8a162ae814

I think it's an error in the plugin loading logic here when the namespace is `@redwoodjs`. This PR doesn't fix the `MODULE_NOT_FOUND` error, just stops the CLI from installing storybook on any CLI invocation.