### PR TITLE
(Do not merge): Try swtiching rwjs/vite to esm output only

### DIFF
--- a/packages/vite/build.mjs
+++ b/packages/vite/build.mjs
@@ -1,0 +1,26 @@
+import fs from 'node:fs'
+
+import * as esbuild from 'esbuild'
+import fg from 'fast-glob'
+
+// Get source files
+const sourceFiles = fg.sync(['./src/**/*.ts'], {
+  ignore: ['**/*.test.ts'],
+})
+
+// Build general source files
+const result = await esbuild.build({
+  entryPoints: sourceFiles,
+  outdir: 'dist',
+  format: 'esm',
+  platform: 'node',
+  target: ['node18'],
+
+  logLevel: 'info',
+
+  // For visualizing dist.
+  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
+  metafile: true,
+})
+
+fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build": "yarn build:js && yarn build:types",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\"",
+    "build:js": "yarn node ./build.mjs",
     "build:types": "tsc --build --verbose",
     "test": "yarn test:node && echo",
     "test:node": "glob './src/**/__tests__/*.test.mts' --cmd='node --loader tsx --no-warnings --test'",


### PR DESCRIPTION
Try switching to building with esbuild and esm in Vite package. Trying to see if this will be feasible, so we can start using `import.meta.X`