### PR TITLE
Adds prisma client to app

### DIFF
--- a/packages/create-redwood-app/templates/js/api/package.json
+++ b/packages/create-redwood-app/templates/js/api/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@prisma/client": "*",
     "@redwoodjs/api": "6.0.6",
     "@redwoodjs/graphql-server": "6.0.6"
   }

--- a/packages/create-redwood-app/templates/ts/api/package.json
+++ b/packages/create-redwood-app/templates/ts/api/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@prisma/client": "*",
     "@redwoodjs/api": "6.0.6",
     "@redwoodjs/graphql-server": "6.0.6"
   }


### PR DESCRIPTION
If you write something like 

```ts
import {} from "@p
```

By default, you do not get `@prisma/client` in the auto-complete. This means you are never offered any of the  prisma types inline either!

That's because it's never explicitly declared in your dependencies:

```json
{
  "name": "api",
  "version": "0.0.0",
  "private": true,
  "dependencies": {
    "@redwoodjs/api": "6.0.6",
    "@redwoodjs/graphql-server": "6.0.6"
  }
}
``` 

So TypeScript doesn't offer it to editors as it has inferred the dependency to be unimportant to you (as you didn't declare it) - this declares it with [`*`](https://docs.npmjs.com/cli/v6/using-npm/semver#x-ranges-12x-1x-12-) which is effectively "whatever" as it's defined elsewhere in the tree.