### PR TITLE
structure: Update lru-cache to v7 to minimize project:copy issues

### DIFF
--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -46,7 +46,7 @@
     "line-column": "1.0.2",
     "lodash": "4.17.21",
     "lodash-decorators": "6.0.1",
-    "lru-cache": "6.0.0",
+    "lru-cache": "7.18.3",
     "proxyquire": "2.1.3",
     "ts-morph": "15.1.0",
     "vscode-languageserver": "6.1.1",

--- a/packages/structure/src/x/ts-morph.ts
+++ b/packages/structure/src/x/ts-morph.ts
@@ -32,7 +32,7 @@ export function createTSMSourceFile(a1: string, a2?: string): tsm.SourceFile {
   }).createSourceFile(filePath, src)
 }
 
-const getCache = memoize(() => new LRU<string, tsm.SourceFile>(200))
+const getCache = memoize(() => new LRU<string, tsm.SourceFile>({ max: 200 }))
 
 /**
  * warning: do NOT modify this file. treat it as immutable

--- a/yarn.lock
+++ b/yarn.lock
@@ -7943,7 +7943,7 @@ __metadata:
     line-column: 1.0.2
     lodash: 4.17.21
     lodash-decorators: 6.0.1
-    lru-cache: 6.0.0
+    lru-cache: 7.18.3
     proxyquire: 2.1.3
     ts-morph: 15.1.0
     typescript: 5.1.3
@@ -22597,12 +22597,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:6.0.0, lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: ^4.0.0
-  checksum: cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
+"lru-cache@npm:7.18.3, lru-cache@npm:^7.10.1, lru-cache@npm:^7.14.1, lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
+  version: 7.18.3
+  resolution: "lru-cache@npm:7.18.3"
+  checksum: b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
   languageName: node
   linkType: hard
 
@@ -22622,10 +22620,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.10.1, lru-cache@npm:^7.14.1, lru-cache@npm:^7.4.4, lru-cache@npm:^7.5.1, lru-cache@npm:^7.7.1":
-  version: 7.18.3
-  resolution: "lru-cache@npm:7.18.3"
-  checksum: b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
+"lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: ^4.0.0
+  checksum: cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The lru-cache package version seems to be upgraded when running `project:copy`, causing issues for `@redwoodjs/structure`. This PR upgrades to v7 which lets us update the syntax we use when calling the `LRU()` constructor to be compatible with the version of lru we get by running `project:copy`

Fixes https://github.com/redwoodjs/redwood/issues/8734