### PR TITLE
vite utils.ts: fix source format

### DIFF
--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,3 +1,3 @@
 export function stripQueryStringAndHashFromPath(url: string) {
-  return url.split('?')[0].split('#')[0];
+  return url.split('?')[0].split('#')[0]
 }


### PR DESCRIPTION
Fixes this warning that shows up in all PRs
![image](https://github.com/redwoodjs/redwood/assets/30793/546f1b6e-c133-4da8-b997-67bbb4aa44e1)
