### PR TITLE
Update name reference in Redwood Docs

### DIFF
--- a/docs/docs/tutorial/chapter2/getting-dynamic.md
+++ b/docs/docs/tutorial/chapter2/getting-dynamic.md
@@ -152,7 +152,7 @@ Here's what happened when we ran that `yarn rw g scaffold post` command:
   - `PostPage` for showing the detail of a post
   - `PostsPage` for listing all the posts
 - Created a _layout_ file in `web/src/layouts/ScaffoldLayout/ScaffoldLayout.{jsx,tsx}` that serves as a container for pages with common elements like page heading and "New Posts" button
-- Created routes wrapped in the `Set` component with the layout as `PostsLayout` for those pages in `web/src/Routes.{jsx,tsx}`
+- Created routes wrapped in the `Set` component with the layout as `ScaffoldLayout` for those pages in `web/src/Routes.{jsx,tsx}`
 - Created three _cells_ in `web/src/components/Post`:
   - `EditPostCell` gets the post to edit in the database
   - `PostCell` gets the post to display


### PR DESCRIPTION
Update old layout name reference in the Docs.
The information with "PostLayout" is outdated. The scaffold is using the shared "ScaffoldLayout".

Chapter 2 > Getting Dynamic

There is no Issue Nr. for this PR.