### PR TITLE
fix(types): wrong type path on server.config.js

### DIFF
--- a/packages/create-redwood-app/templates/js/api/server.config.js
+++ b/packages/create-redwood-app/templates/js/api/server.config.js
@@ -33,7 +33,7 @@ const config = {
  * Note: This configuration does not apply in a serverless deploy.
  */
 
-/** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
+/** @type {import('@redwoodjs/api-server/dist/types').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
     fastify.log.trace({ custom: { options } }, 'Configuring api side')

--- a/packages/create-redwood-app/templates/ts/api/server.config.js
+++ b/packages/create-redwood-app/templates/ts/api/server.config.js
@@ -33,7 +33,7 @@ const config = {
  * Note: This configuration does not apply in a serverless deploy.
  */
 
-/** @type {import('@redwoodjs/api-server/dist/fastify').FastifySideConfigFn} */
+/** @type {import('@redwoodjs/api-server/dist/types').FastifySideConfigFn} */
 const configureFastify = async (fastify, options) => {
   if (options.side === 'api') {
     fastify.log.trace({ custom: { options } }, 'Configuring api side')


### PR DESCRIPTION
The path for the Fastify configuration is not available at the current location when generating a new project.