### PR TITLE
"Cleaning web" is only needed for Webpack

### DIFF
--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -100,7 +100,7 @@ export const handler = async ({
       task: () => {
         return rimraf(rwjsPaths.web.dist)
       },
-      enabled: getConfig().web.bundler !== 'vite',
+      enabled: getConfig().web.bundler === 'webpack',
     },
     side.includes('web') && {
       title: 'Building Web...',


### PR DESCRIPTION
In v6 having no bundler configured means you're using Vite, and should not need to clean web before building. Only when the bundler is explicitly set to 'webpack' should this task be executed.

This change also makes it easier to find this code later, when we need to remove all Webpack related code.