### PR TITLE
docs: add missing `await` in service validation example

### DIFF
--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -60,7 +60,7 @@ export const createUser = async ({ input }) => {
       throw 'Only Admins can create new Managers'
     }
   })
-  validateWith(async () => {
+  await validateWith(async () => {
     const inviteCount = await db.invites.count({ where: { userId: currentUser.id  } })
     if (inviteCount >= 10) {
       throw 'You have already invited your max of 10 users'

--- a/docs/versioned_docs/version-5.x/services.md
+++ b/docs/versioned_docs/version-5.x/services.md
@@ -638,12 +638,12 @@ Either of these errors will be caught and re-thrown as a `ServiceValidationError
 
 You could just write your own function and throw whatever you like, without using `validateWith()`. But, when accessing your Service function through GraphQL, that error would be swallowed and the user would simply see "Something went wrong" for security reasons: error messages could reveal source code or other sensitive information so most are hidden. Errors thrown by Service Validations are considered "safe" and allowed to be shown to the client.
 
-### validateWithSync()
+### validateWith()
 
-The same behavior as `validateWithSync()` but works with Promises.
+The same behavior as `validateWith()` but works with Promises. Remember to `await` the validation.
 
 ```jsx
-validateWithSync(async () => {
+await validateWith(async () => {
   if (await db.products.count() >= 100) {
     throw "There can only be a maximum of 100 products in your store"
   }

--- a/docs/versioned_docs/version-5.x/services.md
+++ b/docs/versioned_docs/version-5.x/services.md
@@ -60,7 +60,7 @@ export const createUser = async ({ input }) => {
       throw 'Only Admins can create new Managers'
     }
   })
-  validateWith(async () => {
+  await validateWith(async () => {
     const inviteCount = await db.invites.count({ where: { userId: currentUser.id  } })
     if (inviteCount >= 10) {
       throw 'You have already invited your max of 10 users'

--- a/docs/versioned_docs/version-5.x/services.md
+++ b/docs/versioned_docs/version-5.x/services.md
@@ -640,7 +640,7 @@ You could just write your own function and throw whatever you like, without usin
 
 ### validateWith()
 
-The same behavior as `validateWith()` but works with Promises. Remember to `await` the validation.
+The same behavior as `validateWithSync()` but works with Promises. Remember to `await` the validation.
 
 ```jsx
 await validateWith(async () => {

--- a/docs/versioned_docs/version-6.0/services.md
+++ b/docs/versioned_docs/version-6.0/services.md
@@ -60,7 +60,7 @@ export const createUser = async ({ input }) => {
       throw 'Only Admins can create new Managers'
     }
   })
-  validateWith(async () => {
+  await validateWith(async () => {
     const inviteCount = await db.invites.count({ where: { userId: currentUser.id  } })
     if (inviteCount >= 10) {
       throw 'You have already invited your max of 10 users'


### PR DESCRIPTION
I've just started looking into redwood and have not gotten to the point of actually using services but I would expect this needs to be awaited and the docs further down for `validateWith` (in the v6 version) says you should `await` it.

(I then also realised the v5 docs actually use `validateWithSync` so I've fixed that)