### PR TITLE
graphql possibleTypes: Fix formatting

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@redwoodjs/vite": "6.0.7",
-    "autoprefixer": "^10.4.15",
-    "postcss": "^8.4.30",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
     "postcss-loader": "^7.3.3",
     "prettier-plugin-tailwindcss": "0.4.1",
     "tailwindcss": "^3.3.3"

--- a/packages/create-redwood-app/templates/js/web/src/graphql/possibleTypes.js
+++ b/packages/create-redwood-app/templates/js/web/src/graphql/possibleTypes.js
@@ -1,6 +1,5 @@
-
 const result = {
-  "possibleTypes": {}
+  possibleTypes: {},
 }
 
 export default result

--- a/packages/create-redwood-app/templates/ts/web/src/graphql/possibleTypes.ts
+++ b/packages/create-redwood-app/templates/ts/web/src/graphql/possibleTypes.ts
@@ -1,4 +1,3 @@
-
 export interface PossibleTypesResultData {
   possibleTypes: {
     [key: string]: string[]
@@ -6,7 +5,7 @@ export interface PossibleTypesResultData {
 }
 
 const result: PossibleTypesResultData = {
-  "possibleTypes": {}
+  possibleTypes: {},
 }
 
-export default result;
+export default result


### PR DESCRIPTION
Fixing GitHub "check annotations" warnings like these

<img width="697" alt="image" src="https://github.com/redwoodjs/redwood/assets/30793/64cec9bf-8503-46d6-9c50-bdeb9fda9f08">
