### PR TITLE
fix(firebase): improve error handling

### DIFF
--- a/packages/auth-providers/firebase/api/src/decoder.ts
+++ b/packages/auth-providers/firebase/api/src/decoder.ts
@@ -1,13 +1,33 @@
 import admin from 'firebase-admin'
+import type { FirebaseError } from 'firebase-admin'
 
 import { Decoder } from '@redwoodjs/api'
 
+// Alternative third-party JWT verification process described here:
+// https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
 export const authDecoder: Decoder = async (token: string, type: string) => {
   if (type !== 'firebase') {
     return null
   }
 
-  return admin.auth().verifyIdToken(token)
-  // Alternative third-party JWT verification process described here:
-  // https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
+  try {
+    return admin.auth().verifyIdToken(token)
+  } catch (error) {
+    const firebaseError = error as FirebaseError
+
+    if (firebaseError.code === 'app/no-app') {
+      const message = [
+        '',
+        '👉 Heads up',
+        '',
+        "The firebase app that the auth decoder is using wasn't initialized, which usually means that you have two different versions of firebase-admin.",
+        'Make sure that you only have one version of firebase-admin: `yarn why firebase-admin`',
+        '',
+      ].join('\n')
+
+      firebaseError.message = `${firebaseError.message}\n${message}`
+    }
+
+    throw error
+  }
 }

--- a/packages/auth-providers/firebase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/firebase/setup/src/setupHandler.ts
@@ -16,7 +16,7 @@ export async function handler({ force: forceArg }: Args) {
     provider: 'firebase',
     authDecoderImport:
       "import { authDecoder } from '@redwoodjs/auth-firebase-api'",
-    webPackages: ['firebase@^9', `@redwoodjs/auth-firebase-web@${version}`],
+    webPackages: ['firebase@^10', `@redwoodjs/auth-firebase-web@${version}`],
     apiPackages: [
       // Note that the version of this package should be exactly the same as the version in `@redwoodjs/auth-firebase-api` .
       'firebase-admin@11.10.1',

--- a/packages/auth-providers/firebase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/firebase/setup/src/setupHandler.ts
@@ -18,7 +18,8 @@ export async function handler({ force: forceArg }: Args) {
       "import { authDecoder } from '@redwoodjs/auth-firebase-api'",
     webPackages: ['firebase@^9', `@redwoodjs/auth-firebase-web@${version}`],
     apiPackages: [
-      'firebase-admin@11.9.0',
+      // Note that the version of this package should be exactly the same as the version in `@redwoodjs/auth-firebase-api` .
+      'firebase-admin@11.10.1',
       `@redwoodjs/auth-firebase-api@${version}`,
     ],
     notes: [


### PR DESCRIPTION
Auditing firebase again for Redwood's v6 release, it was failing and I forgot why. Referring back to https://github.com/redwoodjs/redwood/pull/8305 reminded me that the versions of `firebase-admin` between the framework and a user's project need to be the same. One of the ways they get out of sync is with renovate. I don't want to read from the firebase api package during the firebase setup command—plus the versions can get out of sync in other ways—so for now, may as well save everyone some time by making the error more explicit:

<img width="2012" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/f1090965-5199-42d5-8831-3978e9a68050">

This coupling really isn't ideal at all since any time we bump the version of `firebase-admin` in the framework and release a new versoin, users have to bump it in their projects too. I'm not sure what a better way is yet.

I've also upgraded the version of `firebase` (the package used on the web side) that the setup command installs to v10 since it worked locally.