### PR TITLE
RSC GH action: Move build to after copy

### DIFF
--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -151,17 +151,14 @@ export async function setUpRscTestProject(
   console.log(`Installing node_modules in ${testProjectPath}`)
   await execInProject('yarn install')
 
-  console.log(`Building project in ${testProjectPath}`)
-  await execInProject(`node ${rwBinPath} build -v`)
-  console.log()
-
   console.log(`Copying over framework files to ${testProjectPath}`)
   await execInProject(`node ${rwfwBinPath} project:copy`, {
     env: { RWFW_PATH: REDWOOD_FRAMEWORK_PATH },
   })
   console.log()
 
-  // await cache.saveCache([testProjectPath], dependenciesKey)
-  // console.log(`Cache saved with key: ${dependenciesKey}`)
+  console.log(`Building project in ${testProjectPath}`)
+  await execInProject(`node ${rwBinPath} build -v`)
+  console.log()
 }
 


### PR DESCRIPTION
Copy framework changes over first, and then run build. Otherwise changes to the build command won't be used