### PR TITLE
Make sure env var name starts with REDWOOD_ENV_

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -61,7 +61,9 @@ export default function redwoodPluginVite(): PluginOption[] {
           })
 
           Object.entries(process.env).forEach(([envName, value]) => {
-            newHtml = newHtml.replaceAll(`%${envName}%`, value || '')
+            if (envName.startsWith('REDWOOD_ENV_')) {
+              newHtml = newHtml.replaceAll(`%${envName}%`, value || '')
+            }
           })
 
           return newHtml


### PR DESCRIPTION
Only env vars with names starting with `REDWOOD_ENV_` should be automatically available for substitution in html files