### PR TITLE
Only enable new eslint rule for the Routes file

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -46,9 +46,6 @@ module.exports = {
     requireConfigFile: false,
     babelOptions: getProjectBabelOptions(),
   },
-  rules: {
-    '@redwoodjs/unsupported-route-components': 'error',
-  },
   overrides: [
     {
       files: ['web/src/Routes.js', 'web/src/Routes.jsx', 'web/src/Routes.tsx'],
@@ -60,6 +57,7 @@ module.exports = {
             ignoreNonDOM: true,
           },
         ],
+        '@redwoodjs/unsupported-route-components': 'error',
       },
     },
     // `api` side


### PR DESCRIPTION
Our new `unsupported-route-components` rule only really needs to be enabled for the Routes file

Fixes https://github.com/redwoodjs/redwood/issues/8792