### PR TITLE
Fix: return a jsx elemnet instead of string

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -341,7 +341,7 @@ export const Failure = ({ error }) => (
 )
 
 export const Success = ({ article }) => {
-  return JSON.stringify(article)
+  return <div>{JSON.stringify(article)}</div>
 }
 ```
 
@@ -375,7 +375,7 @@ export const Failure = ({ error }: CellFailureProps) => (
 )
 
 export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => {
-  return JSON.stringify(article)
+  return <div>{JSON.stringify(article)}</div>
 }
 ```
 


### PR DESCRIPTION
The Success Component now returns a JSX Element instead of a string, which leads to an Error in the ArticlePage. Instead of return JSON.stringify(article) it is now return <div>{JSON.stringify(article)}</div> . With this change we don't get any error in the ArticlePage, where we use the ArticleCell