### PR TITLE
web-server: Print localhost instead of 0.0.0.0

### DIFF
--- a/packages/web-server/src/server.ts
+++ b/packages/web-server/src/server.ts
@@ -88,9 +88,13 @@ export async function serve() {
   }
 
   // Start
-  fastify.listen(listenOptions).then((address) => {
+  fastify.listen(listenOptions).then(() => {
     console.log(chalk.italic.dim('Took ' + (Date.now() - tsServer) + ' ms'))
-    console.log(`Web server started on ${address}`)
+    if (options.socket) {
+      console.log(`Web server started on ${options.socket}`)
+    } else {
+      console.log(`Web server started on http://localhost:${port}`)
+    }
   })
 
   process.on('exit', () => {


### PR DESCRIPTION
When I run `yarn rw serve web` I see this printed to the console
![image](https://github.com/redwoodjs/redwood/assets/30793/5d158cd2-665a-46be-b033-df634257fda6)

It's not wrong. But when clicking that link I get "page is not secure" warning icon
![image](https://github.com/redwoodjs/redwood/assets/30793/be6a84ea-ad7b-43aa-ac88-2d6b9d8c13a5)

And I don't get the dev tools I get when using localhost instead
(which look like this)
![image](https://github.com/redwoodjs/redwood/assets/30793/68d7c44b-60fd-414c-a0ea-f529605ac12d)

The devtools thing might be more of a browser thing, but I also think people are just more used to seeing/using localhost.
So I suggest printing `http://localhost:8910` instead.

This issue was introduced with the new web-server package because I switched to just printing the `address` we get from Fastify.