### PR TITLE
CRWA: Manually update rw package versions to v6 canary

### DIFF
--- a/packages/create-redwood-app/templates/js/api/package.json
+++ b/packages/create-redwood-app/templates/js/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "5.0.0",
-    "@redwoodjs/graphql-server": "5.0.0"
+    "@redwoodjs/api": "6.0.0-canary.635",
+    "@redwoodjs/graphql-server": "6.0.0-canary.635"
   }
 }

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "5.0.0"
+    "@redwoodjs/core": "6.0.0-canary.635"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -11,9 +11,9 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "5.0.0",
-    "@redwoodjs/router": "5.0.0",
-    "@redwoodjs/web": "5.0.0",
+    "@redwoodjs/forms": "6.0.0-canary.635",
+    "@redwoodjs/router": "6.0.0-canary.635",
+    "@redwoodjs/web": "6.0.0-canary.635",
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.3.0-canary-035a41c4e-20230704"

--- a/packages/create-redwood-app/templates/ts/api/package.json
+++ b/packages/create-redwood-app/templates/ts/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "5.0.0",
-    "@redwoodjs/graphql-server": "5.0.0"
+    "@redwoodjs/api": "6.0.0-canary.635",
+    "@redwoodjs/graphql-server": "6.0.0-canary.635"
   }
 }

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "5.0.0"
+    "@redwoodjs/core": "6.0.0-canary.635"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -11,9 +11,9 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "5.0.0",
-    "@redwoodjs/router": "5.0.0",
-    "@redwoodjs/web": "5.0.0",
+    "@redwoodjs/forms": "6.0.0-canary.635",
+    "@redwoodjs/router": "6.0.0-canary.635",
+    "@redwoodjs/web": "6.0.0-canary.635",
     "prop-types": "15.8.1",
     "react": "18.3.0-canary-035a41c4e-20230704",
     "react-dom": "18.3.0-canary-035a41c4e-20230704"


### PR DESCRIPTION
When using the canary version of create-redwood-app we want you to also get the canary version of RW itself.
This PR:
 1. Lets me test the theory that you can use `npx create-redwood-app@canary` to get canary versions of RW installed as long as the template package.jsons have the canary version specified
 2. Lets me test the GH action update in #8862 

If both those things work, we can move forward with automating this 🤖 

@jtoar I was unsure about what milestone to use. This isn't something that will ever show up in a released version (because we have proper RW release versions like 5.3.1 or 6.0.0 in the CRWA when we do releases). But it also didn't feel right to use the chore milestone, because this is in code that our users get.

As you can see I also went back and forth on the test project fixture. I decided to leave it as it is for now, with v5.0.0 (latest stable major). What version do you think the test project should use?