### PR TITLE
preview stats when building storybook for Chromatic "TurboSnap"

### DIFF
--- a/packages/cli-packages/storybook/src/commands/storybookHandler.ts
+++ b/packages/cli-packages/storybook/src/commands/storybookHandler.ts
@@ -61,7 +61,10 @@ export async function handler({
   )
 
   let command = ''
-  const flags = [`--config-dir "${storybookConfigPath}"`]
+  const flags = [
+    `--config-dir "${storybookConfigPath}"`,
+    "--webpack-stats-json",
+  ]
 
   if (build) {
     command = `yarn storybook build ${[

--- a/packages/cli-packages/storybook/src/commands/storybookHandler.ts
+++ b/packages/cli-packages/storybook/src/commands/storybookHandler.ts
@@ -63,7 +63,7 @@ export async function handler({
   let command = ''
   const flags = [
     `--config-dir "${storybookConfigPath}"`,
-    "--webpack-stats-json",
+    '--webpack-stats-json',
   ]
 
   if (build) {


### PR DESCRIPTION
## Why is this PR created?
The default `yarn rw storybook --build` doesn't generate preview-stats.json which is required for TurboSnap feature of Chromatic.
![image](https://github.com/redwoodjs/redwood/assets/43738254/bcab7455-0917-4fb2-95d3-afee174c8a6a)

https://www.chromatic.com/docs/turbosnap/

## How it's tested
I made same change in my local environment and build my real project and confirmed successful build and generation of the preview-stats.json.
![image](https://github.com/redwoodjs/redwood/assets/43738254/15b1dd24-c0b9-497b-9775-d41984b1bc73)
