### PR TITLE
fix(server-file): prefix `MODULE_NOT_FOUND` with `ERR_`

### DIFF
--- a/packages/internal/src/generate/graphqlSchema.ts
+++ b/packages/internal/src/generate/graphqlSchema.ts
@@ -24,13 +24,16 @@ export const generateGraphQLSchema = async () => {
     'subscriptions/**/*.{js,ts}': {},
   }
 
-  // If we are serverful and the user is using realtime, we need to include the live directive for realtime support.
+  // If we're serverful and the user is using realtime, we need to include the live directive for realtime support.
+  // Note the `ERR_  prefix in`ERR_MODULE_NOT_FOUND`. Since we're using `await import`,
+  // if the package (here, `@redwoodjs/realtime`) can't be found, it throws this error, with the prefix.
+  // Whereas `require('@redwoodjs/realtime')` would throw `MODULE_NOT_FOUND`.
   if (resolveFile(`${getPaths().api.src}/server`)) {
     try {
       const { liveDirectiveTypeDefs } = await import('@redwoodjs/realtime')
       schemaPointerMap[liveDirectiveTypeDefs] = {}
     } catch (error) {
-      if ((error as { code: string }).code !== 'MODULE_NOT_FOUND') {
+      if ((error as { code: string }).code !== 'ERR_MODULE_NOT_FOUND') {
         throw error
       }
     }


### PR DESCRIPTION
If you try to `await import` a module and it can't be found, it turns out Node throws a different error than if you try to `require` a module and it can't be found:

- `require(mod)` -> `MODULE_NOT_FOUND`
- `await import(mod)` -> `ERR_MODULE_NOT_FOUND`

We used to tranpsile `await import`s to `require`. When we stopped doing that, we forgot to change the error codes we were checking.