### PR TITLE
RSC build without user config

### DIFF
--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -36,7 +36,7 @@ export const buildRscFeServer = async ({
   const { clientEntryFiles, serverEntryFiles } = await rscBuild(viteConfigPath)
 
   const clientBuildOutput = await viteBuild({
-    configFile: viteConfigPath,
+    // configFile: viteConfigPath,
     root: webSrc,
     plugins: [react(), rscIndexPlugin()],
     build: {
@@ -194,7 +194,7 @@ export const buildRscFeServer = async ({
   // https://github.com/microsoft/TypeScript/issues/53656 have both landed we
   // should try to do this instead:
   // const clientBuildManifest: ViteBuildManifest = await import(
-  //   path.join(getPaths().web.dist, 'build-manifest.json'),
+  //   path.join(getPaths().web.dist, 'client-build-manifest.json'),
   //   { with: { type: 'json' } }
   // )
   // NOTES:

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -12,10 +12,9 @@ import { getConfig, getPaths } from '@redwoodjs/project-config'
 import { handleJsAsJsx } from './vite-plugin-jsx-loader'
 
 /**
- * Preconfigured vite plugin, with required config for Redwood apps.
- *
+ * Pre-configured vite plugin, with required config for Redwood apps.
  */
-export function redwoodStreamingSSRPluginVite(): PluginOption[] {
+export default function redwoodPluginVite(): PluginOption[] {
   const rwPaths = getPaths()
   const rwConfig = getConfig()
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -15,7 +15,7 @@ import { handleJsAsJsx } from './vite-plugin-jsx-loader'
  * Preconfigured vite plugin, with required config for Redwood apps.
  *
  */
-export default function redwoodPluginVite(): PluginOption[] {
+export function redwoodStreamingSSRPluginVite(): PluginOption[] {
   const rwPaths = getPaths()
   const rwConfig = getConfig()
 


### PR DESCRIPTION
Our default config clashes with the config needed for our client component build. Will have to figure out how to handle this later. For now having it unconfigurable is good enough.