### PR TITLE
RSC: Fix noExternal rule for server build

### DIFF
--- a/packages/vite/src/rscBuild.ts
+++ b/packages/vite/src/rscBuild.ts
@@ -25,18 +25,19 @@ export async function rscBuild(viteConfigPath: string) {
     root: rwPaths.base,
     plugins: [
       react(),
-      {
-        name: 'rsc-test-plugin',
-        transform(_code, id) {
-          console.log('rsc-test-plugin id', id)
-        },
-      },
+      // {
+      //   name: 'rsc-test-plugin',
+      //   transform(_code, id) {
+      //     console.log('rsc-test-plugin id', id)
+      //   },
+      // },
       rscAnalyzePlugin(
         (id) => clientEntryFileSet.add(id),
         (id) => serverEntryFileSet.add(id)
       ),
     ],
     ssr: {
+      // We can ignore everything that starts with `node:` because it's not going to be RSCs
       noExternal: /^(?!node:)/,
       // TODO (RSC): Figure out what the `external` list should be. Right
       // now it's just copied from waku

--- a/packages/vite/src/waku-lib/build-server.ts
+++ b/packages/vite/src/waku-lib/build-server.ts
@@ -33,12 +33,17 @@ export async function serverBuild(
     // ...configFileConfig,
     root: rwPaths.web.base,
     ssr: {
-      noExternal: true,
-      // TODO (RSC): The code below is pretty much what waku does, but I don't
-      // understand it
+      // Externalize everything except files that have 'use client' in them
+      // (this includes packages in node_modules that you use that have
+      // 'use client' in them)
+      // Files included in `noExternal` are files we want Vite to analyze
+      noExternal: Object.values(clientEntryFiles),
+      // TODO (RSC) This is the original code from waku. I think we can simplify it as above
+      // The code below will for most basic cases just be `[ '..' ]`, which we
+      // believe to be overly broad
       // noExternal: Object.values(clientEntryFiles).map((fname) => {
       //   return path
-      //     .relative(path.join(rwPaths.web.base, 'node_modules'), fname)
+      //     .relative(path.join(rwPaths.base, 'node_modules'), fname)
       //     .split('/')[0]
       // }),
     },

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -155,12 +155,6 @@ const vitePromise = createServer({
   resolve: {
     conditions: ['react-server'],
   },
-  ssr: {
-    noExternal: /^(?!node:)/,
-    // TODO (RSC): Figure out what the `external` list should be. Right
-    // now it's just copied from waku
-    external: ['react', 'minimatch', 'react-server-dom-webpack'],
-  },
   appType: 'custom',
 })
 


### PR DESCRIPTION
Fixing some RSC settings that I broke in #8948

Thanks to @Josh-Walker-GM I now have a better understanding of how `noExternal` works.
If you want Vite to analyze/know about a file, you don't want it to be externalized. So you might want to put it in the `noExternal` list.