### PR TITLE
fix(v6): add back `@storybookreact` as CLI dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,7 @@
     "@redwoodjs/project-config": "6.0.3",
     "@redwoodjs/structure": "6.0.3",
     "@redwoodjs/telemetry": "6.0.3",
+    "@storybook/react": "7.2.0",
     "@types/secure-random-password": "0.2.1",
     "boxen": "5.1.2",
     "camelcase": "6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7857,6 +7857,7 @@ __metadata:
     "@redwoodjs/project-config": 6.0.3
     "@redwoodjs/structure": 6.0.3
     "@redwoodjs/telemetry": 6.0.3
+    "@storybook/react": 7.2.0
     "@types/crypto-js": 4.1.1
     "@types/secure-random-password": 0.2.1
     boxen: 5.1.2


### PR DESCRIPTION
In v6, we decoupled Storybook from the framework. But generators still generate stories. If a user hasn't set up Storybook, but generates a page, etc (which is pretty much what happens in the tutorial), they'll see a type error in the `*.stories.{tsx,jsx}` file. See https://community.redwoodjs.com/t/redwood-v6-0-0-upgrade-guide/5044/35.

Ideally, we just wouldn't generate stories if a user hasn't set up Storybook. But the tutorial is written as if these story files were just around this whole time, which is how the framework worked and works.

I think we can eventually get to the point where Storybook is fully decoupled, but I don't have a good idea of the amount of work that would need to be done, and am already focused on other projects (Docker). So this seems like the simplest fix to me for now. This package isn't small (42 MB) but it's not as bad as adding back all of the Storybook packages.

@Tobbe brought up using declare module. I'm happy to pair on that. Just thought I'd have this fix here ready to go.