### PR TITLE
fix(cli): Prevent multiple update available messages

### DIFF
--- a/packages/cli/src/lib/__tests__/locking.test.js
+++ b/packages/cli/src/lib/__tests__/locking.test.js
@@ -21,6 +21,11 @@ import { setLock, unsetLock, isLockSet, clearLocks } from '../locking'
 beforeEach(() => {
   // Start with no files
   fs.__setMockFiles({})
+  fs.statSync = jest.fn(() => {
+    return {
+      birthtimeMs: Date.now(),
+    }
+  })
 })
 
 it('Set a lock', () => {
@@ -65,6 +70,24 @@ it('Detect if lock is set when it is already unset', () => {
 
   const isSet = isLockSet('TEST')
   expect(isSet).toBe(false)
+})
+
+it('Detects a stale lock', () => {
+  // Fake that the lock is older than 1 hour
+  fs.statSync.mockImplementation(() => {
+    return {
+      birthtimeMs: Date.now() - 3600001,
+    }
+  })
+  const spy = jest.spyOn(fs, 'rmSync')
+
+  setLock('TEST')
+
+  const isSet = isLockSet('TEST')
+  expect(isSet).toBe(false)
+  expect(fs.rmSync).toHaveBeenCalled()
+
+  spy.mockRestore()
 })
 
 it('Clear a list of locks', () => {

--- a/packages/cli/src/lib/__tests__/updateCheck.test.js
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.js
@@ -44,6 +44,10 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
         birthtimeMs: Date.now(),
       }
     })
+
+    // Prevent console output during tests
+    console.log = jest.fn()
+    console.time = jest.fn()
   })
 
   afterAll(() => {
@@ -103,9 +107,7 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
 
   it('Respects the lock', async () => {
     setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
-    await expect(updateCheck.check()).rejects.toThrow(
-      `Lock "${updateCheck.CHECK_LOCK_IDENTIFIER}" is already set`
-    )
+    expect(updateCheck.shouldCheck()).toBe(false)
   })
 })
 
@@ -184,9 +186,7 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
 
   it('Respects the lock', async () => {
     setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
-    await expect(updateCheck.check()).rejects.toThrow(
-      `Lock "${updateCheck.CHECK_LOCK_IDENTIFIER}" is already set`
-    )
+    expect(updateCheck.shouldCheck()).toBe(false)
   })
 })
 
@@ -265,8 +265,6 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
 
   it('Respects the lock', async () => {
     setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
-    await expect(updateCheck.check()).rejects.toThrow(
-      `Lock "${updateCheck.CHECK_LOCK_IDENTIFIER}" is already set`
-    )
+    expect(updateCheck.shouldCheck()).toBe(false)
   })
 })

--- a/packages/cli/src/lib/__tests__/updateCheck.test.js
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.js
@@ -38,6 +38,12 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
         versionUpdates: ['latest'],
       },
     })
+    // Prevent the appearance of stale locks
+    fs.statSync = jest.fn(() => {
+      return {
+        birthtimeMs: Date.now(),
+      }
+    })
   })
 
   afterAll(() => {
@@ -96,9 +102,9 @@ describe('Update is not available (1.0.0 -> 1.0.0)', () => {
   })
 
   it('Respects the lock', async () => {
-    setLock(updateCheck.LOCK_IDENTIFIER)
+    setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
     await expect(updateCheck.check()).rejects.toThrow(
-      `Lock "${updateCheck.LOCK_IDENTIFIER}" is already set`
+      `Lock "${updateCheck.CHECK_LOCK_IDENTIFIER}" is already set`
     )
   })
 })
@@ -112,6 +118,12 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
       notifications: {
         versionUpdates: ['latest'],
       },
+    })
+    // Prevent the appearance of stale locks
+    fs.statSync = jest.fn(() => {
+      return {
+        birthtimeMs: Date.now(),
+      }
     })
   })
 
@@ -171,9 +183,9 @@ describe('Update is available (1.0.0 -> 2.0.0)', () => {
   })
 
   it('Respects the lock', async () => {
-    setLock(updateCheck.LOCK_IDENTIFIER)
+    setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
     await expect(updateCheck.check()).rejects.toThrow(
-      `Lock "${updateCheck.LOCK_IDENTIFIER}" is already set`
+      `Lock "${updateCheck.CHECK_LOCK_IDENTIFIER}" is already set`
     )
   })
 })
@@ -187,6 +199,12 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
       notifications: {
         versionUpdates: ['latest', 'rc'],
       },
+    })
+    // Prevent the appearance of stale locks
+    fs.statSync = jest.fn(() => {
+      return {
+        birthtimeMs: Date.now(),
+      }
     })
   })
 
@@ -246,9 +264,9 @@ describe('Update is available with rc tag (1.0.0-rc.1 -> 1.0.1-rc.58)', () => {
   })
 
   it('Respects the lock', async () => {
-    setLock(updateCheck.LOCK_IDENTIFIER)
+    setLock(updateCheck.CHECK_LOCK_IDENTIFIER)
     await expect(updateCheck.check()).rejects.toThrow(
-      `Lock "${updateCheck.LOCK_IDENTIFIER}" is already set`
+      `Lock "${updateCheck.CHECK_LOCK_IDENTIFIER}" is already set`
     )
   })
 })

--- a/packages/cli/src/lib/locking.js
+++ b/packages/cli/src/lib/locking.js
@@ -53,9 +53,24 @@ export function unsetLock(identifier) {
  * @returns {boolean} `true` if the lock is set, otherwise `false`
  */
 export function isLockSet(identifier) {
-  return fs.existsSync(
-    path.join(getPaths().generated.base, 'locks', identifier)
-  )
+  const lockfilePath = path.join(getPaths().generated.base, 'locks', identifier)
+
+  // Check if the lock file exists
+  const exists = fs.existsSync(lockfilePath)
+  if (!exists) {
+    return false
+  }
+
+  // Ensure this lock isn't stale due to some error
+  // Locks are only valid for 1 hour
+  const createdAt = fs.statSync(lockfilePath).birthtimeMs
+  if (Date.now() - createdAt > 3600000) {
+    unsetLock(identifier)
+    return false
+  }
+
+  // If the lock file exists and isn't stale, the lock is set
+  return true
 }
 
 /**

--- a/packages/cli/src/lib/updateCheck.js
+++ b/packages/cli/src/lib/updateCheck.js
@@ -214,7 +214,7 @@ function getUpdateMessage() {
 export function readUpdateDataFile() {
   try {
     if (!fs.existsSync(getPersistenceDirectory())) {
-      fs.mkdirSync(getPersistenceDirectory())
+      fs.mkdirSync(getPersistenceDirectory(), { recursive: true })
     }
     const persistedData = JSON.parse(
       fs.readFileSync(path.join(getPersistenceDirectory(), 'data.json'))


### PR DESCRIPTION
**Problem**
@Tobbe highlighted a case where the update available message would trigger more than once and would result in output like so:
![Screenshot from 2023-07-01 14-34-45](https://github.com/redwoodjs/redwood/assets/56300765/7f7f3bb9-e3fd-4ac5-a6e3-9060c4f08cd6)

This was happening because some commands were spawning child commands which would show the message too. Adding a lock to make all processes aware an update message is pending fixes this.

**How to reproduce**
1. Delete `./redwood/updateCheck/data.json` to ensure an update check will be triggered.
2. Run some simple command like `yarn rw info` to trigger an update check.
3. Wait a few seconds to ensure the background update check has completed.
4. Run a command which spawns child commands like `yarn rw build web` which will spawn a prerender command. 
5. Observe the duplicate messages.

**Changes**
1. A lock is used to make any spawned process aware that an existing process is already going to show the update message. This approach means it'll always be the top process that outputs the message and not any of the child processes. 
6. Adds a check to the `isLockSet` which ensure stale locks are ignored. We only allow locks to be valid for 1 hour (arbitrary decision by me here). This covers the case where due to some error the lock file persists longer than it should. Tests have been updated accordingly.

**Notes**
I didn't intend to bloat this PR with the new stale check. If needed I'll pull it out this PR and make a new one - I'd rather just have it here.
