### PR TITLE
fix(graphql-server): Move yoga creation to avoid creation on every request

### DIFF
--- a/packages/graphql-server/src/functions/graphql.ts
+++ b/packages/graphql-server/src/functions/graphql.ts
@@ -42,6 +42,29 @@ export const createGraphQLHandler = ({
   schemaOptions,
   openTelemetryOptions,
 }: GraphQLHandlerOptions) => {
+  const { yoga, logger } = createGraphQLYoga({
+    healthCheckId,
+    loggerConfig,
+    context,
+    getCurrentUser,
+    onException,
+    generateGraphiQLHeader,
+    extraPlugins,
+    authDecoder,
+    cors,
+    services,
+    sdls,
+    directives,
+    armorConfig,
+    allowedOperations,
+    allowIntrospection,
+    allowGraphiQL,
+    defaultError,
+    graphiQLEndpoint,
+    schemaOptions,
+    openTelemetryOptions,
+  })
+
   const handlerFn = async (
     event: APIGatewayProxyEvent,
     requestContext: LambdaContext
@@ -50,30 +73,6 @@ export const createGraphQLHandler = ({
     requestContext.callbackWaitsForEmptyEventLoop = false
 
     let lambdaResponse: APIGatewayProxyResult
-
-    const { yoga, logger } = createGraphQLYoga({
-      healthCheckId,
-      loggerConfig,
-      context,
-      getCurrentUser,
-      onException,
-      generateGraphiQLHeader,
-      extraPlugins,
-      authDecoder,
-      cors,
-      services,
-      sdls,
-      directives,
-      armorConfig,
-      allowedOperations,
-      allowIntrospection,
-      allowGraphiQL,
-      defaultError,
-      graphiQLEndpoint,
-      schemaOptions,
-      openTelemetryOptions,
-    })
-
     try {
       // url needs to be normalized
       const [, rest = ''] = event.path.split(graphiQLEndpoint)


### PR DESCRIPTION
**Problem**
v6 has seen some performance issues. These appear to have sneaked in on #8339. This just reverts the change by moving the creation of the yoga object so that it isn't created on every request.

**Changes**
1. Moves yoga creation.

**Outstanding**
1. We still have a tiny bit of work to do analysing a slight performance decline since 4.4.3 