### PR TITLE
dbAuth template: Add missing comma

### DIFF
--- a/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.ts.template
@@ -165,7 +165,7 @@ export const handler = async (
         // If you need to allow other domains (besides the api side) access to
         // the dbAuth session cookie:
         // Domain: 'example.com',
-      }
+      },
       name: cookieName,
     },
 

--- a/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.webAuthn.ts.template
@@ -170,7 +170,7 @@ export const handler = async (
         // If you need to allow other domains (besides the api side) access to
         // the dbAuth session cookie:
         // Domain: 'example.com',
-      }
+      },
       name: cookieName,
     },
 

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.ts.template
@@ -167,7 +167,7 @@ export const handler = async (
         // If you need to allow other domains (besides the api side) access to
         // the dbAuth session cookie:
         // Domain: 'example.com',
-      }
+      },
       name: cookieName,
     },
 

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
@@ -170,7 +170,7 @@ export const handler = async (
         // If you need to allow other domains (besides the api side) access to
         // the dbAuth session cookie:
         // Domain: 'example.com',
-      }
+      },
       name: cookieName,
     },
 


### PR DESCRIPTION
Adds a missing comma in the dbAuth setup templates

*Really* wish there was an easier way to test the auth setup stuff 😆 