### PR TITLE
feat: Update the SDL types lib

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -43,7 +43,7 @@
     "@graphql-codegen/typescript-resolvers": "3.2.1",
     "@redwoodjs/graphql-server": "5.0.0",
     "@redwoodjs/project-config": "5.0.0",
-    "@sdl-codegen/node": "0.0.9",
+    "@sdl-codegen/node": "0.0.10",
     "babel-plugin-graphql-tag": "3.3.0",
     "babel-plugin-polyfill-corejs3": "0.8.1",
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7812,7 +7812,7 @@ __metadata:
     "@graphql-codegen/typescript-resolvers": 3.2.1
     "@redwoodjs/graphql-server": 5.0.0
     "@redwoodjs/project-config": 5.0.0
-    "@sdl-codegen/node": 0.0.9
+    "@sdl-codegen/node": 0.0.10
     "@types/babel-plugin-tester": 9.0.5
     "@types/babel__core": 7.20.1
     "@types/fs-extra": 11.0.1
@@ -8223,16 +8223,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sdl-codegen/node@npm:0.0.9":
-  version: 0.0.9
-  resolution: "@sdl-codegen/node@npm:0.0.9"
+"@sdl-codegen/node@npm:0.0.10":
+  version: 0.0.10
+  resolution: "@sdl-codegen/node@npm:0.0.10"
   dependencies:
     "@mrleebo/prisma-ast": ^0.5.2
     ts-morph: ^18.0.0
   peerDependencies:
     graphql: "*"
+    prettier: ^2
     typescript: "*"
-  checksum: d297180138e1a2f71301ad71575a9562033d28fe4f6ce2abc727208dd82ccd43104510a3ca2912c12e792e69b111045fe9bb17aba18cb123c3eccc74f15b88bd
+  peerDependenciesMeta:
+    prettier:
+      optional: true
+  checksum: 275247e686cc999d91623d67ce09171f9ed17764616bb7941877439ce44b1cba305ac049e91981660cd8690f18d797cd27cecdf26cf436eb81895093e0223f42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Switch my app to run entirely from this lib via Redwood proper now

https://github.com/sdl-codegen/sdl-codegen/blob/main/CHANGELOG.md#0010

- Uses user-app prettier settings to format .d.ts files
- Doesn't ship with any eslint warnings in my codebase at least
- Includes SDL version of #8585 
