### PR TITLE
fix(cli): run dedupe after installing a redwood plugin

### DIFF
--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -66,6 +66,10 @@ export async function installRedwoodModule(module) {
       stdio: 'inherit',
       cwd: getPaths().base,
     })
+    await execa.command(`yarn dedupe`, {
+      stdio: 'inherit',
+      cwd: getPaths().base,
+    })
     return true
   }
   return false


### PR DESCRIPTION
May fix https://github.com/redwoodjs/redwood/issues/9198.