### PR TITLE
chore(cli): Update checker background process logging improvement

### DIFF
--- a/packages/cli/src/lib/background.js
+++ b/packages/cli/src/lib/background.js
@@ -20,14 +20,27 @@ export function spawnBackgroundProcess(name, cmd, args) {
 
   const safeName = name.replace(/[^a-z0-9]/gi, '_').toLowerCase()
 
+  const logHeader = [
+    `Starting log:`,
+    ` - Time: ${new Date().toISOString()}`,
+    ` - Name: ${name} (${safeName})`,
+    ` - Command: ${cmd}`,
+    ` - Arguments: ${args.join(' ')}`,
+    '',
+    '',
+  ].join('\n')
+
   const stdout = fs.openSync(
     path.join(logDirectory, `${safeName}.out.log`),
     'w'
   )
+  fs.writeSync(stdout, logHeader)
+
   const stderr = fs.openSync(
     path.join(logDirectory, `${safeName}.err.log`),
     'w'
   )
+  fs.writeSync(stderr, logHeader)
 
   // We must account for some platform specific behaviour
   const spawnOptions =


### PR DESCRIPTION
**Description**
I recently added a helper for when we need to run background tasks. The aim was to ensure consistent use of spawn options (as they are quite cryptic) and to introduce consistency of the logging for the background processes.

**Changes**
1. The background task used to check for redwood updates now uses the background process helper.
   * Output is now found in logs within `.redwood/logs`
   * The process now has relatively verbose output to aid in debugging if it breaks in the future. 
2. The background process helper now writes some metadata at the head of the log files it creates for the process. This is introduced to ensure relevant data is available should we need to debug the background processes. It looks like so:
```
Starting log:
 - Time: 2023-06-28T15:23:03.386Z
 - Name: updateCheck (updatecheck)
 - Command: yarn
 - Arguments: node /home/josh/Development/redwood/rw-test-background-logs/node_modules/@redwoodjs/cli/dist/lib/updateCheckExecute.js
```

**Pushed**
1. I'd like to reorganise the `.redwood` folder further when it comes to the update checker. Currently it has it's own folder `updateCheck` folder. I'd like to fold everything specifically CLI related into a `cli` folder and then just have a file something like `versions.json` inside that folder.
