### PR TITLE
feat(cli): Enforce a node version via toml option

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -35,6 +35,7 @@ import * as upgradeCommand from './commands/upgrade'
 import { getPaths, findUp } from './lib'
 import { exitWithError } from './lib/exit'
 import * as updateCheck from './lib/updateCheck'
+import { enforceNodeVersionConfig } from './middleware/enforceNodeVersionConfig'
 import { loadPlugins } from './plugin'
 import { startTelemetry, shutdownTelemetry } from './telemetry/index'
 
@@ -171,6 +172,7 @@ async function runYargs() {
           delete argv.telemetry
         },
         telemetry && telemetryMiddleware,
+        enforceNodeVersionConfig,
         updateCheck.isEnabled() && updateCheck.updateCheckMiddleware,
       ].filter(Boolean)
     )

--- a/packages/cli/src/middleware/enforceNodeVersionConfig.js
+++ b/packages/cli/src/middleware/enforceNodeVersionConfig.js
@@ -1,0 +1,39 @@
+import boxen from 'boxen'
+import semver from 'semver'
+
+import { getConfig } from '@redwoodjs/project-config'
+
+export async function enforceNodeVersionConfig() {
+  // only check if a node version is specified in redwood.toml
+  const config = getConfig()
+  if (config.node.version !== undefined) {
+    // get current node version, coerce to semver to remove leading 'v'
+    const currentVersion = semver.coerce(process.version)
+
+    // ensure config value is valid, either a valid semver or semver range
+    const requiredVersion = config.node.version
+    if (
+      semver.valid(requiredVersion) === null &&
+      semver.validRange(requiredVersion) === null
+    ) {
+      console.error(
+        boxen(
+          `Node version '${requiredVersion}' is not valid in your redwood.toml`,
+          { padding: 1, borderColor: 'red', title: 'Node version enforcement' }
+        )
+      )
+      process.exit(1)
+    }
+
+    // ensure current version satisfies required version
+    if (!semver.satisfies(currentVersion, requiredVersion)) {
+      console.error(
+        boxen(
+          `Node version '${currentVersion}' is not allowed by your redwood.toml, it requires '${requiredVersion}'`,
+          { padding: 1, borderColor: 'red', title: 'Node version enforcement' }
+        )
+      )
+      process.exit(1)
+    }
+  }
+}

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -81,6 +81,9 @@ describe('getConfig', () => {
           "stories": true,
           "tests": true,
         },
+        "node": {
+          "version": undefined,
+        },
         "notifications": {
           "versionUpdates": [],
         },

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -93,6 +93,9 @@ export interface Config {
   notifications: {
     versionUpdates: string[]
   }
+  node: {
+    version?: string
+  }
   experimental: {
     opentelemetry: {
       enabled: boolean
@@ -155,6 +158,9 @@ const DEFAULT_CONFIG: Config = {
   },
   notifications: {
     versionUpdates: [],
+  },
+  node: {
+    version: undefined,
   },
   experimental: {
     opentelemetry: {


### PR DESCRIPTION
ping @thedavidprice, @jtoar - I didn't really have much information about what this feature was intended to be. I had agreed to take it on to free up Dom a little more.

Adds a toml option like so:
```toml
[node]
  version = "18 || 20"
```
It defaults to undefined which then avoids any checks. When set the CLI will perform a check before all commands and fail if the current node version does not match the specification set in the toml.

Examples:
![Screenshot from 2023-07-14 13-28-27](https://github.com/redwoodjs/redwood/assets/56300765/16566365-8c19-42bc-b108-cad1c205cb9b)

