### PR TITLE
RSC: Work around an issue in Rollup

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -88,6 +88,7 @@
     "@types/yargs-parser": "21.0.0",
     "glob": "10.3.1",
     "jest": "29.6.4",
+    "rollup": "3.27.2",
     "typescript": "5.2.2"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -7,6 +7,7 @@ import type { Manifest as ViteBuildManifest } from 'vite'
 
 import type { RouteSpec } from '@redwoodjs/internal/dist/routes'
 
+import { onWarn } from './lib/onWarn'
 import { rscBuild } from './rscBuild'
 import type { RWRouteManifest } from './types'
 import { serverBuild } from './waku-lib/build-server'
@@ -45,6 +46,7 @@ export const buildRscFeServer = async ({
       // TODO (RSC) Enable this when we switch to a server-first approach
       // emptyOutDir: false, // Already done when building server
       rollupOptions: {
+        onwarn: onWarn,
         input: {
           main: webHtml,
           ...clientEntryFiles,

--- a/packages/vite/src/lib/onWarn.ts
+++ b/packages/vite/src/lib/onWarn.ts
@@ -1,0 +1,22 @@
+import type { LoggingFunction, RollupLog } from 'rollup'
+
+// Upstream issue: https://github.com/rollup/rollup/issues/4699
+export function onWarn(warning: RollupLog, defaultHandler: LoggingFunction) {
+  const fileName = warning.loc?.file
+
+  if (
+    warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+    /"use (client|server)"/.test(warning.message)
+  ) {
+    return
+  } else if (
+    warning.code === 'SOURCEMAP_ERROR' &&
+    (fileName?.endsWith('.tsx') || fileName?.endsWith('.ts')) &&
+    warning.loc?.column === 0 &&
+    warning.loc?.line === 1
+  ) {
+    return
+  }
+
+  defaultHandler(warning)
+}

--- a/packages/vite/src/rscBuild.ts
+++ b/packages/vite/src/rscBuild.ts
@@ -3,6 +3,7 @@ import { build as viteBuild } from 'vite'
 
 import { getPaths } from '@redwoodjs/project-config'
 
+import { onWarn } from './lib/onWarn'
 import { rscAnalyzePlugin } from './waku-lib/vite-plugin-rsc'
 
 /**
@@ -51,6 +52,7 @@ export async function rscBuild(viteConfigPath: string) {
       write: false,
       ssr: true,
       rollupOptions: {
+        onwarn: onWarn,
         input: {
           entries: rwPaths.web.entries,
         },

--- a/packages/vite/src/waku-lib/build-server.ts
+++ b/packages/vite/src/waku-lib/build-server.ts
@@ -4,6 +4,8 @@ import { build as viteBuild } from 'vite'
 
 import { getPaths } from '@redwoodjs/project-config'
 
+import { onWarn } from '../lib/onWarn'
+
 export async function serverBuild(
   entriesFile: string,
   clientEntryFiles: Record<string, string>,
@@ -60,6 +62,7 @@ export async function serverBuild(
       outDir: rwPaths.web.distServer,
       manifest: 'server-build-manifest.json',
       rollupOptions: {
+        onwarn: onWarn,
         input,
         output: {
           banner: (chunk) => {

--- a/packages/vite/src/waku-lib/builder.ts
+++ b/packages/vite/src/waku-lib/builder.ts
@@ -6,6 +6,8 @@ import path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { build as viteBuild } from 'vite'
 
+import { onWarn } from '../lib/onWarn'
+
 import { configFileConfig, resolveConfig } from './config'
 import {
   shutdown,
@@ -57,6 +59,7 @@ export async function build() {
       write: false,
       ssr: true,
       rollupOptions: {
+        onwarn: onWarn,
         input: {
           entries: entriesFile,
           ...customModules,
@@ -85,6 +88,7 @@ export async function build() {
     build: {
       ssr: true,
       rollupOptions: {
+        onwarn: onWarn,
         input: {
           entries: entriesFile,
           ...clientEntryFiles,
@@ -123,6 +127,7 @@ export async function build() {
     build: {
       outDir: path.join(config.build.outDir, config.framework.outPublic),
       rollupOptions: {
+        onwarn: onWarn,
         input: {
           main: indexHtmlFile,
           ...clientEntryFiles,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9159,6 +9159,7 @@ __metadata:
     jest: 29.6.4
     react: 18.3.0-canary-035a41c4e-20230704
     react-server-dom-webpack: 18.3.0-canary-035a41c4e-20230704
+    rollup: 3.27.2
     typescript: 5.2.2
     vite: 4.4.9
     yargs-parser: 21.1.1
@@ -31237,7 +31238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^3.27.1":
+"rollup@npm:3.27.2, rollup@npm:^3.27.1":
   version: 3.27.2
   resolution: "rollup@npm:3.27.2"
   dependencies:


### PR DESCRIPTION
Rollup would print warnings about "use client" and then also about not being able to use source maps to show the location of that error. 

This is a known issue with Rollup: https://github.com/rollup/rollup/issues/4699
The recommended way to handle the functionality is with the "banner" Rollup plugin, which we already did. The also recommend just filtering out the warning, which is what this PR does