### PR TITLE
Remove unused global var RWJS_WEB_BUNDLER

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -159,7 +159,6 @@ const getSharedPlugins = (isEnvProduction) => {
     // The define plugin will replace these keys with their values during build
     // time. Note that they're used in packages/web/src/config.ts, and made available in globalThis
     new webpack.DefinePlugin({
-      ['RWJS_WEB_BUNDLER']: JSON.stringify('webpack'),
       ['RWJS_ENV']: JSON.stringify({
         RWJS_API_GRAPHQL_URL:
           redwoodConfig.web.apiGraphQLUrl ??

--- a/packages/prerender/ambient.d.ts
+++ b/packages/prerender/ambient.d.ts
@@ -10,8 +10,6 @@ declare global {
     __REDWOOD__APP_TITLE: string
   }
 
-  var RWJS_WEB_BUNDLER: 'webpack' | 'vite'
-
   var RWJS_DEBUG_ENV: {
     RWJS_SRC_ROOT: string
     REDWOOD_ENV_EDITOR?: string

--- a/packages/prerender/src/internal.ts
+++ b/packages/prerender/src/internal.ts
@@ -30,9 +30,6 @@ export const registerShims = (routerPath: string) => {
     RWJS_SRC_ROOT: getPaths().web.src,
   }
 
-  // For now set bundler to webpack for prerendering
-  globalThis.RWJS_WEB_BUNDLER = 'webpack'
-
   globalThis.__REDWOOD__PRERENDERING = true
 
   globalThis.__REDWOOD__HELMET_CONTEXT = {}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -92,7 +92,6 @@ export default function redwoodPluginVite(): PluginOption[] {
           envPrefix: 'REDWOOD_ENV_',
           publicDir: path.join(rwPaths.web.base, 'public'),
           define: {
-            RWJS_WEB_BUNDLER: JSON.stringify('vite'),
             RWJS_ENV: {
               // @NOTE we're avoiding process.env here, unlike webpack
               RWJS_API_GRAPHQL_URL:

--- a/packages/web/ambient.d.ts
+++ b/packages/web/ambient.d.ts
@@ -6,8 +6,6 @@ declare global {
   var __REDWOOD__HELMET_CONTEXT: { helmet?: HelmetServerState }
   var __REDWOOD__APP_TITLE: string
 
-  var RWJS_WEB_BUNDLER: 'vite' | 'webpack'
-
   // Provided by Vite.config, or Webpack in the user's project
   var RWJS_ENV: {
     RWJS_API_GRAPHQL_URL: string

--- a/packages/web/src/global.web-auto-imports.ts
+++ b/packages/web/src/global.web-auto-imports.ts
@@ -17,9 +17,6 @@ declare global {
     /** URL or absolute path to serverless functions */
     RWJS_API_URL: string
     __REDWOOD__APP_TITLE: string
-
-    // Used by FatalErrorPage to determine how to import the DevFatalErrorPage
-    RWJS_WEB_BUNDLER: string
   }
 
   type GraphQLOperationVariables = Record<string, any>


### PR DESCRIPTION
Leftovers from migrating to Vite. We ended up not using/needing this