### PR TITLE
fix(v6, serverless): use named exports instead of default

### DIFF
--- a/packages/cli/src/commands/deploy/__tests__/nftPack.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/nftPack.test.js
@@ -4,7 +4,7 @@ import path from 'path'
 import { buildApi } from '@redwoodjs/internal/dist/build/api'
 import { findApiDistFunctions } from '@redwoodjs/internal/dist/files'
 
-import nftPacker from '../packing/nft'
+import * as nftPacker from '../packing/nft'
 
 const FIXTURE_PATH = path.resolve(
   __dirname,

--- a/packages/cli/src/commands/deploy/packing/nft.js
+++ b/packages/cli/src/commands/deploy/packing/nft.js
@@ -9,7 +9,7 @@ import { ensurePosixPath, getPaths } from '@redwoodjs/project-config'
 
 const ZIPBALL_DIR = './api/dist/zipball'
 
-function zipDirectory(source, out) {
+export function zipDirectory(source, out) {
   const archive = archiver('zip', { zlib: { level: 5 } })
   const stream = fse.createWriteStream(out)
 
@@ -25,7 +25,7 @@ function zipDirectory(source, out) {
 }
 
 // returns a tuple of [filePath, fileContent]
-function generateEntryFile(functionAbsolutePath, name) {
+export function generateEntryFile(functionAbsolutePath, name) {
   const relativeImport = ensurePosixPath(
     path.relative(getPaths().base, functionAbsolutePath)
   )
@@ -35,7 +35,7 @@ function generateEntryFile(functionAbsolutePath, name) {
   ]
 }
 
-async function packageSingleFunction(functionFile) {
+export async function packageSingleFunction(functionFile) {
   const { name: functionName } = path.parse(functionFile)
 
   const { fileList: functionDependencyFileList } = await nodeFileTrace([
@@ -67,18 +67,7 @@ async function packageSingleFunction(functionFile) {
   return
 }
 
-function nftPack() {
+export function nftPack() {
   const filesToBePacked = findApiDistFunctions()
   return Promise.all(filesToBePacked.map(exports.packageSingleFunction))
 }
-
-// We do this, so we can spy the functions in the test
-// It didn't make sense to separate into different files
-const exports = {
-  nftPack,
-  packageSingleFunction,
-  generateEntryFile,
-  zipDirectory,
-}
-
-export default exports

--- a/packages/cli/src/commands/deploy/serverless.js
+++ b/packages/cli/src/commands/deploy/serverless.js
@@ -84,7 +84,7 @@ export const buildCommands = ({ sides }) => {
       task: async () => {
         // Dynamically import this function
         // because its dependencies are only installed when `rw setup deploy serverless` is run
-        const { nftPack } = (await import('./packing/nft.js')).default
+        const { nftPack } = await import('./packing/nft.js')
 
         await nftPack()
       },


### PR DESCRIPTION
The packing/nft helper kind of mixes named exports with default exports and it ends up confusing build tools. It looks like we want named exports, so I just refactored it to that. This was causing `yarn rw deploy serverless --pack-only` to fail in deploy target CI (see https://github.com/redwoodjs/deploy-target-ci/actions/runs/5482609165/jobs/9988107090). Bug was introduced in https://github.com/redwoodjs/redwood/pull/8456.