### PR TITLE
fix: ensure yarn.lock is rebuilt from scratch

### DIFF
--- a/tasks/release/releaseCommand.mjs
+++ b/tasks/release/releaseCommand.mjs
@@ -731,6 +731,7 @@ async function updateCreateRedwoodAppTemplates() {
   console.log()
 
   cd('./packages/create-redwood-app/templates/ts')
+  await $`rm -f yarn.lock`
   await $`touch yarn.lock`
   await $`yarn install`
 


### PR DESCRIPTION
when releasing a patch, we start from the last tag which has a `yarn.lock` file in git history. we need to make sure we remove it otherwise we're building off the last `yarn.lock` for the next patch, which may include unnecessary dependencies. running dedupe would also work, but this is more in line with what we originally wanted.