### PR TITLE
fix(publishing): remove tsconfig.tsbuildinfo

### DIFF
--- a/tasks/release/releaseCommand.mjs
+++ b/tasks/release/releaseCommand.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 import boxen from 'boxen'
 import { Octokit } from 'octokit'
+import { rimraf } from 'rimraf'
 import { cd, chalk, question, $, fs } from 'zx'
 
 import { handler as generateReleaseNotes } from './generateReleaseNotesCommand.mjs'
@@ -412,6 +413,8 @@ async function releaseMajorOrMinor() {
   await $`git commit -am "chore: temporary update to workspaces"`
   console.log()
 
+  await removeTSConfigTSBuildInfo()
+
   //  ------------------------
   try {
     await $`yarn lerna publish from-package`
@@ -572,6 +575,8 @@ async function releasePatch() {
 
   await $`git commit -am "chore: temporary update to workspaces"`
   console.log()
+
+  await removeTSConfigTSBuildInfo()
 
   //  ------------------------
   try {
@@ -786,4 +791,8 @@ async function versionDocs() {
   await $`git add .`
   await $`git commit -m "Version docs to ${nextDocsVersion}"`
   await cd('../')
+}
+
+async function removeTSConfigTSBuildInfo() {
+  await rimraf('packages/**/dist/tsconfig.tsbuildinfo')
 }


### PR DESCRIPTION
I was looking at the contents of `@redwoodjs/tui`'s dist, and most of the files are only a few kilobytes. But one, `tsconfig.tsbuildinfo`, is ~75 kilobytes—several times larger than the rest of the files combined. It's still not that big in the scheme of things (i.e. compared to most dependencies), but it struck as me being completely unnecessary since this file is for speeding up TypeScript's build's step (source: https://www.typescriptlang.org/tsconfig#tsBuildInfoFile).

<img width="792" alt="Screenshot 2023-06-15 at 4 22 30 PM" src="https://github.com/redwoodjs/redwood/assets/32992335/ad01c3a7-e714-496e-b6b2-281a7ab61e06">

Source: https://www.npmjs.com/package/@redwoodjs/tui?activeTab=code

Since this file is to make incremental builds with TS faster, we can't just delete it after we build packages. But we can delete it before we publish, so that's what this PR does.