### PR TITLE
Webpack: Use resolve-url-loader to handle absolute paths in css url()

### DIFF
--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -55,7 +55,7 @@ const getStyleLoaders = (isEnvProduction) => {
     const loaderConfig = {
       loader: require.resolve('css-loader'),
       options: {
-        sourceMap: !isEnvProduction,
+        sourceMap: true, // resolve-url-loader needs source maps
         importLoaders,
       },
     }
@@ -66,6 +66,13 @@ const getStyleLoaders = (isEnvProduction) => {
     }
 
     return loaderConfig
+  }
+
+  const resolveUrlLoader = {
+    loader: require.resolve('resolve-url-loader'),
+    options: {
+      root: path.join(redwoodPaths.web.base, '/public'),
+    },
   }
 
   const paths = getPaths()
@@ -80,6 +87,7 @@ const getStyleLoaders = (isEnvProduction) => {
           postcssOptions: {
             config: paths.web.postcss,
           },
+          sourceMap: true,
         },
       }
     : null
@@ -87,12 +95,20 @@ const getStyleLoaders = (isEnvProduction) => {
   const numImportLoadersForCSS = hasPostCssConfig ? 1 : 0
   const numImportLoadersForSCSS = hasPostCssConfig ? 2 : 1
 
+  const sassLoader = {
+    loader: 'sass-loader',
+    options: {
+      sourceMap: true,
+    },
+  }
+
   return [
     {
       test: /\.module\.css$/,
       use: [
         styleOrExtractLoader,
         cssLoader(true, numImportLoadersForCSS),
+        resolveUrlLoader,
         postCssLoader,
       ].filter(Boolean),
     },
@@ -101,6 +117,7 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(false, numImportLoadersForCSS),
+        resolveUrlLoader,
         postCssLoader,
       ].filter(Boolean),
       sideEffects: true,
@@ -110,8 +127,9 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(true, numImportLoadersForSCSS),
+        resolveUrlLoader,
         postCssLoader,
-        'sass-loader',
+        sassLoader,
       ].filter(Boolean),
     },
     {
@@ -119,8 +137,9 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(false, numImportLoadersForSCSS),
+        resolveUrlLoader,
         postCssLoader,
-        'sass-loader',
+        sassLoader,
       ].filter(Boolean),
       sideEffects: true,
     },

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -55,7 +55,7 @@ const getStyleLoaders = (isEnvProduction) => {
     const loaderConfig = {
       loader: require.resolve('css-loader'),
       options: {
-        sourceMap: true, // resolve-url-loader needs source maps
+        sourceMap: !isEnvProduction,
         importLoaders,
       },
     }
@@ -87,7 +87,7 @@ const getStyleLoaders = (isEnvProduction) => {
           postcssOptions: {
             config: paths.web.postcss,
           },
-          sourceMap: true,
+          sourceMap: true, // required for resolve-url-loader
         },
       }
     : null
@@ -98,7 +98,7 @@ const getStyleLoaders = (isEnvProduction) => {
   const sassLoader = {
     loader: 'sass-loader',
     options: {
-      sourceMap: true,
+      sourceMap: true, // required for resolve-url-loader
     },
   }
 

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -23,6 +23,8 @@ const { getConfig, getPaths } = require('@redwoodjs/project-config')
 const redwoodConfig = getConfig()
 const redwoodPaths = getPaths()
 
+const isUsingVite = redwoodConfig.web.bundler !== 'webpack'
+
 /** @returns {{[key: string]: string}} Env vars */
 const getEnvVars = () => {
   const redwoodEnvPrefix = 'REDWOOD_ENV_'
@@ -108,7 +110,7 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(true, numImportLoadersForCSS),
-        resolveUrlLoader,
+        isUsingVite && resolveUrlLoader,
         postCssLoader,
       ].filter(Boolean),
     },
@@ -117,7 +119,7 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(false, numImportLoadersForCSS),
-        resolveUrlLoader,
+        isUsingVite && resolveUrlLoader,
         postCssLoader,
       ].filter(Boolean),
       sideEffects: true,
@@ -127,7 +129,7 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(true, numImportLoadersForSCSS),
-        resolveUrlLoader,
+        isUsingVite && resolveUrlLoader,
         postCssLoader,
         sassLoader,
       ].filter(Boolean),
@@ -137,7 +139,7 @@ const getStyleLoaders = (isEnvProduction) => {
       use: [
         styleOrExtractLoader,
         cssLoader(false, numImportLoadersForSCSS),
-        resolveUrlLoader,
+        isUsingVite && resolveUrlLoader,
         postCssLoader,
         sassLoader,
       ].filter(Boolean),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "nodemon": "2.0.22",
     "null-loader": "4.0.1",
     "react-refresh": "0.14.0",
-    "resolve-url-loader": "^5.0.0",
+    "resolve-url-loader": "5.0.0",
     "rimraf": "5.0.1",
     "style-loader": "3.3.3",
     "typescript": "5.1.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,6 +75,7 @@
     "nodemon": "2.0.22",
     "null-loader": "4.0.1",
     "react-refresh": "0.14.0",
+    "resolve-url-loader": "^5.0.0",
     "rimraf": "5.0.1",
     "style-loader": "3.3.3",
     "typescript": "5.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7507,7 +7507,7 @@ __metadata:
     nodemon: 2.0.22
     null-loader: 4.0.1
     react-refresh: 0.14.0
-    resolve-url-loader: ^5.0.0
+    resolve-url-loader: 5.0.0
     rimraf: 5.0.1
     style-loader: 3.3.3
     typescript: 5.1.6
@@ -27693,7 +27693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-url-loader@npm:^5.0.0":
+"resolve-url-loader@npm:5.0.0":
   version: 5.0.0
   resolution: "resolve-url-loader@npm:5.0.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7507,6 +7507,7 @@ __metadata:
     nodemon: 2.0.22
     null-loader: 4.0.1
     react-refresh: 0.14.0
+    resolve-url-loader: ^5.0.0
     rimraf: 5.0.1
     style-loader: 3.3.3
     typescript: 5.1.6
@@ -11763,6 +11764,16 @@ __metadata:
   version: 1.2.2
   resolution: "address@npm:1.2.2"
   checksum: 1c8056b77fb124456997b78ed682ecc19d2fd7ea8bd5850a2aa8c3e3134c913847c57bcae418622efd32ba858fa1e242a40a251ac31da0515664fc0ac03a047d
+  languageName: node
+  linkType: hard
+
+"adjust-sourcemap-loader@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "adjust-sourcemap-loader@npm:4.0.0"
+  dependencies:
+    loader-utils: ^2.0.0
+    regex-parser: ^2.2.11
+  checksum: 6a6e5bb8b670e4e1238c708f6163e92aa2ad0308fe5913de73c89e4cbf41738ee0bcc5552b94d0b7bf8be435ee49b78c6de8a6db7badd80762051e843c8aa14f
   languageName: node
   linkType: hard
 
@@ -26234,6 +26245,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.2.14":
+  version: 8.4.27
+  resolution: "postcss@npm:8.4.27"
+  dependencies:
+    nanoid: ^3.3.6
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 41a0476e05cb97514ff8d75e4ff9fdcf778f22b2e0d25b7028f219cd408e01d3c4f50459d4a1cd9a430d8ef08202c881374a4fa4ea6009f4a135a07315d606e5
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.26":
   version: 8.4.26
   resolution: "postcss@npm:8.4.26"
@@ -27407,6 +27429,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regex-parser@npm:^2.2.11":
+  version: 2.2.11
+  resolution: "regex-parser@npm:2.2.11"
+  checksum: 6572acbd46b5444215a73cf164f3c6fdbd73b8a2cde6a31a97307e514d20f5cbb8609f9e4994a7744207f2d1bf9e6fca4bbc0c9854f2b3da77ae0063efdc3f98
+  languageName: node
+  linkType: hard
+
 "regexp-to-ast@npm:0.5.0":
   version: 0.5.0
   resolution: "regexp-to-ast@npm:0.5.0"
@@ -27661,6 +27690,19 @@ __metadata:
   version: 1.0.0
   resolution: "resolve-pkg-maps@npm:1.0.0"
   checksum: fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
+"resolve-url-loader@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "resolve-url-loader@npm:5.0.0"
+  dependencies:
+    adjust-sourcemap-loader: ^4.0.0
+    convert-source-map: ^1.7.0
+    loader-utils: ^2.0.0
+    postcss: ^8.2.14
+    source-map: 0.6.1
+  checksum: 53eef3620332f2fc35a4deffaa4395064b2ffd1bc28be380faa3f1e99c2fb7bbf0f705700b4539387d5b6c39586df54a92cd5d031606f19de4bf9e0ff1b6a522
   languageName: node
   linkType: hard
 
@@ -28817,17 +28859,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:0.6.1, source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.5.6":
   version: 0.5.7
   resolution: "source-map@npm:0.5.7"
   checksum: 904e767bb9c494929be013017380cbba013637da1b28e5943b566031e29df04fba57edf3f093e0914be094648b577372bd8ad247fa98cfba9c600794cd16b599
-  languageName: node
-  linkType: hard
-
-"source-map@npm:^0.6.0, source-map@npm:^0.6.1, source-map@npm:~0.6.0, source-map@npm:~0.6.1":
-  version: 0.6.1
-  resolution: "source-map@npm:0.6.1"
-  checksum: ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -26245,7 +26245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.14":
+"postcss@npm:^8.2.14, postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.26":
   version: 8.4.27
   resolution: "postcss@npm:8.4.27"
   dependencies:
@@ -26253,17 +26253,6 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 41a0476e05cb97514ff8d75e4ff9fdcf778f22b2e0d25b7028f219cd408e01d3c4f50459d4a1cd9a430d8ef08202c881374a4fa4ea6009f4a135a07315d606e5
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.21, postcss@npm:^8.4.24, postcss@npm:^8.4.26":
-  version: 8.4.26
-  resolution: "postcss@npm:8.4.26"
-  dependencies:
-    nanoid: ^3.3.6
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: 29c603d6b30b2f94bf971bc430600f271da76fa3ae38d4c6b255e957213051b8eeb02829e128ec4e9fa2a7bb710ba7992ebaf1997e3a9ace48caf49b48a10f6b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Using [resolve-url-loader](https://github.com/bholloway/resolve-url-loader) to set `root` for absolute imports. This makes it possible to use the same absolute-path style imports in css for both webpack and Vite RW projects.
So CSS like this should work for both Webpack and Vite now 

```css
@layer base {
  @font-face {
    font-family: 'My font';
    src: url('/fonts/abeezee-v22-latin-regular.woff2') format('woff2');
    font-weight: 300;
    ascent-override: 97%;
  }

  * {
    font-family: 'My font';
  }
}
```

Notice `url('/fonts/...')`. The initial `/` is what's important.