### PR TITLE
fix(cli): Escape telemetry in exec command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     "@babel/runtime-corejs3": "7.22.6",
     "@iarna/toml": "2.2.5",
     "@opentelemetry/api": "1.4.1",
+    "@opentelemetry/core": "1.15.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.41.0",
     "@opentelemetry/resources": "1.15.0",
     "@opentelemetry/sdk-trace-node": "1.15.0",

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -1,5 +1,7 @@
 import path from 'path'
 
+import { context } from '@opentelemetry/api'
+import { suppressTracing } from '@opentelemetry/core'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
@@ -134,5 +136,8 @@ export const handler = async (args) => {
     renderer: 'verbose',
   })
 
-  await tasks.run()
+  // Prevent user project telemetry from within the script from being recorded
+  await context.with(suppressTracing(context.active()), async () => {
+    await tasks.run()
+  })
 }

--- a/packages/cli/src/telemetry/exporter.js
+++ b/packages/cli/src/telemetry/exporter.js
@@ -53,9 +53,7 @@ export class CustomFileExporter {
         this.#storageFilePath,
         JSON.stringify(span, undefined, 2)
       )
-      if (i < spans.length - 1) {
-        fs.appendFileSync(this.#storageFilePath, ',')
-      }
+      fs.appendFileSync(this.#storageFilePath, ',')
     }
     resultCallback({ code: 0 })
   }
@@ -64,6 +62,11 @@ export class CustomFileExporter {
   shutdown() {
     // Close the JSON array
     if (!this.#isShutdown) {
+      // Remove the trailing comma
+      fs.truncateSync(
+        this.#storageFilePath,
+        fs.statSync(this.#storageFilePath).size - 1
+      )
       fs.appendFileSync(this.#storageFilePath, ']')
       this.#isShutdown = true
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7320,6 +7320,7 @@ __metadata:
     "@babel/runtime-corejs3": 7.22.6
     "@iarna/toml": 2.2.5
     "@opentelemetry/api": 1.4.1
+    "@opentelemetry/core": 1.15.0
     "@opentelemetry/exporter-trace-otlp-http": 0.41.0
     "@opentelemetry/resources": 1.15.0
     "@opentelemetry/sdk-trace-node": 1.15.0


### PR DESCRIPTION
**Problem**
We now use OpenTelemetry to instrument the CLI. This means that all telemetry generated during the CLI process is gathered and send off to our backend for storage and later analysis. This helps us understand usage and improve the CLI and overall framework.

We also allow users to instrument their project with OpenTelemetry for their own usage. This becomes a problem when we execute user code within the CLI process. This is what happens with `rw exec [script]` where we directly call their script code within the same CLI process. We must suppress telemetry gathering while executing their code or we risk gathering _their_ telemetry as our own. 

This does not apply when we spawn a new node process to run the user code, such as `rw dev` or `rw serve`.

**Changes**
1. We now depend on `@opentelemetry/core` - I asked on their slack if I could achieve the escaping without reaching into core and sticking with api. I didn't get an answer but I can revisit this later if we need to slim down the CLI again.
2. We have to include a small escape wrapper around the point where we actually call user code within the exec command handler.

**Notes**
We never actually recorded any user project telemetry. This is proactive rather than reactive. 