### PR TITLE
fix(rw serve): conditionally import `@redwoodjs/realtime`

### DIFF
--- a/packages/fastify/src/graphql.ts
+++ b/packages/fastify/src/graphql.ts
@@ -11,7 +11,6 @@ import {
   createGraphQLYoga,
   getAsyncStoreInstance,
 } from '@redwoodjs/graphql-server'
-import { useRedwoodRealtime } from '@redwoodjs/realtime'
 
 /**
  * Transform a Fastify Request to an event compatible with the RedwoodGraphQLContext's event
@@ -43,6 +42,8 @@ export async function redwoodFastifyGraphQLServer(
     //
     // These would be plugins that need a server instance such as Redwood Realtime
     if (options.realtime) {
+      const { useRedwoodRealtime } = await import('@redwoodjs/realtime')
+
       const originalExtraPlugins: Array<Plugin<any>> =
         options.extraPlugins || []
       originalExtraPlugins.push(useRedwoodRealtime(options.realtime))


### PR DESCRIPTION
I missed this in https://github.com/redwoodjs/redwood/pull/8878 and it's causing `yarn rw serve` to break. `@redwoodjs/realtime` needs to be conditionally imported since it's an optional peer dependency.