### PR TITLE
chore: Relocated tsbuildinfo out of dist folder

### DIFF
--- a/packages/api-server/tsconfig.json
+++ b/packages/api-server/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src", "ambient.d.ts"],

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src/**/*"]

--- a/packages/auth-providers/auth0/api/tsconfig.json
+++ b/packages/auth-providers/auth0/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/auth0/setup/tsconfig.json
+++ b/packages/auth-providers/auth0/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/auth0/web/tsconfig.json
+++ b/packages/auth-providers/auth0/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/azureActiveDirectory/web/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/clerk/api/tsconfig.json
+++ b/packages/auth-providers/clerk/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/clerk/setup/tsconfig.json
+++ b/packages/auth-providers/clerk/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/clerk/web/tsconfig.json
+++ b/packages/auth-providers/clerk/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/custom/setup/tsconfig.json
+++ b/packages/auth-providers/custom/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/dbAuth/api/tsconfig.json
+++ b/packages/auth-providers/dbAuth/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/dbAuth/setup/tsconfig.json
+++ b/packages/auth-providers/dbAuth/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/dbAuth/web/tsconfig.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src", "ambient.d.ts"],

--- a/packages/auth-providers/firebase/api/tsconfig.json
+++ b/packages/auth-providers/firebase/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/firebase/setup/tsconfig.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/firebase/web/tsconfig.json
+++ b/packages/auth-providers/firebase/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/netlify/api/tsconfig.json
+++ b/packages/auth-providers/netlify/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/netlify/setup/tsconfig.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/netlify/web/tsconfig.json
+++ b/packages/auth-providers/netlify/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/supabase/api/tsconfig.json
+++ b/packages/auth-providers/supabase/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/supabase/setup/tsconfig.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/supabase/web/tsconfig.json
+++ b/packages/auth-providers/supabase/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/supertokens/api/tsconfig.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/supertokens/setup/tsconfig.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth-providers/supertokens/web/tsconfig.json
+++ b/packages/auth-providers/supertokens/web/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src", "ambient.d.ts"]

--- a/packages/babel-config/tsconfig.json
+++ b/packages/babel-config/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/cli-packages/dataMigrate/tsconfig.json
+++ b/packages/cli-packages/dataMigrate/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/cli-packages/storybook/tsconfig.json
+++ b/packages/cli-packages/storybook/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -4,7 +4,6 @@
     "strict": true,
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/fastify/tsconfig.json
+++ b/packages/fastify/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"]

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["ambient.d.ts", "src/**/*"],

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src/**/*", "./ambient.d.ts"],

--- a/packages/mailer/core/tsconfig.json
+++ b/packages/mailer/core/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/mailer/handlers/in-memory/tsconfig.json
+++ b/packages/mailer/handlers/in-memory/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/mailer/handlers/nodemailer/tsconfig.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/mailer/handlers/resend/tsconfig.json
+++ b/packages/mailer/handlers/resend/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/mailer/handlers/studio/tsconfig.json
+++ b/packages/mailer/handlers/studio/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/mailer/renderers/mjml-react/tsconfig.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/mailer/renderers/react-email/tsconfig.json
+++ b/packages/mailer/renderers/react-email/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src"],

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
     "paths": {
       "src/*": ["./src/*"]

--- a/packages/project-config/tsconfig.json
+++ b/packages/project-config/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src/**/*"],

--- a/packages/realtime/tsconfig.json
+++ b/packages/realtime/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src/**/*"],

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",

--- a/packages/structure/tsconfig.json
+++ b/packages/structure/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
     "experimentalDecorators": true,
     "noImplicitReturns": false,

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "rootDir": "api",
-    "tsBuildInfoFile": "dist/api/tsconfig.tsbuildinfo",
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "outDir": "dist/api",
   },
   "include": ["api/**/*"],

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
     "paths": {
       "src/*": ["./src/*"],

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src"],

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["src/**/*", "./ambient.d.ts", "./modules.d.ts"],

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",
   },
   "include": ["src", "ambient.d.ts"],

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist"
   },
   "include": ["./src/**/*", "ambient.d.ts"],

--- a/tasks/release/releaseCommand.mjs
+++ b/tasks/release/releaseCommand.mjs
@@ -413,8 +413,6 @@ async function releaseMajorOrMinor() {
   await $`git commit -am "chore: temporary update to workspaces"`
   console.log()
 
-  await removeTSConfigTSBuildInfo()
-
   //  ------------------------
   try {
     await $`yarn lerna publish from-package`
@@ -575,8 +573,6 @@ async function releasePatch() {
 
   await $`git commit -am "chore: temporary update to workspaces"`
   console.log()
-
-  await removeTSConfigTSBuildInfo()
 
   //  ------------------------
   try {
@@ -792,8 +788,4 @@ async function versionDocs() {
   await $`git add .`
   await $`git commit -m "Version docs to ${nextDocsVersion}"`
   await cd('../')
-}
-
-async function removeTSConfigTSBuildInfo() {
-  await rimraf('packages/**/dist/tsconfig.tsbuildinfo')
 }


### PR DESCRIPTION
**Problem**
The current tsconfig entry for the tsbuildinfo file puts the file into the dist folder. This ultimately results in it being included in the shipped packages on npm. These files are large and in some cases are the bulk of the content in the package. For example in the `@redwoodjs/project-config` package it makes up 75% of the package size.

From what I can read online, and my own understanding of the functionality of that file, there is no need for this content to be shipped with the built code on npm.

I quickly checked on my local machine and this change does not appear to have impacted the build time.

**Change**
1. Delete the explicit entry which will place it in a default location which is fine. The file is already ignored by the existing .gitignore.
2. Remove the code in the release tooling that removes these files. I don't think it was fully functional right now.

**Notes**
I marked this as a chore because it doesn't influence the code just the build step. It does change the bytes that are shipped to users so maybe it's not a chore but I am not that concerned with the label right now.