### PR TITLE
RSC: test-project-rsa: Fix TS type error in onSend

### DIFF
--- a/__fixtures__/test-project-rsa/web/src/chat.ts
+++ b/__fixtures__/test-project-rsa/web/src/chat.ts
@@ -3,7 +3,13 @@
 import { randomWords } from './words'
 
 export async function onSend(formData: FormData) {
-  console.log('message', formData.get('message'))
+  const message = formData.get('message')
+
+  console.log('message', message)
+
+  if (typeof message !== 'string') {
+    throw new Error('message must be a string')
+  }
 
   // Locally you could do this:
   // const words = await fetch(
@@ -12,5 +18,6 @@ export async function onSend(formData: FormData) {
   // But in CI we don't want to hit an external API, so we just do this instead:
   const words = await randomWords(5)
 
-  return { messages: [formData.get('message'), words.join(' ')] }
+  return { messages: [message, words.join(' ')] }
 }
+


### PR DESCRIPTION
The return type of `FormData.get()` is `FormDataEntryValue`, which resolves to `string | File`. This made the return type of `onSend` include `File` as a possible value. We only wanted it to be strings. So this PR adds a check that throws an error if it's not a string (which should never happen in this test project).