### PR TITLE
Add a link in the header to the AI Sidekick

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -55,6 +55,12 @@ const config = {
             className: 'github-logo',
             'aria-label': 'GitHub repository',
           },
+          {
+            href: 'https://redwoodjs.com/sidekick',
+            label: 'AI Sidekick',
+            position: 'right',
+            'aria-label': 'AI Sidekick',
+          },
         ],
       },
       prism: {


### PR DESCRIPTION
This PR adds a link to the AI Sidekick in the navigation header of the docs pages.

It is a simple approach.  But, it may be a reasonable way to add the Fixie AI chatbot quickly.  

Associated with this is a [PR](https://github.com/redwoodjs/redwoodjs.com/pull/130) on the web site repo, add a new page for the Sidekick. 

   