### PR TITLE
RSC: Check for rw-rsc header

### DIFF
--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -151,14 +151,14 @@ export async function setUpRscTestProject(
   console.log(`Installing node_modules in ${testProjectPath}`)
   await execInProject('yarn install')
 
-  console.log(`Building project in ${testProjectPath}`)
-  await execInProject(`node ${rwBinPath} build -v`)
-  console.log()
-
   console.log(`Copying over framework files to ${testProjectPath}`)
   await execInProject(`node ${rwfwBinPath} project:copy`, {
     env: { RWFW_PATH: REDWOOD_FRAMEWORK_PATH },
   })
+  console.log()
+
+  console.log(`Building project in ${testProjectPath}`)
+  await execInProject(`node ${rwBinPath} build -v`)
   console.log()
 
   // await cache.saveCache([testProjectPath], dependenciesKey)

--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -160,3 +160,4 @@ export async function setUpRscTestProject(
   console.log(`Building project in ${testProjectPath}`)
   await execInProject(`node ${rwBinPath} build -v`)
   console.log()
+}

--- a/.github/workflows/weekly_issue_metrics_json.yml
+++ b/.github/workflows/weekly_issue_metrics_json.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Print output of issue metrics tool
       run: |
         cat ./issue_metrics.json
-        cat ./issue_metrics.json | js .total_item_count
-        cat ./issue_metrics.json | js .average_time_to_first_response
+        cat ./issue_metrics.json | jq .total_item_count
+        cat ./issue_metrics.json | jq .average_time_to_first_response

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -17,7 +17,7 @@ const checkStatus = async (
   return response
 }
 
-export function serve<Props>(rscId: string, basePath = '/RSC/') {
+export function serve<Props>(rscId: string, basePath = '/rw-rsc/') {
   type SetRerender = (
     rerender: (next: [ReactElement, string]) => void
   ) => () => void

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -54,6 +54,9 @@ export function serve<Props>(rscId: string, basePath = '/RSC/') {
           const response = fetch(basePath + id + '/' + searchParams, {
             method: 'POST',
             body: await encodeReply(args),
+            headers: {
+              'rw-rsc': '1',
+            },
           })
 
           const data = createFromFetch(response, options)
@@ -76,7 +79,12 @@ export function serve<Props>(rscId: string, basePath = '/RSC/') {
       )
 
       const response =
-        prefetched || fetch(basePath + rscId + '/' + searchParams)
+        prefetched ||
+        fetch(basePath + rscId + '/' + searchParams, {
+          headers: {
+            'rw-rsc': '1',
+          },
+        })
       const data = createFromFetch(checkStatus(response), options)
       console.log('fetchRSC after createFromFetch. data:', data)
 

--- a/packages/vite/src/rsc/rscRequestHandler.ts
+++ b/packages/vite/src/rsc/rscRequestHandler.ts
@@ -10,11 +10,18 @@ const { decodeReply, decodeReplyFromBusboy } = RSDWServer
 
 export function createRscRequestHandler() {
   // This is mounted at /RSC, so will have /RSC stripped from req.url
-  return async (req: Request, res: Response) => {
+  return async (req: Request, res: Response, next: () => void) => {
     const basePath = '/RSC/'
     console.log('basePath', basePath)
     console.log('req.originalUrl', req.originalUrl, 'req.url', req.url)
     console.log('req.headers.host', req.headers.host)
+    console.log("req.headers['rw-rsc']", req.headers['rw-rsc'])
+
+    // https://www.rfc-editor.org/rfc/rfc6648
+    // SHOULD NOT prefix their parameter names with "X-" or similar constructs.
+    if (req.headers['rw-rsc'] !== '1') {
+      return next()
+    }
 
     const url = new URL(req.originalUrl || '', 'http://' + req.headers.host)
     let rscId: string | undefined

--- a/packages/vite/src/rsc/rscRequestHandler.ts
+++ b/packages/vite/src/rsc/rscRequestHandler.ts
@@ -9,9 +9,9 @@ import { renderRsc } from './rscWorkerCommunication'
 const { decodeReply, decodeReplyFromBusboy } = RSDWServer
 
 export function createRscRequestHandler() {
-  // This is mounted at /RSC, so will have /RSC stripped from req.url
+  // This is mounted at /rw-rsc, so will have /rw-rsc stripped from req.url
   return async (req: Request, res: Response, next: () => void) => {
-    const basePath = '/RSC/'
+    const basePath = '/rw-rsc/'
     console.log('basePath', basePath)
     console.log('req.originalUrl', req.originalUrl, 'req.url', req.url)
     console.log('req.headers.host', req.headers.host)

--- a/packages/vite/src/runRscFeServer.ts
+++ b/packages/vite/src/runRscFeServer.ts
@@ -103,8 +103,8 @@ export async function runFeServer() {
     })
   )
 
-  // Mounting middleware at /RSC will strip /RSC from req.url
-  app.use('/RSC', createRscRequestHandler())
+  // Mounting middleware at /rw-rsc will strip /rw-rsc from req.url
+  app.use('/rw-rsc', createRscRequestHandler())
 
   app.use(express.static(rwPaths.web.dist))
 


### PR DESCRIPTION
To not "steal" the `/RSC` endpoint from rw app routes we also check that a special `rw-rsc` header is set. If it's not, we'll call `next()` to pass the request along to the next handler for that path. Also decided to switch from `/RSC` to `/rw-rsc` to make it even less likely it's a path someone else would use, plus it makes it consistent with the header name