### PR TITLE
Streaming fe server: bind to 0.0.0.0 in prod

### DIFF
--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -119,10 +119,25 @@ export async function runFeServer() {
     app.get(expressPathDef, routeHandler)
   }
 
-  app.listen(rwConfig.web.port)
-  console.log(
-    `Started production FE server on http://localhost:${rwConfig.web.port}`
+  const server = app.listen(
+    rwConfig.web.port,
+    process.env.NODE_ENV === 'production' ? '0.0.0.0' : '::'
   )
+
+  server.on('listening', () => {
+    let addressDetails = ''
+    const address = server.address()
+
+    if (typeof address === 'string') {
+      addressDetails = `(${address})`
+    } else if (address && typeof address === 'object') {
+      addressDetails = `(${address.address}:${address.port})`
+    }
+
+    console.log(
+      `Started production FE server on http://localhost:${rwConfig.web.port} ${addressDetails}`
+    )
+  })
 }
 
 runFeServer()


### PR DESCRIPTION
Fixing this problem with fly deploys

![image](https://github.com/redwoodjs/redwood/assets/30793/f2d6d342-854f-4e03-92a5-199d07e22ae8)

But this isn't specific to Fly. Docker deploys in general usually require you to bind to 0.0.0.0. We already do this for regular non-streaming deploys. For example here 
https://github.com/redwoodjs/redwood/blob/8d0ab16aa1c39f1526e4213211608805735f6974/packages/cli/src/commands/serveBothHandler.js#L137

Also added some more details to the console output.
We want to print `http://localhost` etc so you get a nice link you can click in your console. But in reality we're not binding to `localhost` but rather `0.0.0.0` or `::` and knowing what address it's actually binding to is also good to know