### PR TITLE
chore(k6): Fix function context test

### DIFF
--- a/tasks/k6-test/run-k6-tests.mts
+++ b/tasks/k6-test/run-k6-tests.mts
@@ -45,11 +45,11 @@ const SETUPS_DIR = path.join(__dirname, 'setups')
 const TESTS_DIR = path.join(__dirname, 'tests')
 const API_SERVER_COMMANDS = [
   {
-    cmd: `node ${path.resolve(REDWOODJS_FRAMEWORK_PATH, 'packages/cli/dist/index.js')} serve api`,
+    cmd: `node ${path.resolve(REDWOOD_PROJECT_DIRECTORY, 'node_modules/@redwoodjs/cli/dist/index.js')} serve api`,
     host: 'http://localhost:8911',
   },
   {
-    cmd: `node ${path.resolve(REDWOODJS_FRAMEWORK_PATH, 'packages/api-server/dist/index.js')} api`,
+    cmd: `node ${path.resolve(REDWOOD_PROJECT_DIRECTORY, 'node_modules/@redwoodjs/api-server/dist/index.js')} api`,
     host: 'http://localhost:8911'
   },
 ]

--- a/tasks/k6-test/setups/context_magic_number/templates/benchmarks.ts
+++ b/tasks/k6-test/setups/context_magic_number/templates/benchmarks.ts
@@ -2,25 +2,19 @@ import type { MutationResolvers } from 'types/graphql'
 
 import { setContext } from '@redwoodjs/graphql-server'
 
-import { logger } from 'src/lib/logger'
-
 export const magicNumber: MutationResolvers['magicNumber'] = async ({
   value,
 }) => {
   setContext({
-    // ...context,
     magicNumber: value,
   })
-  // context.magicNumber = value
 
   const sleep = Math.random() * 200
-  // logger.info(`Sleeping for ${sleep}ms`)
   await new Promise((resolve) => setTimeout(resolve, sleep))
 
   const numberFromContext = (context.magicNumber ?? -1) as number
   if (value !== numberFromContext) {
-    logger.error(`Expected ${value} but got ${numberFromContext}`)
-    // throw new Error(`Expected ${value} but got ${numberFromContext}`)
+    throw new Error(`Expected ${value} but got ${numberFromContext}`)
   }
 
   return { value: numberFromContext }

--- a/tasks/k6-test/setups/context_magic_number/templates/func.ts
+++ b/tasks/k6-test/setups/context_magic_number/templates/func.ts
@@ -2,8 +2,6 @@ import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 
 import { setContext } from '@redwoodjs/graphql-server'
 
-import { logger } from 'src/lib/logger'
-
 export const handler = async (
   event: APIGatewayProxyEvent,
   _context: Context
@@ -19,7 +17,7 @@ export const handler = async (
 
   const numberFromContext = (context.magicNumber ?? -1) as number
   if (magicNumber !== numberFromContext) {
-    logger.error(`Expected ${magicNumber} but got ${numberFromContext}`)
+    throw new Error(`Expected ${magicNumber} but got ${numberFromContext}`)
   }
 
   return {

--- a/tasks/k6-test/tests/context_functions.js
+++ b/tasks/k6-test/tests/context_functions.js
@@ -19,28 +19,7 @@ export const options = {
 
 export default function () {
   const magicNumber = Math.floor(Math.random() * 16000000)
-
-  const payload = (value) => {
-    return JSON.stringify({
-      query: `mutation MagicNumber($value: Int!) {
-        magicNumber(value: $value) {
-          value
-        }
-      }`,
-      variables: {
-        value,
-      },
-      operationName: 'MagicNumber',
-    })
-  }
-
-  const url = `${__ENV.TEST_HOST}/func`
-  const params = {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  }
-  const res = http.post(url, payload(magicNumber), params)
+  const res = http.get(`${__ENV.TEST_HOST}/func?magicNumber=${magicNumber}`)
 
   const requestPassed = check(res, {
     'status was 200': (r) => r.status == 200,
@@ -51,7 +30,7 @@ export default function () {
 
   const contextPassed = check(res, {
     'correct magic number': (r) =>
-      r.body != null && r.body.includes(`"value":${magicNumber}}`),
+      r.body != null && r.body.includes(`"value":"${magicNumber}"}`),
   })
   if (!contextPassed) {
     contextErrorCounter.add(1)


### PR DESCRIPTION
**Problem**
Follow up to #9358 which didn't completely fix the broken tests.

**Changes**
1. Correct the function test.
2. Update to run the servers in the project not the framework. 

**Status**
You can now see the expected results which show function context is not isolated when running the `rw-server` but is isolated for `rw serve api`

<img width="1405" alt="image" src="https://github.com/redwoodjs/redwood/assets/56300765/5401ef54-e77b-423c-80d5-3fce83259a1b">
