### PR TITLE
chore(eslint): enable `import/no-extraneous-dependencies` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -184,5 +184,23 @@ module.exports = {
         '@redwoodjs/process-env-computed': 'off',
       },
     },
+    {
+      files: ['packages/project-config/**'],
+      excludedFiles: [
+        '**/__tests__/**',
+        '**/*.test.ts?(x)',
+        '**/*.spec.ts?(x)',
+      ],
+      rules: {
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: false,
+            optionalDependencies: false,
+            peerDependencies: true,
+          },
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
# chore(eslint): enable `import/no-extraneous-dependencies` rule

enable `import/no-extraneous-dependencies` rule just for `project-config` (other projects can be added as needed).

## open questions

- [X] [do we want to exclude `create-redwood-app`?](https://github.com/redwoodjs/redwood/pull/9081/files#r1317178678)
- [X] do we want to exclude `@redwoodjs/studio` (see risks section for more context)
- [X] are there other packages we want to exclude?

## risks

- ~~adding explicit dependency definitions to `package.json`s that used to come from a transitive / implicit one can bring issues; usually these explicit definitions are benign, however it is a new risk (it also means more overhead in terms of  dependency management).~~
- ~~`@redwoodjs/studio` ( _synced w/ @Josh-Walker-GM about ignoring this package since that is an experimental one, this might be the approach we want to take; leaving changes to it in this PR for now._ )~~