### PR TITLE
RSC: Use experimental node loader

### DIFF
--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -65,6 +65,7 @@ export const bothRscServerHandler = async (argv) => {
     'node',
     [
       '--experimental-loader @redwoodjs/vite/node-loader',
+      '--experimental-loader @redwoodjs/vite/react-node-loader',
       '--conditions react-server',
       './node_modules/@redwoodjs/vite/dist/runRscFeServer.js',
     ],

--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -64,6 +64,7 @@ export const bothRscServerHandler = async (argv) => {
   const fePromise = execa(
     'node',
     [
+      '--experimental-loader @redwoodjs/vite/node-loader',
       '--conditions react-server',
       './node_modules/@redwoodjs/vite/dist/runRscFeServer.js',
     ],

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -37,6 +37,10 @@
     "./buildFeServer": {
       "types": "./dist/buildFeServer.d.ts",
       "default": "./dist/buildFeServer.js"
+    },
+    "./node-loader": {
+      "types": "./dist/waku-lib/node-loader.d.ts",
+      "default": "./dist/waku-lib/node-loader.js"
     }
   },
   "bin": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -41,6 +41,10 @@
     "./node-loader": {
       "types": "./dist/waku-lib/node-loader.d.ts",
       "default": "./dist/waku-lib/node-loader.js"
+    },
+    "./react-node-loader": {
+      "types": "./dist/react-server-dom-webpack/node-loader.d.ts",
+      "default": "./dist/react-server-dom-webpack/node-loader.js"
     }
   },
   "bin": {

--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -39,6 +39,9 @@ export const buildRscFeServer = async ({
     // configFile: viteConfigPath,
     root: webSrc,
     plugins: [react(), rscIndexPlugin()],
+    resolve: {
+      conditions: ['react-server'],
+    },
     build: {
       outDir: webDist,
       emptyOutDir: true, // Needed because `outDir` is not inside `root`

--- a/packages/vite/src/waku-lib/node-loader.ts
+++ b/packages/vite/src/waku-lib/node-loader.ts
@@ -1,5 +1,22 @@
+// This loader is needed to make react-server-dom-webpack/node-loader work.
+// Without it we get the following error:
+//
+// resolve ./dist/node/index.js {
+//   conditions: [ 'node', 'import', 'node-addons', 'react-server' ],
+//   importAssertions: [Object: null prototype] {},
+//   parentURL: 'file:///Users/tobbe/tmp/rw-rsc-esm/node_modules/vite/index.cjs'
+// }
+// (node:33561) DeprecationWarning: Obsolete loader hook(s) supplied and will be ignored: getSource, transformSource
+// /Users/tobbe/tmp/rw-rsc-esm/node_modules/@redwoodjs/vite/dist/react-server-dom-webpack/node-loader.js:357
+//       throw new Error('Expected source to have been loaded into a string.');
+//             ^
+
+// Error: Expected source to have been loaded into a string.
+//     at load (/Users/tobbe/tmp/rw-rsc-esm/node_modules/@redwoodjs/vite/dist/react-server-dom-webpack/node-loader.js:357:13)
+//     at async nextLoad (node:internal/modules/esm/loader:163:22)
+
 export async function load(url: string, context: any, nextLoad: any) {
-  console.log('waku-lib/node-loader')
+  // console.log('waku-lib/node-loader: load', context.format, url)
 
   const result = await nextLoad(url, context, nextLoad)
 

--- a/packages/vite/src/waku-lib/node-loader.ts
+++ b/packages/vite/src/waku-lib/node-loader.ts
@@ -1,0 +1,17 @@
+export async function load(url: string, context: any, nextLoad: any) {
+  console.log('waku-lib/node-loader')
+
+  const result = await nextLoad(url, context, nextLoad)
+
+  if (result.format === 'module') {
+    let { source } = result
+
+    if (typeof source !== 'string') {
+      source = source.toString()
+    }
+
+    return { ...result, source }
+  }
+
+  return result
+}


### PR DESCRIPTION
Use experimental node loaders when launching the RSC FE Server

This is all done to try to make loading of 3rd party modules work. Specifically have been experimenting with the `server-only` package.

In the end it turned out that it's not working because there's a bug/missing feature in Vite
https://github.com/vitejs/vite/pull/13487