### PR TITLE
Use vite unless bundler === webpack

### DIFF
--- a/packages/cli/src/commands/__tests__/dev.test.js
+++ b/packages/cli/src/commands/__tests__/dev.test.js
@@ -97,7 +97,7 @@ describe('yarn rw dev', () => {
 
     // Uses absolute path, so not doing a snapshot
     expect(webCommand.command).toContain(
-      'yarn cross-env NODE_ENV=development RWJS_WATCH_NODE_MODULES= webpack serve'
+      'yarn cross-env NODE_ENV=development rw-vite-dev'
     )
 
     expect(apiCommand.command).toMatchInlineSnapshot(

--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -104,7 +104,7 @@ export const handler = async ({
     side.includes('web') && {
       title: 'Building Web...',
       task: async () => {
-        if (getConfig().web.bundler === 'vite') {
+        if (getConfig().web.bundler !== 'webpack') {
           // @NOTE: we're using the vite build command here, instead of the buildWeb function
           // because we want the process.cwd to be the web directory, not the root of the project
           // This is important for postcss/tailwind to work correctly

--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -150,7 +150,7 @@ export const handler = async ({
   const redwoodConfigPath = getConfigPath()
 
   const webCommand =
-    redwoodProjectConfig.web.bundler === 'vite' // @NOTE: can't use enums, not TS
+    redwoodProjectConfig.web.bundler !== 'webpack' // @NOTE: can't use enums, not TS
       ? `yarn cross-env NODE_ENV=development rw-vite-dev ${forward}`
       : `yarn cross-env NODE_ENV=development RWJS_WATCH_NODE_MODULES=${
           watchNodeModules ? '1' : ''

--- a/packages/prerender/src/babelPlugins/babel-plugin-redwood-prerender-media-imports.ts
+++ b/packages/prerender/src/babelPlugins/babel-plugin-redwood-prerender-media-imports.ts
@@ -65,7 +65,7 @@ export default function (
           const importConstName = getVariableName(p)
           let copiedAssetPath
 
-          if (bundler === BundlerEnum.VITE) {
+          if (bundler !== BundlerEnum.WEBPACK) {
             if (state.filename === undefined) {
               return
             }

--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -320,7 +320,7 @@ export const runPrerender = async ({
   })
 
   const gqlHandler = await getGqlHandler()
-  const vite = getConfig().web.bundler === 'vite'
+  const vite = getConfig().web.bundler !== 'webpack'
 
   // Prerender specific configuration
   // extends projects web/babelConfig


### PR DESCRIPTION
Vite should be the default. So the only way to use webpack should be to have `bundler === 'webpack'`. As soon as `bundler !== 'webpack'` we use vite