### PR TITLE
fix: Fixes and simplifies the Countdown subscription example for Realtime

### DIFF
--- a/packages/cli/src/commands/experimental/templates/subscriptions/countdown/countdown.ts.template
+++ b/packages/cli/src/commands/experimental/templates/subscriptions/countdown/countdown.ts.template
@@ -10,7 +10,7 @@ export const schema = gql`
  * To test this Countdown subscription, run the following in the GraphQL Playground:
  *
  * subscription CountdownFromInterval {
- *   countdown(from: 10, interval: 100)
+ *   countdown(from: 100, interval: 10)
  * }
  */
 const countdown = {

--- a/packages/cli/src/commands/experimental/templates/subscriptions/countdown/countdown.ts.template
+++ b/packages/cli/src/commands/experimental/templates/subscriptions/countdown/countdown.ts.template
@@ -15,10 +15,12 @@ export const schema = gql`
  */
 const countdown = {
   countdown: {
-    async *subscribe(_, { from, interval }) {
-      for (let i = from; i >= 0; i--) {
-        await new Promise((resolve) => setTimeout(resolve, interval ?? 1000))
-        yield { countdown: i }
+    async *subscribe(_, { from = 10, interval = 100 }) {
+      while (from >= 0) {
+        yield { countdown: from }
+        // pause for 1/4 second
+        await new Promise((resolve) => setTimeout(resolve, 250))
+        from -= interval
       }
     },
   },

--- a/packages/cli/src/commands/experimental/templates/subscriptions/countdown/countdown.ts.template
+++ b/packages/cli/src/commands/experimental/templates/subscriptions/countdown/countdown.ts.template
@@ -15,7 +15,7 @@ export const schema = gql`
  */
 const countdown = {
   countdown: {
-    async *subscribe(_, { from = 10, interval = 100 }) {
+    async *subscribe(_, { from = 100, interval = 10 }) {
       while (from >= 0) {
         yield { countdown: from }
         // pause for 1/4 second


### PR DESCRIPTION
This PR fixes the issue where: 

* the countdown example actually uses the interval to count down by ... and
*  also has a reasonable count pause 
