### PR TITLE
eslint rule: unsupported-route-components

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -46,6 +46,9 @@ module.exports = {
     requireConfigFile: false,
     babelOptions: getProjectBabelOptions(),
   },
+  rules: {
+    '@redwoodjs/unsupported-route-components': 'warn',
+  },
   overrides: [
     {
       files: ['web/src/Routes.js', 'web/src/Routes.jsx', 'web/src/Routes.tsx'],

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/eslint": "8",
     "@types/estree": "1.0.1",
+    "@typescript-eslint/parser": "5.60.1",
     "esbuild": "0.18.10",
     "fast-glob": "3.2.12",
     "glob": "10.3.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -21,6 +21,7 @@
     "test:watch": "glob './src/**/__tests__/*.test.ts' --cmd='node --loader tsx --no-warnings --test --watch'"
   },
   "dependencies": {
+    "@typescript-eslint/utils": "^5.60.1",
     "eslint": "8.43.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -21,7 +21,7 @@
     "test:watch": "glob './src/**/__tests__/*.test.ts' --cmd='node --loader tsx --no-warnings --test --watch'"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.60.1",
+    "@typescript-eslint/utils": "5.60.1",
     "eslint": "8.43.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
+++ b/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
@@ -16,7 +16,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
   valid: [
     {
       filename: '/web/src/Routes.tsx',
-      code: 'const routes = () => <Routes></Routes>',
+      code: 'const Routes = () => <Router></Router>',
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: {
@@ -26,7 +26,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
     },
     {
       filename: '/web/src/Routes.jsx',
-      code: 'const routes = () => <Routes><Route path="/" page={HomePage} name="home" /></Routes>',
+      code: 'const Routes = () => <Router><Route path="/" page={HomePage} name="home" /></Router>',
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: {
@@ -36,7 +36,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
     },
     {
       filename: '/web/src/Routes.js',
-      code: 'const routes = () => <Routes><Set><Route path="/contacts" page={ContactsPage} name="contacts" /></Set></Routes>',
+      code: 'const Routes = () => <Router><Set><Route path="/contacts" page={ContactsPage} name="contacts" /></Set></Router>',
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: {
@@ -47,13 +47,13 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
     {
       filename: '/web/src/Routes.tsx',
       code: `
-        const routes = () => {
+        const Routes = () => {
           return (
-            <Routes>
+            <Router>
               <Set>
                 <Route path="/contacts" page={ContactsPage} name="contacts" />
               </Set>
-            </Routes>
+            </Router>
           )
         }`.replace(/ +/g, ' '),
       parserOptions: {
@@ -67,7 +67,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
   invalid: [
     {
       filename: '/web/src/Routes.tsx',
-      code: 'const routes = () => <Routes><div><Route path="/" page={HomePage} name="home" /></div></Routes>',
+      code: 'const Routes = () => <Router><div><Route path="/" page={HomePage} name="home" /></div></Router>',
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: {
@@ -84,15 +84,15 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
     {
       filename: '/web/src/Routes.tsx',
       code: `
-        const routes = () => {
+        const Routes = () => {
           return (
-            <Routes>
+            <Router>
               <Set>
                 <CustomElement>
                   <Route path="/contacts" page={ContactsPage} name="contacts" />
                 </CustomElement>
               </Set>
-            </Routes>
+            </Router>
           )
         }`.replace(/ +/g, ' '),
       parserOptions: {

--- a/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
+++ b/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test'
+
+import { RuleTester } from 'eslint'
+
+import { unsupportedRouteComponents } from '../unsupported-route-components.js'
+
+// @ts-expect-error - Types are wrong
+RuleTester.describe = describe
+// @ts-expect-error - Types are wrong
+RuleTester.it = it
+
+const ruleTester = new RuleTester()
+
+// @ts-expect-error - unsupportedRouteComponents is typed by @typescript-eslint, but it still works
+ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
+  valid: [
+    {
+      filename: '/web/src/Routes.tsx',
+      code: 'const routes = () => <Routes></Routes>',
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      filename: '/web/src/Routes.jsx',
+      code: 'const routes = () => <Routes><Route path="/" page={HomePage} name="home" /></Routes>',
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      filename: '/web/src/Routes.js',
+      code: 'const routes = () => <Routes><Set><Route path="/contacts" page={ContactsPage} name="contacts" /></Set></Routes>',
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      filename: '/web/src/Routes.tsx',
+      code: `
+        const routes = () => {
+          return (
+            <Routes>
+              <Set>
+                <Route path="/contacts" page={ContactsPage} name="contacts" />
+              </Set>
+            </Routes>
+          )
+        }`.replace(/ +/g, ' '),
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+  ],
+  invalid: [
+    {
+      filename: '/web/src/Routes.tsx',
+      code: 'const routes = () => <Routes><div><Route path="/" page={HomePage} name="home" /></div></Routes>',
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [
+        {
+          message:
+            'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
+        },
+      ],
+    },
+    {
+      filename: '/web/src/Routes.tsx',
+      code: `
+        const routes = () => {
+          return (
+            <Routes>
+              <Set>
+                <CustomElement>
+                  <Route path="/contacts" page={ContactsPage} name="contacts" />
+                </CustomElement>
+              </Set>
+            </Routes>
+          )
+        }`.replace(/ +/g, ' '),
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      errors: [
+        {
+          message:
+            'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
+        },
+      ],
+    },
+  ],
+})

--- a/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
+++ b/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
@@ -77,7 +77,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
       errors: [
         {
           message:
-            'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
+            'Unexpected JSX element <div>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
         },
       ],
     },
@@ -104,7 +104,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
       errors: [
         {
           message:
-            'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
+            'Unexpected JSX element <CustomElement>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
         },
       ],
     },

--- a/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
+++ b/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
@@ -1,48 +1,39 @@
 import { describe, it } from 'node:test'
 
-import { RuleTester } from 'eslint'
+import { ESLintUtils } from '@typescript-eslint/utils'
 
 import { unsupportedRouteComponents } from '../unsupported-route-components.js'
 
-// @ts-expect-error - Types are wrong
-RuleTester.describe = describe
-// @ts-expect-error - Types are wrong
-RuleTester.it = it
+ESLintUtils.RuleTester.describe = describe
+ESLintUtils.RuleTester.it = it
 
-const ruleTester = new RuleTester()
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+})
 
-// @ts-expect-error - unsupportedRouteComponents is typed by @typescript-eslint, but it still works
 ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
   valid: [
     {
       filename: '/web/src/Routes.tsx',
       code: 'const Routes = () => <Router></Router>',
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
     },
     {
       filename: '/web/src/Routes.jsx',
       code: 'const Routes = () => <Router><Route path="/" page={HomePage} name="home" /></Router>',
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
     },
     {
       filename: '/web/src/Routes.js',
       code: 'const Routes = () => <Router><Set><Route path="/contacts" page={ContactsPage} name="contacts" /></Set></Router>',
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
+    },
+    {
+      filename: '/web/src/Routes.js',
+      code: 'const Routes = () => <Router><Private><Route path="/contacts" page={ContactsPage} name="contacts" /></Private></Router>',
     },
     {
       filename: '/web/src/Routes.tsx',
@@ -56,30 +47,13 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
             </Router>
           )
         }`.replace(/ +/g, ' '),
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
     },
   ],
   invalid: [
     {
       filename: '/web/src/Routes.tsx',
       code: 'const Routes = () => <Router><div><Route path="/" page={HomePage} name="home" /></div></Router>',
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
-      errors: [
-        {
-          message:
-            'Unexpected JSX element <div>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
-        },
-      ],
+      errors: [{ messageId: 'unexpected' }],
     },
     {
       filename: '/web/src/Routes.tsx',
@@ -95,18 +69,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
             </Router>
           )
         }`.replace(/ +/g, ' '),
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
-      errors: [
-        {
-          message:
-            'Unexpected JSX element <CustomElement>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
-        },
-      ],
+      errors: [{ messageId: 'unexpected' }],
     },
   ],
 })

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,5 +1,7 @@
 import { processEnvComputedRule } from './process-env-computed.js'
+import { unsupportedRouteComponents } from './unsupported-route-components.js'
 
 export const rules = {
   'process-env-computed': processEnvComputedRule,
+  'unsupported-route-components': unsupportedRouteComponents,
 }

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -4,7 +4,7 @@ import { ESLintUtils } from '@typescript-eslint/utils'
 const createRule = ESLintUtils.RuleCreator.withoutDocs
 
 function isAllowedElement(name: string) {
-  const allowedElements = ['Routes', 'Route', 'Set']
+  const allowedElements = ['Router', 'Route', 'Set']
   return allowedElements.includes(name)
 }
 

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -1,0 +1,49 @@
+import { TSESTree } from '@typescript-eslint/types'
+import { ESLintUtils } from '@typescript-eslint/utils'
+
+const createRule = ESLintUtils.RuleCreator.withoutDocs
+
+function isAllowedElement(name: string) {
+  const allowedElements = ['Routes', 'Route', 'Set']
+  return allowedElements.includes(name)
+}
+
+export const unsupportedRouteComponents = createRule({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Find unsupported route components',
+      recommended: 'warn',
+    },
+    messages: {
+      unexpected:
+        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
+    },
+    schema: [], // No additional configuration needed
+  },
+  defaultOptions: [],
+  create(context) {
+    if (!/\bweb\/src\/Routes\.(tsx|jsx|js)$/.test(context.getFilename())) {
+      return {}
+    }
+
+    return {
+      JSXOpeningElement: function (node: TSESTree.JSXOpeningElement) {
+        let name = ''
+
+        if (node.name.type === 'JSXIdentifier') {
+          name = node.name.name
+        } else {
+          return
+        }
+
+        if (!isAllowedElement(name)) {
+          context.report({
+            node,
+            messageId: 'unexpected',
+          })
+        }
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -1,10 +1,9 @@
-import { TSESTree } from '@typescript-eslint/types'
 import { ESLintUtils } from '@typescript-eslint/utils'
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs
 
 function isAllowedElement(name: string) {
-  const allowedElements = ['Router', 'Route', 'Set']
+  const allowedElements = ['Router', 'Route', 'Set', 'Private']
   return allowedElements.includes(name)
 }
 
@@ -17,7 +16,7 @@ export const unsupportedRouteComponents = createRule({
     },
     messages: {
       unexpected:
-        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, or <Set> are allowed in Router files.',
+        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, <Set> and <Private> are allowed in Router files.',
     },
     schema: [], // No additional configuration needed
   },
@@ -28,7 +27,7 @@ export const unsupportedRouteComponents = createRule({
     }
 
     return {
-      JSXOpeningElement: function (node: TSESTree.JSXOpeningElement) {
+      JSXOpeningElement: function (node) {
         let name = ''
 
         if (node.name.type === 'JSXIdentifier') {

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -41,6 +41,7 @@ export const unsupportedRouteComponents = createRule({
           context.report({
             node,
             messageId: 'unexpected',
+            data: { name },
           })
         }
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,6 +7541,7 @@ __metadata:
   dependencies:
     "@types/eslint": 8
     "@types/estree": 1.0.1
+    "@typescript-eslint/utils": ^5.60.1
     esbuild: 0.18.10
     eslint: 8.43.0
     fast-glob: 3.2.12
@@ -10627,7 +10628,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.60.1":
+"@typescript-eslint/utils@npm:5.60.1, @typescript-eslint/utils@npm:^5.60.1":
   version: 5.60.1
   resolution: "@typescript-eslint/utils@npm:5.60.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,6 +7541,7 @@ __metadata:
   dependencies:
     "@types/eslint": 8
     "@types/estree": 1.0.1
+    "@typescript-eslint/parser": 5.60.1
     "@typescript-eslint/utils": ^5.60.1
     esbuild: 0.18.10
     eslint: 8.43.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -7542,7 +7542,7 @@ __metadata:
     "@types/eslint": 8
     "@types/estree": 1.0.1
     "@typescript-eslint/parser": 5.60.1
-    "@typescript-eslint/utils": ^5.60.1
+    "@typescript-eslint/utils": 5.60.1
     esbuild: 0.18.10
     eslint: 8.43.0
     fast-glob: 3.2.12
@@ -10629,7 +10629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.60.1, @typescript-eslint/utils@npm:^5.60.1":
+"@typescript-eslint/utils@npm:5.60.1":
   version: 5.60.1
   resolution: "@typescript-eslint/utils@npm:5.60.1"
   dependencies:


### PR DESCRIPTION
Our router file officially really only supports `<Router>`, `<Route>`, `<Set>` and `<Private>` elements.

Unofficially you've been able to use other things, like `<div>` and stuff in certain places. But with the new Suspense enabled router we're introducing that's not going to be possible anymore.

So this is an eslint rule that for now only warns on unsupported elements. But when the new router is released we can change that to show an error instead of a warning

![image](https://github.com/redwoodjs/redwood/assets/30793/a993f370-8d42-46f4-8b1b-c780566e96f7)
