### PR TITLE
fix(render): redirect to 200.html for prerender

### DIFF
--- a/packages/cli/src/commands/setup/deploy/templates/render.js
+++ b/packages/cli/src/commands/setup/deploy/templates/render.js
@@ -33,7 +33,7 @@ services:
     destination: replace_with_api_url/*
   - type: rewrite
     source: /*
-    destination: /index.html
+    destination: /200.html
 
 - name: ${PROJECT_NAME}-api
   type: web


### PR DESCRIPTION
@thedavidprice and I were seeing problems in deploy target CI related to CDNs using prerender. Netlify already has this 200.html file for prerender; using it render led to similar success. Original PR on 200.html for context: [https://github.com/redwoodjs/redwood/pull/4782](https://github.com/redwoodjs/redwood/pull/4782)