### PR TITLE
chore: increase server test timeout, fix `yarn build:clean`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "benchmark": "tsx ./tasks/benchmark/run-benchmarks.mts",
     "build": "lerna run build",
-    "build:clean": "yarn clean:prisma && rimraf \"packages/**/dist\" --glob",
+    "build:clean": "yarn node ./tasks/clean.mjs",
     "build:clean:super": "git clean -fdx && yarn && yarn build",
     "build:link": "node ./tasks/build-and-copy",
     "build:test-project": "node ./tasks/test-project/test-project",

--- a/tasks/clean.mjs
+++ b/tasks/clean.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+import { rimraf } from 'rimraf'
+import { $ } from 'zx'
+
+await $`yarn clean:prisma`
+
+await rimraf('packages/**/dist', {
+  glob: {
+    ignore: 'packages/**/{fixtures,__fixtures__}/**/dist',
+  },
+})

--- a/tasks/server-tests/jest.config.js
+++ b/tasks/server-tests/jest.config.js
@@ -1,6 +1,7 @@
 /** @type {import('jest').Config} */
 const config = {
   rootDir: '.',
+  testTimeout: 5_000 * 2,
 }
 
 module.exports = config

--- a/tasks/server-tests/server.test.ts
+++ b/tasks/server-tests/server.test.ts
@@ -34,7 +34,7 @@ afterEach(async () => {
   }
 })
 
-const TIMEOUT = 1_500
+const TIMEOUT = 1_000 * 2
 
 const commandStrings = {
   '@redwoodjs/cli': `node ${path.resolve(


### PR DESCRIPTION
In https://github.com/redwoodjs/redwood/pull/9325, I added a few fixtures to the `@redwoodjs/api-server` package that include dist files. `yarn build:clean` deletes all dist directories in all packages (the glob is `packages/**/dist`), so `yarn rwfw project:sync` ended up deleting twenty or so files. This PR makes `yarn build:clean` a little smarter. I couldn't see a way to do it via the `rimraf` CLI, so I just made a script.

This PR also increases the timeout in the server tests which were a little flakey.