### PR TITLE
yarn rw upgrade: Not < v1 anymore

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -50,7 +50,7 @@ export const builder = (yargs) => {
       `Also see the ${terminalLink(
         'Redwood CLI Reference for the upgrade command',
         'https://redwoodjs.com/docs/cli-commands#upgrade'
-      )} and the ${terminalLink(
+      )}.\nAnd the ${terminalLink(
         'GitHub releases page',
         'https://github.com/redwoodjs/redwood/releases'
       )} for more information on the current release.`

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -48,17 +48,12 @@ export const builder = (yargs) => {
     })
     .epilogue(
       `Also see the ${terminalLink(
-        'Redwood CLI Reference',
+        'Redwood CLI Reference for the upgrade command',
         'https://redwoodjs.com/docs/cli-commands#upgrade'
-      )}`
-    )
-    // Just to make an empty line
-    .epilogue('')
-    .epilogue(
-      `We are < v1.0.0, so breaking changes occur frequently. For more information on the current release, see the ${terminalLink(
-        'release page',
+      )} and the ${terminalLink(
+        'GitHub releases page',
         'https://github.com/redwoodjs/redwood/releases'
-      )}`
+      )} for more information on the current release.`
     )
 }
 


### PR DESCRIPTION
This is the current `yarn rw upgrade --help` output. Notice how it says we're "< v1.0.0". This isn't true anymore.

![image](https://github.com/redwoodjs/redwood/assets/30793/f1e09626-ed62-479a-b995-fd4d6bc24db5)

After these changes:

![image](https://github.com/redwoodjs/redwood/assets/30793/33394da7-0865-468a-a8b1-6bed9093c883)
