### PR TITLE
chore(ci): use canary version of rwjs vite

### DIFF
--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -70,7 +70,6 @@ export async function createCacheKeys(prefix) {
     process.env.RUNNER_OS,
     // @ts-expect-error not sure how to change the lib compiler option to es2021+ here.
     process.env.GITHUB_REF.replaceAll('/', '-'),
-    'test-project',
     await hashFiles(path.join('__fixtures__', 'test-project'))
   ].join('-')
 

--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -1,6 +1,7 @@
 /* eslint-env node */
 // @ts-check
 
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { getExecOutput } from '@actions/exec'
@@ -69,7 +70,12 @@ export async function createCacheKeys(prefix) {
     process.env.RUNNER_OS,
     // @ts-expect-error not sure how to change the lib compiler option to es2021+ here.
     process.env.GITHUB_REF.replaceAll('/', '-'),
+    'test-project',
+    await hashFiles(path.join('__fixtures__', 'test-project'))
   ].join('-')
+
+  // const testProjectKey = [
+  // ]
 
   const dependenciesKey = [
     baseKey,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,21 +247,21 @@ jobs:
 
       - name: 🧑‍💻 Run dev smoke tests
         working-directory: ./tasks/smoke-tests/dev
-        run: npx playwright test --project ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
+        run: npx playwright test --project chromium # ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
         env:
           REDWOOD_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
           REDWOOD_DISABLE_TELEMETRY: 1
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄 Smoke tests / ${{ matrix.os }} / node 18 latest
-          RECORD_REPLAY_TEST_METRICS: 1
+          # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄 Smoke tests / ${{ matrix.os }} / node 18 latest
+          # RECORD_REPLAY_TEST_METRICS: 1
 
       - name: 🔐 Run auth smoke tests
         working-directory: ./tasks/smoke-tests/auth
-        run: npx playwright test --project ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
+        run: npx playwright test --project chromium # ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
         env:
           REDWOOD_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄 Smoke tests / ${{ matrix.os }} / node 18 latest
-          RECORD_REPLAY_TEST_METRICS: 1
+          # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄 Smoke tests / ${{ matrix.os }} / node 18 latest
+          # RECORD_REPLAY_TEST_METRICS: 1
 
       - name: Run `rw build --no-prerender`
         run: |
@@ -275,30 +275,30 @@ jobs:
 
       - name: 🖥️ Run serve smoke tests
         working-directory: tasks/smoke-tests/serve
-        run: npx playwright test --project ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
+        run: npx playwright test --project chromium # ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
         env:
           REDWOOD_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄  Smoke tests / ${{ matrix.os }} / node 18 latest
-          RECORD_REPLAY_TEST_METRICS: 1
+          # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄  Smoke tests / ${{ matrix.os }} / node 18 latest
+          # RECORD_REPLAY_TEST_METRICS: 1
 
       - name: 📄 Run prerender smoke tests
         working-directory: tasks/smoke-tests/prerender
-        run: npx playwright test --project ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
+        run: npx playwright test --project chromium # ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
         env:
           REDWOOD_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄  Smoke tests / ${{ matrix.os }} / node 18 latest
-          RECORD_REPLAY_TEST_METRICS: 1
+          # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄  Smoke tests / ${{ matrix.os }} / node 18 latest
+          # RECORD_REPLAY_TEST_METRICS: 1
 
       - name: 📕 Run Storybook smoke tests
         working-directory: tasks/smoke-tests/storybook
-        run: npx playwright test --project ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
+        run: npx playwright test --project chromium # ${{ matrix.os == 'ubuntu-latest' && 'replay-chromium' || 'chromium' }}
         env:
           REDWOOD_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
-          RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄 Smoke tests / ${{ matrix.os }} / node 18 latest
-          RECORD_REPLAY_TEST_METRICS: 1
+          # RECORD_REPLAY_METADATA_TEST_RUN_TITLE: 🔄 Smoke tests / ${{ matrix.os }} / node 18 latest
+          # RECORD_REPLAY_TEST_METRICS: 1
 
       - name: Run `rw info`
         run: |
@@ -384,11 +384,11 @@ jobs:
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
         continue-on-error: true
 
-      - name: Upload Replays
-        if: always()
-        uses: replayio/action-upload@v0.5.0
-        with:
-          api-key: rwk_cZn4WLe8106j6tC5ygNQxDpxAwCLpFo5oLQftiRN7OP
+      # - name: Upload Replays
+      #   if: always()
+      #   uses: replayio/action-upload@v0.5.0
+      #   with:
+      #     api-key: rwk_cZn4WLe8106j6tC5ygNQxDpxAwCLpFo5oLQftiRN7OP
 
   smoke-tests-docs:
     needs: only-doc-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
         run: yarn rw dev --no-generate --fwd="--no-open" &
         working-directory: ${{ steps.createpath.outputs.project_path }}
 
+      - name: 🌲 Install Cypress
+        run: yarn run cypress install
+
       - name: 🌲 Run cypress
         uses: cypress-io/github-action@v5
         env:

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -23,7 +23,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "5.0.0",
+    "@redwoodjs/vite": "6.0.0-canary.344",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.23",
     "postcss-loader": "^7.3.0",


### PR DESCRIPTION
https://github.com/redwoodjs/redwood/pull/8471 added a new binary to a redwoodjs package. Our current tooling (`yarn rwfw project:deps, copy sync`) alone doesn't handle this use case. Instead we need the package with the binary to be installed, so I'm bumping `@redwoodjs/vite` to canary to see if it fixes it. If it does, I'll have to add a step to rebuilding the test project to persist this fix till we release the next major.