### PR TITLE
Fix the codegen path for the GraphQL context object

### DIFF
--- a/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
@@ -5,7 +5,7 @@ exports[`Generate gql typedefs api 1`] = `
 import { MergePrismaWithSdlTypes, MakeRelationsOptional } from '@redwoodjs/api'
 import { PrismaModelOne as PrismaPrismaModelOne, PrismaModelTwo as PrismaPrismaModelTwo, Post as PrismaPost, Todo as PrismaTodo } from '@prisma/client'
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import { RedwoodGraphQLContext } from '@redwoodjs/graphql-server/dist/functions/types';
+import { RedwoodGraphQLContext } from '@redwoodjs/graphql-server/dist/types';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -252,7 +252,7 @@ function getPluginConfig(side: CodegenSide) {
       // Look at type or source https://shrtm.nu/2BA0 for possible config, not well documented
       resolvers: true,
     },
-    contextType: `@redwoodjs/graphql-server/dist/functions/types#RedwoodGraphQLContext`,
+    contextType: `@redwoodjs/graphql-server/dist/types#RedwoodGraphQLContext`,
   }
 
   return pluginConfig


### PR DESCRIPTION
There isn't a file at `@redwoodjs/graphql-server/dist/functions/types` as the type got merged  into the dist dir at some point

![image](https://github.com/redwoodjs/redwood/assets/49038/3ef9e509-ee19-493d-a63e-7d349333fbad)

