### PR TITLE
chore(crwa): remove React `prop-types` package

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -16,7 +16,6 @@
     "@redwoodjs/router": "6.0.7",
     "@redwoodjs/web": "6.0.7",
     "humanize-string": "2.1.0",
-    "prop-types": "15.8.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },

--- a/babel.config.js
+++ b/babel.config.js
@@ -133,11 +133,6 @@ module.exports = {
                 default: 'React',
                 path: 'react',
               },
-              {
-                // import { PropTypes } from 'prop-types'
-                default: 'PropTypes',
-                path: 'prop-types',
-              },
             ],
           },
         ],

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -62,11 +62,6 @@ export const getWebSideBabelPlugins = (
             path: 'react',
           },
           {
-            // import PropTypes from 'prop-types'
-            default: 'PropTypes',
-            path: 'prop-types',
-          },
-          {
             // import gql from 'graphql-tag'
             default: 'gql',
             path: 'graphql-tag',

--- a/packages/core/config/webpack.common.js
+++ b/packages/core/config/webpack.common.js
@@ -171,7 +171,6 @@ const getSharedPlugins = (isEnvProduction) => {
       new ReactRefreshWebpackPlugin({ overlay: false }),
     new webpack.ProvidePlugin({
       React: 'react',
-      PropTypes: 'prop-types',
       gql: 'graphql-tag',
       ...devTimeAutoImports,
     }),

--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -14,7 +14,6 @@
     "@redwoodjs/forms": "6.0.7",
     "@redwoodjs/router": "6.0.7",
     "@redwoodjs/web": "6.0.7",
-    "prop-types": "15.8.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -14,7 +14,6 @@
     "@redwoodjs/forms": "6.0.7",
     "@redwoodjs/router": "6.0.7",
     "@redwoodjs/web": "6.0.7",
-    "prop-types": "15.8.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },

--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -64,13 +64,7 @@ module.exports = {
       { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
     ],
     // React rules
-    'react/prop-types': [
-      'warn',
-      {
-        skipUndeclared: true,
-        ignore: ['style', 'children', 'className', 'theme'],
-      },
-    ],
+    'react/prop-types': 'off',
     'react/display-name': 'off',
     'react-hooks/exhaustive-deps': 'warn',
     'import/order': [

--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -63,14 +63,6 @@ module.exports = {
       'error',
       { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
     ],
-    // React rules
-    'react/prop-types': [
-      'warn',
-      {
-        skipUndeclared: true,
-        ignore: ['style', 'children', 'className', 'theme'],
-      },
-    ],
     'react/display-name': 'off',
     'react-hooks/exhaustive-deps': 'warn',
     'import/order': [

--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -63,6 +63,14 @@ module.exports = {
       'error',
       { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
     ],
+    // React rules
+    'react/prop-types': [
+      'warn',
+      {
+        skipUndeclared: true,
+        ignore: ['style', 'children', 'className', 'theme'],
+      },
+    ],
     'react/display-name': 'off',
     'react-hooks/exhaustive-deps': 'warn',
     'import/order': [

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -53,20 +53,17 @@
     "@babel/core": "^7.22.20",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
-    "@types/prop-types": "15.7.5",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",
     "@types/testing-library__jest-dom": "5.14.8",
     "jest": "29.7.0",
     "jest-runner-tsd": "5.0.0",
     "nodemon": "2.0.22",
-    "prop-types": "15.8.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913",
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "prop-types": "15.8.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },

--- a/packages/web/src/global.web-auto-imports.ts
+++ b/packages/web/src/global.web-auto-imports.ts
@@ -1,13 +1,11 @@
 import type _React from 'react'
 
 import type _gql from 'graphql-tag'
-import type _PropTypes from 'prop-types'
 
 // These are the global types exposed to a user's project
 // For "internal" global types see ambient.d.ts
 
 declare global {
-  const PropTypes: typeof _PropTypes
   const gql: typeof _gql
 
   // Having this as a type instead of a const allows us to augment/override it

--- a/yarn.lock
+++ b/yarn.lock
@@ -9213,7 +9213,6 @@ __metadata:
     "@redwoodjs/auth": 6.0.7
     "@testing-library/jest-dom": 5.16.5
     "@testing-library/react": 14.0.0
-    "@types/prop-types": 15.7.5
     "@types/react": 18.2.14
     "@types/react-dom": 18.2.6
     "@types/testing-library__jest-dom": 5.14.8
@@ -9224,7 +9223,6 @@ __metadata:
     jest: 29.7.0
     jest-runner-tsd: 5.0.0
     nodemon: 2.0.22
-    prop-types: 15.8.1
     react: 0.0.0-experimental-e5205658f-20230913
     react-dom: 0.0.0-experimental-e5205658f-20230913
     react-helmet-async: 1.3.0
@@ -9233,7 +9231,6 @@ __metadata:
     ts-toolbelt: 9.6.0
     typescript: 5.2.2
   peerDependencies:
-    prop-types: 15.8.1
     react: 0.0.0-experimental-e5205658f-20230913
     react-dom: 0.0.0-experimental-e5205658f-20230913
   bin:
@@ -12021,7 +12018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*, @types/prop-types@npm:15.7.5, @types/prop-types@npm:^15.7.2":
+"@types/prop-types@npm:*, @types/prop-types@npm:^15.7.2":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
   checksum: 648aae41423821c61c83823ae36116c8d0f68258f8b609bdbc257752dcd616438d6343d554262aa9a7edaee5a19aca2e028a74fa2d0f40fffaf2816bc7056857
@@ -29507,7 +29504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:*, prop-types@npm:15.8.1, prop-types@npm:15.x, prop-types@npm:^15.5.4, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:*, prop-types@npm:15.x, prop-types@npm:^15.5.4, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:


### PR DESCRIPTION
TypeScript has long been well established; React prop-types is a vestigial feature. The package hasn't been updated in ~2 years (https://www.npmjs.com/package/prop-types) and the legacy React docs recommend moving off it: https://legacy.reactjs.org/docs/typechecking-with-proptypes.html.

<img width="913" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/acfe01fc-6248-4fc6-a47d-3340b417a637">

There are a few things about this PR that are technically breaking. `prop-types` isn't a huge package so I don't think it's important this goes into the next minor or anything; it can just be scheduled for the next major.