### PR TITLE
ChunkReferencesPlugin: Update types in webpack plugin

### DIFF
--- a/packages/internal/src/webpackPlugins/ChunkReferencesPlugin.ts
+++ b/packages/internal/src/webpackPlugins/ChunkReferencesPlugin.ts
@@ -14,7 +14,7 @@ export class ChunkReferencesPlugin {
   apply(compiler: Compiler) {
     compiler.hooks.emit.tap('ChunkReferencesPlugin', (compilation) => {
       const output: Array<{
-        name: string
+        name: string | undefined
         id: string | number
         files: Array<string>
         referencedChunks: Array<string | number>


### PR DESCRIPTION
`name` is sometimes `undefined`, and that's correct and works as expected.

See https://github.com/redwoodjs/redwood/pull/8549 for more context