### PR TITLE
Add a note about build and runtime environments

### DIFF
--- a/docs/versioned_docs/version-6.0/environment-variables.md
+++ b/docs/versioned_docs/version-6.0/environment-variables.md
@@ -33,6 +33,10 @@ In production, you can get environment variables to the Web Side either by
 
 Just like for the API Side, you'll also have to set them up with your provider.
 
+> **Build and runtime environments**
+>
+> For security, hosting providers distinguish between build and runtime environments for configuring environment variables. Remember to define variables for the web side as build-time and those for the API side as runtime.
+
 #### Option 1: includeEnvironmentVariables in redwood.toml
 
 For Example:


### PR DESCRIPTION
I spent some time today debugging an issue with the Auth0 authentication provider. It turns out that I was not exposing the environment variables that are replaced at build-time, and that caused their value to be `undefined` in production. To save RedwoodJS some time in the future, I'm adding a comment in the documentation.