### PR TITLE
RSC: smoke tests: install and build after project:copy

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -93,13 +93,17 @@ async function setUpRscProject(
   await execInProject(`node ${rwBinPath} experimental setup-rsc`)
   console.log()
 
-  console.log(`Building project in ${rscProjectPath}`)
-  await execInProject(`node ${rwBinPath} build -v`)
-  console.log()
-
   console.log(`Copying over framework files to ${rscProjectPath}`)
   await execInProject(`node ${rwfwBinPath} project:copy`, {
     env: { RWFW_PATH: REDWOOD_FRAMEWORK_PATH },
   })
+  console.log()
+
+  console.log('Installing dependencies')
+  await execInProject('yarn install')
+  console.log()
+
+  console.log(`Building project in ${rscProjectPath}`)
+  await execInProject(`node ${rwBinPath} build -v`)
   console.log()
 }


### PR DESCRIPTION
For RSC smoke tests:
Run `yarn install` and `rw build` after `project:copy` to build with latest changes to the framework