### PR TITLE
fix: resolves Tailwind setup command failing due to unsupported prettier-plugin-tailwindcss v0.5

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -25,7 +25,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.27",
     "postcss-loader": "^7.3.3",
-    "prettier-plugin-tailwindcss": "^0.4.1",
+    "prettier-plugin-tailwindcss": "0.4.1",
     "tailwindcss": "^3.3.3"
   }
 }

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -115,7 +115,7 @@ export const handler = async ({ force, install }) => {
   })
   const rwPaths = getPaths()
 
-  const projectPackages = ['prettier-plugin-tailwindcss']
+  const projectPackages = ['prettier-plugin-tailwindcss@0.4.1']
 
   const webWorkspacePackages = [
     'postcss',

--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -297,7 +297,7 @@ async function webTasks(outputPath, { linkWithLatestFwBuild, verbose }) {
         // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
         task: () =>
           execa(
-            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss',
+            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@0.4.1',
             [],
             getExecaOptions(outputPath)
           ),

--- a/tasks/test-project/tui-tasks.js
+++ b/tasks/test-project/tui-tasks.js
@@ -337,7 +337,7 @@ async function webTasks(outputPath, { linkWithLatestFwBuild }) {
       // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
       task: async () => {
         await exec(
-          'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss',
+          'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@0.4.1',
           [],
           getExecaOptions(outputPath)
         )


### PR DESCRIPTION
fixes #9075

`prettier-plugin-tailwindcss` >= 0.5 requires Prettier v3. This PR pins the version to `0.4.1`, which is the most recent version prior to v0.5.

**NOTE:** This issue will still affect all previous versions of Redwood because the setup ui tailwindcss command defaults to adding the Tailwind deps at latest.

### Next Steps
I'll open two PRs, one to revert this and one to upgrade Prettier to v3 (both for next major).