### PR TITLE
fix(cli): Prevent stale command cache defaults

### DIFF
--- a/packages/cli/src/plugin.js
+++ b/packages/cli/src/plugin.js
@@ -94,7 +94,10 @@ export async function loadPlugins(yargs) {
       valid &&= !Array.isArray(value)
     }
     if (valid) {
-      pluginCommandCache = localCommandCache
+      pluginCommandCache = {
+        ...localCommandCache,
+        ...PLUGIN_CACHE_DEFAULT,
+      }
     }
   } catch (error) {
     // If the cache file doesn't exist we can just ignore it and continue


### PR DESCRIPTION
**Problem**
#9150 highlights that there was a mistake in the cache loading logic.

**Changes**
1. We merge the current cache state with the defaults - this will ensure that the defaults which are hard coded cannot be missing when the user updates versions.

**Notes**
I'm updating some of this plugin loading logic so expect a little churn in this code. 