### PR TITLE
Rebuild fixture: await copyProject

### DIFF
--- a/tasks/test-project/rebuild-test-project-fixture.js
+++ b/tasks/test-project/rebuild-test-project-fixture.js
@@ -496,7 +496,7 @@ async function runCommand() {
 
       // removes existing Fixture and replaces with newly built project,
       // then removes new Project temp directory
-      copyProject()
+      await copyProject()
     },
     skip: skipStep(startStep, 12),
   })


### PR DESCRIPTION
Awaiting `copyProject` also makes sure files are removed properly before copying the project over to the FW folder