### PR TITLE
RSC: Don't set the react-server condition for client builds

### DIFF
--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -39,9 +39,6 @@ export const buildRscFeServer = async ({
     // configFile: viteConfigPath,
     root: webSrc,
     plugins: [react(), rscIndexPlugin()],
-    resolve: {
-      conditions: ['react-server'],
-    },
     build: {
       outDir: webDist,
       emptyOutDir: true, // Needed because `outDir` is not inside `root`


### PR DESCRIPTION
This unbreaks RSC after #8979 landed.

The `react-server` condition shouldn't be used when building the client-side bundle