### PR TITLE
fix(cli): Remove boxen from default error output

### DIFF
--- a/packages/cli/src/lib/exit.js
+++ b/packages/cli/src/lib/exit.js
@@ -1,4 +1,4 @@
-import boxen from 'boxen'
+import chalk from 'chalk'
 import terminalLink from 'terminal-link'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -36,26 +36,23 @@ export function exitWithError(
   // the error in telemetry if needed and if the user chooses to share it
   const errorReferenceCode = uuidv4()
 
+  const line = chalk.red('-'.repeat(process.stderr.columns))
+
   // Generate and print a nice message to the user
   const content = [
+    line,
     message,
-    includeEpilogue && `\n${'-'.repeat(process.stderr.columns - 8)}\n`,
+    includeEpilogue && `\n${line}`,
     includeEpilogue && epilogue,
     includeReferenceCode &&
       ` - Here's your unique error reference to quote: '${errorReferenceCode}'`,
+    line,
   ]
     .filter(Boolean)
     .join('\n')
 
   console.error()
-  console.error(
-    boxen(content, {
-      padding: 1,
-      borderColor: 'red',
-      title: `Error`,
-      titleAlignment: 'left',
-    })
-  )
+  console.error(content)
 
   // Record the error in telemetry
   recordTelemetryError(error ?? new Error(message))


### PR DESCRIPTION
**Problem**
There are too many cases where using boxen for the default error output causes readability issues.

**Change**
1. Remove boxen and simply draw a few straight lines coloured with chalk. This should avoid the readability issues.

**Example**
<img width="1155" alt="image" src="https://github.com/redwoodjs/redwood/assets/56300765/db01fdad-76e2-4a1a-a23e-da83d032e36e">

**Context**
The reason this exists in the first place was to try and centralise the error output. There were so many places in the CLI code where errors are output in various different styles which is not necessarily the best experience. 
