### PR TITLE
Tell the shell how to run the rw-vite-xx bins

### DIFF
--- a/packages/vite/bins/rw-vite-build.mjs
+++ b/packages/vite/bins/rw-vite-build.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fs from 'node:fs'
 
 import yargsParser from 'yargs-parser'

--- a/packages/vite/bins/rw-vite-dev.mjs
+++ b/packages/vite/bins/rw-vite-dev.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { createServer } from 'vite'
 import yargsParser from 'yargs-parser'
 


### PR DESCRIPTION
I've been exploring running redwood in a turborepo monorepo, and this is generally the only issue that has come up with running the build process

This makes it consistent with all the other Redwood bin files