### PR TITLE
fix: handle `tsconfig.tsbuildinfo` in clean, sync

### DIFF
--- a/tasks/clean.mjs
+++ b/tasks/clean.mjs
@@ -11,3 +11,8 @@ await rimraf('packages/**/dist', {
     ignore: 'packages/**/{fixtures,__fixtures__}/**/dist',
   },
 })
+
+// Remove all `tsconfig.tsbuildinfo` files.
+await rimraf('packages/**/tsconfig.tsbuildinfo', {
+  glob: true,
+})

--- a/tasks/framework-tools/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/frameworkSyncToProject.mjs
@@ -49,6 +49,8 @@ const ignored = [
   // esbuild emits meta.json files that we sometimes suffix.
   /meta.(\w*\.?)json/,
 
+  /tsconfig.tsbuildinfo/,
+
   (filePath) => IGNORE_EXTENSIONS.some((ext) => filePath.endsWith(ext)),
 ]
 
@@ -252,6 +254,9 @@ async function main() {
     try {
       logStatus(`Cleaning ${c.magenta(packageName)}...`)
       await rimraf(path.join(path.dirname(packageJsonPath), 'dist'))
+      await rimraf(
+        path.join(path.dirname(packageJsonPath), 'tsconfig.tsbuildinfo')
+      )
 
       logStatus(`Building ${c.magenta(packageName)}...`)
       execSync('yarn build', {


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/9390. Previously, framework sync would remove all of a package's dist, then rebuild it. This meant the `tsconfig.tsbuildinfo` was removed too. 

#9390 moved the `tsconfig.tsbuildinfo`, saving megabytes of space for user's projects, but didn't update `yarn build:clean` or `yarn rwfw project:sync`. This PR restores their behavior. Paired with @Josh-Walker-GM on this one.