### PR TITLE
Remove redundant process.chdir call in rw-vite-build

### DIFF
--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -105,9 +105,15 @@ export const handler = async ({
       title: 'Building Web...',
       task: async () => {
         if (getConfig().web.bundler !== 'webpack') {
-          // @NOTE: we're using the vite build command here, instead of the buildWeb function
-          // because we want the process.cwd to be the web directory, not the root of the project
+          // @NOTE: we're using the vite build command here, instead of the
+          // buildWeb function directly because we want the process.cwd to be
+          // the web directory, not the root of the project.
           // This is important for postcss/tailwind to work correctly
+          // Having a separate binary lets us contain the change of cwd to that
+          // process only. If we changed cwd here, or in the buildWeb function,
+          // it could affect other things that run in parallel while building.
+          // We don't have any parallel tasks right now, but someone might add
+          // one in the future as a performance optimization.
           await execa(`yarn rw-vite-build`, {
             stdio: verbose ? 'inherit' : 'pipe',
             shell: true,

--- a/packages/vite/bins/rw-vite-build.mjs
+++ b/packages/vite/bins/rw-vite-build.mjs
@@ -10,8 +10,6 @@ const buildWebSide = async () => {
     throw new Error('Could not locate your web/vite.config.{js,ts} file')
   }
 
-  // @NOTE: necessary for keeping the cwd correct for postcss/tailwind
-  process.chdir(rwPaths.web.base)
   process.env.NODE_ENV = 'production'
 
   // Right now, the buildWeb function looks up the config file from project-config


### PR DESCRIPTION
I added a comment explaining the reasoning around cwd

I also removed the call to `process.chdir()` in the `rw-vite-build` binary. Since we set `cwd` using execa when calling the binary that extra `process.chdir()` call wasn't necessary anymore.

"But what if you manually want to run the `rw-vite-build` binary?" you ask.
You'll just have to make sure cwd is /web. If it isn't the command will fail with a helpful error message because we check cwd in the `buildWeb()` function.

The other option is of course to keep `process.chdir()` in the binary and remove the `cwd` option from where we invoke it using execa. But I decided to go with what I currently have because passing `cwd` to execa is something we do all the time. Calling `process.chdir()` is not something we do very often, and probably not something we want to encourage either.

I didn't want to keep both the `cwd` execa option and calling `process.chdir()` because I found it confusing when reading the code. Especially with the "important" and "necessary" comments I thought both were really needed, and I didn't understand why. Now I can see "But what's the harm?"/"Better safe than sorry"/etc kind of arguments. But it was extra code I didn't understand the purpose of, and I want to spare future readers (probably me in half a year) the mental overhead.

Running `rw-vite-build` can be done in a few different ways:
```
rw-project/ $ cd web
rw-project/web/ $ yarn rw-vite-build
```
```
rw-project/ $ yarn workspace web rw-vite-build
```
```
rw-project/ $ cd web
rw-project/web/ $ node ../node_modules/.bin/rw-vite-build
``` 