### PR TITLE
Fix failing v5 codemod for DevFatalErrorPage

### DIFF
--- a/packages/codemods/src/codemods/v0.50.x/updateDevFatalErrorPage/updateDevFatalErrorPage.ts
+++ b/packages/codemods/src/codemods/v0.50.x/updateDevFatalErrorPage/updateDevFatalErrorPage.ts
@@ -19,7 +19,7 @@ export const updateDevFatalErrorPage = async () => {
   const dirs = {
     [webFatalErrorPagesDir]: {
       [path.join(webFatalErrorPagesDir, 'FatalErrorPage')]:
-        'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/web/src/pages/FatalErrorPage/FatalErrorPage.tsx',
+        'https://raw.githubusercontent.com/redwoodjs/redwood/v5.3.1/packages/create-redwood-app/templates/ts/web/src/pages/FatalErrorPage/FatalErrorPage.tsx',
     },
   }
 


### PR DESCRIPTION
Codemod for upgrading to v5 should use v5 version of the DevFatalErrorPage file