### PR TITLE
RSC: Fix experimental setup

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -87,7 +87,8 @@ export const handler = async ({ force, verbose }) => {
             'utf-8'
           )
 
-          writeFile(rwPaths.web.entries, entriesTemplate, {
+          // Can't use rwPaths.web.entries because it's not created yet
+          writeFile(path.join(rwPaths.web.src, 'entries.ts'), entriesTemplate, {
             overwriteExisting: force,
           })
         },

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -109,7 +109,7 @@ const PATH_WEB_DIR_CONFIG_WEBPACK = 'web/config/webpack.config.js'
 const PATH_WEB_DIR_CONFIG_VITE = 'web/vite.config' // .js,.ts
 const PATH_WEB_DIR_ENTRY_CLIENT = 'web/src/entry.client' // .jsx,.tsx
 const PATH_WEB_DIR_ENTRY_SERVER = 'web/src/entry.server' // .jsx,.tsx
-const PATH_WEB_DIR_ENTRIES = 'web/src/entries' // .jsx,.tsx
+const PATH_WEB_DIR_ENTRIES = 'web/src/entries' // .js,.ts
 
 const PATH_WEB_DIR_CONFIG_POSTCSS = 'web/config/postcss.config.js'
 const PATH_WEB_DIR_CONFIG_STORYBOOK_CONFIG = 'web/config/storybook.config.js'


### PR DESCRIPTION
Can't use `rwPaths.web.entries` in the setup script, because it's not created yet