### PR TITLE
Revert "Move fastify.logger.infos to fastify.logger.traces (#8590)"

### DIFF
--- a/__fixtures__/test-project/api/server.config.js
+++ b/__fixtures__/test-project/api/server.config.js
@@ -16,7 +16,7 @@
 const config = {
   requestTimeout: 15_000,
   logger: {
-    // Note: If running locally using `yarn rw serve` you may want to adjust
+    // Note: If running locally using `yarn rw serve` you may want to adust
     // the default non-development level to `info`
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
   },
@@ -36,11 +36,11 @@ const config = {
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.trace({ custom: { options } }, 'Configuring api side')
+    fastify.log.info({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.trace({ custom: { options } }, 'Configuring web side')
+    fastify.log.info({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify

--- a/docs/docs/app-configuration-redwood-toml.md
+++ b/docs/docs/app-configuration-redwood-toml.md
@@ -151,11 +151,11 @@ This configuration does **not** apply in a serverless deploy.
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.trace({ custom: { options } }, 'Configuring api side')
+    fastify.log.info({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.trace({ custom: { options } }, 'Configuring web side')
+    fastify.log.info({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify
@@ -184,7 +184,7 @@ yarn workspace api add @fastify/rate-limit @fastify/compress
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.trace({ custom: { options } }, 'Configuring api side')
+    fastify.log.info({ custom: { options } }, 'Configuring api side')
 
     await fastify.register(import('@fastify/compress'), {
       global: true,
@@ -217,7 +217,7 @@ This may seem counter-intuitive, since you're configuring the `web` side, but th
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'web') {
-    fastify.log.trace({ custom: { options } }, 'Configuring web side')
+    fastify.log.info({ custom: { options } }, 'Configuring web side')
 
     fastify.register(import('@fastify/etag'))
   }
@@ -257,7 +257,7 @@ For example, to support image file uploads you'd tell Fastify to allow `/^image\
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.trace({ custom: { options } }, 'Configuring api side')
+    fastify.log.info({ custom: { options } }, 'Configuring api side')
 
     fastify.addContentTypeParser(/^image\/.*/, (req, payload, done) => {
       payload.on('end', () => {

--- a/packages/api-server/src/fastify.ts
+++ b/packages/api-server/src/fastify.ts
@@ -21,7 +21,7 @@ let serverConfigFile: {
 } = {
   config: DEFAULT_OPTIONS,
   configureFastify: async (fastify, options) => {
-    fastify.log.trace(
+    fastify.log.info(
       options,
       `In configureFastify hook for side: ${options?.side}`
     )

--- a/packages/api-server/src/server.ts
+++ b/packages/api-server/src/server.ts
@@ -18,11 +18,11 @@ export const startServer = ({
   fastify.listen({ port: serverPort, host })
 
   fastify.ready(() => {
-    fastify.log.trace(
+    fastify.log.debug(
       { custom: { ...fastify.initialConfig } },
       'Fastify server configuration'
     )
-    fastify.log.trace(`Registered plugins \n${fastify.printPlugins()}`)
+    fastify.log.debug(`Registered plugins \n${fastify.printPlugins()}`)
   })
 
   return fastify

--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -33,11 +33,11 @@ export const apiServerHandler = async (options) => {
   })
 
   fastify.ready(() => {
-    fastify.log.trace(
+    fastify.log.debug(
       { custom: { ...fastify.initialConfig } },
       'Fastify server configuration'
     )
-    fastify.log.trace(`Registered plugins \n${fastify.printPlugins()}`)
+    fastify.log.debug(`Registered plugins \n${fastify.printPlugins()}`)
     console.log(chalk.italic.dim('Took ' + (Date.now() - tsApiServer) + ' ms'))
 
     const on = socket

--- a/packages/create-redwood-app/templates/js/api/server.config.js
+++ b/packages/create-redwood-app/templates/js/api/server.config.js
@@ -16,7 +16,7 @@
 const config = {
   requestTimeout: 15_000,
   logger: {
-    // Note: If running locally using `yarn rw serve` you may want to adjust
+    // Note: If running locally using `yarn rw serve` you may want to adust
     // the default non-development level to `info`
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
   },
@@ -36,11 +36,11 @@ const config = {
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.trace.info({ custom: { options } }, 'Configuring api side')
+    fastify.log.info({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.trace.info({ custom: { options } }, 'Configuring web side')
+    fastify.log.info({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify

--- a/packages/create-redwood-app/templates/ts/api/server.config.js
+++ b/packages/create-redwood-app/templates/ts/api/server.config.js
@@ -16,7 +16,7 @@
 const config = {
   requestTimeout: 15_000,
   logger: {
-    // Note: If running locally using `yarn rw serve` you may want to adjust
+    // Note: If running locally using `yarn rw serve` you may want to adust
     // the default non-development level to `info`
     level: process.env.NODE_ENV === 'development' ? 'debug' : 'warn',
   },
@@ -36,11 +36,11 @@ const config = {
 /** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
-    fastify.log.trace({ custom: { options } }, 'Configuring api side')
+    fastify.log.info({ custom: { options } }, 'Configuring api side')
   }
 
   if (options.side === 'web') {
-    fastify.log.trace({ custom: { options } }, 'Configuring web side')
+    fastify.log.info({ custom: { options } }, 'Configuring web side')
   }
 
   return fastify

--- a/packages/fastify/src/config.ts
+++ b/packages/fastify/src/config.ts
@@ -27,7 +27,7 @@ let serverConfigFile: {
 } = {
   config: DEFAULT_REDWOOD_FASTIFY_CONFIG,
   configureFastify: async (fastify, options) => {
-    fastify.log.trace(
+    fastify.log.info(
       options,
       `In configureFastify hook for side: ${options?.side}`
     )


### PR DESCRIPTION
This reverts commit 65b09e53c326d7582a14435fc06b035cd424e919.

I merged that PR too early; there's something weird going on with the tutorial e2e test in CI. We still want the changes in, but we should let it go through the course of passing CI first.

I'm assuming this branch will pass CI. If it doesn't I have an incorrect understanding of the issue.