### PR TITLE
fix (docs): use default markdown numbered list

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1133,7 +1133,7 @@ Now, we can extend the `test` file which Redwood generated. We're going to want 
 
 1. Import `waitFor` from the `@redwoodjs/testing/web` library.
 2. Add an import to `@testing-library/user-event` for its `default`.
-3.Provide an `onSubmit` prop to our "renders successfully" test.
+3. Provide an `onSubmit` prop to our "renders successfully" test.
 
 ```jsx title="NameForm.test.js"
 import { render, screen, waitFor } from '@redwoodjs/testing/web'

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1131,9 +1131,9 @@ export default NameForm
 
 Now, we can extend the `test` file which Redwood generated. We're going to want to:
 
-1) Import `waitFor` from the `@redwoodjs/testing/web` library.
-2) Add an import to `@testing-library/user-event` for its `default`.
-3) Provide an `onSubmit` prop to our "renders successfully" test.
+1. Import `waitFor` from the `@redwoodjs/testing/web` library.
+2. Add an import to `@testing-library/user-event` for its `default`.
+3.Provide an `onSubmit` prop to our "renders successfully" test.
 
 ```jsx title="NameForm.test.js"
 import { render, screen, waitFor } from '@redwoodjs/testing/web'
@@ -1154,9 +1154,9 @@ describe('NameForm', () => {
 
 Finally, we'll create three simple tests which ensure our form works as expected.
 
-1) Does our component NOT submit when required fields are empty?
-2) Does our component submit when required fields are populated?
-3) Does our component submit, passing our (submit) handler the data we entered?
+1. Does our component NOT submit when required fields are empty?
+2. Does our component submit when required fields are populated?
+3. Does our component submit, passing our (submit) handler the data we entered?
 
 The important takeaways are:
 


### PR DESCRIPTION
Improves the readability of the numbered lists in the "Testing forms" section https://redwoodjs.com/docs/testing#testing-the-form 

Right now it's a paragraph, not an ordered list. This PR fixes #9264