### PR TITLE
Add --no-db-push info to test command in cli-commands.md

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -1999,6 +1999,7 @@ yarn redwood test [side..]
 | `--collectCoverage` | Show test coverage summary and output info to `coverage` directory in project root. See this directory for an .html coverage report                                                                                                                        |
 | `--clearCache`      | Delete the Jest cache directory and exit without running tests                                                                                                                                                                                             |
 | `--db-push`         | Syncs the test database with your Prisma schema without requiring a migration. It creates a test database if it doesn't already exist [default: true]. This flag is ignored if your project doesn't have an `api` side. [👉 More details](#prisma-db-push). |
+| `--no-db-push`      | On the `api` side, runs tests without syncing the test database.     |
 
 > **Note** all other flags are passed onto the jest cli. So for example if you wanted to update your snapshots you can pass the `-u` flag
 


### PR DESCRIPTION
Following Rob's help in this thread, 
https://community.redwoodjs.com/t/run-redwood-tests-without-resetting-the-database/4104
I've added the --no-db-push flag to the table of arguments that can be used with the test command on the CLI documentation page.