### PR TITLE
chore(gh-actions) Dry-run publish to get next canary version

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -75,9 +75,14 @@ jobs:
             --force-publish
             --loglevel verbose
             --no-git-reset
-            --yes
           )
 
+          echo 'n' | yarn lerna publish "${args[@]}" | grep '\-canary\.' | tail -n 1 | sed 's/.*=> //' | sed 's/\+.*//' > canary_version
+
+          echo "Will publish:"
+          echo "Canary version $(cat canary_version)"
+
+          args+=(--yes)
           yarn lerna publish "${args[@]}"
 
         env:


### PR DESCRIPTION
Trying this to see if I can reliably get the next canary version that will be released in our GH action for canary releases.

If this works, the next step is to update the package.json files in our CRWA templates to include this version of all RW packages.