### PR TITLE
fix(router): Fix inheritance of private props in nested sets 

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -45,7 +45,7 @@ export function Set<WrapperProps>(_props: SetProps<WrapperProps>) {
   return null
 }
 
-type PrivateProps<P> = Omit<
+export type PrivateProps<P = any> = Omit<
   SetProps<P>,
   'private' | 'unauthenticated' | 'wrap'
 > & {

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -291,6 +291,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       setProps: [
         {
           private: true,
+          roles: undefined,
           unauthenticated: 'home',
         },
       ],

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect } from 'react'
+
+import '@testing-library/jest-dom/extend-expect'
+import { act, render, waitFor } from '@testing-library/react'
+
+import { navigate, Route, Router } from '../'
+import { Private, Set } from '../Set'
+
+/**
+ * 🎩 Headsup, in this test we're not mocking LazyComponent
+ * because all the tests explicitly define the pages in the router.
+ *
+ * If you add tests with dynamic imports i.e. all the pages aren't explicitly supplied to the route
+ * then you'll need to mock LazyComponent (see router.test.tsx)
+ */
+
+const HomePage = () => <h1>Home Page</h1>
+const Page = () => <h1>Page</h1>
+
+test('Sets nested in Private should not error out if no authenticated prop provided', () => {
+  const Layout1 = ({ children }) => (
+    <div>
+      <p>Layou1</p>
+      {children}
+    </div>
+  )
+
+  const SetInsidePrivate = () => (
+    <Router>
+      <Route path="/" page={HomePage} name="home" />
+      <Route path="/auth" page={() => 'Regular Auth'} name="auth" />
+      <Route path="/adminAuth" page={() => 'Admin Auth'} name="adminAuth" />
+      <Private unauthenticated="auth">
+        <Route path="/two/{slug}" page={Page} name="two" />
+        {/*  👇 This set is private implicitly (nested under private),
+         but should not need an unauthenticated prop */}
+        <Set wrap={Layout1}>
+          <Private roles="admin" unauthenticated="adminAuth">
+            <Route path="/three" page={Page} name="three" />
+          </Private>
+        </Set>
+      </Private>
+      <Set wrap={Layout1} private>
+        <Route path="/four" page={Page} name="four" />
+      </Set>
+    </Router>
+  )
+
+  render(<SetInsidePrivate />)
+
+  expect(() => {
+    act(() => navigate('/three'))
+  }).not.toThrowError()
+
+  // But still throws if you try to navigate to a private route without an unauthenticated prop
+  expect(() => {
+    act(() => navigate('/four'))
+  }).toThrowError('You must specify an `unauthenticated` route')
+})

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import '@testing-library/jest-dom/extend-expect'
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 
 import { navigate, Route, Router } from '../'
 import { Private, Set } from '../Set'

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1687,7 +1687,7 @@ describe('Multiple nested private sets', () => {
     })
   })
 
-  test.only('is authenticated and has a matching role', async () => {
+  test('is authenticated and has a matching role', async () => {
     const screen = render(
       <TestRouter
         useAuthMock={mockUseAuth({

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1601,7 +1601,6 @@ describe('Multiple nested private sets', () => {
   const PrivateAdminPage = () => <h1>Private Admin Page</h1>
 
   const LevelLayout = ({ children, level }) => {
-    children //?
     return (
       <section>
         Level: {level}

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1600,12 +1600,15 @@ describe('Multiple nested private sets', () => {
   const PrivateEmployeePage = () => <h1>Private Employee Page</h1>
   const PrivateAdminPage = () => <h1>Private Admin Page</h1>
 
-  const LevelLayout = ({ children, level }) => (
-    <div>
-      Level: {level}
-      {children}
-    </div>
-  )
+  const LevelLayout = ({ children, level }) => {
+    children //?
+    return (
+      <section>
+        Level: {level}
+        {children}
+      </section>
+    )
+  }
 
   const TestRouter = ({ useAuthMock }) => (
     <Router useAuth={useAuthMock}>
@@ -1684,7 +1687,7 @@ describe('Multiple nested private sets', () => {
     })
   })
 
-  test('is authenticated and has a matching role', async () => {
+  test.only('is authenticated and has a matching role', async () => {
     const screen = render(
       <TestRouter
         useAuthMock={mockUseAuth({
@@ -1697,9 +1700,10 @@ describe('Multiple nested private sets', () => {
     )
 
     act(() => navigate('/admin'))
+
     await waitFor(() => {
-      expect(screen.queryByText(`Private Admin Page`)).toBeInTheDocument()
       expect(screen.queryByText(`Level: 3`)).toBeInTheDocument()
+      expect(screen.queryByText(`Private Admin Page`)).toBeInTheDocument()
     })
   })
 

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -8,6 +8,7 @@ import {
   isValidRoute,
 } from './route-validators'
 import type { PageType } from './router'
+import type { PrivateProps } from './Set'
 import { isPrivateNode, isSetNode } from './Set'
 
 /** Create a React Context with the given name. */
@@ -617,33 +618,32 @@ export function analyzeRoutes(
         // The "private" prop from any parent implies that all children are private.
         // So we also grab other private props from the parent, incase it's not specified on the child
         const inheritedPrivateProps = allInheritProps
-          ? {
+          ? ({
               private: allInheritProps.private,
               roles: allInheritProps.roles,
               unauthenticated: allInheritProps.unauthenticated,
-            }
+            } as PrivateProps)
           : null
 
         const currentPrivateProps =
           node.props.private || isPrivateNode(node)
-            ? {
+            ? ({
                 private: true, // Private component doesn't have "private" prop
                 unauthenticated: node.props.unauthenticated,
                 roles: node.props.roles,
-              }
+              } as PrivateProps)
             : null
 
-        // @MARK note unintuitive, but intentional
         // You cannot make a nested set public if the parent is private
         // i.e. the private prop cannot be overridden by a child Set
         const privateProps =
           currentPrivateProps || inheritedPrivateProps
             ? {
                 ...(inheritedPrivateProps || {}),
-                ...currentPrivateProps,
+                ...(currentPrivateProps || {}),
                 private: true,
               }
-            : {}
+            : null
 
         if (children) {
           recurseThroughRouter({
@@ -661,7 +661,7 @@ export function analyzeRoutes(
                 // Current one takes precedence
                 ...otherPropsFromCurrentSet,
                 // See comment at definition, intentionally at the end
-                ...privateProps,
+                ...(privateProps || {}),
               },
             ],
           })

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -614,8 +614,8 @@ export function analyzeRoutes(
         const allInheritProps = previousSetProps.find((props) => props.private)
 
         // We have to do this, to make sure we don't overwrite other props from parent Sets
-        // auth props from parents take precendence
-        // non-auth props from children take precedence
+        // The "private" prop from any parent implies that all children are private.
+        // So we also grab other private props from the parent, incase it's not specified on the child
         const inheritedPrivateProps = allInheritProps
           ? {
               private: allInheritProps.private,


### PR DESCRIPTION
Fixes the issue described in https://community.redwoodjs.com/t/private-route-error-with-7-0-0-canary-347/5337

**Tldr;**
When you nest `<Private>` or `<Set private>` under another one, we assume the child Set is private also. BUT we had extra logic to check that unauthenticated was also set on any private set. This PR makes sure that the unauthenticated is passed down from the parent set, but also can be overriden in the current Set.

See the test for more details - it's hard to describe!