### PR TITLE
RSC: Use react/experimental types

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -4,6 +4,7 @@ import path from 'path'
 import execa from 'execa'
 import { Listr } from 'listr2'
 
+import { prettify } from '@redwoodjs/cli-helpers'
 import { getConfig, getConfigPath } from '@redwoodjs/project-config'
 import { errorTelemetry } from '@redwoodjs/telemetry'
 
@@ -183,6 +184,27 @@ export const handler = async ({ force, verbose }) => {
           writeFile(rwPaths.web.entryClient, entryClientTemplate, {
             overwriteExisting: true,
           })
+        },
+      },
+      {
+        title: 'Add React experimental types',
+        task: async () => {
+          const tsconfigPath = path.join(rwPaths.web.base, 'tsconfig.json')
+          const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, 'utf-8'))
+
+          if (tsconfig.compilerOptions.types.includes('react/experimental')) {
+            return
+          }
+
+          tsconfig.compilerOptions.types.push('react/experimental')
+
+          writeFile(
+            tsconfigPath,
+            prettify('tsconfig.json', JSON.stringify(tsconfig, null, 2)),
+            {
+              overwriteExisting: true,
+            }
+          )
         },
       },
       {

--- a/packages/vite/ambient.d.ts
+++ b/packages/vite/ambient.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/// <reference types="react/canary" />
+/// <reference types="react/experimental" />
 import type { HelmetServerState } from 'react-helmet-async'
 
 declare global {

--- a/packages/vite/src/fully-react/assets.tsx
+++ b/packages/vite/src/fully-react/assets.tsx
@@ -52,7 +52,6 @@ export function Assets() {
   // Do we also need special code for SSR?
   // if (isClient) return <ClientAssets />
 
-  // @ts-expect-error Need experimental types here for this to work
   return <ServerAssets />
 }
 


### PR DESCRIPTION
Using these types both for RW the framework and RW apps https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/experimental.d.ts

This gives us proper types for `<form action...` in RW apps