### PR TITLE
feat: Draft Fragment Support in Apollo Web with Babel Transform Component

### DIFF
--- a/packages/create-redwood-app/templates/js/graphql.config.js
+++ b/packages/create-redwood-app/templates/js/graphql.config.js
@@ -2,4 +2,5 @@ const { getPaths } = require('@redwoodjs/internal')
 
 module.exports = {
   schema: getPaths().generated.schema,
+  documents: './web/src/**/!(*.d).{ts,tsx,js,jsx}',
 }

--- a/packages/internal/src/build/babel/web.ts
+++ b/packages/internal/src/build/babel/web.ts
@@ -96,6 +96,13 @@ export const getWebSideOverrides = (
 ) => {
   const overrides = [
     {
+      test: /.+Fragment.(js|tsx|jsx)$/,
+      plugins: [
+        require('../babelPlugins/babel-plugin-redwood-fragment-registration')
+          .default,
+      ],
+    },
+    {
       test: /.+Cell.(js|tsx|jsx)$/,
       plugins: [require('../babelPlugins/babel-plugin-redwood-cell').default],
     },

--- a/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-several-entries/code.jsx
+++ b/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-several-entries/code.jsx
@@ -1,0 +1,26 @@
+const VoteButtons = (props) => {
+  return (
+    <div>{JSON.stringify(props)}</div>
+  )
+}
+
+VoteButtons.fragments = {
+  entry: gql`
+    fragment VoteButtonsFragment on FeedEntry {
+      score
+      vote {
+        choice
+      }
+    }
+  `,
+  voter: gql`
+    fragment VoterFragment on FeedEntry {
+      voter {
+        id
+        name
+      }
+    }
+  `,
+};
+
+export default VoteButtons

--- a/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-several-entries/output.jsx
+++ b/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-several-entries/output.jsx
@@ -1,0 +1,23 @@
+import { fragmentRegistry } from '@redwoodjs/web/apollo'
+export const VoteButtons_Fragment_Entry = gql`
+  fragment VoteButtonsFragment on FeedEntry {
+    score
+    vote {
+      choice
+    }
+  }
+`
+fragmentRegistry.register(VoteButtons_Fragment_Entry)
+export const VoteButtons_Fragment2_Voter = gql`
+  fragment VoterFragment on FeedEntry {
+    voter {
+      id
+      name
+    }
+  }
+`
+fragmentRegistry.register(VoteButtons_Fragment2_Voter)
+const VoteButtons = (props) => {
+  return <div>{JSON.stringify(props)}</div>
+}
+export default VoteButtons

--- a/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-single-entry/code.jsx
+++ b/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-single-entry/code.jsx
@@ -1,0 +1,18 @@
+const VoteButtons = (props) => {
+  return (
+    <div>{JSON.stringify(props)}</div>
+  )
+}
+
+VoteButtons.fragments = {
+  entry: gql`
+    fragment VoteButtonsFragment on FeedEntry {
+      score
+      vote {
+        choice
+      }
+    }
+  `,
+};
+
+export default VoteButtons

--- a/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-single-entry/output.jsx
+++ b/packages/internal/src/build/babelPlugins/__tests__/__fixtures__/fragment/fragment-with-single-entry/output.jsx
@@ -1,0 +1,14 @@
+import { fragmentRegistry } from '@redwoodjs/web/apollo'
+export const VoteButtons_Fragment_Entry = gql`
+  fragment VoteButtonsFragment on FeedEntry {
+    score
+    vote {
+      choice
+    }
+  }
+`
+fragmentRegistry.register(VoteButtons_Fragment_Entry)
+const VoteButtons = (props) => {
+  return <div>{JSON.stringify(props)}</div>
+}
+export default VoteButtons

--- a/packages/internal/src/build/babelPlugins/__tests__/babel-plugin-redwood-fragment-registration.test.ts
+++ b/packages/internal/src/build/babelPlugins/__tests__/babel-plugin-redwood-fragment-registration.test.ts
@@ -1,0 +1,15 @@
+import path from 'path'
+
+// import * as p from '@babel/plugin-syntax-jsx'
+import pluginTester from 'babel-plugin-tester'
+
+import redwoodFragmentPlugin from '../babel-plugin-redwood-fragment-registration'
+
+describe('babel-plugin-redwood-fragment-registration', () => {
+  pluginTester({
+    plugin: redwoodFragmentPlugin,
+    babelOptions: { plugins: ['@babel/plugin-syntax-jsx'] },
+    pluginName: 'babel-plugin-redwood-fragment-registration',
+    fixtures: path.join(__dirname, '__fixtures__/fragment'),
+  })
+})

--- a/packages/internal/src/build/babelPlugins/babel-plugin-redwood-fragment-registration.ts
+++ b/packages/internal/src/build/babelPlugins/babel-plugin-redwood-fragment-registration.ts
@@ -1,0 +1,108 @@
+import type { PluginObj, types } from '@babel/core'
+
+export default function ({ types: t }: { types: typeof types }): PluginObj {
+  let nodesToRemove: any[] = []
+  let nodesToPrepend: any[] = []
+  let nodesToAppend: any[] = []
+
+  const pascalCaseName = (value: string) => {
+    return value.replace(/(?:^|-)([a-z])/g, (_, letter) => letter.toUpperCase())
+  }
+
+  return {
+    name: 'babel-plugin-redwood-fragment-registration',
+    visitor: {
+      Program: {
+        enter() {
+          nodesToRemove = []
+          nodesToPrepend = []
+          nodesToAppend = []
+
+          const importDeclaration = t.importDeclaration(
+            [
+              t.importSpecifier(
+                t.identifier('fragmentRegistry'),
+                t.identifier('fragmentRegistry')
+              ),
+            ],
+            t.stringLiteral('@redwoodjs/web/apollo')
+          )
+
+          nodesToPrepend.push(importDeclaration)
+        },
+        exit(path) {
+          for (const n of nodesToRemove) {
+            n.remove()
+          }
+
+          // Insert at the top of the file
+          path.node.body.unshift(...nodesToAppend)
+          path.node.body.unshift(...nodesToPrepend)
+        },
+      },
+      AssignmentExpression(path) {
+        let fragmentName: string
+        nodesToRemove.push(path)
+        const { left, right } = path.node
+
+        if (right.type === 'ObjectExpression') {
+          if (left.type === 'MemberExpression') {
+            if (left.object.type === 'Identifier') {
+              fragmentName = left.object.name
+            }
+          }
+          if (right.properties) {
+            const fragmentAsts = right.properties.map((prop) => {
+              if (prop.type === 'ObjectProperty') {
+                if (prop.value.type === 'TaggedTemplateExpression') {
+                  return {
+                    fragmentName,
+                    fragmentPrefix:
+                      prop.key.type === 'Identifier'
+                        ? pascalCaseName(prop.key.name)
+                        : '',
+                    uid: path.scope.generateUidIdentifier('Fragment').name,
+                    fragmentTaggedTemplate: prop.value,
+                  }
+                }
+              }
+              return
+            })
+
+            if (fragmentAsts) {
+              fragmentAsts.forEach((fragmentAst) => {
+                const fragmentIdentifier = `${fragmentAst?.['fragmentName']}${fragmentAst?.['uid']}_${fragmentAst?.['fragmentPrefix']}`
+
+                const fragment = t.exportNamedDeclaration(
+                  t.variableDeclaration('const', [
+                    t.variableDeclarator(
+                      t.identifier(fragmentIdentifier),
+                      fragmentAst?.['fragmentTaggedTemplate']
+                    ),
+                  ])
+                )
+
+                nodesToAppend.push(fragment)
+
+                // Generate the AST
+                const fragmentRegisterCallExpression = t.callExpression(
+                  t.memberExpression(
+                    t.identifier('fragmentRegistry'),
+                    t.identifier('register')
+                  ),
+                  [t.identifier(fragmentIdentifier)]
+                )
+
+                const fragmentRegisterStatement = t.expressionStatement(
+                  fragmentRegisterCallExpression
+                )
+
+                nodesToAppend.push(fragmentRegisterStatement)
+              })
+            }
+          }
+        }
+      },
+    },
+  }
+}

--- a/packages/web/src/apollo/fragmentRegistry.ts
+++ b/packages/web/src/apollo/fragmentRegistry.ts
@@ -1,0 +1,4 @@
+import { createFragmentRegistry } from '@apollo/client/cache'
+
+// Register named fragments using createFragmentRegistry
+export const fragmentRegistry = createFragmentRegistry()

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -31,6 +31,7 @@ import {
 } from '../components/FetchConfigProvider'
 import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider'
 
+import { fragmentRegistry } from './fragmentRegistry'
 import { SSELink } from './sseLink'
 
 export type ApolloClientCacheConfig = apolloClient.InMemoryCacheConfig
@@ -284,11 +285,13 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
 }
 
 export const RedwoodApolloProvider: React.FunctionComponent<{
+  fragments?: apolloClient.DocumentNode[]
   graphQLClientConfig?: GraphQLClientConfigProp
   useAuth?: UseAuth
   logLevel?: ReturnType<typeof setLogVerbosity>
   children: React.ReactNode
 }> = ({
+  fragments,
   graphQLClientConfig,
   useAuth = useNoAuth,
   logLevel = 'debug',
@@ -298,9 +301,15 @@ export const RedwoodApolloProvider: React.FunctionComponent<{
   // we have to instantiate `InMemoryCache` here, so that it doesn't get wiped.
   const { cacheConfig, ...config } = graphQLClientConfig ?? {}
 
-  const cache = new InMemoryCache(cacheConfig).restore(
-    globalThis?.__REDWOOD__APOLLO_STATE ?? {}
-  )
+  // Auto register fragments
+  if (fragments) {
+    fragmentRegistry.register(...fragments)
+  }
+
+  const cache = new InMemoryCache({
+    fragments: fragmentRegistry,
+    ...cacheConfig,
+  }).restore(globalThis?.__REDWOOD__APOLLO_STATE ?? {})
 
   return (
     <FetchConfigProvider useAuth={useAuth}>


### PR DESCRIPTION
This PR adds support for fragment registration in Apollo Client manually and also via a babel transform that -- similar to how cells are transformed -- can transform code to auto register a fragment with its rendering component.

More info to come ..

EDIT

Due to babel config changes, and difficulty to merge, going to open a different PR and close this.