### PR TITLE
CRWA: Move git init to include yarn.lock

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -657,11 +657,6 @@ async function createRedwoodApp() {
   // Create project files
   await createProjectFiles(newAppDir, { templateDir, overwrite })
 
-  // Initialize git repo
-  if (useGit) {
-    await initializeGit(newAppDir, commitMessage)
-  }
-
   // Install the node packages
   if (yarnInstall) {
     const yarnInstallStart = Date.now()
@@ -678,6 +673,11 @@ async function createRedwoodApp() {
   // Generate types
   if (yarnInstall) {
     await generateTypes(newAppDir)
+  }
+
+  // Initialize git repo
+  if (useGit) {
+    await initializeGit(newAppDir, commitMessage)
   }
 
   // Post install message


### PR DESCRIPTION
When creating a new Redwood app and selecting to initialize a git repo you always end up with an untracked yarn.lock file

![image](https://github.com/redwoodjs/redwood/assets/30793/63044ce0-89bb-4781-99a0-29d06ad8ff22)

This PR makes sure git initialization happens after the lock file has been created.

Screenshot from after my fix (notice that `git status` no longer lists yarn.lock as untracked)
![image](https://github.com/redwoodjs/redwood/assets/30793/708a7b40-cd37-487b-97a3-8129b2c22c61)

@jtoar This one is probably good to get in as soon as possible