### PR TITLE
RSC: react-server condition. Poisoned imports

### DIFF
--- a/packages/vite/src/rscBuild.ts
+++ b/packages/vite/src/rscBuild.ts
@@ -36,13 +36,13 @@ export async function rscBuild(viteConfigPath: string) {
         (id) => serverEntryFileSet.add(id)
       ),
     ],
-    // ssr: {
-    //   // FIXME Without this, waku/router isn't considered to have client
-    //   // entries, and "No client entry" error occurs.
-    //   // Unless we fix this, RSC-capable packages aren't supported.
-    //   // This also seems to cause problems with pnpm.
-    //   // noExternal: ['@redwoodjs/web', '@redwoodjs/router'],
-    // },
+    ssr: {
+      noExternal: /^(?!node:)/,
+      external: ['react', 'minimatch'],
+    },
+    resolve: {
+      conditions: ['react-server'],
+    },
     build: {
       manifest: 'rsc-build-manifest.json',
       write: false,
@@ -52,6 +52,9 @@ export async function rscBuild(viteConfigPath: string) {
           entries: rwPaths.web.entries,
         },
       },
+    },
+    legacy: {
+      buildSsrCjsExternalHeuristics: true,
     },
   })
 

--- a/packages/vite/src/rscBuild.ts
+++ b/packages/vite/src/rscBuild.ts
@@ -38,6 +38,8 @@ export async function rscBuild(viteConfigPath: string) {
     ],
     ssr: {
       noExternal: /^(?!node:)/,
+      // TODO (RSC): Figure out what the `external` list should be. Right
+      // now it's just copied from waku
       external: ['react', 'minimatch'],
     },
     resolve: {

--- a/packages/vite/src/waku-lib/build-server.ts
+++ b/packages/vite/src/waku-lib/build-server.ts
@@ -33,9 +33,19 @@ export async function serverBuild(
     // ...configFileConfig,
     root: rwPaths.web.base,
     ssr: {
-      noExternal: ['..'],
+      noExternal: true,
+      // TODO (RSC): The code below is pretty much what waku does, but I don't
+      // understand it
+      // noExternal: Object.values(clientEntryFiles).map((fname) => {
+      //   return path
+      //     .relative(path.join(rwPaths.web.base, 'node_modules'), fname)
+      //     .split('/')[0]
+      // }),
     },
     plugins: [react()],
+    resolve: {
+      conditions: ['react-server'],
+    },
     build: {
       ssr: true,
       ssrEmitAssets: true,

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -152,12 +152,12 @@ const vitePromise = createServer({
       parentPort.postMessage(mesg)
     }),
   ],
+  resolve: {
+    conditions: ['react-server'],
+  },
   ssr: {
-    // FIXME Without this, "use client" directive in waku/router/client
-    // is ignored, and some errors occur.
-    // Unless we fix this, RSC-capable packages aren't supported.
-    // This also seems to cause problems with pnpm.
-    noExternal: ['waku'],
+    noExternal: /^(?!node:)/,
+    external: ['react', 'minimatch', 'react-server-dom-webpack'],
   },
   appType: 'custom',
 })

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -157,6 +157,8 @@ const vitePromise = createServer({
   },
   ssr: {
     noExternal: /^(?!node:)/,
+    // TODO (RSC): Figure out what the `external` list should be. Right
+    // now it's just copied from waku
     external: ['react', 'minimatch', 'react-server-dom-webpack'],
   },
   appType: 'custom',


### PR DESCRIPTION
Set the react-server condition to support poisoned imports and other multi-environment npm modules. 