### PR TITLE
Streaming: meta charSet=utf-8

### DIFF
--- a/packages/cli/src/commands/experimental/templates/streamingSsr/Document.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/Document.tsx.template
@@ -13,6 +13,7 @@ export const Document: React.FC<DocumentProps> = ({ children, css, meta }) => {
   return (
     <html lang="en">
       <head>
+        <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <Css css={css} />


### PR DESCRIPTION
Without this html entities like `&times;` would render differently on the server vs the client and cause react rehydration errors