### PR TITLE
Update entry.client and disable vite legacy mode

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -136,41 +136,19 @@ export const handler = async ({ force, verbose }) => {
         },
       },
       {
-        title: 'Updating entry.client.tsx...',
+        title: 'Overwrite entry.client.tsx...',
         task: async () => {
-          let entryClientLines = fs
-            .readFileSync(rwPaths.web.entryClient, 'utf-8')
-            .split('\n')
-          let foundRootRender = false
-          entryClientLines = entryClientLines.reduce((acc, line) => {
-            if (foundRootRender) {
-              // skip (remove) this line
+          const entryClientTemplate = fs.readFileSync(
+            path.resolve(
+              __dirname,
+              'templates',
+              'rsc',
+              'entry.client.tsx.template'
+            ),
+            'utf-8'
+          )
 
-              if (/^ {2}\)/.test(line)) {
-                // found ending ). Keeping rest of the file after this line
-                foundRootRender = false
-              }
-            } else if (line.includes('// TODO (STREAMING) This was marked')) {
-              acc.push("import { serve } from '@redwoodjs/vite/client'")
-              acc.push(line)
-            } else if (line.includes("import App from './App'")) {
-              // skip (remove) this line
-            } else if (line.includes('const redwoodAppElement')) {
-              acc.push(line)
-              acc.push('')
-              acc.push("const App = serve('App')")
-            } else if (line.includes('const root = createRoot(document)')) {
-              acc.push('  const root = createRoot(redwoodAppElement)')
-              acc.push('  root.render(<App name="Redwood RSCc" />)')
-              foundRootRender = true
-            } else {
-              acc.push(line)
-            }
-
-            return acc
-          }, [])
-
-          writeFile(rwPaths.web.entryClient, entryClientLines.join('\n'), {
+          writeFile(rwPaths.web.entryClient, entryClientTemplate, {
             overwriteExisting: true,
           })
         },

--- a/packages/cli/src/commands/experimental/templates/rsc/entry.client.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/entry.client.tsx.template
@@ -1,0 +1,10 @@
+import { createRoot } from 'react-dom/client'
+
+import { serve } from '@redwoodjs/vite/client'
+
+const redwoodAppElement = document.getElementById('redwood-app')
+
+const App = serve('App')
+
+const root = createRoot(redwoodAppElement)
+root.render(<App name="Redwood RSCc" />)

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -170,9 +170,10 @@ export default function redwoodPluginVite(): PluginOption[] {
             manifest: !env.ssrBuild ? 'build-manifest.json' : undefined,
             sourcemap: !env.ssrBuild && rwConfig.web.sourceMap, // Note that this can be boolean or 'inline'
           },
-          // To produce a cjs bundle for SSR
           legacy: {
-            buildSsrCjsExternalHeuristics: env.ssrBuild,
+            buildSsrCjsExternalHeuristics: rwConfig.experimental?.rsc?.enabled
+              ? false
+              : env.ssrBuild,
           },
           optimizeDeps: {
             esbuildOptions: {


### PR DESCRIPTION
Disabling the legacy mode was the only change needed to be able to keep having this config available for vite when building.
So thanks to this config no changes are needed to `vite.config.ts` in a user's project when trying RSCs