### PR TITLE
RSC: Add css files to the example

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -122,6 +122,41 @@ export const handler = async ({ force, verbose }) => {
         },
       },
       {
+        title: 'Adding CSS files...',
+        task: async () => {
+          const files = [
+            {
+              template: 'Counter.css.template',
+              path: 'Counter.css',
+            },
+            {
+              template: 'Counter.module.css.template',
+              path: 'Counter.module.css',
+            },
+            {
+              template: 'App.css.template',
+              path: 'App.css',
+            },
+            {
+              template: 'App.module.css.template',
+              path: 'App.module.css',
+            },
+          ]
+
+          files.forEach((file) => {
+            const template = fs.readFileSync(
+              path.resolve(__dirname, 'templates', 'rsc', file.template),
+              'utf-8'
+            )
+            const filePath = path.join(rwPaths.web.src, file.path)
+
+            writeFile(filePath, template, {
+              overwriteExisting: force,
+            })
+          })
+        },
+      },
+      {
         title: 'Updating index.html...',
         task: async () => {
           let indexHtml = fs.readFileSync(rwPaths.web.html, 'utf-8')

--- a/packages/cli/src/commands/experimental/templates/rsc/App.css.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/App.css.template
@@ -1,0 +1,3 @@
+h1 {
+  text-decoration: underline;
+}

--- a/packages/cli/src/commands/experimental/templates/rsc/App.module.css.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/App.module.css.template
@@ -1,0 +1,3 @@
+.title {
+  color: green;
+}

--- a/packages/cli/src/commands/experimental/templates/rsc/App.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/App.tsx.template
@@ -12,9 +12,6 @@ import './App.css'
 
 globalThis.rwRscGlobal = new ProdRwRscServerGlobal()
 
-// Include <Assets /> component from fully-react here somewhere for now. Should be part of the router later
-// https://github.com/nksaraf/fully-react/blob/4f738132a17d94486c8da19d8729044c3998fc54/packages/fully-react/src/shared/assets.tsx#L64C19-L64C19
-
 const App = ({ name = 'Anonymous' }) => {
   return (
     <>

--- a/packages/cli/src/commands/experimental/templates/rsc/App.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/App.tsx.template
@@ -1,12 +1,31 @@
+import { Assets } from '@redwoodjs/vite/assets'
+import { ProdRwRscServerGlobal } from '@redwoodjs/vite/rwRscGlobal'
+
+// @ts-expect-error no types
+import styles from './App.module.css'
 import { Counter } from './Counter'
+
+import './App.css'
+
+// TODO (RSC) Something like this will probably be needed
+// const RwRscGlobal = import.meta.env.PROD ? ProdRwRscServerGlobal : DevRwRscServerGlobal;
+
+globalThis.rwRscGlobal = new ProdRwRscServerGlobal()
+
+// Include <Assets /> component from fully-react here somewhere for now. Should be part of the router later
+// https://github.com/nksaraf/fully-react/blob/4f738132a17d94486c8da19d8729044c3998fc54/packages/fully-react/src/shared/assets.tsx#L64C19-L64C19
 
 const App = ({ name = 'Anonymous' }) => {
   return (
-    <div style={{ border: '3px red dashed', margin: '1em', padding: '1em' }}>
-      <h1>Hello {name}!!</h1>
-      <h3>This is a server component.</h3>
-      <Counter />
-    </div>
+    <>
+      {/* TODO (RSC) <Assets /> should be part of the router later */}
+      <Assets />
+      <div style={{ border: '3px red dashed', margin: '1em', padding: '1em' }}>
+        <h1 className={styles.title}>Hello {name}!!</h1>
+        <h3>This is a server component.</h3>
+        <Counter />
+      </div>
+    </>
   )
 }
 

--- a/packages/cli/src/commands/experimental/templates/rsc/Counter.css.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Counter.css.template
@@ -1,0 +1,7 @@
+/**
+ * This should affect all h3 elements on the page, both server components and
+ * client components. This is just standard CSS stuff
+ */
+h3 {
+  color: orange;
+}

--- a/packages/cli/src/commands/experimental/templates/rsc/Counter.module.css.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Counter.module.css.template
@@ -1,0 +1,3 @@
+.header {
+  font-style: italic;
+}

--- a/packages/cli/src/commands/experimental/templates/rsc/Counter.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Counter.tsx.template
@@ -2,6 +2,10 @@
 
 import React from 'react'
 
+// @ts-expect-error no types
+import styles from './Counter.module.css'
+import './Counter.css'
+
 export const Counter = () => {
   const [count, setCount] = React.useState(0)
 
@@ -9,7 +13,7 @@ export const Counter = () => {
     <div style={{ border: '3px blue dashed', margin: '1em', padding: '1em' }}>
       <p>Count: {count}</p>
       <button onClick={() => setCount((c) => c + 1)}>Increment</button>
-      <h3>This is a client component.</h3>
+      <h3 className={styles.header}>This is a client component.</h3>
     </div>
   )
 }


### PR DESCRIPTION
Includes external css and module.css files in the example

![image](https://github.com/redwoodjs/redwood/assets/30793/c6e17c38-3a67-4e71-93f3-7bbd1b0ca91a)
