### PR TITLE
Include @types/react as devDep in projects

### DIFF
--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -18,6 +18,8 @@
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
+    "@types/react": "18.2.14",
+    "@types/react-dom": "18.2.6",
     "@redwoodjs/vite": "6.0.7"
   }
 }

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -18,6 +18,8 @@
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
+    "@types/react": "18.2.14",
+    "@types/react-dom": "18.2.6",
     "@redwoodjs/vite": "6.0.7"
   }
 }


### PR DESCRIPTION
Include `@types/react` and `@types/react-dom` as development dependencies in RW projects.

JS projects also benefit from having the correct type files, so I include it in the package.json for those projects too.