### PR TITLE
entry.server and entry.client

### DIFF
--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -142,6 +142,13 @@ describe('paths', () => {
             'storybook.manager.js'
           ),
           dist: path.join(FIXTURE_BASEDIR, 'web', 'dist'),
+          distEntryServer: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entry.server.js'
+          ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
             'web',
@@ -397,6 +404,13 @@ describe('paths', () => {
             'storybook.manager.js'
           ),
           dist: path.join(FIXTURE_BASEDIR, 'web', 'dist'),
+          distEntryServer: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entry.server.js'
+          ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
             'web',
@@ -700,6 +714,13 @@ describe('paths', () => {
           entryClient: null,
           entryServer: null,
           dist: path.join(FIXTURE_BASEDIR, 'web', 'dist'),
+          distEntryServer: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entry.server.js'
+          ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
             'web',
@@ -956,6 +977,13 @@ describe('paths', () => {
             'storybook.manager.js'
           ),
           dist: path.join(FIXTURE_BASEDIR, 'web', 'dist'),
+          distEntryServer: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entry.server.js'
+          ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
             'web',

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -46,6 +46,7 @@ export interface WebPaths {
   storybookManagerConfig: string
   dist: string
   distServer: string
+  distEntryServer: string
   distRouteHooks: string
   routeManifest: string
   types: string
@@ -105,7 +106,7 @@ const PATH_WEB_DIR_CONFIG = 'web/config'
 const PATH_WEB_DIR_CONFIG_WEBPACK = 'web/config/webpack.config.js'
 const PATH_WEB_DIR_CONFIG_VITE = 'web/vite.config' // .js,.ts
 const PATH_WEB_DIR_ENTRY_CLIENT = 'web/src/entry.client' // .jsx,.tsx
-const PATH_WEB_DIR_ENTRY_SERVER = 'web/src/entry-server' // .jsx,.tsx
+const PATH_WEB_DIR_ENTRY_SERVER = 'web/src/entry.server' // .jsx,.tsx
 
 const PATH_WEB_DIR_CONFIG_POSTCSS = 'web/config/postcss.config.js'
 const PATH_WEB_DIR_CONFIG_STORYBOOK_CONFIG = 'web/config/storybook.config.js'
@@ -114,6 +115,7 @@ const PATH_WEB_DIR_CONFIG_STORYBOOK_MANAGER = 'web/config/storybook.manager.js'
 
 const PATH_WEB_DIR_DIST = 'web/dist'
 const PATH_WEB_DIR_DIST_SERVER = 'web/dist/server'
+const PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER = 'web/dist/server/entry.server.js'
 const PATH_WEB_DIR_DIST_SERVER_ROUTEHOOKS = 'web/dist/server/routeHooks'
 const PATH_WEB_DIR_ROUTE_MANIFEST = 'web/dist/server/route-manifest.json'
 
@@ -221,6 +223,10 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       ),
       dist: path.join(BASE_DIR, PATH_WEB_DIR_DIST),
       distServer: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER),
+      distEntryServer: path.join(
+        BASE_DIR,
+        PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER
+      ),
       distRouteHooks: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER_ROUTEHOOKS),
       routeManifest: path.join(BASE_DIR, PATH_WEB_DIR_ROUTE_MANIFEST),
       types: path.join(BASE_DIR, 'web/types'),

--- a/packages/vite/src/buildFeServer.ts
+++ b/packages/vite/src/buildFeServer.ts
@@ -29,7 +29,9 @@ export const buildFeServer = async ({ verbose }: BuildOptions) => {
 
   if (!rwPaths.web.entryServer || !rwPaths.web.entryClient) {
     throw new Error(
-      'Vite entry points not found. Please check that your project has an entry-client.{jsx,tsx} and entry-server.{jsx,tsx} file in the web/src directory.'
+      'Vite entry points not found. Please check that your project has an ' +
+        'entry.client.{jsx,tsx} and entry.server.{jsx,tsx} file in the ' +
+        'web/src directory.'
     )
   }
 

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -97,7 +97,9 @@ async function createServer() {
 
       if (!rwPaths.web.entryServer || !rwPaths.web.entryClient) {
         throw new Error(
-          'Vite entry points not found. Please check that your project has an entry-client.{jsx,tsx} and entry-server.{jsx,tsx} file in the web/src directory.'
+          'Vite entry points not found. Please check that your project has ' +
+            'an entry.client.{jsx,tsx} and entry.server.{jsx,tsx} file in ' +
+            'the web/src directory.'
         )
       }
 

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -95,9 +95,7 @@ export async function runFeServer() {
     const currentPathName = stripQueryStringAndHashFromPath(req.originalUrl)
 
     try {
-      const { serverEntry } = await import(
-        path.join(rwPaths.web.distServer, '/entry-server.js')
-      )
+      const { serverEntry } = await import(rwPaths.web.distEntryServer)
 
       // TODO (STREAMING) should we generate individual express Routes for each Route?
       // This would make handling 404s and favicons / public assets etc. easier


### PR DESCRIPTION
Update error messages to use "entry.server" and "entry.client" (dot (.) instead of dash (-))

Include the entry.server dist location in web paths, like all other paths we use in the dist folder