### PR TITLE
Clerk decoder: Fix code format

### DIFF
--- a/packages/auth-providers/clerk/api/src/decoder.ts
+++ b/packages/auth-providers/clerk/api/src/decoder.ts
@@ -38,7 +38,10 @@ export const authDecoder: Decoder = async (token: string, type: string) => {
   }
 }
 
-export const clerkAuthDecoder: Decoder = async (token: string, type: string) => {
+export const clerkAuthDecoder: Decoder = async (
+  token: string,
+  type: string
+) => {
   if (type !== 'clerk') {
     return null
   }


### PR DESCRIPTION
Just wanted to get rid of this warning on all PRs

![image](https://github.com/redwoodjs/redwood/assets/30793/a46ced91-159d-4be1-9d15-e45392824edc)
