### PR TITLE
chore(v6): temporarily revert host-related changes

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1990,12 +1990,12 @@ yarn redwood serve [side]
 
 `yarn rw serve` is useful for debugging locally or for self-hosting—deploying a single server into a serverful environment. Since both the api and the web sides run in the same server, CORS isn't a problem.
 
-| Arguments & Options | Description                                                                                                                                     |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web`                                                                  |
-| `--port`            | What port should the server run on [default: 8911]                                                                                              |
+| Arguments & Options | Description                                                                    |
+| ------------------- | ------------------------------------------------------------------------------ |
+| `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web` |
+| `--port`            | What port should the server run on [default: 8911]                             |
 | `--host`            | What host should the server run on. This defaults to the value of `web.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
-| `--socket`          | The socket the server should run. This takes precedence over port                                                                               |
+| `--socket`          | The socket the server should run. This takes precedence over port              |
 
 ### serve api
 
@@ -2007,12 +2007,12 @@ yarn rw serve api
 
 This command uses `apiUrl` in your `redwood.toml`. Use this command if you want to run just the api side on a server (e.g. running on Render).
 
-| Arguments & Options | Description                                                                                                                                     |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--port`            | What port should the server run on [default: 8911]                                                                                              |
+| Arguments & Options | Description                                                       |
+| ------------------- | ----------------------------------------------------------------- |
+| `--port`            | What port should the server run on [default: 8911]                |
 | `--host`            | What host should the server run on. This defaults to the value of `api.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
-| `--socket`          | The socket the server should run. This takes precedence over port                                                                               |
-| `--apiRootPath`     | The root path where your api functions are served                                                                                               |
+| `--socket`          | The socket the server should run. This takes precedence over port |
+| `--apiRootPath`     | The root path where your api functions are served                 |
 
 For the full list of Server Configuration settings, see [this documentation](app-configuration-redwood-toml.md#api).
 If you want to format your log output, you can pipe the command to the Redwood LogFormatter:
@@ -2035,12 +2035,12 @@ This command serves the contents in `web/dist`. Use this command if you're debug
 >
 > Probably, but it can be a challenge to setup when you just want something running quickly!
 
-| Arguments & Options | Description                                                                                                                                     |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--port`            | What port should the server run on [default: 8911]                                                                                              |
+| Arguments & Options | Description                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------- |
+| `--port`            | What port should the server run on [default: 8911]                                    |
 | `--host`            | What host should the server run on. This defaults to the value of `web.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
-| `--socket`          | The socket the server should run. This takes precedence over port                                                                               |
-| `--apiHost`         | Forwards requests from the `apiUrl` (defined in `redwood.toml`) to the specified host                                                           |
+| `--socket`          | The socket the server should run. This takes precedence over port                     |
+| `--apiHost`         | Forwards requests from the `apiUrl` (defined in `redwood.toml`) to the specified host |
 
 If you want to format your log output, you can pipe the command to the Redwood LogFormatter:
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1994,7 +1994,6 @@ yarn redwood serve [side]
 | ------------------- | ------------------------------------------------------------------------------ |
 | `side`              | Which side(s) to run. Choices are `api` and `web`. Defaults to `api` and `web` |
 | `--port`            | What port should the server run on [default: 8911]                             |
-| `--host`            | What host should the server run on. This defaults to the value of `web.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
 | `--socket`          | The socket the server should run. This takes precedence over port              |
 
 ### serve api
@@ -2010,7 +2009,6 @@ This command uses `apiUrl` in your `redwood.toml`. Use this command if you want 
 | Arguments & Options | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
 | `--port`            | What port should the server run on [default: 8911]                |
-| `--host`            | What host should the server run on. This defaults to the value of `api.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
 | `--socket`          | The socket the server should run. This takes precedence over port |
 | `--apiRootPath`     | The root path where your api functions are served                 |
 
@@ -2038,7 +2036,6 @@ This command serves the contents in `web/dist`. Use this command if you're debug
 | Arguments & Options | Description                                                                           |
 | ------------------- | ------------------------------------------------------------------------------------- |
 | `--port`            | What port should the server run on [default: 8911]                                    |
-| `--host`            | What host should the server run on. This defaults to the value of `web.host` in the `redwood.toml` file which itself defaults to `'localhost'`. |
 | `--socket`          | The socket the server should run. This takes precedence over port                     |
 | `--apiHost`         | Forwards requests from the `apiUrl` (defined in `redwood.toml`) to the specified host |
 

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -29,6 +29,7 @@ export const commonOptions = {
   host: {
     default: redwoodProjectConfig.web.host,
     type: 'string',
+    alias: 'h',
   },
   socket: { type: 'string' },
 } as const
@@ -42,6 +43,7 @@ export const apiCliOptions = {
   host: {
     default: redwoodProjectConfig.api.host,
     type: 'string',
+    alias: 'h',
   },
   socket: { type: 'string' },
   apiRootPath: {
@@ -62,6 +64,7 @@ export const webCliOptions = {
   host: {
     default: redwoodProjectConfig.web.host,
     type: 'string',
+    alias: 'h',
   },
   socket: { type: 'string' },
   apiHost: {

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -18,33 +18,13 @@ const sendProcessReady = () => {
   return process.send && process.send('ready')
 }
 
-const redwoodProjectConfig = getConfig()
-
 export const commonOptions = {
-  port: {
-    default: redwoodProjectConfig.web.port,
-    type: 'number',
-    alias: 'p',
-  },
-  host: {
-    default: redwoodProjectConfig.web.host,
-    type: 'string',
-    alias: 'h',
-  },
+  port: { default: getConfig().web?.port || 8910, type: 'number', alias: 'p' },
   socket: { type: 'string' },
 } as const
 
 export const apiCliOptions = {
-  port: {
-    default: redwoodProjectConfig.api.port,
-    type: 'number',
-    alias: 'p',
-  },
-  host: {
-    default: redwoodProjectConfig.api.host,
-    type: 'string',
-    alias: 'h',
-  },
+  port: { default: getConfig().api?.port || 8911, type: 'number', alias: 'p' },
   socket: { type: 'string' },
   apiRootPath: {
     alias: ['rootPath', 'root-path'],
@@ -56,16 +36,7 @@ export const apiCliOptions = {
 } as const
 
 export const webCliOptions = {
-  port: {
-    default: redwoodProjectConfig.web.port,
-    type: 'number',
-    alias: 'p',
-  },
-  host: {
-    default: redwoodProjectConfig.web.host,
-    type: 'string',
-    alias: 'h',
-  },
+  port: { default: getConfig().web?.port || 8910, type: 'number', alias: 'p' },
   socket: { type: 'string' },
   apiHost: {
     alias: 'api-host',
@@ -75,7 +46,7 @@ export const webCliOptions = {
 } as const
 
 export const apiServerHandler = async (options: ApiServerArgs) => {
-  const { port, host, socket, apiRootPath } = options
+  const { port, socket, apiRootPath } = options
   const tsApiServer = Date.now()
   process.stdout.write(c.dim(c.italic('Starting API Server...\n')))
 
@@ -86,7 +57,6 @@ export const apiServerHandler = async (options: ApiServerArgs) => {
 
   const http = startFastifyServer({
     port,
-    host,
     socket,
     fastify,
   }).ready(() => {
@@ -94,7 +64,7 @@ export const apiServerHandler = async (options: ApiServerArgs) => {
 
     const on = socket
       ? socket
-      : c.magenta(`http://${host}:${port}${apiRootPath}`)
+      : c.magenta(`http://localhost:${port}${apiRootPath}`)
     console.log(`API listening on ${on}`)
     const graphqlEnd = c.magenta(`${apiRootPath}graphql`)
     console.log(`GraphQL endpoint at ${graphqlEnd}`)
@@ -106,10 +76,10 @@ export const apiServerHandler = async (options: ApiServerArgs) => {
 }
 
 export const bothServerHandler = async (options: BothServerArgs) => {
-  const { port, host, socket } = options
+  const { port, socket } = options
   const tsServer = Date.now()
   process.stdout.write(c.dim(c.italic('Starting API and Web Servers...\n')))
-  const apiRootPath = coerceRootPath(redwoodProjectConfig.web.apiUrl)
+  const apiRootPath = coerceRootPath(getConfig().web.apiUrl)
 
   let fastify = createFastifyInstance()
 
@@ -119,16 +89,15 @@ export const bothServerHandler = async (options: BothServerArgs) => {
 
   startFastifyServer({
     port,
-    host,
     socket,
     fastify,
   }).ready(() => {
     console.log(c.italic(c.dim('Took ' + (Date.now() - tsServer) + ' ms')))
     const on = socket
       ? socket
-      : c.magenta(`http://${host}:${port}${apiRootPath}`)
-    const webServer = c.green(`http://${host}:${port}`)
-    const apiServer = c.magenta(`http://${host}:${port}`)
+      : c.magenta(`http://localhost:${port}${apiRootPath}`)
+    const webServer = c.green(`http://localhost:${port}`)
+    const apiServer = c.magenta(`http://localhost:${port}`)
     console.log(`Web server started on ${webServer}`)
     console.log(`API serving from ${apiServer}`)
     console.log(`API listening on ${on}`)
@@ -139,14 +108,14 @@ export const bothServerHandler = async (options: BothServerArgs) => {
 }
 
 export const webServerHandler = async (options: WebServerArgs) => {
-  const { port, host, socket, apiHost } = options
+  const { port, socket, apiHost } = options
   const tsServer = Date.now()
   process.stdout.write(c.dim(c.italic('Starting Web Server...\n')))
-  const apiUrl = redwoodProjectConfig.web.apiUrl
+  const apiUrl = getConfig().web.apiUrl
   // Construct the graphql url from apiUrl by default
   // But if apiGraphQLUrl is specified, use that instead
   const graphqlEndpoint = coerceRootPath(
-    redwoodProjectConfig.web.apiGraphQLUrl ?? `${apiUrl}/graphql`
+    getConfig().web.apiGraphQLUrl ?? `${apiUrl}/graphql`
   )
 
   let fastify = createFastifyInstance()
@@ -163,7 +132,6 @@ export const webServerHandler = async (options: WebServerArgs) => {
 
   startFastifyServer({
     port,
-    host,
     socket,
     fastify,
   }).ready(() => {
@@ -171,7 +139,7 @@ export const webServerHandler = async (options: WebServerArgs) => {
     if (socket) {
       console.log(`Listening on ` + c.magenta(`${socket}`))
     }
-    const webServer = c.green(`http://${host}:${port}`)
+    const webServer = c.green(`http://localhost:${port}`)
     console.log(`Web server started on ${webServer}`)
     console.log(`GraphQL endpoint is set to ` + c.magenta(`${graphqlEndpoint}`))
     sendProcessReady()

--- a/packages/api-server/src/server.ts
+++ b/packages/api-server/src/server.ts
@@ -2,17 +2,16 @@ import { FastifyInstance } from 'fastify'
 
 export interface HttpServerParams {
   port: number
-  host?: string
   socket?: string
   fastify: FastifyInstance
 }
 
 export const startServer = ({
   port = 8911,
-  host = 'localhost',
   socket,
   fastify,
 }: HttpServerParams) => {
+  const host = 'localhost'
   const serverPort = socket ? parseInt(socket) : port
 
   fastify.listen({ port: serverPort, host })

--- a/packages/api-server/src/server.ts
+++ b/packages/api-server/src/server.ts
@@ -11,7 +11,7 @@ export const startServer = ({
   socket,
   fastify,
 }: HttpServerParams) => {
-  const host = 'localhost'
+  const host = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
   const serverPort = socket ? parseInt(socket) : port
 
   fastify.listen({ port: serverPort, host })

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -39,6 +39,7 @@ const argv = yargs(hideBin(process.argv))
     default: redwoodProjectConfig.api.port,
   })
   .option('host', {
+    alias: 'h',
     description: 'Host',
     type: 'string',
     default: redwoodProjectConfig.api.host,

--- a/packages/cli/src/commands/__tests__/dev.test.js
+++ b/packages/cli/src/commands/__tests__/dev.test.js
@@ -76,7 +76,6 @@ describe('yarn rw dev', () => {
     getConfig.mockReturnValue({
       web: {
         port: 8910,
-        host: 'localhost',
       },
       api: {
         port: 8911,
@@ -101,7 +100,7 @@ describe('yarn rw dev', () => {
     )
 
     expect(apiCommand.command).toMatchInlineSnapshot(
-      `"yarn cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --quiet --watch "/mocked/project/redwood.toml" --exec "yarn rw-api-server-watch --port 8911 --host '::' --debug-port 18911 | rw-log-formatter""`
+      `"yarn cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --quiet --watch "/mocked/project/redwood.toml" --exec "yarn rw-api-server-watch --port 8911 --debug-port 18911 | rw-log-formatter""`
     )
 
     expect(generateCommand.command).toEqual('yarn rw-gen-watch')
@@ -111,7 +110,6 @@ describe('yarn rw dev', () => {
     getConfig.mockReturnValue({
       web: {
         port: 8910,
-        host: 'localhost',
       },
       api: {
         port: 8911,
@@ -129,7 +127,7 @@ describe('yarn rw dev', () => {
     const apiCommand = find(concurrentlyArgs, { name: 'api' })
 
     expect(apiCommand.command).toContain(
-      "yarn rw-api-server-watch --port 8911 --host '::' --debug-port 90909090"
+      'yarn rw-api-server-watch --port 8911 --debug-port 90909090'
     )
   })
 
@@ -137,7 +135,6 @@ describe('yarn rw dev', () => {
     getConfig.mockReturnValue({
       web: {
         port: 8910,
-        host: 'localhost',
       },
       api: {
         port: 8911,
@@ -160,7 +157,6 @@ describe('yarn rw dev', () => {
     getConfig.mockReturnValue({
       web: {
         port: 8910,
-        host: 'localhost',
         bundler: 'vite', // <-- enable vite mode
       },
       api: {

--- a/packages/cli/src/commands/__tests__/serve.test.js
+++ b/packages/cli/src/commands/__tests__/serve.test.js
@@ -17,12 +17,7 @@ jest.mock('@redwoodjs/project-config', () => {
     },
     getConfig: () => {
       return {
-        web: {
-          host: 'localhost',
-        },
-        api: {
-          host: 'localhost',
-        },
+        api: {},
       }
     },
   }
@@ -72,7 +67,6 @@ describe('yarn rw serve', () => {
     expect(apiServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 5555,
-        host: 'localhost',
         apiRootPath: expect.stringMatching(/^\/?funkyFunctions\/?$/),
       })
     )
@@ -88,7 +82,6 @@ describe('yarn rw serve', () => {
     expect(apiServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 5555,
-        host: 'localhost',
         rootPath: expect.stringMatching(/^\/?funkyFunctions\/nested\/$/),
       })
     )
@@ -104,7 +97,6 @@ describe('yarn rw serve', () => {
     expect(webServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 9898,
-        host: 'localhost',
         socket: 'abc',
         apiHost: 'https://myapi.redwood/api',
       })
@@ -119,7 +111,6 @@ describe('yarn rw serve', () => {
     expect(bothServerHandler).toHaveBeenCalledWith(
       expect.objectContaining({
         port: 9898,
-        host: 'localhost',
         socket: 'abc',
       })
     )

--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -65,12 +65,11 @@ export const handler = async ({
     watchNodeModules,
   })
 
-  const redwoodProjectPaths = getPaths()
-  const redwoodProjectConfig = getConfig()
+  const rwjsPaths = getPaths()
 
   // Starting values of ports from config (redwood.toml)
-  let apiPreferredPort = parseInt(redwoodProjectConfig.api.port)
-  let webPreferredPort = parseInt(redwoodProjectConfig.web.port)
+  let apiPreferredPort = parseInt(getConfig().api.port)
+  let webPreferredPort = parseInt(getConfig().web.port)
 
   // Assume we can have the ports we want
   let apiAvailablePort = apiPreferredPort
@@ -130,7 +129,7 @@ export const handler = async ({
       await generatePrismaClient({
         verbose: false,
         force: false,
-        schema: redwoodProjectPaths.api.dbSchema,
+        schema: rwjsPaths.api.dbSchema,
       })
     } catch (e) {
       errorTelemetry(
@@ -176,7 +175,7 @@ export const handler = async ({
       return `--debug-port ${defaultApiDebugPort}`
     }
 
-    const apiDebugPortInToml = redwoodProjectConfig.api.debugPort
+    const apiDebugPortInToml = getConfig().api.debugPort
     if (apiDebugPortInToml) {
       return `--debug-port ${apiDebugPortInToml}`
     }
@@ -188,47 +187,26 @@ export const handler = async ({
   const redwoodConfigPath = getConfigPath()
 
   const webCommand =
-    redwoodProjectConfig.web.bundler !== 'webpack' // @NOTE: can't use enums, not TS
+    getConfig().web.bundler !== 'webpack' // @NOTE: can't use enums, not TS
       ? `yarn cross-env NODE_ENV=development rw-vite-dev ${forward}`
       : `yarn cross-env NODE_ENV=development RWJS_WATCH_NODE_MODULES=${
           watchNodeModules ? '1' : ''
         } webpack serve --config "${webpackDevConfig}" ${forward}`
 
-  const apiCommand = [
-    'yarn',
-    'cross-env',
-    'NODE_ENV=development',
-    'NODE_OPTIONS=--enable-source-maps',
-    'yarn',
-    'nodemon',
-    '--quiet',
-    `--watch "${redwoodConfigPath}"`,
-    '--exec',
-    `"${[
-      'yarn',
-      'rw-api-server-watch',
-      `--port ${apiAvailablePort}`,
-      `--host '::'`,
-      getApiDebugFlag(),
-      '|',
-      'rw-log-formatter',
-    ].join(' ')}"`,
-  ].join(' ')
-
   /** @type {Record<string, import('concurrently').CommandObj>} */
   const jobs = {
     api: {
       name: 'api',
-      command: apiCommand,
+      command: `yarn cross-env NODE_ENV=development NODE_OPTIONS=--enable-source-maps yarn nodemon --quiet --watch "${redwoodConfigPath}" --exec "yarn rw-api-server-watch --port ${apiAvailablePort} ${getApiDebugFlag()} | rw-log-formatter"`,
       prefixColor: 'cyan',
-      runWhen: () => fs.existsSync(redwoodProjectPaths.api.src),
+      runWhen: () => fs.existsSync(rwjsPaths.api.src),
     },
     web: {
       name: 'web',
       command: webCommand,
       prefixColor: 'blue',
-      cwd: redwoodProjectPaths.web.base,
-      runWhen: () => fs.existsSync(redwoodProjectPaths.web.src),
+      cwd: rwjsPaths.web.base,
+      runWhen: () => fs.existsSync(rwjsPaths.web.src),
     },
     gen: {
       name: 'gen',

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -37,6 +37,7 @@ export async function builder(yargs) {
           host: {
             default: redwoodProjectConfig.web.host,
             type: 'string',
+            alias: 'h',
           },
           socket: { type: 'string' },
         }),
@@ -88,6 +89,7 @@ export async function builder(yargs) {
           host: {
             default: redwoodProjectConfig.api.host,
             type: 'string',
+            alias: 'h',
           },
           socket: { type: 'string' },
           apiRootPath: {
@@ -143,6 +145,7 @@ export async function builder(yargs) {
           host: {
             default: redwoodProjectConfig.web.host,
             type: 'string',
+            alias: 'h',
           },
           socket: { type: 'string' },
           apiHost: {

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -18,26 +18,18 @@ function hasExperimentalServerFile() {
   return fs.existsSync(serverFilePath)
 }
 
-export async function builder(yargs) {
-  const redwoodProjectPaths = getPaths()
-  const redwoodProjectConfig = getConfig()
-
+export const builder = async (yargs) => {
   yargs
     .usage('usage: $0 <side>')
     .command({
       command: '$0',
-      description: 'Run both api and web servers. Uses the web port and host',
+      description: 'Run both api and web servers',
       builder: (yargs) =>
         yargs.options({
           port: {
-            default: redwoodProjectConfig.web.port,
+            default: getConfig().web?.port || 8910,
             type: 'number',
             alias: 'p',
-          },
-          host: {
-            default: redwoodProjectConfig.web.host,
-            type: 'string',
-            alias: 'h',
           },
           socket: { type: 'string' },
         }),
@@ -64,7 +56,7 @@ export async function builder(yargs) {
             'yarn',
             ['node', path.join('dist', 'server.js'), '--enable-web'],
             {
-              cwd: redwoodProjectPaths.api.base,
+              cwd: getPaths().api.base,
               stdio: 'inherit',
               shell: true,
             }
@@ -82,14 +74,9 @@ export async function builder(yargs) {
       builder: (yargs) =>
         yargs.options({
           port: {
-            default: redwoodProjectConfig.api.port,
+            default: getConfig().api?.port || 8911,
             type: 'number',
             alias: 'p',
-          },
-          host: {
-            default: redwoodProjectConfig.api.host,
-            type: 'string',
-            alias: 'h',
           },
           socket: { type: 'string' },
           apiRootPath: {
@@ -121,7 +108,7 @@ export async function builder(yargs) {
             ].join('\n')
           )
           await execa('yarn', ['node', path.join('dist', 'server.js')], {
-            cwd: redwoodProjectPaths.api.base,
+            cwd: getPaths().api.base,
             stdio: 'inherit',
             shell: true,
           })
@@ -138,14 +125,9 @@ export async function builder(yargs) {
       builder: (yargs) =>
         yargs.options({
           port: {
-            default: redwoodProjectConfig.web.port,
+            default: getConfig().web?.port || 8910,
             type: 'number',
             alias: 'p',
-          },
-          host: {
-            default: redwoodProjectConfig.web.host,
-            type: 'string',
-            alias: 'h',
           },
           socket: { type: 'string' },
           apiHost: {
@@ -177,7 +159,7 @@ export async function builder(yargs) {
 
       if (
         positionalArgs.includes('web') &&
-        !fs.existsSync(path.join(redwoodProjectPaths.web.dist), 'index.html')
+        !fs.existsSync(path.join(getPaths().web.dist), 'index.html')
       ) {
         console.error(
           c.error(
@@ -189,7 +171,7 @@ export async function builder(yargs) {
 
       if (
         positionalArgs.includes('api') &&
-        !fs.existsSync(path.join(redwoodProjectPaths.api.dist))
+        !fs.existsSync(path.join(getPaths().api.dist))
       ) {
         console.error(
           c.error(
@@ -202,8 +184,8 @@ export async function builder(yargs) {
       if (
         // serve both
         positionalArgs.length === 1 &&
-        (!fs.existsSync(path.join(redwoodProjectPaths.api.dist)) ||
-          !fs.existsSync(path.join(redwoodProjectPaths.web.dist), 'index.html'))
+        (!fs.existsSync(path.join(getPaths().api.dist)) ||
+          !fs.existsSync(path.join(getPaths().web.dist), 'index.html'))
       ) {
         console.error(
           c.error(

--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -10,7 +10,7 @@ import { withApiProxy } from '@redwoodjs/fastify/dist/plugins/withApiProxy'
 import { getConfig } from '@redwoodjs/project-config'
 
 export const apiServerHandler = async (options) => {
-  const { port, host, socket, apiRootPath } = options
+  const { port, socket, apiRootPath } = options
   const tsApiServer = Date.now()
 
   console.log(chalk.dim.italic('Starting API Server...'))
@@ -29,7 +29,7 @@ export const apiServerHandler = async (options) => {
 
   fastify.listen({
     port: socket ? parseInt(socket) : port,
-    host,
+    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
   })
 
   fastify.ready(() => {
@@ -42,7 +42,7 @@ export const apiServerHandler = async (options) => {
 
     const on = socket
       ? socket
-      : chalk.magenta(`http://${host}:${port}${apiRootPath}`)
+      : chalk.magenta(`http://localhost:${port}${apiRootPath}`)
 
     console.log(`API listening on ${on}`)
     const graphqlEnd = chalk.magenta(`${apiRootPath}graphql`)
@@ -53,7 +53,7 @@ export const apiServerHandler = async (options) => {
 }
 
 export const bothServerHandler = async (options) => {
-  const { port, host, socket } = options
+  const { port, socket } = options
   const tsServer = Date.now()
 
   console.log(chalk.italic.dim('Starting API and Web Servers...'))
@@ -81,7 +81,7 @@ export const bothServerHandler = async (options) => {
 
   fastify.listen({
     port: socket ? parseInt(socket) : port,
-    host,
+    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
   })
 
   fastify.ready(() => {
@@ -89,10 +89,10 @@ export const bothServerHandler = async (options) => {
 
     const on = socket
       ? socket
-      : chalk.magenta(`http://${host}:${port}${apiRootPath}`)
+      : chalk.magenta(`http://localhost:${port}${apiRootPath}`)
 
-    const webServer = chalk.green(`http://${host}:${port}`)
-    const apiServer = chalk.magenta(`http://${host}:${port}`)
+    const webServer = chalk.green(`http://localhost:${port}`)
+    const apiServer = chalk.magenta(`http://localhost:${port}`)
     console.log(`Web server started on ${webServer}`)
     console.log(`API serving from ${apiServer}`)
     console.log(`API listening on ${on}`)
@@ -104,17 +104,16 @@ export const bothServerHandler = async (options) => {
 }
 
 export const webServerHandler = async (options) => {
-  const redwoodProjectConfig = getConfig()
-  const { port, host, socket, apiHost } = options
+  const { port, socket, apiHost } = options
 
   const tsServer = Date.now()
   console.log(chalk.dim.italic('Starting Web Server...'))
-  const apiUrl = redwoodProjectConfig.web.apiUrl
+  const apiUrl = getConfig().web.apiUrl
 
   // Construct the GraphQL URL from apiUrl by default.
   // But if apiGraphQLUrl is specified, use that instead.
   const graphqlEndpoint = coerceRootPath(
-    redwoodProjectConfig.web.apiGraphQLUrl ?? `${apiUrl}/graphql`
+    getConfig().web.apiGraphQLUrl ?? `${apiUrl}/graphql`
   )
 
   const fastify = createFastifyInstance()
@@ -139,7 +138,7 @@ export const webServerHandler = async (options) => {
 
   fastify.listen({
     port: socket ? parseInt(socket) : port,
-    host,
+    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
   })
 
   fastify.ready(() => {
@@ -149,7 +148,7 @@ export const webServerHandler = async (options) => {
       console.log(`Listening on ` + chalk.magenta(`${socket}`))
     }
 
-    const webServer = chalk.green(`http://${host}:${port}`)
+    const webServer = chalk.green(`http://localhost:${port}`)
     console.log(`Web server started on ${webServer}`)
     console.log(
       `GraphQL endpoint is set to ` + chalk.magenta(`${graphqlEndpoint}`)

--- a/packages/core/config/webpack.development.js
+++ b/packages/core/config/webpack.development.js
@@ -98,7 +98,7 @@ const baseConfig = merge(webpackConfig('development'), {
     historyApiFallback: {
       disableDotRule: true,
     },
-    host: redwoodConfig.web.host,
+    host: redwoodConfig.web.host || 'localhost',
     port: redwoodConfig.web.port,
     proxy: getProxyConfig(),
     open: redwoodConfig.browser.open,


### PR DESCRIPTION
This PR reverts the following three PRs that we've decided to save for the next next major (v7):
- https://github.com/redwoodjs/redwood/pull/8019
- https://github.com/redwoodjs/redwood/pull/8385
- https://github.com/redwoodjs/redwood/pull/8407

After the v6 RC branch is cut, we can revert this PR.