### PR TITLE
feat(Cell Suspense): Allow Cells to not Suspend

### DIFF
--- a/packages/web/src/components/cell/cellTypes.tsx
+++ b/packages/web/src/components/cell/cellTypes.tsx
@@ -180,7 +180,7 @@ export interface CreateCellProps<CellProps, CellVariables> {
   displayName?: string
 }
 
-export type SuperSuccessProps = React.PropsWithChildren<
+export type SuspendingSuccessProps = React.PropsWithChildren<
   Record<string, unknown>
 > & {
   queryRef: QueryReference<DataObject> // from useBackgroundQuery

--- a/packages/web/src/components/cell/cellTypes.tsx
+++ b/packages/web/src/components/cell/cellTypes.tsx
@@ -208,18 +208,20 @@ export interface SuspenseCellQueryResult<
   networkStatus?: NetworkStatus
   called: boolean // can we assume if we have a queryRef its called?
 
-  // Stuff not here:
-  // observable: ObservableQuery<TData, TVariables>
-  // previousData?: TData,  May not be relevant anymore.
+  // Stuff not here compared to useQuery:
+  // observable: ObservableQuery<TData, TVariables> // Lenz: internal implementation detail, should not be required anymore
+  // previousData?: TData,  // emulating suspense, not required in the new Suspense model
 
   // ObservableQueryFields 👇
-  //  subscribeToMore ~ returned from useSuspenseQuery. What would users use this for?
-  //  updateQuery
-  //  refetch
-  //  reobserve
-  //  variables <~ variables passed to the query. Startup club have reported using this, but why?
-  //  fetchMore
-  //  startPolling <~ Apollo team are not ready to expose Polling yet
+  //  subscribeToMore ~ returned from useSuspenseQuery but not useReadQuery. Apollo team **may** expose from useReadQuery.
+  //  updateQuery <~ May not be necessary in the Suspense model
+  //  refetch ~ <~ refetch signature is different in useQuery vs useSuspenseQuery. Apollo team need an internal discussion.
+  //  reobserve <~ avoid
+  //  variables <~ variables passed to the query, useful if you updated the variables using updateQuery or refetch. Apollo team need an internal discussion.
+
+  // Polling: Apollo team are not ready to expose Polling yet. Unlikely to be shipped in the next few months.
+  // But possible to re-implement this in a different way using setInternal or client.startPolling
+  //  startPolling
   //  stopPolling
   // ~~~
 }

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -126,11 +126,11 @@ export function createSuspendingCell<
     }
 
     const wrapInSuspenseIfLoadingPresent = (
-      superSuccessElement: React.ReactNode,
+      suspendingSuccessElement: React.ReactNode,
       LoadingComponent: typeof Loading
     ) => {
       if (!LoadingComponent) {
-        return superSuccessElement
+        return suspendingSuccessElement
       }
 
       return (
@@ -139,7 +139,7 @@ export function createSuspendingCell<
             <LoadingComponent {...props} queryResult={suspenseQueryResult} />
           }
         >
-          {superSuccessElement}
+          {suspendingSuccessElement}
         </Suspense>
       )
     }

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -44,7 +44,7 @@ export function createSuspendingCell<
     }),
     afterQuery = (data) => ({ ...data }),
     isEmpty = isDataEmpty,
-    Loading = () => <>Loading...</>,
+    Loading,
     Failure,
     Empty,
     Success,
@@ -125,17 +125,35 @@ export function createSuspendingCell<
       )
     }
 
+    const wrapInSuspenseIfLoadingPresent = (
+      superSuccessElement: React.ReactNode,
+      LoadingComponent: typeof Loading
+    ) => {
+      if (!LoadingComponent) {
+        return superSuccessElement
+      }
+
+      return (
+        <Suspense
+          fallback={
+            <LoadingComponent {...props} queryResult={suspenseQueryResult} />
+          }
+        >
+          {superSuccessElement}
+        </Suspense>
+      )
+    }
+
     return (
       <CellErrorBoundary renderFallback={FailureComponent}>
-        <Suspense
-          fallback={<Loading {...props} queryResult={suspenseQueryResult} />}
-        >
+        {wrapInSuspenseIfLoadingPresent(
           <SuperSuccess
             userProps={props}
             queryRef={queryRef as QueryReference<DataObject>}
             suspenseQueryResult={suspenseQueryResult}
-          />
-        </Suspense>
+          />,
+          Loading
+        )}
       </CellErrorBoundary>
     )
   }

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -11,7 +11,7 @@ import { CellErrorBoundary, FallbackProps } from './CellErrorBoundary'
 import {
   CreateCellProps,
   DataObject,
-  SuperSuccessProps,
+  SuspendingSuccessProps,
   SuspenseCellQueryResult,
 } from './cellTypes'
 import { isDataEmpty } from './isCellEmpty'
@@ -50,7 +50,7 @@ export function createSuspendingCell<
     Success,
     displayName = 'Cell',
   } = createCellProps
-  function SuperSuccess(props: SuperSuccessProps) {
+  function SuspendingSuccess(props: SuspendingSuccessProps) {
     const { queryRef, suspenseQueryResult, userProps } = props
     const { data, networkStatus } = useReadQuery<DataObject>(queryRef)
     const afterQueryData = afterQuery(data as DataObject)
@@ -79,7 +79,7 @@ export function createSuspendingCell<
     )
   }
 
-  SuperSuccess.displayName = displayName
+  SuspendingSuccess.displayName = displayName
 
   // @NOTE: Note that we are returning a HoC here!
   return (props: CellProps) => {
@@ -147,7 +147,7 @@ export function createSuspendingCell<
     return (
       <CellErrorBoundary renderFallback={FailureComponent}>
         {wrapInSuspenseIfLoadingPresent(
-          <SuperSuccess
+          <SuspendingSuccess
             userProps={props}
             queryRef={queryRef as QueryReference<DataObject>}
             suspenseQueryResult={suspenseQueryResult}


### PR DESCRIPTION
## Context
I'm using the presence of a the `Loading` component in a Cell to decide whether to wrap it in Suspense boundary or not.

**This allows the user to decide two things:**
a) If they want to wait for all the results to load before displaying to the user (by removing all the loading components in cells on a page)
b) If they want to display loaders differently for example:

- Cell 1 is a regular Cell with a loading component
- Cell 2 & 3 do _not_ have a loading component

```jsx
      <Cell 1/> // 👈 Cell 1 has a loading component, so it will show loader
      <Suspense fallback={'Wait for both 2 and 3 to load, and display this in the mean time'}>
	      <Cell2  />
	      <Cell3  />
      </Suspense>
```
