### PR TITLE
fix(cli): Fix plugin loading logic for built-in commands

### DIFF
--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -11,42 +11,42 @@ import { installModule } from './lib/packages'
  */
 const PLUGIN_CACHE_FILENAME = 'command-cache.json'
 
-const DEFAULT_COMMAND_CACHE = {
+const PLUGIN_CACHE_DEFAULT = {
   '@redwoodjs/cli-storybook': ['storybook', 'sb'],
-  _builtin: [
-    'build',
-    'check',
-    'diagnostics',
-    'console',
-    'c',
-    'data-migrate',
-    'dm',
-    'dataMigrate',
-    'deploy',
-    'destroy',
-    'd',
-    'dev',
-    'exec',
-    'experimental',
-    'exp',
-    'generate',
-    'g',
-    'info',
-    'lint',
-    'prerender',
-    'render',
-    'prisma',
-    'record',
-    'serve',
-    'setup',
-    'test',
-    'ts-to-js',
-    'type-check',
-    'tsc',
-    'tc',
-    'upgrade',
-  ],
 }
+const PLUGIN_CACHE_BUILTIN = [
+  'build',
+  'check',
+  'diagnostics',
+  'console',
+  'c',
+  'data-migrate',
+  'dm',
+  'dataMigrate',
+  'deploy',
+  'destroy',
+  'd',
+  'dev',
+  'exec',
+  'experimental',
+  'exp',
+  'generate',
+  'g',
+  'info',
+  'lint',
+  'prerender',
+  'render',
+  'prisma',
+  'record',
+  'serve',
+  'setup',
+  'test',
+  'ts-to-js',
+  'type-check',
+  'tsc',
+  'tc',
+  'upgrade',
+]
 
 /**
  * Attempts to load all CLI plugins as defined in the redwood.toml file
@@ -69,7 +69,7 @@ export async function loadPlugins(yargs) {
 
   // TODO: We should have some mechanism to fetch the cache from an online or precomputed
   // source this will allow us to have a cache hit on the first run of a command
-  let pluginCommandCache = DEFAULT_COMMAND_CACHE
+  let pluginCommandCache = PLUGIN_CACHE_DEFAULT
   try {
     pluginCommandCache = JSON.parse(
       fs.readFileSync(
@@ -82,9 +82,10 @@ export async function loadPlugins(yargs) {
       console.error(error)
     }
   }
+  pluginCommandCache._builtin = PLUGIN_CACHE_BUILTIN
 
   // Check if the command is built in to the base CLI package
-  if (pluginCommandCache?._builtin?.includes(firstWord)) {
+  if (pluginCommandCache._builtin.includes(firstWord)) {
     // If the command is built in we don't need to load any plugins
     return yargs
   }

--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -16,6 +16,7 @@ const DEFAULT_COMMAND_CACHE = {
   _builtin: [
     'build',
     'check',
+    'diagnostics',
     'console',
     'c',
     'data-migrate',

--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -11,6 +11,42 @@ import { installModule } from './lib/packages'
  */
 const PLUGIN_CACHE_FILENAME = 'command-cache.json'
 
+const DEFAULT_COMMAND_CACHE = {
+  '@redwoodjs/cli-storybook': ['storybook', 'sb'],
+  _builtin: [
+    'build',
+    'check',
+    'console',
+    'c',
+    'data-migrate',
+    'dm',
+    'dataMigrate',
+    'deploy',
+    'destroy',
+    'd',
+    'dev',
+    'exec',
+    'experimental',
+    'exp',
+    'generate',
+    'g',
+    'info',
+    'lint',
+    'prerender',
+    'render',
+    'prisma',
+    'record',
+    'serve',
+    'setup',
+    'test',
+    'ts-to-js',
+    'type-check',
+    'tsc',
+    'tc',
+    'upgrade',
+  ],
+}
+
 /**
  * Attempts to load all CLI plugins as defined in the redwood.toml file
  *
@@ -18,6 +54,40 @@ const PLUGIN_CACHE_FILENAME = 'command-cache.json'
  * @returns The yargs instance with plugins loaded
  */
 export async function loadPlugins(yargs) {
+  // We filter plugins based on the first word which depends on if a namespace is in use
+  const firstWord = process.argv[2]?.startsWith('@')
+    ? process.argv[3]
+    : process.argv[2]
+
+  // Check for possible early exit for `yarn rw --version`
+  const showRootVersion = firstWord === '--version'
+  if (showRootVersion) {
+    // We don't need to load any plugins in this case
+    return yargs
+  }
+
+  // TODO: We should have some mechanism to fetch the cache from an online or precomputed
+  // source this will allow us to have a cache hit on the first run of a command
+  let pluginCommandCache = DEFAULT_COMMAND_CACHE
+  try {
+    pluginCommandCache = JSON.parse(
+      fs.readFileSync(
+        path.join(getPaths().generated.base, PLUGIN_CACHE_FILENAME)
+      )
+    )
+  } catch (error) {
+    // If the cache file doesn't exist we can just ignore it and continue
+    if (error.code !== 'ENOENT') {
+      console.error(error)
+    }
+  }
+
+  // Check if the command is built in to the base CLI package
+  if (pluginCommandCache?._builtin?.includes(firstWord)) {
+    // If the command is built in we don't need to load any plugins
+    return yargs
+  }
+
   const { plugins, autoInstall } = getConfig().experimental.cli
 
   const enabledPlugins = plugins.filter(
@@ -70,26 +140,6 @@ export async function loadPlugins(yargs) {
     namespacesInUse.push('@redwoodjs')
   }
 
-  // TODO: We should have some mechanism to fetch the cache from an online or precomputed
-  // source this will allow us to have a cache hit on the first run of a command
-  let pluginCommandCache = {}
-  try {
-    pluginCommandCache = JSON.parse(
-      fs.readFileSync(
-        path.join(getPaths().generated.base, PLUGIN_CACHE_FILENAME)
-      )
-    )
-  } catch (error) {
-    // If the cache file doesn't exist we can just ignore it and continue
-    if (error.code !== 'ENOENT') {
-      console.error(error)
-    }
-  }
-
-  // We filter plugins based on the first word which depends on if a namespace is in use
-  const firstWord = process.argv[2]?.includes('@')
-    ? process.argv[3]
-    : process.argv[2]
   const showNamespaceHelp =
     firstWord === '--help' || firstWord === '-h' || firstWord === undefined
 

--- a/packages/create-redwood-app/templates/js/.redwood/command-cache.json
+++ b/packages/create-redwood-app/templates/js/.redwood/command-cache.json
@@ -1,1 +1,0 @@
-{"@redwoodjs/cli-storybook":["storybook","sb"]}

--- a/packages/create-redwood-app/templates/ts/.redwood/command-cache.json
+++ b/packages/create-redwood-app/templates/ts/.redwood/command-cache.json
@@ -1,1 +1,0 @@
-{"@redwoodjs/cli-storybook":["storybook","sb"]}


### PR DESCRIPTION
Alternative to #8491. The loading logic had not considered built-in commands. This also address the `MODULE_NOT_FOUND` issue.

[Screencast from 2023-06-02 13-47-49.webm](https://github.com/redwoodjs/redwood/assets/56300765/c007228f-89de-4dbf-9481-315a4b2baf66)

**Changes**:
* Provide a list of built in commands which require no plugin loading.
* Rework plugin module loading/install so that we check first if it's installed then load. Rather than attempt to load and catch the module not found exception.