### PR TITLE
serve web: Fix socket support

### DIFF
--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -137,8 +137,9 @@ export const webServerHandler = async (options) => {
   }
 
   fastify.listen({
-    port: socket ? parseInt(socket) : port,
+    port,
     host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
+    path: socket,
   })
 
   fastify.ready(() => {

--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -29,8 +29,8 @@ export const apiServerHandler = async (options) => {
 
   let listenOptions
 
-  if (options.socket) {
-    listenOptions = { path: options.socket }
+  if (socket) {
+    listenOptions = { path: socket }
   } else {
     listenOptions = {
       port,
@@ -89,8 +89,8 @@ export const bothServerHandler = async (options) => {
 
   let listenOptions
 
-  if (options.socket) {
-    listenOptions = { path: options.socket }
+  if (socket) {
+    listenOptions = { path: socket }
   } else {
     listenOptions = {
       port,
@@ -154,8 +154,8 @@ export const webServerHandler = async (options) => {
 
   let listenOptions
 
-  if (options.socket) {
-    listenOptions = { path: options.socket }
+  if (socket) {
+    listenOptions = { path: socket }
   } else {
     listenOptions = {
       port,

--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -27,11 +27,18 @@ export const apiServerHandler = async (options) => {
     },
   })
 
-  fastify.listen({
-    port,
-    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
-    path: socket,
-  })
+  let listenOptions
+
+  if (options.socket) {
+    listenOptions = { path: options.socket }
+  } else {
+    listenOptions = {
+      port,
+      host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
+    }
+  }
+
+  fastify.listen(listenOptions)
 
   fastify.ready(() => {
     fastify.log.trace(
@@ -80,11 +87,18 @@ export const bothServerHandler = async (options) => {
     },
   })
 
-  fastify.listen({
-    port,
-    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
-    path: socket,
-  })
+  let listenOptions
+
+  if (options.socket) {
+    listenOptions = { path: options.socket }
+  } else {
+    listenOptions = {
+      port,
+      host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
+    }
+  }
+
+  fastify.listen(listenOptions)
 
   fastify.ready(() => {
     console.log(chalk.italic.dim('Took ' + (Date.now() - tsServer) + ' ms'))
@@ -138,11 +152,18 @@ export const webServerHandler = async (options) => {
     fastify.register(withApiProxy, { apiHost, apiUrl })
   }
 
-  fastify.listen({
-    port,
-    host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
-    path: socket,
-  })
+  let listenOptions
+
+  if (options.socket) {
+    listenOptions = { path: options.socket }
+  } else {
+    listenOptions = {
+      port,
+      host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
+    }
+  }
+
+  fastify.listen(listenOptions)
 
   fastify.ready(() => {
     console.log(chalk.italic.dim('Took ' + (Date.now() - tsServer) + ' ms'))

--- a/packages/cli/src/commands/serveHandler.js
+++ b/packages/cli/src/commands/serveHandler.js
@@ -28,8 +28,9 @@ export const apiServerHandler = async (options) => {
   })
 
   fastify.listen({
-    port: socket ? parseInt(socket) : port,
+    port,
     host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
+    path: socket,
   })
 
   fastify.ready(() => {
@@ -80,8 +81,9 @@ export const bothServerHandler = async (options) => {
   })
 
   fastify.listen({
-    port: socket ? parseInt(socket) : port,
+    port,
     host: process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::',
+    path: socket,
   })
 
   fastify.ready(() => {


### PR DESCRIPTION
From Fastify's docs

> **listen**
> Starts the server and internally waits for the `.ready()` event. The signature is `.listen([options][, callback])`. Both the `options` object and the `callback` parameters extend the [Node.js core](https://nodejs.org/api/net.html#serverlistenoptions-callback) options object.

And looking at Node's docs we can read
> `path` `<string>` Will be ignored if port is specified. See [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).

Digging deeper into IPC (link above)
> The path is a file system pathname. It gets truncated to an OS-dependent length of sizeof(sockaddr_un.sun_path) - 1. Typical values are 107 bytes on Linux and 103 bytes on macOS. If a Node.js API abstraction creates the Unix domain socket, it will unlink the Unix domain socket as well. [...] a Unix domain socket will be visible in the file system and will persist until unlinked.

Fastify also has a test for sockets support here

https://github.com/fastify/fastify/blob/bf01ba4438fd662361a23087d23056caa044aa5e/test/listen.test.js#L199-L208

```
    const sockFile = path.join(os.tmpdir(), `${(Math.random().toString(16) + '0000000').slice(2, 10)}-server.sock`)
    try {
      fs.unlinkSync(sockFile)
    } catch (e) { }

    fastify.listen({ path: sockFile }, (err, address) => {
      t.error(err)
      t.strictSame(fastify.addresses(), [sockFile])
      t.equal(address, sockFile)
    })
```

Our way of doing it comes from way back when we were using Express instead of Fastify. It was changed here
https://github.com/redwoodjs/redwood/commit/c5106bef2d0d7728f3e96bf3ced82b9c2396653d#diff-80bc4dde3874386abddfb3621160bc9393a0ae318b4b8b86d144582f39c1c35bL12
For Express you'd pass `socket || port` as the "port" argument. But that's not how Fastify works.


## How to verify

* git checkout this PR
* Build a test project and --link
* `yarn rw build`
* `yarn rw serve web --port 8915`
* `curl localhost:8915`

We've now verified that it works to specify a port and you'll get a normal looking url (http://localhost:8915)

* `yarn rw serve web --socket tmp.sock`
* `curl --unix-socket tmp.sock http://dummy`

You should see the same output when curling the unix socket as you did when curling localhost:8915
Remove the socket when you're done `rm tmp.sock`