### PR TITLE
RSC: Include entries.ts in paths

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -86,9 +86,8 @@ export const handler = async ({ force, verbose }) => {
             path.resolve(__dirname, 'templates', 'rsc', 'entries.ts.template'),
             'utf-8'
           )
-          const entriesPath = path.join(rwPaths.web.src, 'entries.ts')
 
-          writeFile(entriesPath, entriesTemplate, {
+          writeFile(rwPaths.web.entries, entriesTemplate, {
             overwriteExisting: force,
           })
         },

--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -157,11 +157,19 @@ describe('paths', () => {
             'routeHooks'
           ),
           distServer: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'server'),
+          distServerEntries: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entries.js'
+          ),
           types: path.join(FIXTURE_BASEDIR, 'web', 'types'),
           // Vite paths ~ not configured in empty-project
           viteConfig: null,
           entryClient: null,
           entryServer: null,
+          entries: null,
         },
       }
 
@@ -419,11 +427,19 @@ describe('paths', () => {
             'routeHooks'
           ),
           distServer: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'server'),
+          distServerEntries: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entries.js'
+          ),
           types: path.join(FIXTURE_BASEDIR, 'web', 'types'),
           // New Vite paths
           viteConfig: path.join(FIXTURE_BASEDIR, 'web', 'vite.config.ts'),
           entryClient: null, // doesn't exist in example-todo-main
           entryServer: null, // doesn't exist in example-todo-main
+          entries: null, // doesn't exist in example-todo-main
         },
       }
 
@@ -713,6 +729,7 @@ describe('paths', () => {
           ),
           entryClient: null,
           entryServer: null,
+          entries: null,
           dist: path.join(FIXTURE_BASEDIR, 'web', 'dist'),
           distEntryServer: path.join(
             FIXTURE_BASEDIR,
@@ -729,6 +746,13 @@ describe('paths', () => {
             'routeHooks'
           ),
           distServer: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'server'),
+          distServerEntries: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entries.js'
+          ),
           types: path.join(FIXTURE_BASEDIR, 'web', 'types'),
         },
       }
@@ -992,11 +1016,19 @@ describe('paths', () => {
             'routeHooks'
           ),
           distServer: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'server'),
+          distServerEntries: path.join(
+            FIXTURE_BASEDIR,
+            'web',
+            'dist',
+            'server',
+            'entries.js'
+          ),
           types: path.join(FIXTURE_BASEDIR, 'web', 'types'),
           // Vite paths
           viteConfig: path.join(FIXTURE_BASEDIR, 'web', 'vite.config.ts'),
           entryClient: path.join(FIXTURE_BASEDIR, 'web/src/entry.client.tsx'),
           entryServer: null,
+          entries: null,
         },
       }
 

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -40,6 +40,7 @@ export interface WebPaths {
   viteConfig: string | null // because vite is opt-in only
   entryClient: string | null
   entryServer: string | null
+  entries: string | null
   postcss: string
   storybookConfig: string
   storybookPreviewConfig: string
@@ -48,6 +49,7 @@ export interface WebPaths {
   distServer: string
   distEntryServer: string
   distRouteHooks: string
+  distServerEntries: string
   routeManifest: string
   types: string
 }
@@ -107,6 +109,7 @@ const PATH_WEB_DIR_CONFIG_WEBPACK = 'web/config/webpack.config.js'
 const PATH_WEB_DIR_CONFIG_VITE = 'web/vite.config' // .js,.ts
 const PATH_WEB_DIR_ENTRY_CLIENT = 'web/src/entry.client' // .jsx,.tsx
 const PATH_WEB_DIR_ENTRY_SERVER = 'web/src/entry.server' // .jsx,.tsx
+const PATH_WEB_DIR_ENTRIES = 'web/src/entries' // .jsx,.tsx
 
 const PATH_WEB_DIR_CONFIG_POSTCSS = 'web/config/postcss.config.js'
 const PATH_WEB_DIR_CONFIG_STORYBOOK_CONFIG = 'web/config/storybook.config.js'
@@ -117,6 +120,7 @@ const PATH_WEB_DIR_DIST = 'web/dist'
 const PATH_WEB_DIR_DIST_SERVER = 'web/dist/server'
 const PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER = 'web/dist/server/entry.server.js'
 const PATH_WEB_DIR_DIST_SERVER_ROUTEHOOKS = 'web/dist/server/routeHooks'
+const PATH_WEB_DIR_DIST_SERVER_ENTRIES = 'web/dist/server/entries.js'
 const PATH_WEB_DIR_ROUTE_MANIFEST = 'web/dist/server/route-manifest.json'
 
 /**
@@ -228,10 +232,12 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
         PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER
       ),
       distRouteHooks: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER_ROUTEHOOKS),
+      distServerEntries: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER_ENTRIES),
       routeManifest: path.join(BASE_DIR, PATH_WEB_DIR_ROUTE_MANIFEST),
       types: path.join(BASE_DIR, 'web/types'),
       entryClient: resolveFile(path.join(BASE_DIR, PATH_WEB_DIR_ENTRY_CLIENT)), // new vite/stream entry point for client
       entryServer: resolveFile(path.join(BASE_DIR, PATH_WEB_DIR_ENTRY_SERVER)),
+      entries: resolveFile(path.join(BASE_DIR, PATH_WEB_DIR_ENTRIES)),
     },
   }
 

--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -62,8 +62,7 @@ export const buildFeServer = async ({ verbose: _verbose }: BuildOptions) => {
       ssr: true,
       rollupOptions: {
         input: {
-          // entries: rwPaths.web.entryServer,
-          entries: path.join(rwPaths.web.src, 'entries.ts'),
+          entries: rwPaths.web.entries,
         },
       },
     },
@@ -148,8 +147,7 @@ export const buildFeServer = async ({ verbose: _verbose }: BuildOptions) => {
   }
 
   const serverBuildOutput = await serverBuild(
-    // rwPaths.web.entryServer,
-    path.join(rwPaths.web.src, 'entries.ts'),
+    rwPaths.web.entries,
     clientEntryFiles,
     serverEntryFiles,
     {}

--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -24,6 +24,10 @@ export const buildFeServer = async ({ verbose: _verbose }: BuildOptions) => {
     throw new Error('Vite config not found')
   }
 
+  if (!rwPaths.web.entries) {
+    throw new Error('RSC entries file not found')
+  }
+
   const clientEntryFileSet = new Set<string>()
   const serverEntryFileSet = new Set<string>()
 

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -211,8 +211,7 @@ const getEntriesFile = async (
     )
   }
 
-  // TODO: Don't hardcode the name of the entries file
-  return path.join(rwPaths.web.distServer, 'entries.js') // path.join(config.root, config.framework.entriesJs)
+  return rwPaths.web.distServerEntries
 }
 
 const getFunctionComponent = async (


### PR DESCRIPTION
`entries.ts` is a central file to RSC. Shouldn't treat the path to that file just like every other path and have it included in `getPaths()` in `@redwoodjs/project-config`.