### PR TITLE
`<PrivateSet>`

### DIFF
--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -3,7 +3,7 @@ import { ESLintUtils } from '@typescript-eslint/utils'
 const createRule = ESLintUtils.RuleCreator.withoutDocs
 
 function isAllowedElement(name: string) {
-  const allowedElements = ['Router', 'Route', 'Set', 'Private']
+  const allowedElements = ['Router', 'Route', 'Set', 'PrivateSet', 'Private']
   return allowedElements.includes(name)
 }
 
@@ -16,7 +16,7 @@ export const unsupportedRouteComponents = createRule({
     },
     messages: {
       unexpected:
-        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, <Set> and <Private> are allowed in the Routes file.',
+        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, <Set>, <PrivateSet> and <Private> are allowed in the Routes file.',
     },
     schema: [], // No additional configuration needed
   },

--- a/packages/router/src/AuthenticatedRoute.tsx
+++ b/packages/router/src/AuthenticatedRoute.tsx
@@ -8,20 +8,16 @@ import type { GeneratedRoutesMap } from './util'
 interface AuthenticatedRouteProps {
   children: React.ReactNode
   roles?: string | string[]
-  unauthenticated?: keyof GeneratedRoutesMap
+  unauthenticated: keyof GeneratedRoutesMap
   whileLoadingAuth?: () => React.ReactElement | null
-  private?: boolean
 }
-export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = (
-  props
-) => {
-  const {
-    private: isPrivate,
-    unauthenticated,
-    roles,
-    whileLoadingAuth,
-    children,
-  } = props
+
+export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = ({
+  unauthenticated,
+  roles,
+  whileLoadingAuth,
+  children,
+}) => {
   const routerState = useRouterState()
   const {
     loading: authLoading,
@@ -34,14 +30,7 @@ export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = (
   }, [isAuthenticated, roles, hasRole])
 
   // Make sure `wrappers` is always an array with at least one wrapper component
-  if (isPrivate && unauthorized()) {
-    if (!unauthenticated) {
-      throw new Error(
-        'Private Sets need to specify what route to redirect unauthorized ' +
-          'users to by setting the `unauthenticated` prop'
-      )
-    }
-
+  if (unauthorized()) {
     if (authLoading) {
       return whileLoadingAuth?.() || null
     } else {

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
-import React from 'react'
+import * as React from 'react'
 
 export type WrapperType<WTProps> = (
   props: WTProps & { children: ReactNode }
@@ -12,9 +12,11 @@ type SetProps<P> = P & {
   //   <Set<{theme: string}> wrap={ThemeableLayout} theme="dark">
   wrap?: WrapperType<P> | WrapperType<P>[]
   /**
-   * `Routes` nested in a `<Set>` with `private` specified require
+   *`Routes` nested in a `<Set>` with `private` specified require
    * authentication. When a user is not authenticated and attempts to visit
    * the wrapped route they will be redirected to `unauthenticated` route.
+   *
+   * @deprecated Please use `<PrivateSet>` instead
    */
   private?: boolean
   /** The page name where a user will be redirected when not authenticated */
@@ -45,7 +47,7 @@ export function Set<WrapperProps>(_props: SetProps<WrapperProps>) {
   return null
 }
 
-type PrivateProps<P> = Omit<
+type PrivateSetProps<P> = Omit<
   SetProps<P>,
   'private' | 'unauthenticated' | 'wrap'
 > & {
@@ -54,7 +56,16 @@ type PrivateProps<P> = Omit<
   wrap?: WrapperType<P> | WrapperType<P>[]
 }
 
-export function Private<WrapperProps>(_props: PrivateProps<WrapperProps>) {
+/** @deprecated Please use `<PrivateSet>` instead */
+export function Private<WrapperProps>(_props: PrivateSetProps<WrapperProps>) {
+  // @MARK Virtual Component, this is actually never rendered
+  // See analyzeRoutes in utils.tsx, inside the isSetNode block
+  return null
+}
+
+export function PrivateSet<WrapperProps>(
+  _props: PrivateSetProps<WrapperProps>
+) {
   // @MARK Virtual Component, this is actually never rendered
   // See analyzeRoutes in utils.tsx, inside the isSetNode block
   return null
@@ -64,8 +75,15 @@ export const isSetNode = (
   node: ReactNode
 ): node is ReactElement<SetProps<any>> => {
   return (
-    React.isValidElement(node) && (node.type === Set || node.type === Private)
+    React.isValidElement(node) &&
+    (node.type === Set || node.type === PrivateSet || node.type === Private)
   )
+}
+
+export const isPrivateSetNode = (
+  node: ReactNode
+): node is ReactElement<PrivateSetProps<unknown>> => {
+  return React.isValidElement(node) && node.type === PrivateSet
 }
 
 // Only identifies <Private> nodes, not <Set private> nodes

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -154,10 +154,10 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         name: 'routeA',
         path: '/a',
         whileLoadingPage: undefined,
-        wrappers: [WrapperX],
         sets: [
           {
             id: 1,
+            wrappers: [WrapperX],
             isPrivate: false,
             props: {
               id: 'set-one',
@@ -174,10 +174,10 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         name: 'routeB',
         path: '/b',
         whileLoadingPage: undefined,
-        wrappers: [WrapperX, WrapperY], // both wrappers
         sets: [
           {
             id: 1,
+            wrappers: [WrapperX],
             isPrivate: false,
             props: {
               id: 'set-one',
@@ -187,6 +187,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
           {
             id: 2,
             isPrivate: false,
+            wrappers: [WrapperY],
             props: {
               id: 'set-two',
               theme: 'blue',
@@ -202,10 +203,10 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         name: 'routeC',
         path: '/c',
         whileLoadingPage: undefined,
-        wrappers: [WrapperX, WrapperY], // both wrappers
         sets: [
           {
             id: 1,
+            wrappers: [WrapperX],
             isPrivate: false,
             props: {
               id: 'set-one',
@@ -214,6 +215,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
           },
           {
             id: 2,
+            wrappers: [WrapperY],
             isPrivate: false,
             props: {
               id: 'set-two',
@@ -274,11 +276,10 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         name: 'routeA',
         path: '/a',
         whileLoadingPage: undefined,
-        wrappers: [WrapperX],
-        // Props passed through from set
         sets: [
           {
             id: 1,
+            wrappers: [WrapperX],
             isPrivate: false,
             props: {
               id: 'set-one',
@@ -295,10 +296,10 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         name: 'routeB',
         path: '/b',
         whileLoadingPage: undefined,
-        wrappers: [WrapperX, WrapperY], // both wrappers
         sets: [
           {
             id: 1,
+            wrappers: [WrapperX],
             isPrivate: false,
             props: {
               id: 'set-one',
@@ -307,6 +308,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
           },
           {
             id: 2,
+            wrappers: [WrapperY],
             isPrivate: false,
             props: {
               id: 'set-two',
@@ -323,10 +325,11 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         name: 'routeC',
         path: '/c',
         whileLoadingPage: undefined,
-        wrappers: [WrapperX, WrapperY], // both wrappers
+        setId: 2,
         sets: [
           {
             id: 1,
+            wrappers: [WrapperX],
             isPrivate: false,
             props: {
               id: 'set-one',
@@ -335,6 +338,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
           },
           {
             id: 2,
+            wrappers: [WrapperY],
             isPrivate: false,
             props: {
               id: 'set-two',
@@ -438,10 +442,15 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       path: '/private',
       whileLoadingPage: undefined,
       page: FakePage,
-      wrappers: [],
       setId: 1,
-      isPrivate: true,
-      sets: [{ id: 1, isPrivate: true, props: { unauthenticated: 'home' } }],
+      sets: [
+        {
+          id: 1,
+          wrappers: [],
+          isPrivate: true,
+          props: { unauthenticated: 'home' },
+        },
+      ],
     })
   })
 
@@ -465,10 +474,15 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       path: '/private',
       whileLoadingPage: undefined,
       page: FakePage,
-      wrappers: [],
       setId: 1,
-      isPrivate: true,
-      sets: [{ id: 1, isPrivate: true, props: { unauthenticated: 'home' } }],
+      sets: [
+        {
+          id: 1,
+          wrappers: [],
+          isPrivate: true,
+          props: { unauthenticated: 'home' },
+        },
+      ],
     })
   })
 
@@ -552,12 +566,11 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(pathRouteMap).toMatchObject({
       '/no-roles-assigned': {
         redirect: null,
-        isPrivate: true,
         sets: [
           {
             id: 1,
             isPrivate: true,
-            props: expect.objectContaining({ unauthenticated: 'home' }),
+            props: { unauthenticated: 'home' },
           },
         ],
       },
@@ -569,24 +582,32 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(pathRouteMap).toMatchObject({
       '/employee': {
         redirect: null,
-        isPrivate: true,
-        sets: expect.arrayContaining([
-          // Should have the first one, but also..
+        sets: [
           {
             id: 1,
+            wrappers: [],
             isPrivate: true,
-            props: expect.objectContaining({ unauthenticated: 'home' }),
+            props: { unauthenticated: 'home' },
           },
-          // ...the second private set's props
           {
             id: 2,
+            wrappers: [],
             isPrivate: true,
             props: expect.objectContaining({
               unauthenticated: 'noRolesAssigned',
               roles: ['ADMIN', 'EMPLOYEE'],
             }),
           },
-        ]),
+          {
+            id: 3,
+            wrappers: [],
+            isPrivate: true,
+            props: {
+              unauthenticated: 'admin',
+              roles: 'EMPLOYEE',
+            },
+          },
+        ],
       },
     })
 
@@ -594,31 +615,33 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(pathRouteMap).toMatchObject({
       '/admin': {
         redirect: null,
-        isPrivate: true,
         sets: [
           // Should have the first one, but also..
           {
             id: 1,
+            wrappers: [],
             isPrivate: true,
-            props: expect.objectContaining({ unauthenticated: 'home' }),
+            props: { unauthenticated: 'home' },
           },
           // ...the second private set's props
           {
             id: 2,
+            wrappers: [],
             isPrivate: true,
-            props: expect.objectContaining({
+            props: {
               unauthenticated: 'noRolesAssigned',
               roles: ['ADMIN', 'EMPLOYEE'],
-            }),
+            },
           },
           // ...and the third private set's props
           {
             id: 4,
+            wrappers: [],
             isPrivate: true,
-            props: expect.objectContaining({
+            props: {
               unauthenticated: 'employee',
               roles: 'ADMIN',
-            }),
+            },
           },
         ],
       },

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -155,11 +155,14 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         path: '/a',
         whileLoadingPage: undefined,
         wrappers: [WrapperX],
-        // Props passed through from set
-        setProps: [
+        sets: [
           {
-            id: 'set-one',
-            passThruProp: 'bazinga',
+            id: 1,
+            isPrivate: false,
+            props: {
+              id: 'set-one',
+              passThruProp: 'bazinga',
+            },
           },
         ],
       })
@@ -172,14 +175,22 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         path: '/b',
         whileLoadingPage: undefined,
         wrappers: [WrapperX, WrapperY], // both wrappers
-        setProps: [
+        sets: [
           {
-            id: 'set-one',
-            passThruProp: 'bazinga',
+            id: 1,
+            isPrivate: false,
+            props: {
+              id: 'set-one',
+              passThruProp: 'bazinga',
+            },
           },
           {
-            id: 'set-two',
-            theme: 'blue',
+            id: 2,
+            isPrivate: false,
+            props: {
+              id: 'set-two',
+              theme: 'blue',
+            },
           },
         ],
       })
@@ -192,14 +203,143 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         path: '/c',
         whileLoadingPage: undefined,
         wrappers: [WrapperX, WrapperY], // both wrappers
-        setProps: [
+        sets: [
           {
-            id: 'set-one',
-            passThruProp: 'bazinga',
+            id: 1,
+            isPrivate: false,
+            props: {
+              id: 'set-one',
+              passThruProp: 'bazinga',
+            },
           },
           {
-            id: 'set-two',
-            theme: 'blue',
+            id: 2,
+            isPrivate: false,
+            props: {
+              id: 'set-two',
+              theme: 'blue',
+            },
+          },
+        ],
+      })
+    )
+  })
+
+  test('Connects Set wrapper props with correct Set', () => {
+    interface WrapperXProps {
+      children: React.ReactNode
+      id: string
+      passThruProp: string
+    }
+
+    const WrapperX = ({ children }: WrapperXProps) => (
+      <>
+        <h1>WrapperA</h1>
+        {children}
+      </>
+    )
+
+    interface WrapperYProps {
+      children: React.ReactNode
+      id: string
+      theme: string
+    }
+
+    const WrapperY = ({ children }: WrapperYProps) => (
+      <>
+        <h1>WrapperY</h1>
+        {children}
+      </>
+    )
+
+    const Simple = (
+      <Router>
+        <Set wrap={[WrapperX]} id="set-one" passThruProp="bazinga">
+          <Route path="/a" name="routeA" page={FakePage} />
+          <Set wrap={[WrapperY]} id="set-two" theme="blue">
+            <Route name="routeB" path="/b" page={FakePage} />
+            <Route name="routeC" path="/c" page={FakePage} />
+          </Set>
+        </Set>
+      </Router>
+    )
+
+    const { pathRouteMap } = analyzeRoutes(Simple.props.children, {
+      currentPathName: '/',
+    })
+
+    expect(pathRouteMap['/a']).toEqual(
+      expect.objectContaining({
+        redirect: null,
+        name: 'routeA',
+        path: '/a',
+        whileLoadingPage: undefined,
+        wrappers: [WrapperX],
+        // Props passed through from set
+        sets: [
+          {
+            id: 1,
+            isPrivate: false,
+            props: {
+              id: 'set-one',
+              passThruProp: 'bazinga',
+            },
+          },
+        ],
+      })
+    )
+
+    expect(pathRouteMap['/b']).toEqual(
+      expect.objectContaining({
+        redirect: null,
+        name: 'routeB',
+        path: '/b',
+        whileLoadingPage: undefined,
+        wrappers: [WrapperX, WrapperY], // both wrappers
+        sets: [
+          {
+            id: 1,
+            isPrivate: false,
+            props: {
+              id: 'set-one',
+              passThruProp: 'bazinga',
+            },
+          },
+          {
+            id: 2,
+            isPrivate: false,
+            props: {
+              id: 'set-two',
+              theme: 'blue',
+            },
+          },
+        ],
+      })
+    )
+
+    expect(pathRouteMap['/c']).toEqual(
+      expect.objectContaining({
+        redirect: null,
+        name: 'routeC',
+        path: '/c',
+        whileLoadingPage: undefined,
+        wrappers: [WrapperX, WrapperY], // both wrappers
+        sets: [
+          {
+            id: 1,
+            isPrivate: false,
+            props: {
+              id: 'set-one',
+              passThruProp: 'bazinga',
+            },
+          },
+          {
+            id: 2,
+            isPrivate: false,
+            props: {
+              id: 'set-two',
+              theme: 'blue',
+            },
           },
         ],
       })
@@ -301,7 +441,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       wrappers: [],
       setId: 1,
       isPrivate: true,
-      setProps: [{ unauthenticated: 'home' }],
+      sets: [{ id: 1, isPrivate: true, props: { unauthenticated: 'home' } }],
     })
   })
 
@@ -328,7 +468,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       wrappers: [],
       setId: 1,
       isPrivate: true,
-      setProps: [{ unauthenticated: 'home' }],
+      sets: [{ id: 1, isPrivate: true, props: { unauthenticated: 'home' } }],
     })
   })
 
@@ -413,9 +553,13 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       '/no-roles-assigned': {
         redirect: null,
         isPrivate: true,
-        setProps: expect.arrayContaining([
-          expect.objectContaining({ unauthenticated: 'home' }),
-        ]),
+        sets: [
+          {
+            id: 1,
+            isPrivate: true,
+            props: expect.objectContaining({ unauthenticated: 'home' }),
+          },
+        ],
       },
     })
 
@@ -426,14 +570,22 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       '/employee': {
         redirect: null,
         isPrivate: true,
-        setProps: expect.arrayContaining([
+        sets: expect.arrayContaining([
           // Should have the first one, but also..
-          expect.objectContaining({ unauthenticated: 'home' }),
+          {
+            id: 1,
+            isPrivate: true,
+            props: expect.objectContaining({ unauthenticated: 'home' }),
+          },
           // ...the second private set's props
-          expect.objectContaining({
-            unauthenticated: 'noRolesAssigned',
-            roles: ['ADMIN', 'EMPLOYEE'],
-          }),
+          {
+            id: 2,
+            isPrivate: true,
+            props: expect.objectContaining({
+              unauthenticated: 'noRolesAssigned',
+              roles: ['ADMIN', 'EMPLOYEE'],
+            }),
+          },
         ]),
       },
     })
@@ -443,20 +595,32 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       '/admin': {
         redirect: null,
         isPrivate: true,
-        setProps: expect.arrayContaining([
+        sets: [
           // Should have the first one, but also..
-          expect.objectContaining({ unauthenticated: 'home' }),
+          {
+            id: 1,
+            isPrivate: true,
+            props: expect.objectContaining({ unauthenticated: 'home' }),
+          },
           // ...the second private set's props
-          expect.objectContaining({
-            unauthenticated: 'noRolesAssigned',
-            roles: ['ADMIN', 'EMPLOYEE'],
-          }),
+          {
+            id: 2,
+            isPrivate: true,
+            props: expect.objectContaining({
+              unauthenticated: 'noRolesAssigned',
+              roles: ['ADMIN', 'EMPLOYEE'],
+            }),
+          },
           // ...and the third private set's props
-          expect.objectContaining({
-            unauthenticated: 'employee',
-            roles: 'ADMIN',
-          }),
-        ]),
+          {
+            id: 4,
+            isPrivate: true,
+            props: expect.objectContaining({
+              unauthenticated: 'employee',
+              roles: 'ADMIN',
+            }),
+          },
+        ],
       },
     })
   })

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -1,7 +1,7 @@
 import React, { isValidElement } from 'react'
 
 import { Route, Router } from '../router'
-import { Private, Set } from '../Set'
+import { Private, PrivateSet, Set } from '../Set'
 import { analyzeRoutes } from '../util'
 
 const FakePage = () => <h1>Fake Page</h1>
@@ -106,14 +106,26 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
   })
 
   test('Creates setWrapper map', () => {
-    const WrapperX = ({ children }) => (
+    interface WrapperXProps {
+      children: React.ReactNode
+      id: string
+      passThruProp: string
+    }
+
+    const WrapperX = ({ children }: WrapperXProps) => (
       <>
         <h1>WrapperA</h1>
         {children}
       </>
     )
 
-    const WrapperY = ({ children }) => (
+    interface WrapperYProps {
+      children: React.ReactNode
+      id: string
+      theme: string
+    }
+
+    const WrapperY = ({ children }: WrapperYProps) => (
       <>
         <h1>WrapperY</h1>
         {children}
@@ -196,7 +208,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
 
   test('Creates setWrapper map with nested sets', () => {
     const KrismasTree = (
-      <Private unauthenticated="signIn">
+      <PrivateSet unauthenticated="signIn">
         <Route path="/dashboard" page={FakePage} name="dashboard" />
         <Set wrap={[FakeLayout1, FakeLayout2]}>
           <Route
@@ -254,7 +266,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
             />
           </Set>
         </Set>
-      </Private>
+      </PrivateSet>
     )
 
     const { pathRouteMap } = analyzeRoutes(KrismasTree.props.children, {
@@ -273,6 +285,37 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
         <Private unauthenticated="home">
           <Route path="/private" name="privateRoute" page={FakePage} />
         </Private>
+      </Router>
+    )
+
+    const { pathRouteMap } = analyzeRoutes(Routes.props.children, {
+      currentPathName: '/',
+    })
+
+    expect(pathRouteMap['/private']).toStrictEqual({
+      redirect: null,
+      name: 'privateRoute',
+      path: '/private',
+      whileLoadingPage: undefined,
+      page: FakePage,
+      wrappers: [],
+      setId: 1,
+      setProps: [
+        {
+          private: true,
+          unauthenticated: 'home',
+        },
+      ],
+    })
+  })
+
+  test('Handles PrivateSet', () => {
+    const Routes = (
+      <Router>
+        <Route path="/" name="home" page={FakePage} />
+        <PrivateSet unauthenticated="home">
+          <Route path="/private" name="privateRoute" page={FakePage} />
+        </PrivateSet>
       </Router>
     )
 
@@ -334,7 +377,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     const RedirectedRoutes = (
       <Router>
         <Route path="/" page={HomePage} name="home" />
-        <Private unauthenticated="home">
+        <PrivateSet unauthenticated="home">
           <Route
             path="/no-roles-assigned"
             page={PrivateNoRolesAssigned}
@@ -346,23 +389,23 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
             roles={['ADMIN', 'EMPLOYEE']}
             someProp="propFromNoRolesSet"
           >
-            <Private unauthenticated="admin" roles={'EMPLOYEE'}>
+            <PrivateSet unauthenticated="admin" roles={'EMPLOYEE'}>
               <Route
                 path="/employee"
                 page={PrivateEmployeePage}
                 name="privateEmployee"
               />
-            </Private>
+            </PrivateSet>
 
-            <Private unauthenticated="employee" roles={'ADMIN'}>
+            <PrivateSet unauthenticated="employee" roles={'ADMIN'}>
               <Route
                 path="/admin"
                 page={PrivateAdminPage}
                 name="privateAdmin"
               />
-            </Private>
+            </PrivateSet>
           </Set>
-        </Private>
+        </PrivateSet>
       </Router>
     )
 

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -300,12 +300,8 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       page: FakePage,
       wrappers: [],
       setId: 1,
-      setProps: [
-        {
-          private: true,
-          unauthenticated: 'home',
-        },
-      ],
+      isPrivate: true,
+      setProps: [{ unauthenticated: 'home' }],
     })
   })
 
@@ -331,12 +327,8 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       page: FakePage,
       wrappers: [],
       setId: 1,
-      setProps: [
-        {
-          private: true,
-          unauthenticated: 'home',
-        },
-      ],
+      isPrivate: true,
+      setProps: [{ unauthenticated: 'home' }],
     })
   })
 
@@ -420,11 +412,9 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(pathRouteMap).toMatchObject({
       '/no-roles-assigned': {
         redirect: null,
+        isPrivate: true,
         setProps: expect.arrayContaining([
-          expect.objectContaining({
-            unauthenticated: 'home',
-            private: true,
-          }),
+          expect.objectContaining({ unauthenticated: 'home' }),
         ]),
       },
     })
@@ -435,15 +425,12 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(pathRouteMap).toMatchObject({
       '/employee': {
         redirect: null,
+        isPrivate: true,
         setProps: expect.arrayContaining([
           // Should have the first one, but also..
-          expect.objectContaining({
-            unauthenticated: 'home',
-            private: true,
-          }),
+          expect.objectContaining({ unauthenticated: 'home' }),
           // ...the second private set's props
           expect.objectContaining({
-            private: true,
             unauthenticated: 'noRolesAssigned',
             roles: ['ADMIN', 'EMPLOYEE'],
           }),
@@ -455,24 +442,19 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(pathRouteMap).toMatchObject({
       '/admin': {
         redirect: null,
+        isPrivate: true,
         setProps: expect.arrayContaining([
           // Should have the first one, but also..
-          expect.objectContaining({
-            unauthenticated: 'home',
-            private: true,
-          }),
+          expect.objectContaining({ unauthenticated: 'home' }),
           // ...the second private set's props
           expect.objectContaining({
-            private: true,
             unauthenticated: 'noRolesAssigned',
             roles: ['ADMIN', 'EMPLOYEE'],
           }),
-
           // ...and the third private set's props
           expect.objectContaining({
             unauthenticated: 'employee',
             roles: 'ADMIN',
-            private: true,
           }),
         ]),
       },

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+
+import '@testing-library/jest-dom/extend-expect'
+import { act, render } from '@testing-library/react'
+
+import { navigate, Route, Router } from '../'
+import { Private, Set } from '../Set'
+
+/**
+ * 🎩 Heads-up, in this test we're not mocking LazyComponent
+ * because all the tests explicitly define the pages in the router.
+ *
+ * If you add tests with dynamic imports i.e. all the pages aren't explicitly supplied to the route
+ * then you'll need to mock LazyComponent (see router.test.tsx)
+ */
+
+const HomePage = () => <h1>Home Page</h1>
+const Page = () => <h1>Page</h1>
+
+test('Sets nested in Private should not error out if no authenticated prop provided', () => {
+  const Layout1 = ({ children }) => (
+    <div>
+      <p>Layout1</p>
+      {children}
+    </div>
+  )
+
+  const SetInsidePrivate = () => (
+    <Router>
+      <Route path="/" page={HomePage} name="home" />
+      <Route path="/auth" page={() => 'Regular Auth'} name="auth" />
+      <Route path="/adminAuth" page={() => 'Admin Auth'} name="adminAuth" />
+      <Private unauthenticated="auth">
+        <Route path="/two/{slug}" page={Page} name="two" />
+        {/* The Set below is private implicitly (nested under private), but
+        should not need an unauthenticated prop */}
+        <Set wrap={Layout1}>
+          <Private roles="admin" unauthenticated="adminAuth">
+            <Route path="/three" page={Page} name="three" />
+          </Private>
+        </Set>
+      </Private>
+      <Set wrap={Layout1} private>
+        <Route path="/four" page={Page} name="four" />
+      </Set>
+    </Router>
+  )
+
+  render(<SetInsidePrivate />)
+
+  expect(() => {
+    act(() => navigate('/three'))
+  }).not.toThrowError()
+
+  // But still throws if you try to navigate to a private route without an unauthenticated prop
+  expect(() => {
+    act(() => navigate('/four'))
+  }).toThrowError('You must specify an `unauthenticated` route')
+})

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -6,13 +6,12 @@ import { act, render } from '@testing-library/react'
 import { navigate, Route, Router } from '../'
 import { Private, Set } from '../Set'
 
-/**
- * 🎩 Heads-up, in this test we're not mocking LazyComponent
- * because all the tests explicitly define the pages in the router.
- *
- * If you add tests with dynamic imports i.e. all the pages aren't explicitly supplied to the route
- * then you'll need to mock LazyComponent (see router.test.tsx)
- */
+// Heads-up, in this test we're not mocking LazyComponent because all the tests
+// explicitly define the pages in the router.
+//
+// If you add tests with dynamic imports, i.e. all the pages aren't explicitly
+// supplied to the router, then you'll need to mock LazyComponent (see
+// router.test.tsx)
 
 const HomePage = () => <h1>Home Page</h1>
 const Page = () => <h1>Page</h1>

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -17,6 +17,22 @@ import { Private, Set } from '../Set'
 const HomePage = () => <h1>Home Page</h1>
 const Page = () => <h1>Page</h1>
 
+beforeEach(() => {
+  window.history.pushState({}, '', '/')
+})
+
+let err: typeof console.error
+
+beforeAll(() => {
+  // Hide thrown exceptions. We're expecting them, and they clutter the output
+  err = console.error
+  console.error = jest.fn()
+})
+
+afterAll(() => {
+  console.error = err
+})
+
 test('Sets nested in Private should not error out if no authenticated prop provided', () => {
   const Layout1 = ({ children }) => (
     <div>
@@ -56,4 +72,43 @@ test('Sets nested in Private should not error out if no authenticated prop provi
   expect(() => {
     act(() => navigate('/four'))
   }).toThrowError('You must specify an `unauthenticated` route')
+})
+
+test('Sets nested in `<Set private>` should not error out if no authenticated prop provided', () => {
+  const Layout1 = ({ children }) => (
+    <div>
+      <p>Layout1</p>
+      {children}
+    </div>
+  )
+
+  const SetInsideSetPrivate = () => (
+    <Router>
+      <Route path="/" page={HomePage} name="home" />
+      <Route path="/auth" page={() => 'Regular Auth'} name="auth" />
+      <Route path="/adminAuth" page={() => 'Admin Auth'} name="adminAuth" />
+      <Set private unauthenticated="auth">
+        <Route path="/two/{slug}" page={Page} name="two" />
+        {/* The Set below is private implicitly (nested under private), but
+        should not need an unauthenticated prop */}
+        <Set wrap={Layout1}>
+          <Private roles="admin" unauthenticated="adminAuth">
+            <Route path="/three" page={Page} name="three" />
+          </Private>
+        </Set>
+      </Set>
+      <Set wrap={Layout1} private>
+        <Route path="/four" page={Page} name="four" />
+      </Set>
+    </Router>
+  )
+
+  render(<SetInsideSetPrivate />)
+
+  expect(() => act(() => navigate('/three'))).not.toThrowError()
+
+  // But still throws if you try to navigate to a private route without an unauthenticated prop
+  expect(() => act(() => navigate('/four'))).toThrowError(
+    'You must specify an `unauthenticated` route'
+  )
 })

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1625,13 +1625,8 @@ describe('Multiple nested private sets', () => {
         <PrivateSet
           unauthenticated="noRolesAssigned"
           roles={['ADMIN', 'EMPLOYEE']}
-          level="2"
         >
-          <PrivateSet
-            unauthenticated="privateAdmin"
-            roles={['EMPLOYEE']}
-            level="3"
-          >
+          <PrivateSet unauthenticated="privateAdmin" roles={['EMPLOYEE']}>
             <Route
               path="/employee"
               page={PrivateEmployeePage}
@@ -1639,11 +1634,7 @@ describe('Multiple nested private sets', () => {
             />
           </PrivateSet>
 
-          <PrivateSet
-            unauthenticated="privateEmployee"
-            roles={['ADMIN']}
-            level="3"
-          >
+          <PrivateSet unauthenticated="privateEmployee" roles={['ADMIN']}>
             <Route path="/admin" page={PrivateAdminPage} name="privateAdmin" />
           </PrivateSet>
         </PrivateSet>
@@ -1702,7 +1693,6 @@ describe('Multiple nested private sets', () => {
     act(() => navigate('/admin'))
     await waitFor(() => {
       expect(screen.queryByText(`Private Admin Page`)).toBeInTheDocument()
-      expect(screen.queryByText(`Level: 3`)).toBeInTheDocument()
     })
   })
 
@@ -1722,7 +1712,6 @@ describe('Multiple nested private sets', () => {
 
     await waitFor(() => {
       expect(screen.queryByText(`Private Admin Page`)).toBeInTheDocument()
-      expect(screen.queryByText(`Level: 3`)).toBeInTheDocument()
     })
   })
 })
@@ -1758,25 +1747,27 @@ describe('Multiple nested sets', () => {
   )
 
   test('level 1, matches expected props', async () => {
-    const screen = render(<TestRouter />)
-
     act(() => navigate('/level1'))
 
+    const screen = render(<TestRouter />)
+
     await waitFor(() => {
-      expect(screen.queryByText(`Theme: blue`)).toBeInTheDocument()
-      expect(screen.queryByText(`Page Level: 1`)).toBeInTheDocument()
+      expect(screen.queryByText('Theme: blue')).toBeInTheDocument()
+      expect(screen.queryByText('Other Prop:')).toBeInTheDocument()
+      expect(screen.queryByText('Page Level: 1')).toBeInTheDocument()
     })
   })
 
-  test('level 2, should override level 1', async () => {
-    const screen = render(<TestRouter />)
-
+  test('level 2, should not affect level 1 set props', async () => {
     act(() => navigate('/level2'))
 
+    const screen = render(<TestRouter />)
+
     await waitFor(() => {
-      expect(screen.queryByText(`Theme: red`)).toBeInTheDocument()
-      expect(screen.queryByText(`Other Prop: bazinga`)).toBeInTheDocument()
-      expect(screen.queryByText(`Page Level: 2`)).toBeInTheDocument()
+      expect(screen.queryByText('Page')).toBeInTheDocument()
+      expect(screen.queryByText('Theme: blue')).toBeInTheDocument()
+      expect(screen.queryByText('Other Prop:')).toBeInTheDocument()
+      expect(screen.queryByText('Page Level: 1')).toBeInTheDocument()
     })
   })
 
@@ -1786,9 +1777,9 @@ describe('Multiple nested sets', () => {
     act(() => navigate('/level3'))
 
     await waitFor(() => {
-      expect(screen.queryByText(`Theme: green`)).toBeInTheDocument()
-      expect(screen.queryByText(`Other Prop: bazinga`)).toBeInTheDocument()
-      expect(screen.queryByText(`Page Level: 3`)).toBeInTheDocument()
+      expect(screen.queryByText('Theme: blue')).toBeInTheDocument()
+      expect(screen.queryByText('Other Prop:')).toBeInTheDocument()
+      expect(screen.queryByText('Page Level: 1')).toBeInTheDocument()
     })
   })
 })

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -37,6 +37,7 @@ import {
   Link,
   navigate,
   Private,
+  PrivateSet,
   Redirect,
   Route,
   Router,
@@ -248,22 +249,24 @@ describe('slow imports', () => {
         name="login"
         whileLoadingPage={LoginPagePlaceholder}
       />
-      <Private unauthenticated="login">
+      <PrivateSet unauthenticated="login">
         <Route
           path="/private"
           page={PrivatePage}
           name="private"
           whileLoadingPage={PrivatePagePlaceholder}
         />
-      </Private>
-      <Private unauthenticated="login" roles="admin">
+      </PrivateSet>
+      <PrivateSet unauthenticated="login" roles="admin">
         <Route
           path="/private_with_role"
           page={PrivatePage}
           name="private_with_role"
           whileLoadingPage={PrivatePagePlaceholder}
         />
-      </Private>
+      </PrivateSet>
+      {/* Keeping this one around for now, so we don't accidentally break
+      Private until we're ready to remove it */}
       <Private unauthenticated="login" roles={['admin', 'moderator']}>
         <Route
           path="/private_with_several_roles"
@@ -551,9 +554,9 @@ describe('inits routes and navigates as expected', () => {
       <Route path="/about" page={AboutPage} name="about" />
       <Route path="/redirect" page={RedirectPage} name="redirect" />
       <Route path="/redirect2/{value}" redirect="/param-test/{value}" />
-      <Private unauthenticated="home">
+      <PrivateSet unauthenticated="home">
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
       <Route path="/param-test/{value}" page={ParamPage} name="params" />
       <Route notfound page={NotFoundPage} />
     </Router>
@@ -762,9 +765,9 @@ test('unauthenticated user is redirected away from private page', async () => {
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={LoginPage} name="login" />
       <Route path="/about" page={AboutPage} name="about" />
-      <Private unauthenticated="login">
+      <PrivateSet unauthenticated="login">
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
     </Router>
   )
   const screen = render(<TestRouter />)
@@ -789,9 +792,9 @@ test('unauthenticated user is redirected including search params', async () => {
     <Router>
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={LoginPage} name="login" />
-      <Private unauthenticated="login">
+      <PrivateSet unauthenticated="login">
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
     </Router>
   )
   const screen = render(<TestRouter />)
@@ -817,9 +820,9 @@ test('authenticated user can access private page', async () => {
   const TestRouter = () => (
     <Router useAuth={mockUseAuth({ isAuthenticated: true })}>
       <Route path="/" page={HomePage} name="home" />
-      <Private unauthenticated="home">
+      <PrivateSet unauthenticated="home">
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
     </Router>
   )
   const screen = render(<TestRouter />)
@@ -840,12 +843,12 @@ test('can display a loading screen whilst waiting for auth', async () => {
   const TestRouter = () => (
     <Router useAuth={mockUseAuth({ isAuthenticated: false, loading: true })}>
       <Route path="/" page={HomePage} name="home" />
-      <Private
+      <PrivateSet
         unauthenticated="home"
         whileLoadingAuth={() => <>Authenticating...</>}
       >
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
     </Router>
   )
   const screen = render(<TestRouter />)
@@ -883,9 +886,9 @@ test('can display a loading screen with a hook', async () => {
       })}
     >
       <Route path="/" page={HomePage} name="home" />
-      <Private unauthenticated="home" whileLoadingAuth={HookLoader}>
+      <PrivateSet unauthenticated="home" whileLoadingAuth={HookLoader}>
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
     </Router>
   )
   const screen = render(<TestRouter />)
@@ -914,10 +917,10 @@ test('inits routes two private routes with a space in between and loads as expec
       <Route path="/" page={HomePage} name="home" />
       <Route path="/about" page={AboutPage} name="about" />
       <Route path="/redirect" page={RedirectPage} name="redirect" />
-      <Private unauthenticated="home">
+      <PrivateSet unauthenticated="home">
         <Route path="/private" page={PrivatePage} name="private" />{' '}
         <Route path="/another-private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
 
       <Route
         path="/param-test/:value"
@@ -946,14 +949,14 @@ test('supports <Set>', async () => {
         <Route path="/" page={HomePage} name="home" />
         <Route path="/about" page={AboutPage} name="about" />
         <Route path="/redirect" page={RedirectPage} name="redirect" />
-        <Private unauthenticated="home">
+        <PrivateSet unauthenticated="home">
           <Route path="/private" page={PrivatePage} name="private" />
           <Route
             path="/another-private"
             page={PrivatePage}
             name="anotherPrivate"
           />
-        </Private>
+        </PrivateSet>
       </Set>
     </Router>
   )
@@ -1097,7 +1100,7 @@ test('renders first matching route only, even if multiple routes have the same n
   expect(screen.queryByText('About Two Page')).not.toBeInTheDocument()
 })
 
-test('renders first matching route only, also with Private', async () => {
+test('renders first matching route only, also with PrivateSet', async () => {
   const ParamPage = ({ param }: { param: string }) => <div>param {param}</div>
 
   const TestRouter = () => (
@@ -1105,9 +1108,9 @@ test('renders first matching route only, also with Private', async () => {
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={LoginPage} name="login" />
       <Route path="/about" page={AboutPage} name="about" />
-      <Private unauthenticated="login">
+      <PrivateSet unauthenticated="login">
         <Route path="/{param}" page={ParamPage} name="param" />
-      </Private>
+      </PrivateSet>
     </Router>
   )
 
@@ -1121,15 +1124,15 @@ test('renders first matching route only, also with Private', async () => {
   expect(screen.queryByText(/param/)).not.toBeInTheDocument()
 })
 
-test('renders first matching route only, also with param path outside Private', async () => {
+test('renders first matching route only, also with param path outside PrivateSet', async () => {
   const ParamPage = ({ param }: { param: string }) => <div>param {param}</div>
 
   const TestRouter = () => (
     <Router useAuth={mockUseAuth({ isAuthenticated: true })}>
       <Route path="/" page={HomePage} name="home" />
-      <Private unauthenticated="login">
+      <PrivateSet unauthenticated="login">
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
       <Route path="/{param}" page={ParamPage} name="param" />
     </Router>
   )
@@ -1259,9 +1262,9 @@ test('Set is not rendered for unauthenticated user.', async () => {
 
   const TestRouter = () => (
     <Router>
-      <Set private wrap={SetWithUseParams} unauthenticated="login">
+      <PrivateSet wrap={SetWithUseParams} unauthenticated="login">
         <Route path="/test/{documentId}" page={ParamPage} name="param" />
-      </Set>
+      </PrivateSet>
       <Route path="/" page={HomePage} name="home" />
       <Route path="/login" page={() => <div>auth thyself</div>} name="login" />
     </Router>
@@ -1292,6 +1295,8 @@ test('Set is not rendered for unauthenticated user on direct navigation', async 
 
   const TestRouter = () => (
     <Router>
+      {/* Keeping this around so we don't accidentally break the `private` prop
+      on Set until we're ready to remove it */}
       <Set private wrap={SetWithUseParams} unauthenticated="login">
         <Route path="/test/{documentId}" page={ParamPage} name="param" />
       </Set>
@@ -1305,6 +1310,7 @@ test('Set is not rendered for unauthenticated user on direct navigation', async 
   await waitFor(() => screen.getByText(/auth thyself/))
 })
 
+// TODO: Remove this entire test once we remove the `<Private>` component
 test('Private is an alias for Set private', async () => {
   const PrivateLayout = ({ children, theme }) => (
     <div>
@@ -1335,9 +1341,9 @@ test('redirect to last page', async () => {
     <Router>
       <Route path="/" page={HomePage} name="home" />
       <Route path="/about" page={AboutPage} name="about" />
-      <Private unauthenticated="login">
+      <PrivateSet unauthenticated="login">
         <Route path="/private" page={PrivatePage} name="private" />
-      </Private>
+      </PrivateSet>
       <Route path="/login" page={LoginPage} name="login" />
     </Router>
   )
@@ -1559,13 +1565,13 @@ describe('Unauthorized redirect error messages', () => {
     console.error = err
   })
 
-  test('Private set with unauthenticated prop with nonexisting page', async () => {
+  test('PrivateSet with unauthenticated prop with nonexisting page', async () => {
     const TestRouter = ({ authenticated }: { authenticated?: boolean }) => (
       <Router useAuth={mockUseAuth({ isAuthenticated: authenticated })}>
         <Route path="/" page={HomePage} name="home" />
-        <Set private unauthenticated="does-not-exist">
+        <PrivateSet unauthenticated="does-not-exist">
           <Route path="/private" page={PrivatePage} name="private" />
-        </Set>
+        </PrivateSet>
       </Router>
     )
 
@@ -1575,14 +1581,14 @@ describe('Unauthorized redirect error messages', () => {
     )
   })
 
-  test('Private set redirecting to page that needs parameters', async () => {
+  test('PrivateSet redirecting to page that needs parameters', async () => {
     const TestRouter = ({ authenticated }: { authenticated?: boolean }) => (
       <Router useAuth={mockUseAuth({ isAuthenticated: authenticated })}>
         <Route path="/" page={HomePage} name="home" />
         <Route path="/param-test/{value}" page={ParamPage} name="params" />
-        <Set private unauthenticated="params">
+        <PrivateSet unauthenticated="params">
           <Route path="/private" page={PrivatePage} name="private" />
-        </Set>
+        </PrivateSet>
       </Router>
     )
 
@@ -1610,41 +1616,38 @@ describe('Multiple nested private sets', () => {
   const TestRouter = ({ useAuthMock }) => (
     <Router useAuth={useAuthMock}>
       <Route path="/" page={HomePage} name="home" />
-      <Set unauthenticated="home" level="1" wrap={LevelLayout} private>
+      <PrivateSet unauthenticated="home" level="1" wrap={LevelLayout}>
         <Route
           path="/no-roles-assigned"
           page={PrivateNoRolesAssigned}
           name="noRolesAssigned"
         />
-        <Set
-          private
+        <PrivateSet
           unauthenticated="noRolesAssigned"
           roles={['ADMIN', 'EMPLOYEE']}
           level="2"
         >
-          <Set
+          <PrivateSet
             unauthenticated="privateAdmin"
             roles={['EMPLOYEE']}
             level="3"
-            private
           >
             <Route
               path="/employee"
               page={PrivateEmployeePage}
               name="privateEmployee"
             />
-          </Set>
+          </PrivateSet>
 
-          <Set
+          <PrivateSet
             unauthenticated="privateEmployee"
             roles={['ADMIN']}
             level="3"
-            private
           >
             <Route path="/admin" page={PrivateAdminPage} name="privateAdmin" />
-          </Set>
-        </Set>
-      </Set>
+          </PrivateSet>
+        </PrivateSet>
+      </PrivateSet>
     </Router>
   )
 

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1727,7 +1727,7 @@ describe('Multiple nested private sets', () => {
   })
 })
 
-describe('Multiple nested private sets', () => {
+describe('Multiple nested sets', () => {
   const HomePage = () => <h1>Home Page</h1>
   const Page = () => <h1>Page</h1>
 

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -221,6 +221,14 @@ const WrappedPage = memo(({ routeLoaderElement, sets }: WrappedPageProps) => {
   }
 
   return sets.reduceRight<ReactNode | undefined>((acc, set) => {
+    // For each set in `sets`, if you have `<Set wrap={[a,b,c]} p="p" />` then
+    // this will return
+    // <a p="p"><b p="p"><c p="p"><routeLoaderElement /></c></b></a>
+    // If you have `<PrivateSet wrap={[a,b,c]} p="p" />` instead it will return
+    // <AuthenticatedRoute>
+    //   <a p="p"><b p="p"><c p="p"><routeLoaderElement /></c></b></a>
+    // </AuthenticatedRoute>
+
     // Bundle up all the wrappers into a single element with each wrapper as a
     // child of the previous (that's why we do reduceRight)
     let wrapped = set.wrappers.reduceRight((acc, Wrapper) => {

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -640,7 +640,7 @@ export function analyzeRoutes(
                   // The following three conditions can be removed when we remove
                   // the deprecated private prop
                   isPrivateNode(node) ||
-                  previousSets.some((set) => set.props.private) ||
+                  // previousSets.some((set) => set.props.private) ||
                   !!otherPropsFromCurrentSet.private,
                 props: otherPropsFromCurrentSet,
               },

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -637,10 +637,9 @@ export function analyzeRoutes(
                 wrappers: wrapperComponentsArray,
                 isPrivate:
                   isPrivateSetNode(node) ||
-                  // The following three conditions can be removed when we remove
+                  // The following two conditions can be removed when we remove
                   // the deprecated private prop
                   isPrivateNode(node) ||
-                  // previousSets.some((set) => set.props.private) ||
                   !!otherPropsFromCurrentSet.private,
                 props: otherPropsFromCurrentSet,
               },

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -472,6 +472,8 @@ interface AnalyzedRoute {
       [key: string]: unknown
     }
   }>
+  // TODO: Figure out if we can remove setId and isPrivate below now that it's
+  // included in the per-set info
   setId: number
   isPrivate: boolean
 }

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -637,8 +637,6 @@ export function analyzeRoutes(
                 wrappers: wrapperComponentsArray,
                 isPrivate:
                   isPrivateSetNode(node) ||
-                  // TODO: Is this needed?
-                  previousSets.some((set) => set.isPrivate) ||
                   // The following three conditions can be removed when we remove
                   // the deprecated private prop
                   isPrivateNode(node) ||

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -8,7 +8,7 @@ import {
   isValidRoute,
 } from './route-validators'
 import type { PageType } from './router'
-import { isPrivateNode, isSetNode } from './Set'
+import { isPrivateNode, isPrivateSetNode, isSetNode } from './Set'
 
 /** Create a React Context with the given name. */
 export function createNamedContext<T>(name: string, defaultValue?: T) {
@@ -594,7 +594,7 @@ export function analyzeRoutes(
         }
       }
 
-      // @NOTE: A <Private> is also a Set
+      // @NOTE: A <PrivateSet> is also a Set
       if (isSetNode(node)) {
         setId = setId + 1 // increase the Set id for each Set found
         const {
@@ -614,7 +614,9 @@ export function analyzeRoutes(
         // You cannot make a nested set public if the parent is private
         // i.e. the private prop cannot be overridden by a child Set
         const privateProps =
-          isPrivateNode(node) || previousSetProps.some((props) => props.private)
+          isPrivateNode(node) ||
+          isPrivateSetNode(node) ||
+          previousSetProps.some((props) => props.private)
             ? { private: true }
             : {}
 


### PR DESCRIPTION
Deprecate the `<Private>` component and the `private` prop on `<Set>`. Instead we introduce a new `<PrivateSet>` component.

This PR should be fully backwards compatible. 
Fully removing `<Private>` and `private` will be done in RW v7 (or later major version)

See also: https://github.com/redwoodjs/redwood/pull/9271

Fixes https://github.com/redwoodjs/redwood/issues/2562
Fixes https://github.com/redwoodjs/redwood/issues/9304

Also fixes the issue addressed by https://github.com/redwoodjs/redwood/pull/9306