### PR TITLE
chore(babel): Remove preset-env excludes and do not configure them separately

### DIFF
--- a/packages/internal/src/build/babel/api.ts
+++ b/packages/internal/src/build/babel/api.ts
@@ -42,12 +42,6 @@ export const getApiSideBabelPresets = (
           // List of supported proposals: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#ecmascript-proposals
           proposals: true,
         },
-        exclude: [
-          // Remove class-properties from preset-env, and include separately with loose
-          // https://github.com/webpack/webpack/issues/9708
-          '@babel/plugin-transform-class-properties',
-          '@babel/plugin-transform-private-methods',
-        ],
       },
     ],
   ].filter(Boolean) as TransformOptions['presets']

--- a/packages/internal/src/build/babel/common.ts
+++ b/packages/internal/src/build/babel/common.ts
@@ -61,14 +61,7 @@ if (!RUNTIME_CORE_JS_VERSION) {
 }
 
 export const getCommonPlugins = () => {
-  return [
-    ['@babel/plugin-transform-class-properties', { loose: true }],
-    // Note: The private method loose mode configuration setting must be the
-    // same as @babel/plugin-proposal class-properties.
-    // (https://babeljs.io/docs/en/babel-plugin-proposal-private-methods#loose)
-    ['@babel/plugin-transform-private-methods', { loose: true }],
-    ['@babel/plugin-transform-private-property-in-object', { loose: true }],
-  ]
+  return []
 }
 
 // TODO (STREAMING) double check this, think about it more carefully please!

--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -165,12 +165,6 @@ export const getWebSideBabelPresets = (options: Flags) => {
           version: CORE_JS_VERSION,
           proposals: true,
         },
-        exclude: [
-          // Remove class-properties from preset-env, and include separately
-          // https://github.com/webpack/webpack/issues/9708
-          '@babel/plugin-transform-class-properties',
-          '@babel/plugin-transform-private-methods',
-        ],
       },
       'rwjs-babel-preset-env',
     ],


### PR DESCRIPTION
**Context**
We originally had the excludes block in preset-env - because it was printing warnings when building with babel/webpack 4 (way back when) - see the comment in the removed code for a link to the issue.

So the solution was to exclude it from preset-env, and include it as a separate plugin.

I don't think we need to do this anymore - and seems to work fine with project:copy. But I'm not a 100% sure its all OK until we merge into canary.