### PR TITLE
Rudimentary CSS check in our smoke tests

### DIFF
--- a/tasks/smoke-tests/common.ts
+++ b/tasks/smoke-tests/common.ts
@@ -21,7 +21,8 @@ export async function smokeTest({ page }: PlaywrightTestArgs) {
   const textBlue400 = 'rgb(96, 165, 250)'
   expect(
     await page
-      .locator('text=Redwood Blog')
+      .locator('header a')
+      .filter({ hasText: 'Redwood Blog' })
       .evaluate((e) => window.getComputedStyle(e).color)
   ).toBe(textBlue400)
 

--- a/tasks/smoke-tests/common.ts
+++ b/tasks/smoke-tests/common.ts
@@ -11,6 +11,20 @@ export async function smokeTest({ page }: PlaywrightTestArgs) {
     'text=baby single- origin coffee kickstarter lo - fi paleo skateboard.'
   )
 
+  const bgBlue700 = 'rgb(29, 78, 216)'
+  expect(
+    await page
+      .locator('#redwood-app > header')
+      .evaluate((e) => window.getComputedStyle(e).backgroundColor)
+  ).toBe(bgBlue700)
+
+  const textBlue400 = 'rgb(96, 165, 250)'
+  expect(
+    await page
+      .locator('text=Redwood Blog')
+      .evaluate((e) => window.getComputedStyle(e).color)
+  ).toBe(textBlue400)
+
   // Click text=About
   await page.click('text=About')
 


### PR DESCRIPTION
Made our dev and serve smoke tests verify the computed css values for the blue header and the blue header text

![image](https://github.com/redwoodjs/redwood/assets/30793/8e40054c-0c2f-4814-881f-815b38f136cb)

When moving to vite and a new frontend server getting CSS right is surprisingly difficult. So just adding a couple of checks here to make sure things don't break in the transition, and that no one accidentally breaks things in the future