### PR TITLE
fix: tutorial fix updated routing-params

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -144,7 +144,7 @@ const Routes = () => {
       </Set>
       <Set wrap={BlogLayout}>
         // highlight-next-line
-        <Route path="/article/{id}" page={ArticlePage} name="article" />
+        <Route path="/article/{id:Int}" page={ArticlePage} name="article" />
         <Route path="/about" page={AboutPage} name="about" />
         <Route path="/" page={HomePage} name="home" />
       </Set>


### PR DESCRIPTION
# Tutorial Fix
## Chapter 2: Routing Params
Looks like this type was missing on the id here. Without it, I was encountering a 400 error. 

Before:
![rwtutbefore](https://github.com/redwoodjs/redwood/assets/6319880/2af906fb-a29a-4d3b-8e34-98fd5b668571)

After:
![rwtutafter](https://github.com/redwoodjs/redwood/assets/6319880/8cc56268-ce99-4f1c-904f-d27d71b992fd)

Hope this helps!