### PR TITLE
RSC fix: setup description

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -10,11 +10,7 @@ import { getPaths, writeFile } from '../../lib'
 import c from '../../lib/colors'
 import { isTypeScriptProject } from '../../lib/project'
 
-import {
-  command,
-  description,
-  EXPERIMENTAL_TOPIC_ID,
-} from './setupStreamingSsr'
+import { command, description, EXPERIMENTAL_TOPIC_ID } from './setupRsc'
 import { printTaskEpilogue } from './util'
 
 export const handler = async ({ force, verbose }) => {


### PR DESCRIPTION
Was previously reusing the description from the streaming ssr setup command. Now correctly uses its own description.