### PR TITLE
fix(api-sever): stop infinite loop on large projects

### DIFF
--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -187,6 +187,13 @@ chokidar
     await validate()
   })
   .on('all', async (eventName, filePath) => {
+    // On sufficiently large projects (500+ files, or >= 2000 ms build times) on older machines, esbuild opening the api directory
+    // makes chokidar emit an `addDir` event. This starts an infinite loop where the api starts building itself as soon as its finished building.
+    // This could probably be fixed with build caching, or by digging into chokidar/esbuild.
+    if (eventName === 'addDir' && filePath === rwjsPaths.api.base) {
+      return
+    }
+
     // We validate here, so that developers will see the error
     // As they're running the dev server
     if (filePath.includes('.sdl')) {

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -187,9 +187,9 @@ chokidar
     await validate()
   })
   .on('all', async (eventName, filePath) => {
-    // On sufficiently large projects (500+ files, or >= 2000 ms build times) on older machines, esbuild opening the api directory
-    // makes chokidar emit an `addDir` event. This starts an infinite loop where the api starts building itself as soon as its finished building.
-    // This could probably be fixed with build caching, or by digging into chokidar/esbuild.
+    // On sufficiently large projects (500+ files, or >= 2000 ms build times) on older machines, esbuild writing to the api directory
+    // makes chokidar emit an `addDir` event. This starts an infinite loop where the api starts building itself as soon as it's finished.
+    // This could probably be fixed with some sort of build caching.
     if (eventName === 'addDir' && filePath === rwjsPaths.api.base) {
       return
     }


### PR DESCRIPTION
Fixes https://github.com/redwoodjs/redwood/issues/9237, using @shivghai's solution. At first I thought this solution was (borrowing his term) kludgy because we didn't know why it was happening. But after a few hours I was able to reproduce it on my machine in an app that wasn't his.

(I think) I was able to isolate the problem to the `transpileApi` step, which uses esbuild's `buildSync` method. This actually writes to disk, populating the `api/dist` directory. This must happen so slowly on his project that the "change" event from the original filesystem change becomes separate from the "addDir" event. (The more details I go into, the more I'm speculating, so I'll stop there for now.) All I can say is that at first we thought this problem was isolated tho Shiv's project and machine, and since I've disproven both, it's a bug.

I still think there are "better" solutions, but they require considerably more work. Like 1) diving into the chokidar codebase or esbuild codebase, 3) replacing chokidar with something else like `@parcel/watcher`, or 4) being smarter about building the api so that it's not completely rebuilt every time.