### PR TITLE
Use "import type" for all types

### DIFF
--- a/packages/vite/src/triggerRouteHooks.ts
+++ b/packages/vite/src/triggerRouteHooks.ts
@@ -1,8 +1,12 @@
 import { Request } from 'express'
 import { ViteDevServer } from 'vite'
 
-import { MetaHook, TagDescriptor } from '@redwoodjs/web'
-import type { RouteHookEvent, RouteHookOutput } from '@redwoodjs/web'
+import type {
+  MetaHook,
+  RouteHookEvent,
+  RouteHookOutput,
+  TagDescriptor,
+} from '@redwoodjs/web'
 
 interface RouteHooks {
   meta?: MetaHook


### PR DESCRIPTION
Just cleaning up some imports. We were already using `import type` for some types. Cleaner to use it for all types 🙂 