### PR TITLE
chore(cli-storybook): improve types, style changes

### DIFF
--- a/packages/cli-packages/storybook/build.mjs
+++ b/packages/cli-packages/storybook/build.mjs
@@ -9,10 +9,12 @@ const sourceFiles = fg.sync(['./src/**/*.ts'])
 // Build general source files
 const result = await esbuild.build({
   entryPoints: sourceFiles,
+  outdir: 'dist',
+
   format: 'cjs',
   platform: 'node',
   target: ['node18'],
-  outdir: 'dist',
+
   logLevel: 'info',
 
   // For visualizing the bundle.
@@ -20,4 +22,4 @@ const result = await esbuild.build({
   metafile: true,
 })
 
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile))
+fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))

--- a/packages/cli-packages/storybook/package.json
+++ b/packages/cli-packages/storybook/package.json
@@ -23,7 +23,6 @@
       "/dist/"
     ]
   },
-  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
   "dependencies": {
     "@redwoodjs/project-config": "5.0.0",
     "@redwoodjs/telemetry": "5.0.0",
@@ -39,9 +38,11 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
+    "@types/yargs": "17.0.24",
     "esbuild": "0.17.19",
     "fast-glob": "3.2.12",
     "jest": "29.5.0",
     "typescript": "5.1.3"
-  }
+  },
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cli-packages/storybook/src/commands/storybook.ts
+++ b/packages/cli-packages/storybook/src/commands/storybook.ts
@@ -1,9 +1,8 @@
 import terminalLink from 'terminal-link'
+import type { Argv } from 'yargs'
 
 import c from '../lib/colors'
 import { StorybookYargsOptions } from '../types'
-
-import type { Argv } from 'yargs'
 
 export const command = 'storybook'
 export const aliases = ['sb']
@@ -20,7 +19,9 @@ export const defaultOptions: StorybookYargsOptions = {
 }
 
 // TODO: Provide a type for the `yargs` argument
-export function builder(yargs: Argv<StorybookYargsOptions>): Argv<StorybookYargsOptions> {
+export function builder(
+  yargs: Argv<StorybookYargsOptions>
+): Argv<StorybookYargsOptions> {
   return yargs
     .option('build', {
       describe: 'Build Storybook',

--- a/packages/cli-packages/storybook/src/commands/storybook.ts
+++ b/packages/cli-packages/storybook/src/commands/storybook.ts
@@ -3,6 +3,8 @@ import terminalLink from 'terminal-link'
 import c from '../lib/colors'
 import { StorybookYargsOptions } from '../types'
 
+import type { Argv } from 'yargs'
+
 export const command = 'storybook'
 export const aliases = ['sb']
 export const description =
@@ -18,8 +20,8 @@ export const defaultOptions: StorybookYargsOptions = {
 }
 
 // TODO: Provide a type for the `yargs` argument
-export const builder = (yargs: any) => {
-  yargs
+export function builder(yargs: Argv<StorybookYargsOptions>): Argv<StorybookYargsOptions> {
+  return yargs
     .option('build', {
       describe: 'Build Storybook',
       type: 'boolean',
@@ -42,7 +44,7 @@ export const builder = (yargs: any) => {
     })
     .option('port', {
       describe: 'Which port to run storybook on',
-      type: 'integer',
+      type: 'number',
       default: defaultOptions.port,
     })
     .option('smoke-test', {
@@ -51,8 +53,8 @@ export const builder = (yargs: any) => {
       type: 'boolean',
       default: defaultOptions.smokeTest,
     })
-    // TODO: Provide a type for the `argv` argument
-    .check((argv: any) => {
+
+    .check((argv) => {
       if (argv.build && argv.smokeTest) {
         throw new Error('Can not provide both "--build" and "--smoke-test"')
       }
@@ -67,6 +69,7 @@ export const builder = (yargs: any) => {
 
       return true
     })
+
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
@@ -75,7 +78,7 @@ export const builder = (yargs: any) => {
     )
 }
 
-export const handler = async (options: StorybookYargsOptions) => {
+export async function handler(options: StorybookYargsOptions): Promise<void> {
   // NOTE: We should provide some visual output before the import to increase
   // the perceived performance of the command as there will be delay while we
   // load the handler.

--- a/packages/cli-packages/storybook/src/commands/storybookHandler.ts
+++ b/packages/cli-packages/storybook/src/commands/storybookHandler.ts
@@ -11,14 +11,14 @@ import c from '../lib/colors'
 import { getPaths } from '../lib/project'
 import { StorybookYargsOptions } from '../types'
 
-export const handler = async ({
+export async function handler({
   build,
   buildDirectory,
   ci,
   open,
   port,
   smokeTest,
-}: StorybookYargsOptions) => {
+}: StorybookYargsOptions) {
   const cwd = getPaths().web.base
   const staticAssetsFolder = path.join(cwd, 'public')
   const execaOptions: Partial<execa.Options> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7434,6 +7434,7 @@ __metadata:
     "@storybook/addon-docs": 7.0.18
     "@storybook/addon-essentials": 7.0.18
     "@storybook/react-webpack5": 7.0.18
+    "@types/yargs": 17.0.24
     chalk: 4.1.2
     esbuild: 0.17.19
     execa: 5.1.1


### PR DESCRIPTION
@Josh-Walker-GM here's a small set of changes to the cli-storybook package after our discussion earlier. I think the types could still be better, or at least I could be more confident in them, but what's in this PR is probably better than before. Most of this PR is just style changes though, and I thought I'd get those out of the way before we start moving other commands over.

I took a small crack at adding dependency cruiser, and adding it to every package.json seems like overkill, so I'm going to try making that into a script in `tasks/`.

Style changes:
- spaces between related config options in build.mjs
- functions over arrow functions in command module
- sorted the package.json