### PR TITLE
Setup vite: No longer experimental

### DIFF
--- a/packages/cli/src/commands/setup/vite/vite.js
+++ b/packages/cli/src/commands/setup/vite/vite.js
@@ -3,7 +3,7 @@ import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
 export const command = 'vite'
 
 export const description =
-  '[Experimental] Configure the web side to use Vite, instead of Webpack'
+  'Configure the web side to use Vite, instead of Webpack'
 
 export const builder = (yargs) => {
   yargs.option('force', {


### PR DESCRIPTION
Vite support is no longer (as of v6) experimental, so removing notice in help text

![image](https://github.com/redwoodjs/redwood/assets/30793/f855235f-d15a-45e5-96f1-95be56541dd2)
