### PR TITLE
Tweak vite setup output

### DIFF
--- a/packages/cli/src/commands/setup/vite/viteHandler.js
+++ b/packages/cli/src/commands/setup/vite/viteHandler.js
@@ -53,7 +53,7 @@ export const handler = async ({ force, verbose, addPackage }) => {
               'You have the bundler set to webpack in your redwood.toml. Remove this line, or change it to "vite" and try again.'
             )
           } else {
-            task.skip('Vite already configured as bundler')
+            task.skip('Vite already configured as the bundler')
           }
         },
       },

--- a/packages/cli/src/commands/setup/vite/viteHandler.js
+++ b/packages/cli/src/commands/setup/vite/viteHandler.js
@@ -53,12 +53,13 @@ export const handler = async ({ force, verbose, addPackage }) => {
               'You have the bundler set to webpack in your redwood.toml. Remove this line, or change it to "vite" and try again.'
             )
           } else {
-            task.skip('Vite bundler flag already set in redwood.toml')
+            task.skip('Vite already configured as bundler')
           }
         },
       },
       {
-        title: 'Creating new entry point in `web/src/entry.client.{jt}sx`...',
+        title:
+          'Creating new entry point in `web/src/entry.client.{jsx,tsx}`...',
         task: () => {
           const entryPointFile = path.join(
             getPaths().web.src,


### PR DESCRIPTION
![image](https://github.com/redwoodjs/redwood/assets/30793/4a6d671e-47df-40b5-99fe-062e71cfd993)

Because Vite is now the default this message wasn't exactly right in that Vite is also set as the bundler if no flag exists in redwood.toml. So I updated the messaging a bit

The above was the main thing. But then I also noticed this
![image](https://github.com/redwoodjs/redwood/assets/30793/6fddff25-db2b-4143-a752-c9d75a36a200)
I changed that to be in line with how we do it in the tutorial 
![image](https://github.com/redwoodjs/redwood/assets/30793/35964518-64ae-4ed4-9de4-9c8b8f874250)

Here's the final output
![image](https://github.com/redwoodjs/redwood/assets/30793/43347750-cff1-49a0-969a-8c6dc85c7150)
