### PR TITLE
Make unsupported route components rule error for v6

### DIFF
--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -9,10 +9,10 @@ function isAllowedElement(name: string) {
 
 export const unsupportedRouteComponents = createRule({
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Find unsupported route components',
-      recommended: 'warn',
+      recommended: 'error',
     },
     messages: {
       unexpected:


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/8774. For v6, we want this rule to error.