### PR TITLE
fix(docker): pass `task` to `writeFile`

### DIFF
--- a/packages/cli/src/commands/experimental/setupDockerHandler.js
+++ b/packages/cli/src/commands/experimental/setupDockerHandler.js
@@ -185,20 +185,36 @@ export async function handler({ force }) {
             ].join('\n')
           }
 
-          writeFile(dockerfilePath, dockerfileTemplateContent, {
-            existingFiles: force ? 'OVERWRITE' : 'SKIP',
-          })
-          writeFile(dockerComposeDevFilePath, dockerComposeDevTemplateContent, {
-            existingFiles: force ? 'OVERWRITE' : 'SKIP',
-          })
+          writeFile(
+            dockerfilePath,
+            dockerfileTemplateContent,
+            {
+              existingFiles: force ? 'OVERWRITE' : 'SKIP',
+            },
+            task
+          )
+          writeFile(
+            dockerComposeDevFilePath,
+            dockerComposeDevTemplateContent,
+            {
+              existingFiles: force ? 'OVERWRITE' : 'SKIP',
+            },
+            task
+          )
           writeFile(
             dockerComposeProdFilePath,
             dockerComposeProdTemplateContent,
-            { existingFiles: force ? 'OVERWRITE' : 'SKIP' }
+            { existingFiles: force ? 'OVERWRITE' : 'SKIP' },
+            task
           )
-          writeFile(dockerignoreFilePath, dockerignoreTemplateContent, {
-            existingFiles: force ? 'OVERWRITE' : 'SKIP',
-          })
+          writeFile(
+            dockerignoreFilePath,
+            dockerignoreTemplateContent,
+            {
+              existingFiles: force ? 'OVERWRITE' : 'SKIP',
+            },
+            task
+          )
         },
       },
 


### PR DESCRIPTION
Discovered this bug while trying out the setup command on the v6.40 RC with @KrisCoulson. We were seeing the following error:

<img width="572" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/fd2ae8d2-0f74-4d7a-aebe-88faa3ee9ac7">

Turns out I forgot to pass task through to `writeFile`.