### PR TITLE
Fix babel devDeps in internal

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,6 @@
     "@babel/core": "7.22.5",
     "@babel/eslint-plugin": "7.22.5",
     "@babel/node": "7.22.5",
-    "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-decorators": "7.22.5",
     "@babel/plugin-transform-runtime": "7.22.5",
     "@babel/preset-env": "7.22.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,6 @@
     "@babel/node": "7.22.5",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-decorators": "7.22.5",
-    "@babel/plugin-proposal-private-property-in-object": "7.21.11",
     "@babel/plugin-transform-runtime": "7.22.5",
     "@babel/preset-env": "7.22.5",
     "@babel/preset-react": "7.22.5",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@babel/cli": "7.22.5",
     "@babel/core": "7.22.5",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11",
     "@types/babel-plugin-tester": "9.0.5",
     "@types/babel__core": "7.20.1",
     "@types/fs-extra": "11.0.1",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -29,7 +29,9 @@
   },
   "dependencies": {
     "@babel/parser": "7.22.5",
+    "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-private-methods": "7.18.6",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11",
     "@babel/plugin-transform-typescript": "7.22.5",
     "@babel/register": "7.22.5",
     "@babel/runtime-corejs3": "7.22.5",
@@ -67,7 +69,6 @@
   "devDependencies": {
     "@babel/cli": "7.22.5",
     "@babel/core": "7.22.5",
-    "@babel/plugin-proposal-private-property-in-object": "7.21.11",
     "@types/babel-plugin-tester": "9.0.5",
     "@types/babel__core": "7.20.1",
     "@types/fs-extra": "11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7591,7 +7591,6 @@ __metadata:
     "@babel/core": 7.22.5
     "@babel/eslint-plugin": 7.22.5
     "@babel/node": 7.22.5
-    "@babel/plugin-proposal-class-properties": 7.18.6
     "@babel/plugin-proposal-decorators": 7.22.5
     "@babel/plugin-transform-runtime": 7.22.5
     "@babel/preset-env": 7.22.5
@@ -7806,6 +7805,7 @@ __metadata:
     "@babel/cli": 7.22.5
     "@babel/core": 7.22.5
     "@babel/parser": 7.22.5
+    "@babel/plugin-proposal-class-properties": 7.18.6
     "@babel/plugin-proposal-private-methods": 7.18.6
     "@babel/plugin-proposal-private-property-in-object": 7.21.11
     "@babel/plugin-transform-typescript": 7.22.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -7593,7 +7593,6 @@ __metadata:
     "@babel/node": 7.22.5
     "@babel/plugin-proposal-class-properties": 7.18.6
     "@babel/plugin-proposal-decorators": 7.22.5
-    "@babel/plugin-proposal-private-property-in-object": 7.21.11
     "@babel/plugin-transform-runtime": 7.22.5
     "@babel/preset-env": 7.22.5
     "@babel/preset-react": 7.22.5
@@ -7808,6 +7807,7 @@ __metadata:
     "@babel/core": 7.22.5
     "@babel/parser": 7.22.5
     "@babel/plugin-proposal-private-methods": 7.18.6
+    "@babel/plugin-proposal-private-property-in-object": 7.21.11
     "@babel/plugin-transform-typescript": 7.22.5
     "@babel/register": 7.22.5
     "@babel/runtime-corejs3": 7.22.5


### PR DESCRIPTION
![image](https://github.com/redwoodjs/redwood/assets/30793/03d076ec-9125-4c41-899c-40f18822c647)

We're also using `proposal-class-properties`, so I'm moving that one over from core to internal too