### PR TITLE
RSC: Use exported defineEntries()

### DIFF
--- a/packages/cli/src/commands/experimental/templates/rsc/entries.ts.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/entries.ts.template
@@ -1,16 +1,4 @@
-export type GetEntry = (rscId: string) => Promise<
-  | React.FunctionComponent
-  | {
-      default: React.FunctionComponent
-    }
-  | null
->
-
-export function defineEntries(getEntry: GetEntry) {
-  return {
-    getEntry,
-  }
-}
+import { defineEntries } from '@redwoodjs/vite/entries'
 
 export default defineEntries(
   // getEntry

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./entries": {
+      "types": "./dist/entries.d.ts",
+      "default": "./dist/entries.js"
+    },
     "./client": {
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"

--- a/packages/vite/src/entries.ts
+++ b/packages/vite/src/entries.ts
@@ -5,7 +5,8 @@ export type GetEntry = (
 ) => Promise<FunctionComponent | { default: FunctionComponent } | null>
 
 export type GetBuilder = (
-  // FIXME can we somehow avoid leaking internal implementation?
+  // FIXME (from original waku code) can we somehow avoid leaking internal
+  // implementation?
   unstable_decodeId: (encodedId: string) => [id: string, name: string]
 ) => Promise<{
   [pathStr: string]: {
@@ -16,12 +17,10 @@ export type GetBuilder = (
   }
 }>
 
-// This is for ignored dynamic imports
-// XXX Are there any better ways?
-export type unstable_GetCustomModules = () => Promise<{
-  [name: string]: string
-}>
-
+/**
+ * Used to look up the component to import when calling `serve('App')` in
+ * entry.client.tsx
+ */
 export function defineEntries(getEntry: GetEntry, getBuilder?: GetBuilder) {
   return { getEntry, getBuilder }
 }


### PR DESCRIPTION
Get rid of copy/pasted code and import it from the framework instead. Also makes it much easier to see how the entries file is used when you can follow the import into the framework from the app code.