### PR TITLE
Remove `.only` from `createCell` test

### DIFF
--- a/packages/web/src/components/createCell.test.tsx
+++ b/packages/web/src/components/createCell.test.tsx
@@ -54,7 +54,7 @@ describe('createCell', () => {
     screen.getByText(/^42$/)
   })
 
-  test.only('Renders Success if any of the fields have data (i.e. not just the first)', async () => {
+  test('Renders Success if any of the fields have data (i.e. not just the first)', async () => {
     const TestCell = createCell({
       // @ts-expect-error - Purposefully using a plain string here.
       QUERY: 'query TestQuery { users { name } posts { title } }',


### PR DESCRIPTION
While exploring the cell-related source, I noticed there was a `test.only` that seems to have inadvertently been left in.

Removing this restores 19 passing ✅ tests that would otherwise be skipped.

Context: In the `web` package...
```bash
% git rev-parse --show-prefix
packages/web/
```

Before:
```bash
% yarn test
...
Tests:       19 skipped, 15 passed, 34 total
```

After:
```bash
% yarn test
...
Tests:       34 passed, 34 total
```