### PR TITLE
fix(vite): correctly parse `--open` from forwarded args

### DIFF
--- a/packages/vite/bins/rw-vite-dev.mjs
+++ b/packages/vite/bins/rw-vite-dev.mjs
@@ -17,7 +17,7 @@ const startDevServer = async () => {
   // e.g. yarn rw dev web --fwd="--force"
   const {
     force: forceOptimize,
-    forwardedServerArgs,
+    open,
     debug,
   } = yargsParser(process.argv.slice(2), {
     boolean: ['https', 'open', 'strictPort', 'force', 'cors', 'debug'],
@@ -31,7 +31,9 @@ const startDevServer = async () => {
       // This is the only value that isn't a server option
       force: forceOptimize,
     },
-    server: forwardedServerArgs,
+    server: {
+      open,
+    },
     logLevel: debug ? 'info' : undefined,
   })
 


### PR DESCRIPTION
Fixes an issue with our experimental Docker setup.

If `browser.open` is set to `true` (which it is by default) in a user's `redwood.toml`, `docker compose -f docker-compose.dev.yml up` (which is basically `yarn rw dev`) breaks:

<img width="1048" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/d115a435-677c-47c0-873f-4ca56c03a7e2">

Vite can't find a binary it needs to open the browser. The solution is telling Vite not to open the browser (it's running in a container). Since `--fwd` was never implemented for Vite, right now `yarn rw exp setup-docker` codemods the toml file:

<img width="1532" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/9c4a8cfb-e182-471d-8d07-30af32201a02">

This is overkill but more importantly it's not a great user experience. It'd be better to just pass `--fwd="--open=false"` in the Docker compose file.

At first I wanted to solve this by swapping `rw-vite-dev` for the Vite CLI, but since we handle env vars differently, we can't because the Vite CLI doesn't have an option for disabling env files. I.e. there's no Vite CLI option for this:

https://github.com/redwoodjs/redwood/blob/43227f3b66a66c304ac2dbe513024a3ebc1ae145/packages/vite/bins/rw-vite-dev.mjs#L29

We could see about adding that to Vite. But for right now, let's at least parse `--fwd="--open"`.