### PR TITLE
docs: update ArticleQuery type in routing-params.md

### DIFF
--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -319,7 +319,7 @@ Now over to the cell, we need access to that `{id}` route param so we can look u
 
 ```jsx title="web/src/components/ArticleCell/ArticleCell.jsx"
 export const QUERY = gql`
-  query ArticleQuery($id: Int!) {
+  query FindArticleQuery($id: Int!) {
     // highlight-next-line
     article: post(id: $id) {
       id
@@ -349,11 +349,11 @@ export const Success = ({ article }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticleCell/ArticleCell.tsx"
-import type { ArticleQuery } from 'types/graphql'
+import type { FindArticleQuery } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`
-  query ArticleQuery($id: Int!) {
+  query FindArticleQuery($id: Int!) {
     // highlight-next-line
     article: post(id: $id) {
       id
@@ -374,7 +374,7 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => {
+export const Success = ({ article }: CellSuccessProps<FindArticleQuery, FindArticleQueryVariables>) => {
   return <div>{JSON.stringify(article)}</div>
 }
 ```
@@ -514,7 +514,7 @@ export const Success = ({ article, id, rand }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx
-interface Props extends CellSuccessProps<ArticleQuery> {
+interface Props extends CellSuccessProps<FindArticleQuery, FindArticleQueryVariables> {
   id: number
   rand: number
 }
@@ -744,7 +744,7 @@ Last but not least we can update the `ArticleCell` to properly display our blog 
 import Article from 'src/components/Article'
 
 export const QUERY = gql`
-  query ArticleQuery($id: Int!) {
+  query FindArticleQuery($id: Int!) {
     article: post(id: $id) {
       id
       title
@@ -775,11 +775,11 @@ export const Success = ({ article }) => {
 // highlight-next-line
 import Article from 'src/components/Article'
 
-import type { ArticleQuery } from 'types/graphql'
+import type { FindArticleQuery } from 'types/graphql'
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`
-  query ArticleQuery($id: Int!) {
+  query FindArticleQuery($id: Int!) {
     article: post(id: $id) {
       id
       title
@@ -797,7 +797,7 @@ export const Failure = ({ error }: CellFailureProps) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ article }: CellSuccessProps<ArticleQuery>) => {
+export const Success = ({ article }: CellSuccessProps<FindArticleQuery, FindArticleQueryVariables>) => {
   // highlight-next-line
   return <Article article={article} />
 }


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/8889

This PR replaces `ArticleQuery` type with `FindArticleQuery`, which is the generated code when running `yarn rw g cell Article` (any singular-form name).

To be fair, it does not matter whether `ArticleQuery` or `FindArticleQuery` is used (ie. will not cause error either way), _except_ when user copy-pastes from the following block and does not modify their auto-generated code accordingly.

![CleanShot 2023-07-13 at 7 15 23](https://github.com/redwoodjs/redwood/assets/6597211/627effce-2b80-4eea-bbe5-0313137571a6)

Thus it may be better to update the tutorial code to reflect the auto-generated code.