### PR TITLE
RSC e2e scripts: Fix console.log text. Change local test path

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -97,7 +97,7 @@ async function setUpRscProject(
   await execInProject(`node ${rwBinPath} build -v`)
   console.log()
 
-  console.log(`Building project in ${rscProjectPath}`)
+  console.log(`Copying over framework files to ${rscProjectPath}`)
   await execInProject(`node ${rwfwBinPath} project:copy`, {
     env: { RWFW_PATH: REDWOOD_FRAMEWORK_PATH },
   })

--- a/.github/actions/set-up-rsc-project/setUpRscProjectLocally.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProjectLocally.mjs
@@ -73,7 +73,7 @@ function getExecaOptions(cwd, env = {}) {
 
 const rscProjectPath = path.join(
   os.tmpdir(),
-  'rsc-project',
+  'redwood-rsc-project',
   // ":" is problematic with paths
   new Date().toISOString().split(':').join('-')
 )


### PR DESCRIPTION
The console.log text was copy/pasted from an earlier step and not changed. Fixed it to reflect what's actually happening.

Updated the test project path we use to make it easier to find among all other folders in the tmp path. Now you can do `ls -la | grep redwood` and you'll find both the regular test project and the rsc test project.