### PR TITLE
fix(serverless): try-catch `getConfigPath` for `cookieName`

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -1,7 +1,7 @@
 import type { APIGatewayProxyEvent } from 'aws-lambda'
 import CryptoJS from 'crypto-js'
 
-import { getConfig } from '@redwoodjs/project-config'
+import { getConfig, getConfigPath } from '@redwoodjs/project-config'
 
 import * as DbAuthError from './errors'
 
@@ -125,8 +125,21 @@ export const hashPassword = (text: string, salt?: string) => {
 }
 
 export const cookieName = (name: string | undefined) => {
-  const port = getConfig().api?.port || 8911
+  const port = getPort()
   const cookieName = name?.replace('%port%', '' + port) ?? 'session'
 
   return cookieName
+}
+
+function getPort() {
+  let configPath
+
+  try {
+    configPath = getConfigPath()
+  } catch {
+    // If this throws, we're in a serverless environment, and the `redwood.toml` file doesn't exist.
+    return 8911
+  }
+
+  return getConfig(configPath).api.port
 }


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/9281. The functionality added in https://github.com/redwoodjs/redwood/pull/9248 depends on the `redwood.toml` file. This file doesn't exist in serverless environments.

A quick note on the implementation. I could've done this:

```js
let config

try {
  config = getConfig()
} catch (e) {
  if (e.message !== `Could not find a "redwood.toml" file, are you sure you're in a Redwood project?`) {
    throw e
  }
}

// ...
```

But that seemed more brittle because it depends on the error message.

Lastly, `getConfig` merges defaults with the raw config, so I don't think the `api?.port` is necessary.