### PR TITLE
Experimental Dockerfile: Fix typo in setup command

### DIFF
--- a/packages/cli/src/commands/experimental/setupDockerHandler.js
+++ b/packages/cli/src/commands/experimental/setupDockerHandler.js
@@ -311,7 +311,7 @@ export async function handler({ force }) {
         "Lastly, ensure you have Docker. If you don't, see https://docs.docker.com/desktop/",
         '',
         "There's a lot in the Dockerfile and there's a reason for every line.",
-        'Be sure to check ou the docs: https://redwoodjs.com/docs/docker',
+        'Be sure to check out the docs: https://redwoodjs.com/docs/docker',
       ].join('\n')
     )
   } catch (e) {


### PR DESCRIPTION
Tried the dockerfile setup command yesterday and noticed a typo. This PR fixes that.