### PR TITLE
Add "Checked" label to gh-Actions how-to docs

### DIFF
--- a/docs/docs/how-to/test-in-github-actions.md
+++ b/docs/docs/how-to/test-in-github-actions.md
@@ -1,4 +1,5 @@
 # Testing Redwood in GitHub actions
+> ✅ Checked on  2023-10-03 with RedwoodJS v6.3.1
 
 A good testing strategy is important for any project. Redwood offers a few different types of tests that you can write to make your app more robust—to ship with confidence. In this guide we'll focus on how to run your Redwood tests in GitHub Actions, so you can test your app on every push or pull request.
 


### PR DESCRIPTION
I ran the how to instructions once again to make sure everything works and it's still up to date. 

I was able to accomplish the goal by following the how-to doc.

The added label can give users confidence about each section. 
@pantheredeye what do you think?

This may give folks an incentive to contribute and help keep the docs up to date.