### PR TITLE
Fix infinite loops on nested private routes with roles

### DIFF
--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -18,35 +18,34 @@ jest.mock('../util', () => {
   }
 })
 
-import React, { Children, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
+import '@testing-library/jest-dom/extend-expect'
 import {
+  act,
+  configure,
+  fireEvent,
   render,
   waitFor,
-  act,
-  fireEvent,
-  configure,
-  cleanup,
 } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 
 import type { AuthContextInterface } from '@redwoodjs/auth'
 
 import {
-  Router,
-  Route,
-  Private,
-  Redirect,
+  back,
   routes as generatedRoutes,
   Link,
   navigate,
-  back,
+  Private,
+  Redirect,
+  Route,
+  Router,
   usePageLoadingContext,
 } from '../'
 import { useLocation } from '../location'
 import { useParams } from '../params'
 import { Set } from '../Set'
-import type { Spec, GeneratedRoutesMap } from '../util'
+import type { GeneratedRoutesMap, Spec } from '../util'
 
 /** running into intermittent test timeout behavior in https://github.com/redwoodjs/redwood/pull/4992
  attempting to work around by bumping the default timeout of 5000 */

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1649,11 +1649,6 @@ describe('Multiple nested private sets', () => {
     </Router>
   )
 
-  // We need to test if the user is unauthenticated they should be sent to`/home`
-  // if the specified roles are not assigned to the user they are
-  // sent to noRolesAssigned Page if the user is authenticated and has role
-  // EMPLOYEE they should be sent to `/employee` if the user is authenticated
-  // and has role ADMIN they should be sent to `/admin`
   test('is authenticated but does not have matching roles', async () => {
     const screen = render(
       <TestRouter
@@ -1760,11 +1755,6 @@ describe('Multiple nested private sets', () => {
     </Router>
   )
 
-  // We need to test if the user is unauthenticated they should be sent to`/home`
-  // if the specified roles are not assigned to the user they are
-  // sent to noRolesAssigned Page if the user is authenticated and has role
-  // EMPLOYEE they should be sent to `/employee` if the user is authenticated
-  // and has role ADMIN they should be sent to `/admin`
   test('level 1, matches expected props', async () => {
     const screen = render(<TestRouter />)
 

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -188,7 +188,6 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
                   spec={normalizePage(page as any)}
                   params={allParams}
                   whileLoadingPage={whileLoadingPage as any}
-                  {...setProps}
                 />
               }
               setProps={setProps}
@@ -203,7 +202,7 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
 interface WrappedPageProps {
   wrappers: Wrappers
   routeLoaderElement: ReactNode
-  setProps: Record<any, any>
+  setProps: Record<any, any>[]
 }
 
 /**
@@ -220,27 +219,49 @@ const WrappedPage = memo(
   ({ wrappers, routeLoaderElement, setProps }: WrappedPageProps) => {
     // @NOTE: don't mutate the wrappers array, it causes full page re-renders
     // Instead just create a new array with the AuthenticatedRoute wrapper
-    let wrappersWithAuthMaybe = wrappers
-    if (setProps.private) {
-      if (!setProps.unauthenticated) {
-        throw new Error(
-          'You must specify an `unauthenticated` route when marking a Route as private'
-        )
-      }
 
-      wrappersWithAuthMaybe = [AuthenticatedRoute, ...wrappers]
-    }
+    // we need to pass the setProps from each set to each wrapper
+    let wrappersWithAuthMaybe = wrappers
+    const reveresedSetProps = [...setProps].reverse()
+
+    reveresedSetProps
+      // @MARK note the reverse() here, because we spread wrappersWithAuthMaybe
+      .forEach((propsFromSet) => {
+        if (propsFromSet.private) {
+          if (!propsFromSet.unauthenticated) {
+            throw new Error(
+              'You must specify an `unauthenticated` route when marking a Route as private'
+            )
+          }
+
+          // @MARK: this component intentionally removes all props except children
+          // because the .reduce below will apply props inside out
+          const AuthComponent: React.FC<{ children: ReactNode }> = ({
+            children,
+          }) => {
+            return (
+              <AuthenticatedRoute {...propsFromSet}>
+                {children}
+              </AuthenticatedRoute>
+            )
+          }
+
+          wrappersWithAuthMaybe = [AuthComponent, ...wrappersWithAuthMaybe]
+        }
+      })
 
     if (wrappersWithAuthMaybe.length > 0) {
       // If wrappers exist e.g. [a,b,c] -> <a><b><c><routeLoader></c></b></a> and returns a single ReactNode
       // Wrap AuthenticatedRoute this way, because if we mutate the wrappers array itself
       // it causes full rerenders of the page
       return wrappersWithAuthMaybe.reduceRight((acc, wrapper) => {
+        const outputProps = setProps.reduce((acc, props, i) => {
+          return { ...acc, ...props }
+        }, {})
+
         return React.createElement(
           wrapper as any,
-          {
-            ...setProps,
-          },
+          outputProps,
           acc ? acc : routeLoaderElement
         )
       }, undefined as ReactNode)

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -255,13 +255,14 @@ const WrappedPage = memo(
       // Wrap AuthenticatedRoute this way, because if we mutate the wrappers array itself
       // it causes full rerenders of the page
       return wrappersWithAuthMaybe.reduceRight((acc, wrapper) => {
-        const outputProps = setProps.reduce((acc, props, i) => {
+        // Merge props from set, the lowest set props will override the higher ones
+        const mergedSetProps = setProps.reduce((acc, props) => {
           return { ...acc, ...props }
         }, {})
 
         return React.createElement(
           wrapper as any,
-          outputProps,
+          mergedSetProps,
           acc ? acc : routeLoaderElement
         )
       }, undefined as ReactNode)


### PR DESCRIPTION
Fix for #9131

This handles use cases where there are multiple nested routes with different levels of authentication and redirect contexts