### PR TITLE
DX: Tweak comments in redwood.toml

### DIFF
--- a/__fixtures__/test-project/redwood.toml
+++ b/__fixtures__/test-project/redwood.toml
@@ -8,8 +8,11 @@
 [web]
   title = "Redwood App"
   port = "${WEB_DEV_PORT:8910}"
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [
+    # Add any ENV vars that should be available to the web side to this array
+    # See https://redwoodjs.com/docs/environment-variables#web
+  ]
 [api]
   port = "${API_DEV_PORT:8911}"
 [browser]

--- a/packages/create-redwood-app/templates/js/redwood.toml
+++ b/packages/create-redwood-app/templates/js/redwood.toml
@@ -8,8 +8,11 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [
+    # Add any ENV vars that should be available to the web side to this array
+    # See https://redwoodjs.com/docs/environment-variables#web
+  ]
 [api]
   port = 8911
 [browser]

--- a/packages/create-redwood-app/templates/ts/redwood.toml
+++ b/packages/create-redwood-app/templates/ts/redwood.toml
@@ -8,8 +8,11 @@
 [web]
   title = "Redwood App"
   port = 8910
-  apiUrl = "/.redwood/functions" # you can customise graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
-  includeEnvironmentVariables = [] # any ENV vars that should be available to the web side, see https://redwoodjs.com/docs/environment-variables#web
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+  includeEnvironmentVariables = [
+    # Add any ENV vars that should be available to the web side to this array
+    # See https://redwoodjs.com/docs/environment-variables#web
+  ]
 [api]
   port = 8911
 [browser]


### PR DESCRIPTION
I always get insecure about the array syntax in the toml for listing env vars. Like, am I allowed to have newlines?
Hopefully adding the comments on new lines inside the array makes it clear that you're allowed to do that.

Ideally I'd like the comment to say: 
> Add ENV_VARs each on their own line. Quote the variable name and end the line with a comma (,). Like this:
>  'EXAMPLE_VAR_ONE',
>  'EXAMPLE_VAR_TWO',

I figured that was too long, but happy to take suggestions on how to further improve the wording in the PR