### PR TITLE
Fix context in directive tests

### DIFF
--- a/packages/graphql-server/src/plugins/useRedwoodDirective.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodDirective.ts
@@ -11,7 +11,7 @@ import {
 } from 'graphql'
 import { Plugin } from 'graphql-yoga'
 
-import { GlobalContext } from '../index'
+import type { GlobalContext } from '../index'
 
 export interface DirectiveParams<
   FieldType = any,

--- a/packages/testing/src/api/directive.ts
+++ b/packages/testing/src/api/directive.ts
@@ -5,7 +5,11 @@ import type {
   ValidatorDirective,
   TransformerDirective,
 } from '@redwoodjs/graphql-server'
-import { setContext, DirectiveType } from '@redwoodjs/graphql-server'
+import {
+  DirectiveType,
+  setContext,
+  context as globalContext,
+} from '@redwoodjs/graphql-server'
 
 export { getDirectiveName } from '@redwoodjs/graphql-server'
 
@@ -73,20 +77,22 @@ export const mockRedwoodDirective: DirectiveMocker = (
 
   if (directive.onResolvedValue.constructor.name === 'AsyncFunction') {
     return async () => {
-      if (context) {
-        setContext(context || {})
+      if (context !== undefined) {
+        setContext(context)
       }
 
       if (directive.type === DirectiveType.TRANSFORMER) {
         const { mockedResolvedValue } = others as TransformerMock
         return directive.onResolvedValue({
           resolvedValue: mockedResolvedValue,
-          directiveArgs: directiveArgs || {},
+          directiveArgs: directiveArgs ?? {},
+          context: globalContext,
           ...others,
         } as DirectiveParams)
       } else {
         await directive.onResolvedValue({
-          directiveArgs: directiveArgs || {},
+          directiveArgs: directiveArgs ?? {},
+          context: globalContext,
           ...others,
         } as DirectiveParams)
       }
@@ -94,20 +100,22 @@ export const mockRedwoodDirective: DirectiveMocker = (
   }
 
   return () => {
-    if (context) {
-      setContext(context || {})
+    if (context !== undefined) {
+      setContext(context)
     }
 
     if (directive.type === DirectiveType.TRANSFORMER) {
       const { mockedResolvedValue } = others as TransformerMock
       return directive.onResolvedValue({
         resolvedValue: mockedResolvedValue,
-        directiveArgs: directiveArgs || {},
+        directiveArgs: directiveArgs ?? {},
+        context: globalContext,
         ...others,
       } as DirectiveParams)
     } else {
       directive.onResolvedValue({
-        directiveArgs: directiveArgs || {},
+        directiveArgs: directiveArgs ?? {},
+        context: globalContext,
         ...others,
       } as DirectiveParams)
     }


### PR DESCRIPTION
**Problem**
Context isolation was not behaving as expect when using directive tests. See https://community.redwoodjs.com/t/redwood-v6-0-0-upgrade-guide/5044/46 for more details.

**Changes**
1. We set the global context to match the context passed in to the `mockRedwoodDirective` and then the mock directive gets the global context during execution.

**Notes**
It looks like in v5 we didn't pass through the context that was provided as a parameter to `mockRedwoodDirective`. It can be somewhat tricky to understand exactly what is happening due to a few layers and that in <v6 the context was not isolated between tests.

**Outstanding**
1. People may not fully expect the side effect that passing in the context to the mock directive sets the global context? 