### PR TITLE
chore(vite) Remove invalid comment

### DIFF
--- a/packages/internal/src/build/web.ts
+++ b/packages/internal/src/build/web.ts
@@ -49,11 +49,8 @@ interface BuildOptions {
 }
 
 /**
- *
- * @WARN: This is currently only used in testing
  * Builds the web side with Vite, but not used in the buildHandler currently
  * because we want to set the process.cwd to web.base
- *
  */
 export const buildWeb = async ({ verbose }: BuildOptions) => {
   // @NOTE: Using dynamic import, because vite is still opt-in


### PR DESCRIPTION
To me it looks like this comment is not true anymore. The `buildWeb` function is used from `rw-vite-build` which is invoked when you run `yarn rw build`

It's silly how minor this PR is. But I wanted to get @dac09's eyes on it, to make sure I'm not misunderstanding something