### PR TITLE
GH Action: Increase commit count based version by one

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -81,12 +81,17 @@ jobs:
           #   these packages?" prompt.
           # `|&` to pipe both stdout and stderr to grep. Mostly do this keep
           #   the github action output clean.
+          # At the end we use awk to increase the commit count by 1, because
+          #   we'll commit updated package.jsons in the next step, which will
+          #   increase increase the final number that lerna will use when
+          #   publishing the canary packages.
           echo 'n' \
             | yarn lerna publish "${args[@]}" \
             |& grep '\-canary\.' \
             | tail -n 1 \
             | sed 's/.*=> //' \
             | sed 's/\+.*//' \
+            | awk -F. '{ $NF = $NF + 1 } 1' OFS=. \
             > canary_version
 
           cat packages/create-redwood-app/templates/js/package.json \


### PR DESCRIPTION
When running the canary publishing GH action we first do a dry-run to get the version the next canary will get.
We then update all rw package versions in the CRWA templates and commit those changes. That commit will change the version we got from the dry-run because the version is based on the number of commits, which we just changed.

So now we increase the version number from the dry-run in anticipation of the commit we'll create.