### PR TITLE
fix: JSON parsing error, workspace error

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -229,7 +229,7 @@ async function getAuthHandler(module) {
       version = version.split('+')[0]
     }
 
-    const versionIsPublished = JSON.parse(stdout).versions.includes(version)
+    const versionIsPublished = stdout.includes(version)
 
     if (!versionIsPublished) {
       // Fallback to canary. This is most likely because it's a new package
@@ -238,7 +238,7 @@ async function getAuthHandler(module) {
 
     // We use `version` to make sure we install the same version of the auth
     // setup package as the rest of the RW packages
-    await execa.command(`yarn add -D ${module}@${version}`, {
+    await execa.command(`yarn add -W -D ${module}@${version}`, {
       stdio: 'inherit',
       cwd: getPaths().base,
     })


### PR DESCRIPTION
- "Unexpected token $ in JSON at position 0" from line 162 of `/auth/auth.js`. Since `stdout` is already an array this ends up generating an error at this line. https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/commands/setup/auth/auth.js#L232
- The following line errors when it does not specify workspace. Hence adding a `-W` flag to install in the root workspace. https://github.com/redwoodjs/redwood/blob/main/packages/cli/src/commands/setup/auth/auth.js#L241