### PR TITLE
chore(rwfw): working refactor, make `project:sync` ignore more files

### DIFF
--- a/tasks/framework-tools/frameworkDepsToProject.mjs
+++ b/tasks/framework-tools/frameworkDepsToProject.mjs
@@ -1,23 +1,31 @@
 #!/usr/bin/env node
 /* eslint-env node */
+// @ts-check
 
 import path from 'node:path'
 
 import { addDependenciesToPackageJson } from './lib/project.mjs'
 
-const projectPath = process.argv?.[2] ?? process.env.RWJS_CWD
+function main() {
+  const projectPath = process.argv?.[2] ?? process.env.RWJS_CWD
 
-if (!projectPath) {
-  console.log('Error: Please specify the path to your Redwood Project')
-  console.log(`Usage: ${process.argv?.[1]} /path/to/rwjs/proect`)
-  process.exit(1)
+  if (!projectPath) {
+    process.exitCode = 1
+    console.error([
+      'Error: Please specify the path to your Redwood project',
+      `Usage: ${process.argv?.[1]} ./path/to/rw/project`,
+    ])
+    return
+  }
+
+  try {
+    const packageJsonPath = path.join(projectPath, 'package.json')
+    addDependenciesToPackageJson(packageJsonPath)
+    console.log('Done. Now run `yarn install`.')
+  } catch (e) {
+    console.log('Error:', e.message)
+    process.exitCode = 1
+  }
 }
 
-try {
-  const packageJsonPath = path.join(projectPath, 'package.json')
-  addDependenciesToPackageJson(packageJsonPath)
-  console.log('Done. Now run `yarn install`.')
-} catch (e) {
-  console.log('Error:', e.message)
-  process.exit(1)
-}
+main()

--- a/tasks/framework-tools/frameworkFilesToProject.mjs
+++ b/tasks/framework-tools/frameworkFilesToProject.mjs
@@ -1,19 +1,28 @@
 #!/usr/bin/env node
 /* eslint-env node */
+// @ts-check
 
 import { copyFrameworkFilesToProject } from './lib/project.mjs'
 
-const projectPath = process.argv?.[2] ?? process.env.RWJS_CWD
+async function main() {
+  const redwoodProjectPath = process.argv?.[2] ?? process.env.RWJS_CWD
 
-if (!projectPath) {
-  console.log('Error: Please specify the path to your Redwood Project')
-  console.log(`Usage: ${process.argv?.[1]} /path/to/rwjs/proect`)
-  process.exit(1)
+  // Mostly just making TS happy with the second condition.
+  if (!redwoodProjectPath || typeof redwoodProjectPath !== 'string') {
+    process.exitCode = 1
+    console.error([
+      'Error: Please specify the path to your Redwood project',
+      `Usage: ${process.argv?.[1]} ./path/to/rw/project`,
+    ])
+    return
+  }
+
+  try {
+    await copyFrameworkFilesToProject(redwoodProjectPath)
+  } catch (e) {
+    console.error('Error:', e.message)
+    process.exitCode = 1
+  }
 }
 
-try {
-  await copyFrameworkFilesToProject(projectPath)
-} catch (e) {
-  console.error('Error:', e.message)
-  process.exit(1)
-}
+main()

--- a/tasks/framework-tools/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/frameworkSyncToProject.mjs
@@ -8,6 +8,7 @@ import path from 'node:path'
 import c from 'ansi-colors'
 import chokidar from 'chokidar'
 import fs from 'fs-extra'
+import { rimraf } from 'rimraf'
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 
@@ -237,13 +238,7 @@ async function main() {
 
     try {
       logStatus(`Cleaning ${c.magenta(packageName)}...`)
-      execSync(
-        `yarn rimraf ${path.join(path.dirname(packageJsonPath), 'dist')}`,
-        {
-          stdio: options.verbose ? 'inherit' : 'pipe',
-          cwd: REDWOOD_FRAMEWORK_PATH,
-        }
-      )
+      await rimraf(path.join(path.dirname(packageJsonPath), 'dist'))
 
       logStatus(`Building ${c.magenta(packageName)}...`)
       execSync('yarn build', {

--- a/tasks/framework-tools/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/frameworkSyncToProject.mjs
@@ -31,6 +31,9 @@ const IGNORE_EXTENSIONS = ['.DS_Store']
 const ignored = [
   /node_modules/,
 
+  /packages\/codemods/,
+  /packages\/create-redwood-app/,
+
   /dist/,
 
   /__fixtures__/,

--- a/tasks/framework-tools/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/frameworkSyncToProject.mjs
@@ -1,129 +1,316 @@
 #!/usr/bin/env node
 /* eslint-env node */
+// @ts-check
 
-import fs from 'node:fs'
+import { execSync } from 'node:child_process'
 import path from 'node:path'
 
 import c from 'ansi-colors'
 import chokidar from 'chokidar'
+import fs from 'fs-extra'
+import { hideBin } from 'yargs/helpers'
+import yargs from 'yargs/yargs'
 
 import {
-  REDWOOD_PACKAGES_PATH,
-  packageJsonName,
+  getPackageJsonName,
   resolvePackageJsonPath,
-  buildPackages,
+  REDWOOD_FRAMEWORK_PATH,
+  REDWOOD_PACKAGES_PATH,
 } from './lib/framework.mjs'
-import { cleanPackages } from './lib/framework.mjs'
 import {
-  installProjectPackages,
   addDependenciesToPackageJson,
   copyFrameworkFilesToProject,
 } from './lib/project.mjs'
 
-const projectPath = process.argv?.[2] ?? process.env.RWJS_CWD
+const IGNORE_EXTENSIONS = ['.DS_Store']
 
-if (!projectPath) {
-  console.log('Error: Please specify the path to your Redwood Project')
-  console.log(`Usage: ${process.argv?.[1]} /path/to/rwjs/project`)
-  process.exit(1)
-}
+// Add to this array of strings, RegExps, or functions (whichever makes the most sense)
+// to ignore files that we don't want triggering package rebuilds.
+const ignored = [
+  /node_modules/,
 
-// Cache the original package.json and restore it when this process exits.
-const projectPackageJsonPath = path.join(projectPath, 'package.json')
+  /dist/,
 
-const projectPackageJson = fs.readFileSync(projectPackageJsonPath, 'utf-8')
-process.on('SIGINT', () => {
-  console.log()
-  console.log(`Removing framework packages from 'package.json'...`)
-  fs.writeFileSync(projectPackageJsonPath, projectPackageJson)
-  // TODO: Delete `node_modules/@redwoodjs`
-  console.log("...Done. Run 'yarn install'")
-  process.exit(0)
-})
+  /__fixtures__/,
+  /__mocks__/,
+  /__tests__/,
+  /.test./,
+  /jest.config.{js,ts}/,
 
-function logStatus(m) {
-  console.log(c.bgYellow(c.black('rwfw ')), c.yellow(m))
-}
+  /README.md/,
 
-function logError(m) {
-  console.log(c.bgRed(c.black('rwfw ')), c.red(m))
-}
+  // esbuild emits meta.json files that we sometimes suffix.
+  /meta.(\w*\.?)json/,
 
-chokidar
-  .watch(REDWOOD_PACKAGES_PATH, {
+  (filePath) => IGNORE_EXTENSIONS.some((ext) => filePath.endsWith(ext)),
+]
+
+const separator = '-'.repeat(process.stdout.columns)
+
+async function main() {
+  const { _: positionals, ...options } = yargs(hideBin(process.argv))
+    .options({
+      cleanFramework: {
+        description:
+          'Clean any built framework packages before watching for changes',
+        type: 'boolean',
+        default: true,
+      },
+      buildFramework: {
+        description:
+          'Build all the framework packages before watching for changes',
+        type: 'boolean',
+        default: true,
+      },
+      addDependencies: {
+        description:
+          "Add the framework's dependencies to the project and yarn install before watching for changes",
+        type: 'boolean',
+        default: true,
+      },
+      copyFiles: {
+        description:
+          "Copy the framework packages' files to the project's node_modules before watching for changes",
+        type: 'boolean',
+        default: true,
+      },
+      cleanUp: {
+        description:
+          "Restore the project's package.json when this process exits",
+        type: 'boolean',
+        default: true,
+      },
+      watch: {
+        description: 'Watch for changes to the framework packages',
+        type: 'boolean',
+        default: true,
+      },
+      verbose: {
+        description: 'Print more',
+        type: 'boolean',
+        default: true,
+      },
+    })
+    .parseSync()
+
+  const redwoodProjectPath = positionals[0] ?? process.env.RWJS_CWD
+
+  // Mostly just making TS happy with the second condition.
+  if (!redwoodProjectPath || typeof redwoodProjectPath !== 'string') {
+    process.exitCode = 1
+    console.error([
+      'Error: Please specify the path to your Redwood project',
+      `Usage: ${process.argv?.[1]} ./path/to/rw/project`,
+    ])
+    return
+  }
+
+  if (options.cleanFramework) {
+    logStatus('Cleaning the Redwood framework...')
+    execSync('yarn build:clean', {
+      stdio: options.verbose ? 'inherit' : 'pipe',
+      cwd: REDWOOD_FRAMEWORK_PATH,
+    })
+  }
+
+  if (options.buildFramework) {
+    try {
+      logStatus('Building the Redwood framework...')
+      execSync('yarn build', {
+        stdio: options.verbose ? 'inherit' : 'pipe',
+        cwd: REDWOOD_FRAMEWORK_PATH,
+      })
+      console.log()
+    } catch (e) {
+      // Temporary error handling for.
+      //  >  Lerna (powered by Nx)   ENOENT: no such file or directory, open '/Users/dom/projects/redwood/redwood/node_modules/lerna/node_modules/nx/package.json'
+      process.exitCode = 1
+      console.error(
+        [
+          c.bgYellow(c.black('Heads up ')),
+          '',
+          "If this failed because Nx couldn't find its package.json file in node_modules, it's a known issue. The workaround is just trying again.",
+        ].join('\n')
+      )
+      return
+    }
+  }
+
+  // Settig up here first before we add the first SIGINT handler
+  // just for visual output.
+  process.on('SIGINT', () => {
+    console.log()
+  })
+
+  if (options.addDependencies) {
+    // Save the project's package.json so that we can restore it when this process exits.
+    const redwoodProjectPackageJsonPath = path.join(
+      redwoodProjectPath,
+      'package.json'
+    )
+    const redwoodProjectPackageJson = fs.readFileSync(
+      redwoodProjectPackageJsonPath,
+      'utf-8'
+    )
+
+    if (options.cleanUp) {
+      logStatus('Setting up clean up on SIGINT or process exit...')
+
+      const cleanUp = createCleanUp({
+        redwoodProjectPackageJsonPath,
+        redwoodProjectPackageJson,
+      })
+
+      process.on('SIGINT', cleanUp)
+      process.on('exit', cleanUp)
+    }
+
+    logStatus("Adding the Redwood framework's dependencies...")
+    addDependenciesToPackageJson(redwoodProjectPackageJsonPath)
+
+    try {
+      execSync('yarn install', {
+        cwd: redwoodProjectPath,
+        stdio: options.verbose ? 'inherit' : 'pipe',
+      })
+      console.log()
+    } catch (e) {
+      process.exitCode = 1
+      console.error(e)
+      return
+    }
+  }
+
+  if (options.copyFiles) {
+    logStatus('Copying the Redwood framework files...')
+    await copyFrameworkFilesToProject(redwoodProjectPath)
+    console.log()
+  }
+
+  if (!options.watch) {
+    return
+  }
+
+  logStatus('Waiting for changes')
+  console.log(separator)
+
+  const watcher = chokidar.watch(REDWOOD_PACKAGES_PATH, {
+    ignored,
+    // We don't want chokidar to emit events as it discovers paths, only as they change.
     ignoreInitial: true,
-    persistent: true,
+    // Debounce the events.
     awaitWriteFinish: true,
-    ignored: (file) =>
-      file.includes('/node_modules/') ||
-      file.includes('/dist/') ||
-      file.includes('/dist') ||
-      file.includes('/__tests__/') ||
-      file.includes('/__fixtures__/') ||
-      file.includes('/.test./') ||
-      ['.DS_Store'].some((ext) => file.endsWith(ext)),
   })
-  .on('ready', async () => {
-    logStatus('Cleaning Framework...')
-    cleanPackages()
 
-    logStatus('Building Framework...')
-    buildPackages()
+  let closedWatcher = false
 
-    console.log()
-    logStatus('Adding dependencies...')
-    addDependenciesToPackageJson(projectPackageJsonPath)
-    installProjectPackages(projectPath)
+  async function closeWatcher() {
+    if (closedWatcher) {
+      return
+    }
 
-    console.log()
-    logStatus('Copying files...')
-    await copyFrameworkFilesToProject(projectPath)
+    logStatus('Closing the watcher...')
+    await watcher.close()
+    closedWatcher = true
+  }
 
-    console.log()
-    logStatus('Done, and waiting for changes...')
-    console.log('-'.repeat(80))
-  })
-  .on('all', async (_event, filePath) => {
-    logStatus(filePath)
+  process.on('SIGINT', closeWatcher)
+  process.on('exit', closeWatcher)
+
+  watcher.on('all', async (_event, filePath) => {
+    logStatus(`${filePath} changed`)
 
     if (filePath.endsWith('package.json')) {
       logStatus(
-        `${c.red(
-          'Warning:'
-        )} You modified a package.json file. If you've modified the ${c.underline(
-          'dependencies'
-        )}, then you must run ${c.underline('yarn rwfw project:sync')} again.`
+        [
+          `${c.red('Warning:')} You modified a package.json file.`,
+          `If you've modified the ${c.underline('dependencies')}`,
+          `then you must run ${c.underline('yarn rwfw project:sync')} again.`,
+        ].join(' ')
       )
     }
 
     const packageJsonPath = resolvePackageJsonPath(filePath)
-    const packageName = packageJsonName(packageJsonPath)
-    logStatus(c.magenta(packageName))
+    const packageName = getPackageJsonName(packageJsonPath)
 
-    let hasHadError = false
+    let errored = false
 
     try {
-      console.log()
-      logStatus(`Cleaning ${packageName}...`)
-      cleanPackages([packageJsonPath])
+      logStatus(`Cleaning ${c.magenta(packageName)}...`)
+      execSync(
+        `yarn rimraf ${path.join(path.dirname(packageJsonPath), 'dist')}`,
+        {
+          stdio: options.verbose ? 'inherit' : 'pipe',
+          cwd: REDWOOD_FRAMEWORK_PATH,
+        }
+      )
 
-      console.log()
-      logStatus(`Building ${packageName}...`)
-      buildPackages([packageJsonPath])
+      logStatus(`Building ${c.magenta(packageName)}...`)
+      execSync('yarn build', {
+        stdio: options.verbose ? 'inherit' : 'pipe',
+        cwd: path.dirname(packageJsonPath),
+      })
 
-      console.log()
       logStatus(`Copying ${packageName}...`)
-      await copyFrameworkFilesToProject(projectPath, [packageJsonPath])
-    } catch (error) {
-      hasHadError = true
-      console.log(error)
+      await copyFrameworkFilesToProject(redwoodProjectPath, [packageJsonPath])
       console.log()
-      logError(`Error building ${packageName}...`)
+    } catch (error) {
+      errored = true
     }
 
-    if (!hasHadError) {
-      console.log()
-      logStatus(`Done, and waiting for changes...`)
-      console.log('-'.repeat(80))
+    if (errored) {
+      logError(`Error building ${packageName}`)
     }
+
+    logStatus(`Done, and waiting for changes...`)
+    console.log(separator)
   })
+}
+
+/**
+ * @param {string} m
+ */
+function logStatus(m) {
+  console.log(c.bgYellow(c.black('rwfw ')), c.yellow(m))
+}
+
+/**
+ * @param {string} m
+ */
+function logError(m) {
+  console.error(c.bgRed(c.black('rwfw ')), c.red(m))
+}
+
+function createCleanUp({
+  redwoodProjectPackageJsonPath,
+  redwoodProjectPackageJson,
+}) {
+  let cleanedUp = false
+
+  return function () {
+    if (cleanedUp) {
+      return
+    }
+
+    logStatus("Restoring the Redwood project's package.json...")
+
+    fs.writeFileSync(redwoodProjectPackageJsonPath, redwoodProjectPackageJson)
+
+    console.log(
+      [
+        '',
+        'To get your project back to its original state...',
+        "- undo the changes to project's your yarn.lock file",
+        "- remove your project's node_modules directory",
+        "- run 'yarn install'",
+        '',
+      ].join('\n')
+    )
+
+    cleanedUp = true
+  }
+}
+
+// ------------------------
+
+main()

--- a/tasks/framework-tools/lib/framework.mjs
+++ b/tasks/framework-tools/lib/framework.mjs
@@ -21,6 +21,8 @@ export const REDWOOD_PACKAGES_PATH = path.join(
 const IGNORE_PACKAGES = ['@redwoodjs/codemods', 'create-redwood-app']
 
 /**
+ * Get the names, locations, and absolute package.json file paths of all the packages we publish to NPM.
+ *
  * @returns {{ location: string, name: string, packageJsonPath: string }[]}
  */
 function getFrameworkPackagesData() {
@@ -49,13 +51,7 @@ function getFrameworkPackagesData() {
 }
 
 /**
- * Returns a list of the `@redwoodjs` package.json files that are published to npm
- * and installed into a Redwood Project.
- *
- * The reason there's more logic here than seems necessary is because we have package.json files
- * like packages/web/toast/package.json that aren't real packages, but just entry points.
- *
- * @returns {string[]} A list of package.json file paths.
+ * @returns {string[]} A list of absolute package.json file paths.
  */
 export function getFrameworkPackageJsonPaths() {
   return getFrameworkPackagesData().map(
@@ -99,8 +95,8 @@ export function getFrameworkDependencies(
 }
 
 /**
- * The files included in `@redwoodjs` packages.
- * Note: The packages must be built.
+ * The files included in all the `@redwoodjs` packages.
+ * The packages must be built for this to work.
  *
  * @returns {Promise<{ [key: string]: string[] }>} A map of package names to files.
  */

--- a/tasks/framework-tools/lib/framework.mjs
+++ b/tasks/framework-tools/lib/framework.mjs
@@ -157,7 +157,7 @@ export function resolvePackageJsonPathFromFilePath(filePath) {
 
   // There's some directories that have their own package.json, but aren't published to npm,
   // like @redwoodjs/web/apollo. We want the path to @redwoodjs/web's package.json, not @redwoodjs/web/apollo's.
-  return findUp('package.json', path.dirname(filePath))
+  return findUp('package.json', path.resolve(filePath, '../../'))
 }
 
 /**

--- a/tasks/framework-tools/lib/framework.mjs
+++ b/tasks/framework-tools/lib/framework.mjs
@@ -5,7 +5,6 @@ import path from 'node:path'
 import url from 'node:url'
 
 import Arborist from '@npmcli/arborist'
-import execa from 'execa'
 import fs from 'fs-extra'
 import packlist from 'npm-packlist'
 

--- a/tasks/framework-tools/lib/framework.mjs
+++ b/tasks/framework-tools/lib/framework.mjs
@@ -20,16 +20,10 @@ export const REDWOOD_PACKAGES_PATH = path.join(
 
 const IGNORE_PACKAGES = ['@redwoodjs/codemods', 'create-redwood-app']
 
-const cache = new Map()
-
 /**
  * @returns {{ location: string, name: string, packageJsonPath: string }[]}
  */
 function getFrameworkPackagesData() {
-  if (cache.has('frameworkPackagesData')) {
-    return cache.get('frameworkPackagesData')
-  }
-
   const output = execSync('yarn workspaces list --json', {
     encoding: 'utf-8',
   })
@@ -51,8 +45,6 @@ function getFrameworkPackagesData() {
     )
   }
 
-  cache.set('frameworkPackagesData', frameworkPackagesData)
-
   return frameworkPackagesData
 }
 
@@ -66,17 +58,9 @@ function getFrameworkPackagesData() {
  * @returns {string[]} A list of package.json file paths.
  */
 export function getFrameworkPackageJsonPaths() {
-  if (cache.has('frameworkPackageJsonPaths')) {
-    return cache.get('frameworkPackageJsonPaths')
-  }
-
-  const frameworkPackageJsonPaths = getFrameworkPackagesData().map(
+  return getFrameworkPackagesData().map(
     ({ packageJsonPath }) => packageJsonPath
   )
-
-  cache.set('frameworkPackagesData', frameworkPackageJsonPaths)
-
-  return frameworkPackageJsonPaths
 }
 
 /**

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -26,12 +26,14 @@ export function fixProjectBinaries(projectPath) {
     // if the binPath doesn't exist, create it.
     const binSymlink = path.join(projectPath, 'node_modules/.bin', binName)
     binPath = path.join(projectPath, 'node_modules', binPath)
+
     if (!fs.existsSync(binSymlink)) {
       fs.mkdirSync(path.dirname(binSymlink), {
         recursive: true,
       })
       fs.symlinkSync(binPath, binSymlink)
     }
+
     console.log('chmod +x', terminalLink(binName, binPath))
     fs.chmodSync(binSymlink, '755')
     fs.chmodSync(binPath, '755')

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -1,26 +1,27 @@
 /* eslint-env node */
 
-import fs from 'node:fs'
 import path from 'node:path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import ora from 'ora'
 import { rimraf } from 'rimraf'
 import terminalLink from 'terminal-link'
 
 import {
-  frameworkDependencies,
-  frameworkPkgJsonFiles,
-  frameworkPackagesFiles,
-  frameworkPackagesBins,
-  packageJsonName,
+  getFrameworkDependencies,
+  getFrameworkPackageJsonPaths,
+  getFrameworkPackagesFiles,
+  getFrameworkPackagesBins,
+  getPackageJsonName,
 } from './framework.mjs'
 
 /**
  * Sets binaries as executable and creates symlinks to `node_modules/.bin` if they do not exist.
  */
 export function fixProjectBinaries(projectPath) {
-  const bins = frameworkPackagesBins()
+  const bins = getFrameworkPackagesBins()
+
   for (let [binName, binPath] of Object.entries(bins)) {
     // if the binPath doesn't exist, create it.
     const binSymlink = path.join(projectPath, 'node_modules/.bin', binName)
@@ -38,46 +39,49 @@ export function fixProjectBinaries(projectPath) {
 }
 
 /**
- * Append all the `@redwoodjs` dependencies to the root `package.json` in a Redwood Project.
+ * Add all the `@redwoodjs` packages' dependencies to the root `package.json` in a Redwood Project.
+ *
+ * @param {string} packageJsonPath - The path to the root `package.json` in a Redwood Project.
+ * @param {{ [key: string]: string }?} dependencies - A map of package names to versions.
+ *
+ * @returns {void}
  */
 export function addDependenciesToPackageJson(
   packageJsonPath,
-  dependencies = frameworkDependencies()
+  dependencies = getFrameworkDependencies()
 ) {
-  if (!fs.existsSync(packageJsonPath)) {
-    console.log(
-      `Error: The package.json path: ${packageJsonPath} does not exist.`
-    )
-    process.exit(1)
-  }
-
   const packageJsonLink = terminalLink(
     'package.json',
     'file://' + packageJsonPath
   )
 
-  const numOfDeps = Object.keys(dependencies).length
+  const numberOfDependencies = Object.keys(dependencies).length
 
   const spinner = ora(
-    `Adding ${numOfDeps} framework dependencies to ${packageJsonLink}...`
+    `Adding ${numberOfDependencies} framework dependencies to ${packageJsonLink}...`
   ).start()
 
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+  const packageJson = fs.readJSONSync(packageJsonPath)
+
   packageJson.dependencies = {
-    ...(packageJson.dependencies || {}),
+    ...packageJson.dependencies,
     ...dependencies,
   }
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2))
+
+  fs.writeJSONSync(packageJsonPath, packageJson, { spaces: 2 })
+
   spinner.succeed(
-    `Added ${numOfDeps} framework dependencies to ${packageJsonLink}`
+    `Added ${numberOfDependencies} framework dependencies to ${packageJsonLink}`
   )
 }
 
 export function installProjectPackages(projectPath) {
   const spinner = ora("Running 'yarn install'...")
+
   spinner.start()
+
   try {
-    execa.sync('yarn install', {
+    execa.commandSync('yarn install', {
       cwd: projectPath,
       shell: true,
     })
@@ -89,21 +93,22 @@ export function installProjectPackages(projectPath) {
         'file://' + path.join(projectPath, 'yarn-error.log')
       )} for more information.`
     )
+
     console.log('-'.repeat(80))
   }
 }
 
 export async function copyFrameworkFilesToProject(
   projectPath,
-  packages = frameworkPkgJsonFiles()
+  packageJsonPaths = getFrameworkPackageJsonPaths()
 ) {
   // Loop over every package, delete all existing files, copy over the new files,
   // and fix binaries.
-  const packagesFiles = await frameworkPackagesFiles(packages)
+  const packagesFiles = await getFrameworkPackagesFiles(packageJsonPaths)
 
-  const packageNamesToPaths = packages.reduce(
+  const packageNamesToPaths = packageJsonPaths.reduce(
     (packageNamesToPaths, packagePath) => {
-      packageNamesToPaths[packageJsonName(packagePath)] =
+      packageNamesToPaths[getPackageJsonName(packagePath)] =
         path.dirname(packagePath)
       return packageNamesToPaths
     },

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -147,6 +147,4 @@ export async function copyFrameworkFilesToProject(
       fs.copyFileSync(src, dest)
     }
   }
-
-  console.log()
 }

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -31,6 +31,7 @@ export function fixProjectBinaries(projectPath) {
       fs.mkdirSync(path.dirname(binSymlink), {
         recursive: true,
       })
+      fs.unlinkSync(binSymlink)
       fs.symlinkSync(binPath, binSymlink)
     }
 

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -31,7 +31,18 @@ export function fixProjectBinaries(projectPath) {
       fs.mkdirSync(path.dirname(binSymlink), {
         recursive: true,
       })
-      fs.unlinkSync(binSymlink)
+
+      // `fs.existsSync` checks if the target of the symlink exists, not the symlink. If the symlink exists,
+      // we have to remove it before we can fix it. As far as I can tell, there's no way to check if a symlink exists but not its target,
+      // so we try-catch removing it so that we cover both cases.
+      try {
+        fs.unlinkSync(binSymlink)
+      } catch (e) {
+        if (e.code !== 'ENOENT') {
+          throw new Error(e)
+        }
+      }
+
       fs.symlinkSync(binPath, binSymlink)
     }
 

--- a/tasks/framework-tools/lib/project.mjs
+++ b/tasks/framework-tools/lib/project.mjs
@@ -13,7 +13,7 @@ import {
   getFrameworkPackageJsonPaths,
   getFrameworkPackagesFiles,
   getFrameworkPackagesBins,
-  getPackageJsonName,
+  getPackageName,
 } from './framework.mjs'
 
 /**
@@ -110,7 +110,7 @@ export async function copyFrameworkFilesToProject(
 
   const packageNamesToPaths = packageJsonPaths.reduce(
     (packageNamesToPaths, packagePath) => {
-      packageNamesToPaths[getPackageJsonName(packagePath)] =
+      packageNamesToPaths[getPackageName(packagePath)] =
         path.dirname(packagePath)
       return packageNamesToPaths
     },
@@ -118,22 +118,23 @@ export async function copyFrameworkFilesToProject(
   )
 
   for (const [packageName, files] of Object.entries(packagesFiles)) {
-    const packageDstPath = path.join(projectPath, 'node_modules', packageName)
+    const packageDistPath = path.join(projectPath, 'node_modules', packageName)
+
     console.log(
-      terminalLink(packageName, 'file://' + packageDstPath),
+      terminalLink(packageName, 'file://' + packageDistPath),
       files.length,
       'files'
     )
-    await rimraf(packageDstPath)
+
+    await rimraf(packageDistPath)
 
     for (const file of files) {
       const src = path.join(packageNamesToPaths[packageName], file)
-      const dst = path.join(packageDstPath, file)
-      fs.mkdirSync(path.dirname(dst), { recursive: true })
-      fs.copyFileSync(src, dst)
+      const dest = path.join(packageDistPath, file)
+      fs.mkdirSync(path.dirname(dest), { recursive: true })
+      fs.copyFileSync(src, dest)
     }
   }
 
   console.log()
-  fixProjectBinaries(projectPath)
 }


### PR DESCRIPTION
When I clean the framework (`git clean -fxd -e .env`) so that build has to happen from scratch instead of pulling from the Nx cache, I can reproduce `yarn rwfw project:sync` failing with:

```
rwfw  /<path>/redwood/packages/cli-packages/storybook/meta.json
node:fs:601
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open '/<path>/redwood/packages/cli-packages/package.json'
    at Object.openSync (node:fs:601:3)
    at Object.readFileSync (node:fs:469:35)
    at packageJsonName (file:///<path>/redwood/tasks/framework-tools/lib/framework.mjs:146:24)
    at FSWatcher.<anonymous> (file:///<path>/redwood/tasks/framework-tools/frameworkSyncToProject.mjs:100:25)
    at FSWatcher.emit (node:events:513:28)
    at FSWatcher.emitWithAll (/<path>/redwood/node_modules/chokidar/index.js:541:32)
    at awfEmit (/<path>/redwood/node_modules/chokidar/index.js:607:14)
    at /<path>/redwood/node_modules/chokidar/index.js:728:9
    at FSReqCallback.oncomplete (node:fs:209:5) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/<path>/redwood/packages/cli-packages/package.json'
}
```

I'm not sure exactly why this is happening, but the code for `yarn rwfw project:sync` could be stricter about what it watches, how it finds package.jsons, and a few other things. So far these changes seem to fix it it for me, but it doesn't seem like that's true for everyone yet. 

#### Working list of changes

- `cleanPackages` stopped working at some point; I've fixed it for cleaning all packages by keeping it simple and just calling the script in the root package.json. And on a per-packge basis, I just call `rimraf`
- I've move the logic in the ready handler. Now it just happens before we call watch. I feel like the less chokidar, the better, but let me know if there's a reason the ready handler is better
- I've renamed a bunch of functions. This is a stylistic preference of mine; most of the functions were named as if they were constants. And some names for local vars were too vague
- [ ] I still want to do work on the fixBins logic. I think it's happening too often
- [ ] I've added some options; too many probably. Sometimes when `yarn rwfw project:sync` fails, you don't want to have to clean everything. I could probably make this easier by having a `set-up-for-watch` flag or something like that, to do all the steps before watching. Also, yargs aliases are making no sense right now and are duplicating properties, so figuring that out