### PR TITLE
Adds a way to opt-out of the web or API's type generation

### DIFF
--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -149,6 +149,24 @@ And if you're on an experimental release line, like canary, there's new versions
 
 If you'd like to get notified (at most, once a day) when there's a new version, set `versionUpdates` to include the version tags you're interested in.
 
+## [typegen]
+
+By default Redwood generates types for both the web and api side, if you would like to disable one of these sides - you can do so by changing the `graphql` array in `[typegen]`
+
+The default settings are: 
+
+```toml title="redwood.toml"
+[typegen]
+    graphql = ['web', 'api']
+```
+
+For example if you would like to remove the types for the api side you can do so by changing the `graphql` array to:
+
+```toml title="redwood.toml"
+[typegen]
+    graphql = ['web']
+```
+
 ## Using Environment Variables in `redwood.toml`
 
 You may find yourself wanting to change keys in `redwood.toml` based on the environment you're deploying to.

--- a/packages/internal/src/__tests__/graphqlCodeGen.test.ts
+++ b/packages/internal/src/__tests__/graphqlCodeGen.test.ts
@@ -16,7 +16,6 @@ import {
   generateTypeDefGraphQLWeb,
 } from '../generate/graphqlCodeGen'
 import { generateGraphQLSchema } from '../generate/graphqlSchema'
-
 const FIXTURE_PATH = path.resolve(
   __dirname,
   '../../../../__fixtures__/example-todo-main',
@@ -209,5 +208,21 @@ describe("Doesn't swallow legit errors", () => {
     expect((errors[0].error as Error).toString()).toMatch(/field.*done.*Todo/)
 
     delete process.env.RWJS_CWD
+  })
+})
+
+describe('disabling type-gen', () => {
+  test('generateTypeDefGraphQLWeb NOOPs if typegen.graphql does not include web', async () => {
+    const files = await generateTypeDefGraphQLWeb({
+      typegen: { graphql: [] },
+    })
+    expect(files.typeDefFiles).toHaveLength(0)
+  })
+
+  test('generateTypeDefGraphQLApi NOOPs if typegen.graphql does not include api', async () => {
+    const files = await generateTypeDefGraphQLApi({
+      typegen: { graphql: [] },
+    })
+    expect(files.typeDefFiles).toHaveLength(0)
   })
 })

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -17,6 +17,7 @@ import type { LoadTypedefsOptions } from '@graphql-tools/load'
 import execa from 'execa'
 import type { DocumentNode } from 'graphql'
 
+import type { Config } from '@redwoodjs/project-config'
 import { getPaths, getConfig } from '@redwoodjs/project-config'
 
 import { getTsConfigs } from '../project'
@@ -32,11 +33,19 @@ type TypeDefResult = {
   errors: { message: string; error: unknown }[]
 }
 
-export const generateTypeDefGraphQLApi = async (): Promise<TypeDefResult> => {
-  const config = getConfig()
+export const generateTypeDefGraphQLApi = async (
+  config?: Config,
+): Promise<TypeDefResult> => {
+  const appConfig = config || getConfig()
+  if (appConfig.typegen.graphql.includes('api')) {
+    return {
+      typeDefFiles: [],
+      errors: [],
+    }
+  }
   const errors: { message: string; error: unknown }[] = []
 
-  if (config.experimental.useSDLCodeGenForGraphQLTypes) {
+  if (appConfig.experimental.useSDLCodeGenForGraphQLTypes) {
     const paths = getPaths()
     const sdlCodegen = await import('@sdl-codegen/node')
 
@@ -114,7 +123,17 @@ export const generateTypeDefGraphQLApi = async (): Promise<TypeDefResult> => {
   }
 }
 
-export const generateTypeDefGraphQLWeb = async (): Promise<TypeDefResult> => {
+export const generateTypeDefGraphQLWeb = async (
+  config?: Config,
+): Promise<TypeDefResult> => {
+  const appConfig = config || getConfig()
+  if (!appConfig.typegen.graphql.includes('web')) {
+    return {
+      typeDefFiles: [],
+      errors: [],
+    }
+  }
+
   const filename = path.join(getPaths().web.types, 'graphql.d.ts')
   const options = getLoadDocumentsOptions(filename)
   const documentsGlob = './web/src/**/!(*.d).{ts,tsx,js,jsx}'

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -93,6 +93,12 @@ describe('getConfig', () => {
             },
           },
         },
+        "typegen": {
+          "graphql": [
+            "web",
+            "api",
+          ],
+        },
         "web": {
           "a11y": true,
           "apiUrl": "/.redwood/functions",

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -119,6 +119,9 @@ export interface Config {
       enabled: boolean
     }
   }
+  typegen: {
+    graphql: Array<'web' | 'api'>
+  }
 }
 
 export interface CLIPlugin {
@@ -199,6 +202,9 @@ const DEFAULT_CONFIG: Config = {
     realtime: {
       enabled: false,
     },
+  },
+  typegen: {
+    graphql: ['web', 'api'],
   },
 }
 


### PR DESCRIPTION
The check on whether the web types should be generated is based on effectively looking at all files in web for any `graphql` tagged strings in TS/JS files. Which would likely hit every graphql client which exists to my knowledge. 

This PR adds a config option to explicitly disable the type generation, it'll save a small amount of time pretty often (but I'm more interested in trying to keep the number of types in my codebase down).

If you're (very reasonably IMO) config-phobic I totally get it 👍🏻 