### PR TITLE
chore(ssr-e2e): Re-enable windows in e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,9 +263,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        # [ubuntu-latest, windows-latest] disabled, because windows misbehaving
-        # waiting for help from main-man Josh
+        os: [ubuntu-latest, windows-latest]
 
     name: 🔁 SSR Smoke tests / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Temporary disabled running ssr smoke tests in #9349 on Windows, as I am unable to debug. 

This PR re-enables it, pending @Josh-Walker-GM having some time to help me with this ☮️