### PR TITLE
fix(cli): Prevent unwanted SIGINT error message from storybook

### DIFF
--- a/packages/cli-packages/storybook/src/commands/storybook.ts
+++ b/packages/cli-packages/storybook/src/commands/storybook.ts
@@ -74,6 +74,8 @@ export async function handler(options: StorybookYargsOptions): Promise<void> {
     open: options.open,
     smokeTest: options.smokeTest,
   })
+  // @ts-expect-error - Custom workaround for storybook telemetry
+  process.emit('shutdown-telemetry')
 
   const { handler: storybookHandler } = await import('./storybookHandler.js')
   await storybookHandler(options)


### PR DESCRIPTION
**Problem**
Storybook is showing an error message when you exit via a SIGINT. 

We have spent a few hours trying to understand why and work around this with no success.

*Changes**
1. Conditionally disable the additional default signal listeners based on the argv contents.
2. Emit a custom event on `process` to trigger the telemetry shutdown.

**Notes**
I'm not really proud of this PR. Disabling based on the contents of argv isn't all that robust against false positives. Emitting a custom event on `process` is not really supposed to be done - hence why TS is complaining about the name of the signal.

This work has also highlighted that on my windows 11 machine the background scripts are not firing... This was working when I updated the span values to match those found to work in this PR comment https://github.com/nodejs/node/issues/21825#issuecomment-503766781 when I reenabled windows telemetry. Maybe something has changed, maybe it's version specific (os or node). This is an active nodejs issue so my ability to solve this in redwood code is understandably limited. 

Why isn't our CI finding this? We should investigate this too.

@jtoar Could you confirm on mac and windows that this PR prevents those additional error messages from storybook. If you also have the time I'd appreciate if you could check if the telemetry background job is firing when you test on windows. 

I'll test this on ubuntu locally. 