### PR TITLE
chore: Remind to setup auth in server file GraphQL configuration

### DIFF
--- a/packages/cli/src/commands/experimental/templates/server.ts.template
+++ b/packages/cli/src/commands/experimental/templates/server.ts.template
@@ -17,10 +17,15 @@ import { getPaths, getConfig } from '@redwoodjs/project-config'
 import directives from 'src/directives/**/*.{js,ts}'
 import sdls from 'src/graphql/**/*.sdl.{js,ts}'
 import services from 'src/services/**/*.{js,ts}'
+
 // Import if using RedwoodJS Realtime and subscriptions
 // import subscriptions from 'src/subscriptions/**/*.{js,ts}'
 
+// Import if using RedwoodJS authentication
+// import { authDecoder } from '@redwoodjs/<your-auth-provider>'
+// import { getCurrentUser } from 'src/lib/auth'
 import { logger } from './lib/logger'
+
 // Import if using RedwoodJS Realtime via `yarn rw exp setup-realtime`
 // import { pubSub, liveQueryStore } from './lib/realtime'
 
@@ -69,6 +74,9 @@ async function serve() {
   })
 
   await fastify.register(redwoodFastifyGraphQLServer, {
+    // If authenticating, be sure to import and add in
+    // authDecoder,
+    // getCurrentUser,
     loggerConfig: {
       logger: logger,
     },


### PR DESCRIPTION
When testing out the server file setup on an existing RedwoodJS project with auth, we forgot to setup the same auth used in the graphql handler function in the server file graphql options.

And of course -- authentication didn't work.

This PR simply adds some comment for the moment to remind the user and call out that if they use auth to import their decoder and getCurrentUser function and include in the options.