### PR TITLE
chore(ci): Record PR number in CI telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  REDWOOD_CI_PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   only-doc-changes:

--- a/packages/cli/src/telemetry/resource.js
+++ b/packages/cli/src/telemetry/resource.js
@@ -90,7 +90,9 @@ export async function getResources() {
   const sides = project.sides.join(',')
 
   const isRedwoodCI = !!process.env.REDWOOD_CI
-  const redwoodPRNumber = isRedwoodCI ? process.env.REDWOOD_CI_PR_NUMBER : undefined
+  const redwoodPRNumber = isRedwoodCI
+    ? process.env.REDWOOD_CI_PR_NUMBER
+    : undefined
 
   return {
     [SemanticResourceAttributes.SERVICE_NAME]: packageName,

--- a/packages/cli/src/telemetry/resource.js
+++ b/packages/cli/src/telemetry/resource.js
@@ -89,6 +89,9 @@ export async function getResources() {
   ].join('.')
   const sides = project.sides.join(',')
 
+  const isRedwoodCI = !!process.env.REDWOOD_CI
+  const redwoodPRNumber = isRedwoodCI ? process.env.REDWOOD_CI_PR_NUMBER : undefined
+
   return {
     [SemanticResourceAttributes.SERVICE_NAME]: packageName,
     [SemanticResourceAttributes.SERVICE_VERSION]: packageVersion,
@@ -102,7 +105,8 @@ export async function getResources() {
     'cpu.count': cpu.physicalCores,
     'memory.gb': Math.round(mem.total / 1073741824),
     'env.node_env': process.env.NODE_ENV || null,
-    'ci.redwood': !!process.env.REDWOOD_CI,
+    'ci.redwood': isRedwoodCI,
+    'ci.redwood.pr': redwoodPRNumber,
     'ci.isci': ci.isCI,
     complexity,
     sides,

--- a/packages/create-redwood-app/src/telemetry.js
+++ b/packages/create-redwood-app/src/telemetry.js
@@ -57,6 +57,9 @@ export async function startTelemetry() {
   const cpu = await system.cpu()
   const mem = await system.mem()
 
+  const isRedwoodCI = !!process.env.REDWOOD_CI
+  const redwoodPRNumber = isRedwoodCI ? process.env.REDWOOD_CI_PR_NUMBER : undefined
+
   const resource = Resource.default().merge(
     new Resource({
       [SemanticResourceAttributes.SERVICE_NAME]: packageName,
@@ -71,7 +74,8 @@ export async function startTelemetry() {
       'cpu.count': cpu.physicalCores,
       'memory.gb': Math.round(mem.total / 1073741824),
       'env.node_env': process.env.NODE_ENV || null,
-      'ci.redwood': !!process.env.REDWOOD_CI,
+      'ci.redwood': isRedwoodCI,
+      'ci.redwood.pr': redwoodPRNumber,
       'ci.isci': ci.isCI,
       uid: UID,
     })

--- a/packages/create-redwood-app/src/telemetry.js
+++ b/packages/create-redwood-app/src/telemetry.js
@@ -58,7 +58,9 @@ export async function startTelemetry() {
   const mem = await system.mem()
 
   const isRedwoodCI = !!process.env.REDWOOD_CI
-  const redwoodPRNumber = isRedwoodCI ? process.env.REDWOOD_CI_PR_NUMBER : undefined
+  const redwoodPRNumber = isRedwoodCI
+    ? process.env.REDWOOD_CI_PR_NUMBER
+    : undefined
 
   const resource = Resource.default().merge(
     new Resource({


### PR DESCRIPTION
Record the PR number in telemetry generated by Redwood's CI. This should help make it easier to identify the source of changes when reviewing telemetry.

Notes:
1. Docs on the github action event data for pull request events: https://docs.github.com/en/webhooks-and-events/events/github-event-types#pullrequestevent

Outstanding:
1. Will this cause issues when CI is triggered by a push to the other branches (not by a pull request event)? Wouldn't be an issue if there is just no value recorded.
