### PR TITLE
test-project: yarn resolution for @types/react

### DIFF
--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -20,5 +20,8 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@3.6.3"
+  "packageManager": "yarn@3.6.3",
+  "resolutions": {
+    "@types/react": "18.2.14"
+  }
 }


### PR DESCRIPTION
Our CI is currently failing with this error
![image](https://github.com/redwoodjs/redwood/assets/30793/589272d5-98fb-4ce2-9b5a-adec360c8342)
```
src/entry.client.tsx(13,34): error TS2345: Argument of type 'Element' is not assignable to parameter of type 'ReactNode'.
  Property 'children' is missing in type 'Element' but required in type 'ReactPortal'.
```

This is also affecting RW apps, not just our test-project
![image](https://github.com/redwoodjs/redwood/assets/30793/a56bb6e7-8cbf-421f-8c42-d43b71d9cdf1)

I've decided to only add the resolution to our test-project for now, to get CI passing. We should discuss in the team how we want to handle RW projects. We've historically been very careful about adding resolutions because they're difficult to get users to remove later once they're not needed anymore.

The issue is tracked upstream here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/66841