### PR TITLE
fix(babel-config): read TS config files using TS parser functions

### DIFF
--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -47,8 +47,7 @@
     "@types/babel__core": "7.20.1",
     "babel-plugin-tester": "11.0.4",
     "esbuild": "0.18.19",
-    "jest": "29.6.4",
-    "typescript": "5.1.6"
+    "jest": "29.6.4"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -39,7 +39,8 @@
     "babel-plugin-module-resolver": "5.0.0",
     "core-js": "3.32.0",
     "fast-glob": "3.3.1",
-    "graphql": "16.8.0"
+    "graphql": "16.8.0",
+    "typescript": "5.1.6"
   },
   "devDependencies": {
     "@types/babel-plugin-tester": "9.0.5",

--- a/packages/babel-config/src/__tests__/common.test.ts
+++ b/packages/babel-config/src/__tests__/common.test.ts
@@ -212,7 +212,7 @@ describe('common', () => {
       })
     })
 
-    it.only('handles invalid JSON', () => {
+    it('handles invalid JSON', () => {
       const apiTSConfig =
         '{"compilerOptions": {"noEmit": true,"allowJs": true,"esModuleInterop": true,"target": "esnext","module": "esnext","moduleResolution": "node","baseUrl": "./","rootDirs": ["./src","../.redwood/types/mirror/api/src"],"paths": {"src/*": ["./src/*","../.redwood/types/mirror/api/src/*"],"types/*": ["./types/*", "../types/*"],"@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/api"]},"typeRoots": ["../node_modules/@types","./node_modules/@types"],"types": ["jest"],},"include": ["src","../.redwood/types/includes/all-*","../.redwood/types/includes/api-*","../types"]}'
       const webTSConfig =
@@ -231,10 +231,7 @@ describe('common', () => {
         redwoodProjectPath
       )
 
-      const typeScriptConfig = parseTypeScriptConfigFiles()
-      expect('abc').toBe('def')
-      // expect(typeScriptConfig.api).toMatchObject(JSON.parse(apiTSConfig))
-      // expect(typeScriptConfig.web).toMatchObject(JSON.parse(webTSConfig))
+      expect(parseTypeScriptConfigFiles).not.toThrow()
     })
   })
 })

--- a/packages/babel-config/src/__tests__/common.test.ts
+++ b/packages/babel-config/src/__tests__/common.test.ts
@@ -211,5 +211,30 @@ describe('common', () => {
         )
       })
     })
+
+    it.only('handles invalid JSON', () => {
+      const apiTSConfig =
+        '{"compilerOptions": {"noEmit": true,"allowJs": true,"esModuleInterop": true,"target": "esnext","module": "esnext","moduleResolution": "node","baseUrl": "./","rootDirs": ["./src","../.redwood/types/mirror/api/src"],"paths": {"src/*": ["./src/*","../.redwood/types/mirror/api/src/*"],"types/*": ["./types/*", "../types/*"],"@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/api"]},"typeRoots": ["../node_modules/@types","./node_modules/@types"],"types": ["jest"],},"include": ["src","../.redwood/types/includes/all-*","../.redwood/types/includes/api-*","../types"]}'
+      const webTSConfig =
+        '{"compilerOptions": {"noEmit": true,"allowJs": true,"esModuleInterop": true,"target": "esnext","module": "esnext","moduleResolution": "node","baseUrl": "./","rootDirs": ["./src","../.redwood/types/mirror/web/src","../api/src","../.redwood/types/mirror/api/src"],"paths": {"src/*": ["./src/*","../.redwood/types/mirror/web/src/*","../api/src/*","../.redwood/types/mirror/api/src/*"],"$api/*": [ "../api/*" ],"types/*": ["./types/*", "../types/*"],"@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]},"typeRoots": ["../node_modules/@types", "./node_modules/@types"],"types": ["jest", "@testing-library/jest-dom"],"jsx": "preserve",},"include": ["src","../.redwood/types/includes/all-*","../.redwood/types/includes/web-*","../types","./types"]}'
+
+      vol.fromNestedJSON(
+        {
+          'redwood.toml': '',
+          api: {
+            'tsconfig.json': apiTSConfig,
+          },
+          web: {
+            'tsconfig.json': webTSConfig,
+          },
+        },
+        redwoodProjectPath
+      )
+
+      const typeScriptConfig = parseTypeScriptConfigFiles()
+      expect('abc').toBe('def')
+      // expect(typeScriptConfig.api).toMatchObject(JSON.parse(apiTSConfig))
+      // expect(typeScriptConfig.web).toMatchObject(JSON.parse(webTSConfig))
+    })
   })
 })

--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import type { TransformOptions, PluginItem } from '@babel/core'
-// import { parseConfigFileTextToJson } from 'typescript'
+import { parseConfigFileTextToJson } from 'typescript'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -103,22 +103,23 @@ export const parseTypeScriptConfigFiles = () => {
 
   const parseConfigFile = (basePath: string) => {
     let configPath = path.join(basePath, 'tsconfig.json')
-
     if (!fs.existsSync(configPath)) {
       configPath = path.join(basePath, 'jsconfig.json')
       if (!fs.existsSync(configPath)) {
         return null
       }
     }
-
-    return JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+    return parseConfigFileTextToJson(
+      configPath,
+      fs.readFileSync(configPath, 'utf-8')
+    )
   }
   const apiConfig = parseConfigFile(rwPaths.api.base)
   const webConfig = parseConfigFile(rwPaths.web.base)
 
   return {
-    api: apiConfig,
-    web: webConfig,
+    api: apiConfig?.config ?? null,
+    web: webConfig?.config ?? null,
   }
 }
 

--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import type { TransformOptions, PluginItem } from '@babel/core'
+// import { parseConfigFileTextToJson } from 'typescript'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -109,6 +110,7 @@ export const parseTypeScriptConfigFiles = () => {
         return null
       }
     }
+
     return JSON.parse(fs.readFileSync(configPath, 'utf-8'))
   }
   const apiConfig = parseConfigFile(rwPaths.api.base)


### PR DESCRIPTION
It looks like I have to add the `typescript` package, which is ~40 MB, back to the `@redwoodjs/babel-config` package because TS config files aren't valid JSON. I'm not sure what they are; this issue here (https://github.com/microsoft/TypeScript/issues/44573) makes it sound like they're their own format, which means we need to use TypeScript's parser to be 100% sure we can read these files.

I had a look at how the `ts-morph` packages get around this problem. They bundle using rollup. That's probably the answer for the future, but we don't have experience bundling external dependencies like this, and I'm trying not to introduce breaking changes, so leaving that for a major and just taking the size hit for now.