### PR TITLE
chore(crwa): Fix blank UID on project creation

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -220,7 +220,8 @@ async function createProjectFiles(newAppDir, { templateDir, overwrite }) {
   )
 
   // Write the uid
-  fs.ensureFileSync(path.join(newAppDir, '.redwood', 'telemetry.txt'), UID)
+  fs.ensureDirSync(path.join(newAppDir, '.redwood'))
+  fs.writeFileSync(path.join(newAppDir, '.redwood', 'telemetry.txt'), UID)
 
   tuiContent.update({
     spinner: {


### PR DESCRIPTION
**Problem**
On creation the UID was not set and was being returned as "" for the next 24 hours.

**Changes**
1. Corrects incorrect file io. 

**Notes**
@thedavidprice Corrects the issue you have detected.