### PR TITLE
chore(renovate): improve config to reduce noise

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
 
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
 
   "postUpdateOptions": [
     "yarnDedupeHighest"
   ],
+  "prConcurrentLimit": 3,
+  "rebaseWhen": "conflicted",
 
   "packageRules": [
     {
@@ -19,6 +22,9 @@
     },
 
     {
+      "groupName": "ESM and @redwoodjs packages",
+      "enabled": false,
+
       "matchPackageNames": [
         "boxen",
         "chalk",
@@ -31,13 +37,29 @@
         "pascalcase",
         "pretty-bytes",
         "pretty-ms",
+        "stdout-update",
         "tempy",
         "terminal-link"
       ],
       "matchPackagePatterns": [
         "^@redwoodjs/"
-      ],
-      "enabled": false
+      ]
+    },
+
+    {
+      "groupName": "chore",
+
+      "matchPackageNames": [
+        "all-contributors-cli",
+        "cypress",
+        "cypress-wait-until",
+        "dependency-cruiser",
+        "glob",
+        "mheap/github-action-required-labels action",
+        "nx",
+        "sort-package-json",
+        "zx"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/8856. Renovate is invaluable but noisy in a few ways; this PR doesn't address all the ways it's noisy, but does address two major ones.

The tradeoff with these kinds of changes is that merging Renovate PRs will be more manual. But honestly it always is right now. I'm always looking at them. The idea that they just automerge isn't true, but I  think we can get there. I need to make changes like this first though.

#### 1. GitHub Notifications

Nearly always, the first ~ten GitHub notifications are from renovate. And as soon as you dismiss them, they come back because Renovate updates PRs when they're behind main. We should rely on GitHub notifications more for triage, but renovate constantly rebasing PRs makes this difficult. This PR adds the `rebaseWhen: "conflicted"` setting to minimize this.

<img width="1423" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/09841d15-f8bd-4e71-be03-b9005505afad">


#### 2. CI

Because renovate is always rebasing when it's behind main, it'll cause CI to run. That's 10 PRs running CI for every commit to main. This is unacceptable really, and it's why checks on some PRs seem to be waiting forever, stuck with the yellow circle.