### PR TITLE
fix(crwa): use JSDoc in JS template for vite config

### DIFF
--- a/packages/create-redwood-app/templates/js/web/vite.config.js
+++ b/packages/create-redwood-app/templates/js/web/vite.config.js
@@ -1,6 +1,6 @@
 import dns from 'dns'
 
-import { defineConfig, UserConfig } from 'vite'
+import { defineConfig } from 'vite'
 
 // See: https://vitejs.dev/config/server-options.html#server-host
 // So that Vite will load on local instead of 127.0.0.1
@@ -8,7 +8,8 @@ dns.setDefaultResultOrder('verbatim')
 
 import redwood from '@redwoodjs/vite'
 
-const viteConfig: UserConfig = {
+/** @type {import('vite').UserConfig} */
+const viteConfig = {
   plugins: [redwood()],
 }
 

--- a/packages/create-redwood-app/tsToJS.mjs
+++ b/packages/create-redwood-app/tsToJS.mjs
@@ -48,7 +48,7 @@ console.log('Copying TS template to JS template')
 fs.copySync(TS_TEMPLATE_FILEPATH, JS_TEMPLATE_FILEPATH)
 
 // Find files and transform.
-const apiWebFilePaths = fg.sync('{api,web}/src/**/*.{ts,tsx}', {
+const apiWebFilePaths = fg.sync('{api,web}/**/*.{ts,tsx}', {
   cwd: JS_TEMPLATE_FILEPATH,
   absolute: true,
 })


### PR DESCRIPTION
First patch for v6. Missed this during release; the release script needs an update as well.