### PR TITLE
fix(crwa): clarify docs to avoid issues in yarn modern installs

### DIFF
--- a/docs/docs/tutorial/chapter1/prerequisites.md
+++ b/docs/docs/tutorial/chapter1/prerequisites.md
@@ -46,13 +46,20 @@ Please do upgrade accordingly. Then proceed to the Redwood installation when you
 
 There are many ways to install and manage both Node.js and Yarn. If you're installing for the first time, we recommend the following:
 
-**1. Yarn**
-We recommend following the [instructions via Yarnpkg.com](https://yarnpkg.com/getting-started/install).
-
-**2. Node.js**
+**1. Node.js**
 Using the recommended [LTS version from Nodejs.org](https://nodejs.org/en/) is preferred.
 
 - `nvm` is a great tool for managing multiple versions of Node on one system. It takes a bit more effort to set up and learn, however. Follow the [nvm installation instructions](https://github.com/nvm-sh/nvm#installing-and-updating). (Windows users should go to [nvm-windows](https://github.com/coreybutler/nvm-windows/releases)). For **Mac** users with Homebrew installed, you can alternatively use it to [install `nvm`](https://formulae.brew.sh/formula/nvm). Or, refer to our how to guide [using nvm](../../how-to/using-nvm.md).
+
+**2. Yarn**
+As of Node.js v18+, Node.js ships with a CLI tool called [Corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) to manage package managers. All you have to do is enable it, then you'll have Yarn:
+
+```
+corepack enable
+yarn -v
+```
+
+The version of Yarn will probably be `1.22.21`, but don't worry—in your Redwood project, Corepack will know to use a modern version of Yarn because of the `packageManager` field in the root `package.json`.
 
 **Windows:** Recommended Development Setup
 


### PR DESCRIPTION
Fix for https://github.com/redwoodjs/redwood/issues/9578 and https://community.redwoodjs.com/t/yarn-redwood-dev-throwing-internal-error/5557. @Tobbe and I paired on this one. Basically, there's a footgun in the yarn docs. If you read them too quickly, it seems like you can update your global version of yarn via `yarn set version stable`. But that command is actually only meant to be used in the context of a project (like a Redwood app).