### PR TITLE
Docs: remove useless code in code snippet

### DIFF
--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -239,12 +239,6 @@ export const schema = gql`
     message: String!
   }
 
-  input UpdateContactInput {
-    name: String
-    email: String
-    message: String
-  }
-
   // highlight-start
   type Mutation {
     createContact(input: CreateContactInput!): Contact! @skipAuth


### PR DESCRIPTION
The paragraph above this code block says:
`We're not going to let anyone update or delete a message, so we can remove those fields completely. Here's what the SDL file looks like after the changes:`
Everything is removed from the code block except the `UpdateContactInput` that is not gonna be used by anything. This is just for the TS file, the JS file has the `UpdateContactInput` removed correctly.