### PR TITLE
smoke-tests: Fix red squiggles (type import, * as)

### DIFF
--- a/tasks/smoke-tests/auth/tests/rbacChecks.spec.ts
+++ b/tasks/smoke-tests/auth/tests/rbacChecks.spec.ts
@@ -1,9 +1,9 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 
 import { test, expect } from '@playwright/test'
 import type { PlaywrightTestArgs, Page } from '@playwright/test'
-import execa from 'execa'
+import * as execa from 'execa'
 
 import { loginAsTestUser, signUpTestUser } from '../../common'
 

--- a/tasks/smoke-tests/auth/tests/rbacChecks.spec.ts
+++ b/tasks/smoke-tests/auth/tests/rbacChecks.spec.ts
@@ -3,7 +3,8 @@ import * as path from 'node:path'
 
 import { test, expect } from '@playwright/test'
 import type { PlaywrightTestArgs, Page } from '@playwright/test'
-import * as execa from 'execa'
+// @ts-expect-error - With `* as` you have to use .default() when calling execa
+import execa from 'execa'
 
 import { loginAsTestUser, signUpTestUser } from '../../common'
 

--- a/tasks/smoke-tests/common.ts
+++ b/tasks/smoke-tests/common.ts
@@ -1,4 +1,5 @@
-import { expect, PlaywrightTestArgs } from '@playwright/test'
+import { expect } from '@playwright/test'
+import type { PlaywrightTestArgs } from '@playwright/test'
 
 export async function smokeTest({ page }: PlaywrightTestArgs) {
   await page.goto('/')

--- a/tasks/smoke-tests/prerender/tests/prerender.spec.ts
+++ b/tasks/smoke-tests/prerender/tests/prerender.spec.ts
@@ -7,7 +7,8 @@ import type {
   PlaywrightTestArgs,
   PlaywrightWorkerArgs,
 } from '@playwright/test'
-import * as execa from 'execa'
+// @ts-expect-error - With `* as` you have to use .default() when calling execa
+import execa from 'execa'
 
 let noJsBrowser: BrowserContext
 

--- a/tasks/smoke-tests/prerender/tests/prerender.spec.ts
+++ b/tasks/smoke-tests/prerender/tests/prerender.spec.ts
@@ -1,14 +1,13 @@
-import fs from 'fs'
-import path from 'path'
+import * as fs from 'fs'
+import * as path from 'path'
 
-import {
-  test,
+import { test, expect } from '@playwright/test'
+import type {
   BrowserContext,
-  expect,
   PlaywrightTestArgs,
   PlaywrightWorkerArgs,
 } from '@playwright/test'
-import execa from 'execa'
+import * as execa from 'execa'
 
 let noJsBrowser: BrowserContext
 

--- a/tasks/smoke-tests/storybook/tests/storybook.spec.ts
+++ b/tasks/smoke-tests/storybook/tests/storybook.spec.ts
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import path from 'path'
+import * as fs from 'fs'
+import * as path from 'path'
 
 import { test, expect } from '@playwright/test'
 import type { PlaywrightTestArgs } from '@playwright/test'


### PR DESCRIPTION
Fixes errors like this:
![image](https://github.com/redwoodjs/redwood/assets/30793/2d1a36d3-b287-4a38-9a6c-1b4f36a5ad12)

And this:
![image](https://github.com/redwoodjs/redwood/assets/30793/bd749f8e-8080-41a4-97ef-650f07e91f19)
