### PR TITLE
fix(ci): due to introduction of new vite binaries

### DIFF
--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -2,6 +2,7 @@
 // @ts-check
 
 import { fileURLToPath } from 'node:url'
+import path from 'node:path'
 
 import { getExecOutput } from '@actions/exec'
 import { hashFiles } from '@actions/glob'
@@ -69,6 +70,7 @@ export async function createCacheKeys(prefix) {
     process.env.RUNNER_OS,
     // @ts-expect-error not sure how to change the lib compiler option to es2021+ here.
     process.env.GITHUB_REF.replaceAll('/', '-'),
+    await hashFiles(path.join('__fixtures__', 'test-project')),
   ].join('-')
 
   const dependenciesKey = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
         run: yarn rw dev --no-generate --fwd="--no-open" &
         working-directory: ${{ steps.createpath.outputs.project_path }}
 
+      - name: 🌲 Install Cypress
+        run: yarn run cypress install
+
       - name: 🌲 Run cypress
         uses: cypress-io/github-action@v5
         env:

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -23,7 +23,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "5.0.0",
+    "@redwoodjs/vite": "6.0.0-canary.344",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.23",
     "postcss-loader": "^7.3.0",


### PR DESCRIPTION
https://github.com/redwoodjs/redwood/pull/8471 added a new binary to a redwoodjs package. Our current tooling (yarn rwfw project:deps, copy sync) alone doesn't handle this use case.

### This PR:
1. manually bumps `@redwoodjs/vite` to canary in the test-project fixture, so that the binary for rw-vite-build gets installed (we have to maintain this manually until release)
2. Adds cypress installation for e2e tests
