### PR TITLE
fix(data-migrate): add `dotenv-defaults`, properly plug into CLI

### DIFF
--- a/packages/cli-packages/dataMigrate/e2eTest.mjs
+++ b/packages/cli-packages/dataMigrate/e2eTest.mjs
@@ -118,8 +118,6 @@ await execa.command('yarn rw g data-migration test', {
   stdio: 'inherit',
 })
 
-await execa.command('yarn rw data-migrate up', {
-  stdio: 'inherit',
-})
+await execa.command(command)
 
 // check that up worked...

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -29,6 +29,7 @@
     "@redwoodjs/project-config": "6.0.7",
     "@redwoodjs/telemetry": "6.0.7",
     "chalk": "4.1.2",
+    "dotenv-defaults": "5.0.2",
     "execa": "5.1.1",
     "fs-extra": "11.1.1",
     "listr2": "6.6.0",

--- a/packages/cli-packages/dataMigrate/src/bin.ts
+++ b/packages/cli-packages/dataMigrate/src/bin.ts
@@ -1,11 +1,23 @@
+import path from 'path'
+
+// @ts-expect-error not sure; other packages use this and don't provide the types
+import { config } from 'dotenv-defaults'
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
+
+import { getPaths } from '@redwoodjs/project-config'
 
 import { description, builder } from './commands/up'
 import { handler } from './commands/upHandler'
 
+config({
+  path: path.join(getPaths().base, '.env'),
+  defaults: path.join(getPaths().base, '.env.defaults'),
+  multiline: true,
+})
+
 yargs(hideBin(process.argv))
   .scriptName('data-migrate')
-  // @ts-expect-error not sure why
+  // @ts-expect-error not sure; this is a valid signature
   .command('$0', description, builder, handler)
   .parse()

--- a/packages/cli-packages/dataMigrate/src/index.ts
+++ b/packages/cli-packages/dataMigrate/src/index.ts
@@ -1,3 +1,6 @@
+import terminalLink from 'terminal-link'
+import type { Argv } from 'yargs'
+
 import {
   command as installCommand,
   description as installDescription,
@@ -11,17 +14,28 @@ import {
   handler as upHandler,
 } from './commands/up'
 
+const command = 'data-migrate <command>'
+const aliases = ['dataMigrate', 'dm']
+const description = 'Migrate the data in your database'
+
+function builder(yargs: Argv) {
+  yargs
+    .command(installCommand, installDescription, installBuilder, installHandler)
+    // @ts-expect-error not sure; this is a valid signature
+    .command(upCommand, upDescription, upBuilder, upHandler)
+    .epilogue(
+      `Also see the ${terminalLink(
+        'Redwood CLI Reference',
+        'https://redwoodjs.com/docs/cli-commands#datamigrate'
+      )}`
+    )
+}
+
 export const commands = [
   {
-    command: installCommand,
-    description: installDescription,
-    builder: installBuilder,
-    handler: installHandler,
-  },
-  {
-    command: upCommand,
-    description: upDescription,
-    builder: upBuilder,
-    handler: upHandler,
+    command,
+    aliases,
+    description,
+    builder,
   },
 ]

--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -19,6 +19,12 @@ const PLUGIN_CACHE_DEFAULT = {
         'Launch Storybook: a tool for building UI components and pages in isolation',
     },
   },
+  '@redwoodjs/cli-data-migrate': {
+    'data-migrate': {
+      aliases: ['dataMigrate', 'dm'],
+      description: 'Migrate the data in your database',
+    },
+  },
 }
 
 const PLUGIN_CACHE_BUILTIN = [
@@ -27,9 +33,6 @@ const PLUGIN_CACHE_BUILTIN = [
   'diagnostics',
   'console',
   'c',
-  'data-migrate',
-  'dm',
-  'dataMigrate',
   'deploy',
   'destroy',
   'd',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7876,6 +7876,7 @@ __metadata:
     "@types/fs-extra": 11.0.1
     "@types/yargs": 17.0.24
     chalk: 4.1.2
+    dotenv-defaults: 5.0.2
     esbuild: 0.18.19
     execa: 5.1.1
     fast-glob: 3.3.1


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/8572. The latest suite of fixes to the new `@redwoodjs/cli-data-migrate` package. The previous were:
- https://github.com/redwoodjs/redwood/commit/c27f318e7a86c6bddea4fa3f5a8a68219ae8c114 fix(data-migrate): fix canary publishing
- https://github.com/redwoodjs/redwood/commit/2d6b93d2f7661025eb49ffe5321f9fef2d65d4eb fix(data-migrate): add missing dependency `@redwoodjs/cli-helpers`

@Josh-Walker-GM I'm going to take a shot at it, but I'll probably need your help making sure this is properly plugged into the CLI.