### PR TITLE
Update all GitHub actions to run on Node 20

### DIFF
--- a/.github/actions/check_create_redwood_app/action.yml
+++ b/.github/actions/check_create_redwood_app/action.yml
@@ -1,8 +1,7 @@
 name: Check create redwood app
 description: Determines if the create redwood app JS template should be rebuilt
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: check_create_redwood_app.mjs
 inputs:
   labels:

--- a/.github/actions/check_test_project_fixture/action.yml
+++ b/.github/actions/check_test_project_fixture/action.yml
@@ -1,8 +1,7 @@
 name: Check test project fixture
 description: Determines if the test project fixture should be rebuilt
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: check_test_project_fixture.mjs
 inputs:
   labels:

--- a/.github/actions/only_doc_changes/action.yml
+++ b/.github/actions/only_doc_changes/action.yml
@@ -4,6 +4,5 @@ outputs:
   only-doc-changes:
     description: If the PR only changes docs
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: only_doc_changes.mjs

--- a/.github/actions/require-milestone/action.yml
+++ b/.github/actions/require-milestone/action.yml
@@ -2,6 +2,5 @@ name: Require milestone
 description: Ensures that a PR has a valid milestone
 
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: requireMilestone.mjs

--- a/.github/actions/rsc_related_changes/action.yml
+++ b/.github/actions/rsc_related_changes/action.yml
@@ -4,6 +4,5 @@ outputs:
   rsc-related-changes:
     description: If the PR makes any RSC related changes
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: rsc_related_changes.mjs

--- a/.github/actions/set-up-test-project/action.yaml
+++ b/.github/actions/set-up-test-project/action.yaml
@@ -2,8 +2,7 @@ name: Set up test project
 description: Sets up the test project fixture in CI for smoke tests and CLI checks
 
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: 'setUpTestProject.mjs'
 
 inputs:

--- a/.github/actions/update_all_contributors/action.yml
+++ b/.github/actions/update_all_contributors/action.yml
@@ -1,6 +1,5 @@
 name: Update all contributors
 description: Updates all contributors
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: update_all_contributors.mjs

--- a/tasks/check/action.yml
+++ b/tasks/check/action.yml
@@ -1,6 +1,5 @@
 name: 'Check'
 description: "Check constraints, dependencies, and package.json's"
 runs:
-  # `node18` isn't supported yet
-  using: node16
+  using: node20
   main: 'check.mjs'


### PR DESCRIPTION
Node 16 is almost End of Life and GitHub recommends that all actions should be updated to use Node 20
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/