### PR TITLE
feat(vite): add plugin to remove modules from the bundle

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -8,7 +8,8 @@ import { normalizePath } from 'vite'
 import { getWebSideDefaultBabelConfig } from '@redwoodjs/internal/dist/build/babel/web'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 
-import { handleJsAsJsx } from './vite-plugin-jsx-loader'
+import handleJsAsJsx from './plugins/vite-plugin-jsx-loader'
+import removeFromBundle from './plugins/vite-plugin-remove-from-bundle'
 
 /**
  * Pre-configured vite plugin, with required config for Redwood apps.
@@ -260,6 +261,8 @@ export default function redwoodPluginVite(): PluginOption[] {
     },
     // -----------------
     handleJsAsJsx(),
+    // Remove the splash-page from the bundle.
+    removeFromBundle([{ id: /splash-page/, parentId: /@redwoodjs\/router/ }]),
     react({
       babel: {
         ...getWebSideDefaultBabelConfig({

--- a/packages/vite/src/plugins/__tests__/remove-from-bundle.test.mts
+++ b/packages/vite/src/plugins/__tests__/remove-from-bundle.test.mts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { getShouldExclude } from '../vite-plugin-remove-from-bundle'
+
+describe('excludeModule', () => {
+  it('should return true if idToExclude matches id', () => {
+    const shouldExcludeModule = getShouldExclude({
+      id: './splash-page',
+      idToExclude: /splash-page/,
+    })
+
+    assert.equal(shouldExcludeModule, true)
+  })
+
+  it("should return false if idToExclude doesn't match id", () => {
+    const shouldExcludeModule = getShouldExclude({
+      id: './splash-page',
+      idToExclude: /bazinga-page/,
+    })
+
+    assert.equal(shouldExcludeModule, false)
+  })
+
+  it('should return true if idToExclude matches id and parentIdToExclude matches parentId ', () => {
+    const shouldExcludeModule = getShouldExclude({
+      id: './splash-page',
+      parentId: '/redwood-app/node_modules/@redwoodjs/router/dist/router.js',
+      idToExclude: /splash-page/,
+      parentIdToExclude: /@redwoodjs\/router/,
+    })
+
+    assert.equal(shouldExcludeModule, true)
+  })
+
+  it("should return false if parentIdToExclude is specified but there's no parentId", () => {
+    const shouldExcludeModule = getShouldExclude({
+      id: './splash-page',
+      idToExclude: /splash-page/,
+      parentIdToExclude: /@redwoodjs\/router/,
+    })
+
+    assert.equal(shouldExcludeModule, false)
+  })
+})

--- a/packages/vite/src/plugins/vite-plugin-jsx-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-jsx-loader.ts
@@ -5,7 +5,7 @@ import { PluginOption, transformWithEsbuild } from 'vite'
  * This is a vite plugin to load and transform JS files as JSX.
  *
  */
-export function handleJsAsJsx(): PluginOption {
+export default function handleJsAsJsx(): PluginOption {
   return {
     name: 'transform-js-files-as-jsx',
     async transform(code: string, id: string) {

--- a/packages/vite/src/plugins/vite-plugin-remove-from-bundle.ts
+++ b/packages/vite/src/plugins/vite-plugin-remove-from-bundle.ts
@@ -1,0 +1,62 @@
+import type { PluginOption } from 'vite'
+
+type ModulesToExclude = Array<{ id: RegExp; parentId?: RegExp }>
+
+/**
+ *
+ * This is a vite plugin to remove modules from the bundle.
+ *
+ */
+export default function removeFromBundle(
+  modulesToExclude: ModulesToExclude
+): PluginOption {
+  const isMissingIdToExclude = modulesToExclude.some(
+    (module) => module.id === undefined
+  )
+
+  if (isMissingIdToExclude) {
+    throw new Error('You must specify an id to exclude')
+  }
+
+  return {
+    name: 'remove-from-bundle',
+    config: () => {
+      return {
+        build: {
+          rollupOptions: {
+            external(id, parentId = '') {
+              const shouldExcludeModule = modulesToExclude.some((module) => {
+                return getShouldExclude({
+                  id,
+                  parentId,
+                  idToExclude: module.id,
+                  parentIdToExclude: module.parentId,
+                })
+              })
+
+              return shouldExcludeModule
+            },
+          },
+        },
+      }
+    },
+  }
+}
+
+export function getShouldExclude({
+  id,
+  idToExclude,
+  parentId = '',
+  parentIdToExclude,
+}: {
+  id: string
+  idToExclude: RegExp
+  parentId?: string
+  parentIdToExclude?: RegExp
+}) {
+  if (parentIdToExclude) {
+    return idToExclude.test(id) && parentIdToExclude.test(parentId)
+  }
+
+  return idToExclude.test(id)
+}


### PR DESCRIPTION
Analyzing the bundle produced by `yarn rw build web` with Vite reveals a few things we could improve. This PR improves one of them, which is not bundling the splash page you see when you have no Routes in dev. This sheds ~4% off a default Redwood app:

<img width="1532" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/225e902d-0e1e-41c8-b0a3-9011f6817f82">

Next would be core-js-pure.

Note that I actually can't get this test to run. When I run `yarn test` in `packages/vite`, I get the following error...

```
ℹ ~/projects/redwood/redwood/packages/vite/src/plugins/__tests__/remove-from-bundle.test.mts:1
ℹ import { getShouldExclude } from '../vite-plugin-remove-from-bundle.ts'
ℹ          ^
ℹ 
ℹ SyntaxError: The requested module '../vite-plugin-remove-from-bundle.ts' does not provide an export named 'getShouldExclude'
ℹ     at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
ℹ     at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
ℹ 
ℹ Node.js v18.16.1
✖ ~/projects/redwood/redwood/packages/vite/src/plugins/__tests__/remove-from-bundle.test.mts (104.293542ms)
  'test failed'
```

@Tobbe was hoping you had ideas since I think you wrote the test in this package? I need to merge this, so not going to wait for that to be resolved. Will confirm it works manually for now, but if you get the chance, you can tell me or open a PR