### PR TITLE
RSC: Check if index.html has already been updated during setup

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -158,6 +158,16 @@ export const handler = async ({ force, verbose }) => {
         title: 'Updating index.html...',
         task: async () => {
           let indexHtml = fs.readFileSync(rwPaths.web.html, 'utf-8')
+
+          if (
+            /\n\s*<script type="module" src="entry.client.tsx"><\/script>/.test(
+              indexHtml
+            )
+          ) {
+            // index.html is already updated
+            return
+          }
+
           indexHtml = indexHtml.replace(
             'href="/favicon.png" />',
             'href="/favicon.png" />\n  <script type="module" src="entry.client.tsx"></script>'


### PR DESCRIPTION
With this check in place it's now safe to run the setup command multiple times, which is great when testing it.