### PR TITLE
fix(serverless): move project-config to auth-dbauth-api dependencies

### DIFF
--- a/packages/auth-providers/dbAuth/api/package.json
+++ b/packages/auth-providers/dbAuth/api/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.23.1",
+    "@redwoodjs/project-config": "6.0.7",
     "base64url": "3.0.1",
     "core-js": "3.32.2",
     "crypto-js": "4.1.1",
@@ -33,7 +34,6 @@
     "@babel/cli": "7.23.0",
     "@babel/core": "^7.22.20",
     "@redwoodjs/api": "6.0.7",
-    "@redwoodjs/project-config": "6.0.7",
     "@simplewebauthn/server": "7.3.1",
     "@types/crypto-js": "4.1.1",
     "@types/md5": "2.3.2",


### PR DESCRIPTION
After cherry picking https://github.com/redwoodjs/redwood/pull/9248, Netlify and Vercel deploys were broken with the following error:

<img width="1532" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/2e366cd9-48e7-46e6-a32e-1c7872418674">

It took me a second to realize it, but `@redwoodjs/project-config` is listed as a dev dependency in `@redwoodjs/auth-dbauth-api` despite being used in a source file:

https://github.com/redwoodjs/redwood/blob/040589a4e600e298837e3f2b7373d1c2403eb784/packages/auth-providers/dbAuth/api/src/shared.ts#L4

@Tobbe this may not be the end of it—in those environments, there's no `redwood.toml` either, so I think `getConfig` will throw. But we can solve one bug at a time.