### PR TITLE
React 18.3.0-canary-035a41c4e-20230704

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -17,7 +17,7 @@
     "@redwoodjs/web": "5.0.0",
     "humanize-string": "2.1.0",
     "prop-types": "15.8.1",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0"
   },
   "devDependencies": {

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -18,7 +18,7 @@
     "humanize-string": "2.1.0",
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0"
+    "react-dom": "18.3.0-canary-035a41c4e-20230704"
   },
   "devDependencies": {
     "@redwoodjs/vite": "6.0.0-canary.450",

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "7.22.5",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -33,7 +33,7 @@
     "@types/netlify-identity-widget": "1.9.3",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -33,7 +33,7 @@
     "@clerk/types": "3.46.1",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -34,7 +34,7 @@
     "@simplewebauthn/typescript-types": "7.0.0",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -32,7 +32,7 @@
     "@types/react": "18.2.14",
     "firebase": "9.23.0",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -32,7 +32,7 @@
     "@types/netlify-identity-widget": "1.9.3",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -31,7 +31,7 @@
     "@supabase/supabase-js": "2.26.0",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -31,7 +31,7 @@
     "@babel/core": "7.22.5",
     "@types/react": "18.2.14",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "supertokens-auth-react": "0.33.1",
     "typescript": "5.1.3"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "7.22.5",
     "core-js": "3.31.0",
-    "react": "18.2.0"
+    "react": "18.3.0-canary-035a41c4e-20230704"
   },
   "devDependencies": {
     "@babel/cli": "7.22.5",

--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -15,7 +15,7 @@
     "@redwoodjs/router": "5.0.0",
     "@redwoodjs/web": "5.0.0",
     "prop-types": "15.8.1",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0"
   },
   "devDependencies": {

--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -16,7 +16,7 @@
     "@redwoodjs/web": "5.0.0",
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0"
+    "react-dom": "18.3.0-canary-035a41c4e-20230704"
   },
   "devDependencies": {
     "@redwoodjs/vite": "5.0.0"

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -15,7 +15,7 @@
     "@redwoodjs/router": "5.0.0",
     "@redwoodjs/web": "5.0.0",
     "prop-types": "15.8.1",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0"
   },
   "devDependencies": {

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -16,7 +16,7 @@
     "@redwoodjs/web": "5.0.0",
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0"
+    "react-dom": "18.3.0-canary-035a41c4e-20230704"
   },
   "devDependencies": {
     "@redwoodjs/vite": "5.0.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -42,7 +42,7 @@
     "jest": "29.5.0",
     "nodemon": "2.0.22",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0",
+    "react-dom": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -41,13 +41,13 @@
     "graphql": "16.7.1",
     "jest": "29.5.0",
     "nodemon": "2.0.22",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0",
     "typescript": "5.1.3"
   },
   "peerDependencies": {
     "graphql": "16.7.1",
-    "react": "18.2.0"
+    "react": "18.3.0-canary-035a41c4e-20230704"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -47,7 +47,7 @@
     "typescript": "5.1.3"
   },
   "peerDependencies": {
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0"
   },
   "externals": {

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0"
+    "react-dom": "18.3.0-canary-035a41c4e-20230704"
   },
   "externals": {
     "react": "react",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,12 +33,12 @@
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "jest": "29.5.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0",
     "typescript": "5.1.3"
   },
   "peerDependencies": {
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -34,12 +34,12 @@
     "@types/react-dom": "18.2.6",
     "jest": "29.5.0",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0",
+    "react-dom": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0"
+    "react-dom": "18.3.0-canary-035a41c4e-20230704"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/studio/frontend/package.json
+++ b/packages/studio/frontend/package.json
@@ -26,7 +26,7 @@
     "graphql-scalars": "1.22.2",
     "json-bigint-patch": "0.0.8",
     "pretty-ms": "7.0.0",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0",
     "react-error-boundary": "4.0.10",
     "react-grid-layout": "1.3.4",

--- a/packages/studio/frontend/package.json
+++ b/packages/studio/frontend/package.json
@@ -27,7 +27,7 @@
     "json-bigint-patch": "0.0.8",
     "pretty-ms": "7.0.0",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0",
+    "react-dom": "18.3.0-canary-035a41c4e-20230704",
     "react-error-boundary": "4.0.10",
     "react-grid-layout": "1.3.4",
     "react-router-dom": "6.8.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -59,13 +59,13 @@
     "jest-runner-tsd": "5.0.0",
     "nodemon": "2.0.22",
     "prop-types": "15.8.1",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0",
     "typescript": "5.1.3"
   },
   "peerDependencies": {
     "prop-types": "15.8.1",
-    "react": "18.2.0",
+    "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.2.0"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -60,13 +60,13 @@
     "nodemon": "2.0.22",
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0",
+    "react-dom": "18.3.0-canary-035a41c4e-20230704",
     "typescript": "5.1.3"
   },
   "peerDependencies": {
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
-    "react-dom": "18.2.0"
+    "react-dom": "18.3.0-canary-035a41c4e-20230704"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,7 +7014,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     "@auth0/auth0-spa-js": 2.0.8
@@ -7067,7 +7067,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     "@azure/msal-browser": 2.37.1
@@ -7118,7 +7118,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     "@clerk/clerk-react": 4.20.5
@@ -7196,7 +7196,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   languageName: unknown
   linkType: soft
@@ -7244,7 +7244,7 @@ __metadata:
     core-js: 3.31.0
     firebase: 9.23.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     firebase: 9.23.0
@@ -7295,7 +7295,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     netlify-identity-widget: 1.9.2
@@ -7345,7 +7345,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     "@supabase/supabase-js": 2.26.0
@@ -7397,7 +7397,7 @@ __metadata:
     "@types/react": 18.2.14
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     supertokens-auth-react: 0.33.1
     typescript: 5.1.3
   peerDependencies:
@@ -7417,7 +7417,7 @@ __metadata:
     core-js: 3.31.0
     jest: 29.5.0
     msw: 1.2.2
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   languageName: unknown
   linkType: soft
@@ -7746,13 +7746,13 @@ __metadata:
     jest: 29.5.0
     nodemon: 2.0.22
     pascalcase: 1.0.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     react-dom: 18.2.0
     react-hook-form: 7.45.1
     typescript: 5.1.3
   peerDependencies:
     graphql: 16.7.1
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
   languageName: unknown
   linkType: soft
 
@@ -7878,7 +7878,7 @@ __metadata:
     mime-types: 2.1.35
     typescript: 5.1.3
   peerDependencies:
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     react-dom: 18.2.0
   languageName: unknown
   linkType: soft
@@ -7927,11 +7927,11 @@ __metadata:
     "@types/react-dom": 18.2.6
     core-js: 3.31.0
     jest: 29.5.0
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     react-dom: 18.2.0
     typescript: 5.1.3
   peerDependencies:
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     react-dom: 18.2.0
   languageName: unknown
   linkType: soft
@@ -8151,7 +8151,7 @@ __metadata:
     jest-runner-tsd: 5.0.0
     nodemon: 2.0.22
     prop-types: 15.8.1
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     react-dom: 18.2.0
     react-helmet-async: 1.3.0
     react-hot-toast: 2.4.1
@@ -8160,7 +8160,7 @@ __metadata:
     typescript: 5.1.3
   peerDependencies:
     prop-types: 15.8.1
-    react: 18.2.0
+    react: 18.3.0-canary-035a41c4e-20230704
     react-dom: 18.2.0
   bin:
     cross-env: ./dist/bins/cross-env.js
@@ -26797,12 +26797,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:18.3.0-canary-035a41c4e-20230704":
+  version: 18.3.0-canary-035a41c4e-20230704
+  resolution: "react@npm:18.3.0-canary-035a41c4e-20230704"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: b562d9b569b0cb315e44b48099f7712283d93df36b19a39a67c254c6686479d3980b7f013dc931f4a5a3ae7645eae6386b4aa5eea933baa54ecd0f9acb0902b8
+  checksum: 01a8d9ccb5d636a789a68404ea428f9eabc7d6d8fa5759c30653eef04d9a251a5c3a9b5c2c0f7768b0827d6ce250cd37cab5825af31583756ee2a8af669a6d27
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7747,7 +7747,7 @@ __metadata:
     nodemon: 2.0.22
     pascalcase: 1.0.0
     react: 18.3.0-canary-035a41c4e-20230704
-    react-dom: 18.2.0
+    react-dom: 18.3.0-canary-035a41c4e-20230704
     react-hook-form: 7.45.1
     typescript: 5.1.3
   peerDependencies:
@@ -7879,7 +7879,7 @@ __metadata:
     typescript: 5.1.3
   peerDependencies:
     react: 18.3.0-canary-035a41c4e-20230704
-    react-dom: 18.2.0
+    react-dom: 18.3.0-canary-035a41c4e-20230704
   languageName: unknown
   linkType: soft
 
@@ -7928,11 +7928,11 @@ __metadata:
     core-js: 3.31.0
     jest: 29.5.0
     react: 18.3.0-canary-035a41c4e-20230704
-    react-dom: 18.2.0
+    react-dom: 18.3.0-canary-035a41c4e-20230704
     typescript: 5.1.3
   peerDependencies:
     react: 18.3.0-canary-035a41c4e-20230704
-    react-dom: 18.2.0
+    react-dom: 18.3.0-canary-035a41c4e-20230704
   languageName: unknown
   linkType: soft
 
@@ -8152,7 +8152,7 @@ __metadata:
     nodemon: 2.0.22
     prop-types: 15.8.1
     react: 18.3.0-canary-035a41c4e-20230704
-    react-dom: 18.2.0
+    react-dom: 18.3.0-canary-035a41c4e-20230704
     react-helmet-async: 1.3.0
     react-hot-toast: 2.4.1
     stacktracey: 2.1.8
@@ -8161,7 +8161,7 @@ __metadata:
   peerDependencies:
     prop-types: 15.8.1
     react: 18.3.0-canary-035a41c4e-20230704
-    react-dom: 18.2.0
+    react-dom: 18.3.0-canary-035a41c4e-20230704
   bin:
     cross-env: ./dist/bins/cross-env.js
     msw: ./dist/bins/msw.js
@@ -26664,15 +26664,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:18.2.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:18.3.0-canary-035a41c4e-20230704":
+  version: 18.3.0-canary-035a41c4e-20230704
+  resolution: "react-dom@npm:18.3.0-canary-035a41c4e-20230704"
   dependencies:
     loose-envify: ^1.1.0
-    scheduler: ^0.23.0
+    scheduler: 0.24.0-canary-035a41c4e-20230704
   peerDependencies:
-    react: ^18.2.0
-  checksum: 66dfc5f93e13d0674e78ef41f92ed21dfb80f9c4ac4ac25a4b51046d41d4d2186abc915b897f69d3d0ebbffe6184e7c5876f2af26bfa956f179225d921be713a
+    react: 18.3.0-canary-035a41c4e-20230704
+  checksum: 5fbc98baf3e9a9ac52a8160f5e4b5c90c6d339dfcc296b9d02e3df8d06d5b4938d825b6f660d401bfd6449ba9a70bbfc2f498b707621cdd4369f2faf2e7faff9
   languageName: node
   linkType: hard
 
@@ -27869,12 +27869,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:0.24.0-canary-035a41c4e-20230704":
+  version: 0.24.0-canary-035a41c4e-20230704
+  resolution: "scheduler@npm:0.24.0-canary-035a41c4e-20230704"
   dependencies:
     loose-envify: ^1.1.0
-  checksum: b777f7ca0115e6d93e126ac490dbd82642d14983b3079f58f35519d992fa46260be7d6e6cede433a92db70306310c6f5f06e144f0e40c484199e09c1f7be53dd
+  checksum: aaaf1b219c01bc5dc579362a5486f3d28092407f711748bd8ed7cd57f1431ca07f8469c6e9b7c8c70c21ef6d40faf2c575fd3564dffac55a13443db08991282c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For RSC we need to use a canary version of React.

I set the Milestone to 7.0.0, but most likely it shouldn't go out until v8 at the earliest 