### PR TITLE
RSC: Patch vite when running setup command

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
+import execa from 'execa'
 import { Listr } from 'listr2'
 
 import { getConfig, getConfigPath } from '@redwoodjs/project-config'
@@ -181,6 +182,46 @@ export const handler = async ({ force, verbose }) => {
 
           writeFile(rwPaths.web.entryClient, entryClientTemplate, {
             overwriteExisting: true,
+          })
+        },
+      },
+      {
+        title: 'Patch vite',
+        task: async () => {
+          const vitePatchTemplate = fs.readFileSync(
+            path.resolve(
+              __dirname,
+              'templates',
+              'rsc',
+              'vite-npm-4.4.9-e845c1bbf8.patch.template'
+            ),
+            'utf-8'
+          )
+
+          const yarnPatchDir = path.join(rwPaths.base, '.yarn', 'patches')
+          const vitePatchPath = path.join(
+            yarnPatchDir,
+            'vite-npm-4.4.9-e845c1bbf8.patch'
+          )
+          writeFile(vitePatchPath, vitePatchTemplate, {
+            overwriteExisting: force,
+          })
+
+          const packageJsonPath = path.join(rwPaths.base, 'package.json')
+          const packageJson = JSON.parse(
+            fs.readFileSync(packageJsonPath, 'utf-8')
+          )
+          packageJson.resolutions = packageJson.resolutions || {}
+          packageJson.resolutions['vite@4.4.9'] =
+            'patch:vite@npm%3A4.4.9#./.yarn/patches/vite-npm-4.4.9-e845c1bbf8.patch'
+          writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), {
+            overwriteExisting: true,
+          })
+
+          await execa('yarn install', {
+            stdio: 'ignore',
+            shell: true,
+            cwd: rwPaths.base,
           })
         },
       },

--- a/packages/cli/src/commands/experimental/templates/rsc/vite-npm-4.4.9-e845c1bbf8.patch.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/vite-npm-4.4.9-e845c1bbf8.patch.template
@@ -1,0 +1,19 @@
+diff --git a/dist/node/chunks/dep-df561101.js b/dist/node/chunks/dep-df561101.js
+index 1bc8674177fe73120171b22436e6104713c5d764..f0fee7b385868cb01c6d47b80d7f64a7368c0412 100644
+--- a/dist/node/chunks/dep-df561101.js
++++ b/dist/node/chunks/dep-df561101.js
+@@ -55890,12 +55890,12 @@ async function instantiateModule(url, server, context = { global }, urlStack = [
+     };
+     urlStack = urlStack.concat(url);
+     const isCircular = (url) => urlStack.includes(url);
+-    const { isProduction, resolve: { dedupe, preserveSymlinks }, root, } = server.config;
++    const { isProduction, resolve: { dedupe, preserveSymlinks, conditions }, root, } = server.config;
+     const resolveOptions = {
+         mainFields: ['main'],
+         browserField: true,
+         conditions: [],
+-        overrideConditions: ['production', 'development'],
++        overrideConditions: [...conditions, 'production', 'development'],
+         extensions: ['.js', '.cjs', '.json'],
+         dedupe,
+         preserveSymlinks,


### PR DESCRIPTION
This is needed until https://github.com/vitejs/vite/pull/13487 is merged and released and RW uses that new version of Vite