### PR TITLE
RSC fix typo in example code

### DIFF
--- a/packages/cli/src/commands/experimental/templates/rsc/entry.client.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/entry.client.tsx.template
@@ -7,4 +7,4 @@ const redwoodAppElement = document.getElementById('redwood-app')
 const App = serve('App')
 
 const root = createRoot(redwoodAppElement)
-root.render(<App name="Redwood RSCc" />)
+root.render(<App name="Redwood RSCs" />)


### PR DESCRIPTION
RSCc -> RSCs

![image](https://github.com/redwoodjs/redwood/assets/30793/46c30d7b-eeca-4c21-9413-ac82486af671)
