### PR TITLE
feat(crwa): Make `.redwood/` folder readonly in VS Code

### DIFF
--- a/__fixtures__/test-project/.vscode/settings.json
+++ b/__fixtures__/test-project/.vscode/settings.json
@@ -7,5 +7,8 @@
   },
   "[prisma]": {
     "editor.formatOnSave": true
+  },
+  "files.readonlyInclude": {
+    ".redwood/**": true
   }
 }

--- a/packages/create-redwood-app/templates/js/.vscode/settings.json
+++ b/packages/create-redwood-app/templates/js/.vscode/settings.json
@@ -7,5 +7,8 @@
   },
   "[prisma]": {
     "editor.formatOnSave": true
+  },
+  "files.readonlyInclude": {
+    ".redwood/**": true
   }
 }

--- a/packages/create-redwood-app/templates/ts/.vscode/settings.json
+++ b/packages/create-redwood-app/templates/ts/.vscode/settings.json
@@ -7,5 +7,8 @@
   },
   "[prisma]": {
     "editor.formatOnSave": true
+  },
+  "files.readonlyInclude": {
+    ".redwood/**": true
   }
 }


### PR DESCRIPTION
Version 1.19 of VSCode added [Readonly mode](https://code.visualstudio.com/updates/v1_79#_readonly-mode). This marks the generated code in `.redwood/` as read-only in the editor. I thought this might be a helpful addition.
Maybe there is even a way to add this to existing projects? Codemods?

Happy to hear your thoughts on this.