### PR TITLE
Move fastify.logger.infos to fastify.logger.traces

### DIFF
--- a/__fixtures__/test-project/api/server.config.js
+++ b/__fixtures__/test-project/api/server.config.js
@@ -36,11 +36,11 @@ const config = {
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.info({ custom: { options } }, 'Configuring api side')
+    fastify.log.trace({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.info({ custom: { options } }, 'Configuring web side')
+    fastify.log.trace({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify

--- a/__fixtures__/test-project/api/server.config.js
+++ b/__fixtures__/test-project/api/server.config.js
@@ -16,7 +16,7 @@
 const config = {
   requestTimeout: 15_000,
   logger: {
-    // Note: If running locally using `yarn rw serve` you may want to adust
+    // Note: If running locally using `yarn rw serve` you may want to adjust
     // the default non-development level to `info`
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
   },

--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -151,11 +151,11 @@ This configuration does **not** apply in a serverless deploy.
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.info({ custom: { options } }, 'Configuring api side')
+    fastify.log.trace({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.info({ custom: { options } }, 'Configuring web side')
+    fastify.log.trace({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify
@@ -184,7 +184,7 @@ yarn workspace api add @fastify/rate-limit @fastify/compress
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.info({ custom: { options } }, 'Configuring api side')
+    fastify.log.trace({ custom: { options } }, 'Configuring api side')
 
     await fastify.register(import('@fastify/compress'), {
       global: true,
@@ -217,7 +217,7 @@ This may seem counter-intuitive, since you're configuring the `web` side, but th
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'web') {
-    fastify.log.info({ custom: { options } }, 'Configuring web side')
+    fastify.log.trace({ custom: { options } }, 'Configuring web side')
 
     fastify.register(import('@fastify/etag'))
   }
@@ -257,7 +257,7 @@ For example, to support image file uploads you'd tell Fastify to allow `/^image\
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.info({ custom: { options } }, 'Configuring api side')
+    fastify.log.trace({ custom: { options } }, 'Configuring api side')
 
     fastify.addContentTypeParser(/^image\/.*/, (req, payload, done) => {
       payload.on('end', () => {

--- a/packages/api-server/src/fastify.ts
+++ b/packages/api-server/src/fastify.ts
@@ -21,7 +21,7 @@ let serverConfigFile: {
 } = {
   config: DEFAULT_OPTIONS,
   configureFastify: async (fastify, options) => {
-    fastify.log.info(
+    fastify.log.trace(
       options,
       `In configureFastify hook for side: ${options?.side}`
     )

--- a/packages/api-server/src/server.ts
+++ b/packages/api-server/src/server.ts
@@ -18,11 +18,11 @@ export const startServer = ({
   fastify.listen({ port: serverPort, host })
 
   fastify.ready(() => {
-    fastify.log.debug(
+    fastify.log.trace(
       { custom: { ...fastify.initialConfig } },
       'Fastify server configuration'
     )
-    fastify.log.debug(`Registered plugins \n${fastify.printPlugins()}`)
+    fastify.log.trace(`Registered plugins \n${fastify.printPlugins()}`)
   })
 
   return fastify

--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -33,11 +33,11 @@ export const apiServerHandler = async (options) => {
   })
 
   fastify.ready(() => {
-    fastify.log.debug(
+    fastify.log.trace(
       { custom: { ...fastify.initialConfig } },
       'Fastify server configuration'
     )
-    fastify.log.debug(`Registered plugins \n${fastify.printPlugins()}`)
+    fastify.log.trace(`Registered plugins \n${fastify.printPlugins()}`)
     console.log(chalk.italic.dim('Took ' + (Date.now() - tsApiServer) + ' ms'))
 
     const on = socket

--- a/packages/create-redwood-app/templates/js/api/server.config.js
+++ b/packages/create-redwood-app/templates/js/api/server.config.js
@@ -16,7 +16,7 @@
 const config = {
   requestTimeout: 15_000,
   logger: {
-    // Note: If running locally using `yarn rw serve` you may want to adust
+    // Note: If running locally using `yarn rw serve` you may want to adjust
     // the default non-development level to `info`
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
   },

--- a/packages/create-redwood-app/templates/js/api/server.config.js
+++ b/packages/create-redwood-app/templates/js/api/server.config.js
@@ -36,11 +36,11 @@ const config = {
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.info({ custom: { options } }, 'Configuring api side')
+    fastify.trace.info({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.info({ custom: { options } }, 'Configuring web side')
+    fastify.trace.info({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify

--- a/packages/create-redwood-app/templates/ts/api/server.config.js
+++ b/packages/create-redwood-app/templates/ts/api/server.config.js
@@ -36,11 +36,11 @@ const config = {
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.info({ custom: { options } }, 'Configuring api side')
+    fastify.log.trace({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.info({ custom: { options } }, 'Configuring web side')
+    fastify.log.trace({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify

--- a/packages/create-redwood-app/templates/ts/api/server.config.js
+++ b/packages/create-redwood-app/templates/ts/api/server.config.js
@@ -16,7 +16,7 @@
 const config = {
   requestTimeout: 15_000,
   logger: {
-    // Note: If running locally using `yarn rw serve` you may want to adust
+    // Note: If running locally using `yarn rw serve` you may want to adjust
     // the default non-development level to `info`
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
   },

--- a/packages/fastify/src/config.ts
+++ b/packages/fastify/src/config.ts
@@ -24,7 +24,7 @@ let serverConfigFile: {
 } = {
   config: DEFAULT_REDWOOD_FASTIFY_CONFIG,
   configureFastify: async (fastify, options) => {
-    fastify.log.info(
+    fastify.log.trace(
       options,
       `In configureFastify hook for side: ${options?.side}`
     )


### PR DESCRIPTION
The default experience of `yarn dev` lets you know a bunch of stuff you don't really care about WRT fastify (e.g. I've never once cared about what plugins are installed, but it fills my terminal) 

This moves them all (and the templated files) to use trace so that they are opt-in when you want to know about those sort of internal details - pairs with #8588