### PR TITLE
Update Tailwind setup. Show extensions to install

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -79,11 +79,19 @@ async function recommendExtensionsToInstall() {
     return
   }
 
-  const { stdout } = await execa('code', ['--list-extensions'])
-  const installedExtensions = stdout.split('\n').map((ext) => ext.trim())
-  const recommendations = recommendedVSCodeExtensions.filter(
-    (ext) => !installedExtensions.includes(ext)
-  )
+  let recommendations = []
+
+  try {
+    const { stdout } = await execa('code', ['--list-extensions'])
+    const installedExtensions = stdout.split('\n').map((ext) => ext.trim())
+    recommendations = recommendedVSCodeExtensions.filter(
+      (ext) => !installedExtensions.includes(ext)
+    )
+  } catch {
+    // `code` probably not in PATH so can't check for installed extensions.
+    // We'll just recommend all extensions
+    recommendations = recommendedVSCodeExtensions
+  }
 
   if (recommendations.length > 0) {
     console.log()

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -60,7 +60,7 @@ const tailwindImportsAndNotes = [
 
 const recommendedVSCodeExtensions = [
   'csstools.postcss',
-  'radlc.vscode-tailwindcss',
+  'bradlc.vscode-tailwindcss',
 ]
 
 const recommendationTexts = {
@@ -68,7 +68,7 @@ const recommendationTexts = {
     'PostCSS Language Support',
     'https://marketplace.visualstudio.com/items?itemName=csstools.postcss'
   ),
-  'radlc.vscode-tailwindcss': terminalLink(
+  'bradlc.vscode-tailwindcss': terminalLink(
     'Tailwind CSS IntelliSense',
     'https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss'
   ),

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -11,7 +11,6 @@ import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { getPaths, usingVSCode } from '../../../../lib'
 import c from '../../../../lib/colors'
-import { isTypeScriptProject } from '../../../../lib/project'
 
 export const command = 'tailwindcss'
 export const aliases = ['tailwind', 'tw']
@@ -224,9 +223,7 @@ export const handler = async ({ force, install }) => {
           const tailwindConfig = fs.readFileSync(tailwindConfigPath, 'utf-8')
           const newTailwindConfig = tailwindConfig.replace(
             'content: []',
-            isTypeScriptProject()
-              ? "content: ['src/**/*.{ts,tsx}']"
-              : "content: ['src/**/*.{js,jsx}']"
+            "content: ['src/**/*.{js,jsx,ts,tsx}']"
           )
           fs.writeFileSync(tailwindConfigPath, newTailwindConfig)
         },

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -88,12 +88,14 @@ async function recommendExtensionsToInstall() {
   if (recommendations.length > 0) {
     console.log()
     console.log(
-      'For the best experience we recommend you install the following ' +
-        (recommendations.length === 1 ? 'extension:' : 'extensions:')
+      c.info(
+        'For the best experience we recommend that you install the following ' +
+          (recommendations.length === 1 ? 'extension:' : 'extensions:')
+      )
     )
 
     recommendations.forEach((extension) => {
-      console.log('  ' + recommendationTexts[extension])
+      console.log(c.info('  ' + recommendationTexts[extension]))
     })
   }
 }


### PR DESCRIPTION
I recently setup a new RW project with Tailwind and noticed a few improvements I thought could be made

First I wanted our setup to as closely as possible follow the latest instructions on https://tailwindcss.com/docs/installation/using-postcss
Mainly that meant to use `@tailwind base;` etc instead of `@import ...`

Unfortunately (?) I couldn't use their postcss config syntax, because they're using Next-specific syntax
https://github.com/tailwindlabs/tailwindcss.com/pull/870 TW PR that updated their docs
https://github.com/vercel/next.js/issues/10117 Next issue about the syntax with some good info in the comments, including motivation on why they use this non-standard syntax

Secondly I got syntax warnings in my css files after setting up Tailwind. After some googling I fixed that by installing the VS Code Tailwind intellisense extension. Looking at our code I then realized we do add that extension to the list of recommended extensions in the user's project. But we never actually tell the user to install it. I should have looked at all the files the setup command modified, but even if I had, I probably wouldn't have realized that was one of the plugins that we recommend, because the plugin ID doesn't match the name of the plugin (the ID is `bradlc.vscode-tailwindcss`)

This is the first warning I spotted (`Unknown at rule @tailwind css(unknownAtRules)`)
![image](https://github.com/redwoodjs/redwood/assets/30793/bfe13012-dc9d-437f-9f5a-6807c9a52337)

This is what it looks like when running the setup command after my changes:
![image](https://github.com/redwoodjs/redwood/assets/30793/3eff2c9f-4375-4a7b-8466-379b8c9e8fc2)

---

@jtoar 
 * I selected the v6 milestone, but this totally doesn't have to go out in an RC. It can wait for v6.1 or whatever. It's non-breaking, but you decide when you want to release it.
 * For the upgrade guide we could suggest people switch to the declaration syntax instead of imports. But the imports still seem to work, so we could also just skip it.