### PR TITLE
RSC: Handle Windows paths in clientEntries

### DIFF
--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -102,8 +102,15 @@ export const buildRscFeServer = async ({
           'moduleIds' in item &&
           item.moduleIds.includes(clientEntryFiles[name] as string)
       )?.fileName
+
     if (entryFile) {
-      clientEntries[entryFile] = fileName
+      if (process.platform === 'win32') {
+        // Prevent errors on Windows like
+        // Error: No client entry found for D:/a/redwood/rsc-project/web/dist/server/assets/rsc0.js
+        clientEntries[entryFile.replaceAll('\\', '/')] = fileName
+      } else {
+        clientEntries[entryFile] = fileName
+      }
     }
   }
 

--- a/packages/vite/src/buildRscFeServer.ts
+++ b/packages/vite/src/buildRscFeServer.ts
@@ -104,10 +104,13 @@ export const buildRscFeServer = async ({
       )?.fileName
 
     if (entryFile) {
+      console.log('entryFile', entryFile)
       if (process.platform === 'win32') {
+        const entryFileSlash = entryFile.replaceAll('\\', '/')
+        console.log('entryFileSlash', entryFileSlash)
         // Prevent errors on Windows like
         // Error: No client entry found for D:/a/redwood/rsc-project/web/dist/server/assets/rsc0.js
-        clientEntries[entryFile.replaceAll('\\', '/')] = fileName
+        clientEntries[entryFileSlash] = fileName
       } else {
         clientEntries[entryFile] = fileName
       }

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -259,7 +259,7 @@ export async function setClientEntries(
   }
   const config = await configPromise
   const entriesFile = await getEntriesFile(config, false)
-  console.log('entriesFile', entriesFile)
+  console.log('setClientEntries :: entriesFile', entriesFile)
   const { clientEntries } = await loadServerFile(entriesFile)
   console.log('setClientEntries :: clientEntries', clientEntries)
   if (!clientEntries) {
@@ -273,7 +273,10 @@ export async function setClientEntries(
     ])
   )
 
-  console.log('absoluteClientEntries', absoluteClientEntries)
+  console.log(
+    'setClientEntries :: absoluteClientEntries',
+    absoluteClientEntries
+  )
 }
 
 export async function renderRSC(input: RenderInput): Promise<PipeableStream> {

--- a/packages/vite/src/waku-lib/rsc-handler-worker.ts
+++ b/packages/vite/src/waku-lib/rsc-handler-worker.ts
@@ -261,6 +261,7 @@ export async function setClientEntries(
   const entriesFile = await getEntriesFile(config, false)
   console.log('entriesFile', entriesFile)
   const { clientEntries } = await loadServerFile(entriesFile)
+  console.log('setClientEntries :: clientEntries', clientEntries)
   if (!clientEntries) {
     throw new Error('Failed to load clientEntries')
   }


### PR DESCRIPTION
I saw this when running the RSC smoke tests on Windows
![image](https://github.com/redwoodjs/redwood/assets/30793/9f7ba9fa-b37e-45a0-8399-44e123e6a1d6)
![image](https://github.com/redwoodjs/redwood/assets/30793/0387f428-b3fa-48dd-907c-7749ef27392b)

It's using double backslashes in the keys for `absoluteClientEntries`, but forward slashes later when trying to look up values in that map. And that's not going to work 🙂 