### PR TITLE
Use existing rw-vite-build bin for SSR as well

### DIFF
--- a/packages/vite/bins/rw-vite-build.mjs
+++ b/packages/vite/bins/rw-vite-build.mjs
@@ -4,7 +4,7 @@ import yargsParser from 'yargs-parser'
 
 import { buildWeb } from '@redwoodjs/internal/dist/build/web.js'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
-import { buildFeServer } from '@redwoodjs/vite'
+import { buildFeServer } from '@redwoodjs/vite/dist/buildFeServer.js'
 
 const rwPaths = getPaths()
 

--- a/packages/vite/bins/rw-vite-build.mjs
+++ b/packages/vite/bins/rw-vite-build.mjs
@@ -3,12 +3,14 @@ import fs from 'node:fs'
 import yargsParser from 'yargs-parser'
 
 import { buildWeb } from '@redwoodjs/internal/dist/build/web.js'
-import projectConfig from '@redwoodjs/project-config'
+import { getConfig, getPaths } from '@redwoodjs/project-config'
+import { buildFeServer } from '@redwoodjs/vite'
 
-const rwPaths = projectConfig.getPaths()
+const rwPaths = getPaths()
 
-const { webDir } = yargsParser(process.argv.slice(2), {
+const { webDir, verbose } = yargsParser(process.argv.slice(2), {
   string: ['webDir'],
+  boolean: ['verbose'],
 })
 
 if (!webDir) {
@@ -43,11 +45,13 @@ const buildWebSide = async (webDir) => {
   process.chdir(webDir)
   process.env.NODE_ENV = 'production'
 
-  // Right now, the buildWeb function looks up the config file from project-config
-  // In the future, if we have multiple web spaces we could pass in the cwd here
-  buildWeb({
-    verbose: true,
-  })
+  if (getConfig().experimental?.streamingSsr?.enabled) {
+    await buildFeServer({ verbose })
+  } else {
+    // Right now, the buildWeb function looks up the config file from project-config
+    // In the future, if we have multiple web spaces we could pass in the cwd here
+    buildWeb({ verbose })
+  }
 }
 
 buildWebSide(webDir)

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -214,5 +214,3 @@ export default function redwoodPluginVite(): PluginOption[] {
     }),
   ]
 }
-
-export { buildFeServer } from './buildFeServer'


### PR DESCRIPTION
Both existing vite build process and the new one for streaming/ssr needs `process.chdir` to be set for postcss/tw etc. So reusing the existing one here for new Streaming/SSR function call as well