### PR TITLE
chore(ssr): Move LocationProvider inside framework for SSR

### DIFF
--- a/packages/cli/src/commands/experimental/templates/streamingSsr/entry.server.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/entry.server.tsx.template
@@ -4,17 +4,14 @@ import App from './App'
 import { Document } from './Document'
 
 interface Props {
-  url: string
   css: string[]
   meta?: any[]
 }
 
-export const ServerEntry: React.FC<Props> = ({ url, css, meta }) => {
+export const ServerEntry: React.FC<Props> = ({ css, meta }) => {
   return (
-    <LocationProvider location={{ pathname: url }}>
-      <Document css={css} meta={meta}>
-        <App />
-      </Document>
-    </LocationProvider>
+    <Document css={css} meta={meta}>
+      <App />
+    </Document>
   )
 }

--- a/packages/cli/src/commands/experimental/templates/streamingSsr/entry.server.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/entry.server.tsx.template
@@ -1,5 +1,3 @@
-import { LocationProvider } from '@redwoodjs/router'
-
 import App from './App'
 import { Document } from './Document'
 

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -7,6 +7,7 @@ import type {
   ReactDOMServerReadableStream,
 } from 'react-dom/server'
 
+import { LocationProvider } from '@redwoodjs/router'
 import type { TagDescriptor } from '@redwoodjs/web'
 // @TODO (ESM), use exports field. Cannot import from web because of index exports
 import {
@@ -88,11 +89,19 @@ export async function reactRenderToStreamResponse(
       {
         value: injectToPage,
       },
-      ServerEntry({
-        url: path,
-        css: cssLinks,
-        meta: metaTags,
-      })
+      React.createElement(
+        LocationProvider,
+        {
+          location: {
+            pathname: path,
+          },
+        },
+        ServerEntry({
+          url: path,
+          css: cssLinks,
+          meta: metaTags,
+        })
+      )
     )
   }
 


### PR DESCRIPTION
Moves the LocationProvider out of the Entry server template, and into the framework.

We still pass the path to the ServerEntry (for now). 

### What does the `LocationProvider` do?
During SSR, it tells the router what URL is being rendered (since you can't use browser apis on the server). 

Todo:
- [x] Check if it will break for old template
Works fine with old template, because we still pass the url/path to entry server. 