### PR TITLE
RSC: Support 'use client' in 3pp packages

### DIFF
--- a/packages/vite/src/waku-lib/builder.ts
+++ b/packages/vite/src/waku-lib/builder.ts
@@ -49,6 +49,7 @@ export async function build() {
       ),
     ],
     ssr: {
+      // TODO (RSC): Is this still relevant?
       // FIXME Without this, waku/router isn't considered to have client
       // entries, and "No client entry" error occurs.
       // Unless we fix this, RSC-capable packages aren't supported.

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -238,12 +238,15 @@ const resolveClientEntry = (
   filePath: string
 ) => {
   const clientEntry = absoluteClientEntries[filePath]
+
   if (!clientEntry) {
     if (absoluteClientEntries['*'] === '*') {
       return config.base + path.relative(config.root, filePath)
     }
+
     throw new Error('No client entry found for ' + filePath)
   }
+
   return clientEntry
 }
 


### PR DESCRIPTION
By configuring `noExternal` for the server side build correctly we now support using npm modules with client side only React components, i.e. components with `'use client'` at the top of the file.

Currently you have to patch vite for this to work. Still waiting for https://github.com/vitejs/vite/pull/13487 to be merged.