### PR TITLE
Router Set: deprecate private. Introduce isPrivate

### DIFF
--- a/packages/router/src/AuthenticatedRoute.tsx
+++ b/packages/router/src/AuthenticatedRoute.tsx
@@ -11,12 +11,14 @@ interface AuthenticatedRouteProps {
   unauthenticated?: keyof GeneratedRoutesMap
   whileLoadingAuth?: () => React.ReactElement | null
   private?: boolean
+  isPrivate?: boolean
 }
 export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = (
   props
 ) => {
   const {
-    private: isPrivate,
+    private: privateProp,
+    isPrivate,
     unauthenticated,
     roles,
     whileLoadingAuth,
@@ -34,7 +36,7 @@ export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = (
   }, [isAuthenticated, roles, hasRole])
 
   // Make sure `wrappers` is always an array with at least one wrapper component
-  if (isPrivate && unauthorized()) {
+  if ((privateProp || isPrivate) && unauthorized()) {
     if (!unauthenticated) {
       throw new Error(
         'Private Sets need to specify what route to redirect unauthorized ' +

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -12,10 +12,12 @@ type SetProps<P> = P & {
   //   <Set<{theme: string}> wrap={ThemeableLayout} theme="dark">
   wrap?: WrapperType<P> | WrapperType<P>[]
   /**
-   * `Routes` nested in a `<Set>` with `private` specified require
+   * `Routes` nested in a `<Set>` with `isPrivate` specified require
    * authentication. When a user is not authenticated and attempts to visit
    * the wrapped route they will be redirected to `unauthenticated` route.
    */
+  isPrivate?: boolean
+  /** @deprecated use `isPrivate` instead */
   private?: boolean
   /** The page name where a user will be redirected when not authenticated */
   unauthenticated?: string
@@ -47,7 +49,7 @@ export function Set<WrapperProps>(_props: SetProps<WrapperProps>) {
 
 type PrivateProps<P> = Omit<
   SetProps<P>,
-  'private' | 'unauthenticated' | 'wrap'
+  'private' | 'isPrivate' | 'unauthenticated' | 'wrap'
 > & {
   /** The page name where a user will be redirected when not authenticated */
   unauthenticated: string
@@ -68,7 +70,7 @@ export const isSetNode = (
   )
 }
 
-// Only identifies <Private> nodes, not <Set private> nodes
+/** Only identifies <Private> nodes, not <Set isPrivate> nodes */
 export const isPrivateNode = (
   node: ReactNode
 ): node is ReactElement<SetProps<any>> => {

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -290,7 +290,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       setId: 1,
       setProps: [
         {
-          private: true,
+          isPrivate: true,
           unauthenticated: 'home',
         },
       ],

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1259,7 +1259,7 @@ test('Set is not rendered for unauthenticated user.', async () => {
 
   const TestRouter = () => (
     <Router>
-      <Set private wrap={SetWithUseParams} unauthenticated="login">
+      <Set isPrivate wrap={SetWithUseParams} unauthenticated="login">
         <Route path="/test/{documentId}" page={ParamPage} name="param" />
       </Set>
       <Route path="/" page={HomePage} name="home" />
@@ -1292,7 +1292,7 @@ test('Set is not rendered for unauthenticated user on direct navigation', async 
 
   const TestRouter = () => (
     <Router>
-      <Set private wrap={SetWithUseParams} unauthenticated="login">
+      <Set isPrivate wrap={SetWithUseParams} unauthenticated="login">
         <Route path="/test/{documentId}" page={ParamPage} name="param" />
       </Set>
       <Route path="/" page={HomePage} name="home" />

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -227,7 +227,7 @@ const WrappedPage = memo(
     reveresedSetProps
       // @MARK note the reverse() here, because we spread wrappersWithAuthMaybe
       .forEach((propsFromSet) => {
-        if (propsFromSet.private) {
+        if (propsFromSet.private || propsFromSet.isPrivate) {
           if (!propsFromSet.unauthenticated) {
             throw new Error(
               'You must specify an `unauthenticated` route when marking a Route as private'

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -609,14 +609,14 @@ export function analyzeRoutes(
             : [wrapFromCurrentSet]
         }
 
-        // @MARK note unintuitive, but intentional
         // You cannot make a nested set public if the parent is private
-        // i.e. the private prop cannot be overriden by a child Set
+        // i.e. the isPrivate prop cannot be overridden by a child Set
 
         // @TODO: Double check this logic is correct for privatge logic in previous set props
-        const privateProps =
-          isPrivateNode(node) || previousSetProps.some((props) => props.private)
-            ? { private: true }
+        const isPrivateProps =
+          isPrivateNode(node) ||
+          previousSetProps.some((props) => props.private || props.isPrivate)
+            ? { isPrivate: true }
             : {}
 
         if (children) {
@@ -634,8 +634,8 @@ export function analyzeRoutes(
               {
                 // Current one takes precedence
                 ...otherPropsFromCurrentSet,
-                // See comment at definiion, intenionally at the end
-                ...privateProps,
+                // See comment at definition, intentionally at the end
+                ...isPrivateProps,
               },
             ],
           })


### PR DESCRIPTION
`private` is a reserved word in JavaScript. Switch to `isPrivate` instead. 

I decided to keep `private` around, to make it easier for people to upgrade. But unfortunately this is still breaking because if people are already passing a `isPrivate` prop on their own it will now take on a new meaning.

Fixes #2562