### PR TITLE
fix: fully resolves Tailwind setup command failing due to Prettier v3 dependency

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -25,7 +25,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.27",
     "postcss-loader": "^7.3.3",
-    "prettier-plugin-tailwindcss": "0.4.1",
+    "prettier-plugin-tailwindcss": "^0.4.1",
     "tailwindcss": "^3.3.3"
   }
 }

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -115,7 +115,7 @@ export const handler = async ({ force, install }) => {
   })
   const rwPaths = getPaths()
 
-  const projectPackages = ['prettier-plugin-tailwindcss@0.4.1']
+  const projectPackages = ['prettier-plugin-tailwindcss']
 
   const webWorkspacePackages = [
     'postcss',

--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -297,7 +297,7 @@ async function webTasks(outputPath, { linkWithLatestFwBuild, verbose }) {
         // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
         task: () =>
           execa(
-            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@0.4.1',
+            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss',
             [],
             getExecaOptions(outputPath)
           ),

--- a/tasks/test-project/tui-tasks.js
+++ b/tasks/test-project/tui-tasks.js
@@ -337,7 +337,7 @@ async function webTasks(outputPath, { linkWithLatestFwBuild }) {
       // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
       task: async () => {
         await exec(
-          'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@0.4.1',
+          'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss',
           [],
           getExecaOptions(outputPath)
         )


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/9075 (this is the full resolution; previously workaround)

## Dependencies
- [ ] Must first merge https://github.com/redwoodjs/redwood/pull/9077
- [ ] Must rebuild `fixtures/test-project` and confirm `prettier-plugin-tailwindcss` at latest and working correctly (0.4.1 is currently hardcoded and must be updated)
