### PR TITLE
RSC: Move loaders to worker thread

### DIFF
--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -60,12 +60,7 @@ export const bothRscServerHandler = async (argv) => {
   // TODO (RSC) More gracefully handle Ctrl-C
   const fePromise = execa(
     'node',
-    [
-      // TODO (RSC): Do we need these on the worker thread?
-      '--experimental-loader @redwoodjs/vite/node-loader',
-      '--experimental-loader @redwoodjs/vite/react-node-loader',
-      './node_modules/@redwoodjs/vite/dist/runRscFeServer.js',
-    ],
+    ['./node_modules/@redwoodjs/vite/dist/runRscFeServer.js'],
     {
       cwd: getPaths().base,
       stdio: 'inherit',

--- a/packages/vite/src/rsc/rscWorkerCommunication.ts
+++ b/packages/vite/src/rsc/rscWorkerCommunication.ts
@@ -5,9 +5,12 @@ import { Worker } from 'node:worker_threads'
 
 const worker = new Worker(path.join(__dirname, 'rscWorker.js'), {
   execArgv: [
-    '--conditions react-server',
-    '--experimental-loader @redwoodjs/vite/node-loader',
-    '--experimental-loader @redwoodjs/vite/react-node-loader',
+    '--conditions',
+    'react-server',
+    '--experimental-loader',
+    '@redwoodjs/vite/node-loader',
+    '--experimental-loader',
+    '@redwoodjs/vite/react-node-loader',
   ],
 })
 

--- a/packages/vite/src/rsc/rscWorkerCommunication.ts
+++ b/packages/vite/src/rsc/rscWorkerCommunication.ts
@@ -4,7 +4,11 @@ import type { Readable } from 'node:stream'
 import { Worker } from 'node:worker_threads'
 
 const worker = new Worker(path.join(__dirname, 'rscWorker.js'), {
-  execArgv: ['--conditions', 'react-server'],
+  execArgv: [
+    '--conditions react-server',
+    '--experimental-loader @redwoodjs/vite/node-loader',
+    '--experimental-loader @redwoodjs/vite/react-node-loader',
+  ],
 })
 
 export type RenderInput<


### PR DESCRIPTION
Now that we use a worker thread to be able to run the main process without the react-server condition we should use our custom loaders on that worker thread only. It kind of worked before too because arguments from the main thread are inherited by worker threads. But we got a bunch of warnings. And this is the proper way to do it anyway!