### PR TITLE
Cell generator: Fix formatting in template

### DIFF
--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -510,6 +510,7 @@ describe('UserProfileCell', () => {
 
 exports[`TypeScript: generates list cells if list flag passed in 1`] = `
 "import type { FindBazingaQuery, FindBazingaQueryVariables } from 'types/graphql'
+
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql\`
@@ -633,6 +634,7 @@ export const standard = (/* vars, { ctx, req } */) => ({
 
 exports[`TypeScript: generates list cells if name is plural 1`] = `
 "import type { MembersQuery } from 'types/graphql'
+
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql\`

--- a/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
@@ -1,4 +1,5 @@
 import type { ${operationName}, ${operationName}Variables } from 'types/graphql'
+
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`

--- a/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
@@ -1,4 +1,5 @@
 import type { ${operationName} } from 'types/graphql'
+
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 

--- a/packages/internal/src/__tests__/ast.test.ts
+++ b/packages/internal/src/__tests__/ast.test.ts
@@ -103,7 +103,7 @@ test('tests default exports', () => {
 })
 
 test('Returns the exported query from a cell (ignoring others)', () => {
-  const cellFileAst = fileToAst(getFixturePath('web/src/cell.ts'))
+  const cellFileAst = fileToAst(getFixturePath('web/src/cell.tsx'))
 
   const cellQuery = getCellGqlQuery(cellFileAst)
   expect(cellQuery).toMatchInlineSnapshot(`
@@ -117,8 +117,8 @@ test('Returns the exported query from a cell (ignoring others)', () => {
   `)
 })
 
-test('Returns the all quries from a file using getGqlQueries', () => {
-  const cellFileAst = fileToAst(getFixturePath('web/src/cell.ts'))
+test('Returns the all queries from a file using getGqlQueries', () => {
+  const cellFileAst = fileToAst(getFixturePath('web/src/cell.tsx'))
 
   const cellQuery = getGqlQueries(cellFileAst)
   expect(cellQuery).toMatchInlineSnapshot(`

--- a/packages/internal/src/__tests__/fixtures/web/src/cell.tsx
+++ b/packages/internal/src/__tests__/fixtures/web/src/cell.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable */
 
 import type { BazingaQuery } from 'types/graphql'
+
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
 export const QUERY = gql`


### PR DESCRIPTION
By default when generating a Cell you get a long red squiggly line at the top of the file. This simple fix gets rid of that by fixing the default formatting in the template.

This is what it used to look like
![image](https://github.com/redwoodjs/redwood/assets/30793/08c2ee1d-8cc6-464f-a19e-4708bd997a60)

And if you hover it you get this error explanation
![image](https://github.com/redwoodjs/redwood/assets/30793/1784867a-9f58-4e96-8c2f-59d705ecfbd8)

And this is what it looks like after the fix in this PR
![image](https://github.com/redwoodjs/redwood/assets/30793/ab369b70-a6fa-4798-954f-a99014f961c0)

