### PR TITLE
fix: Remove "god code" typos from auth READMEs

### DIFF
--- a/packages/auth-providers/auth0/api/README.md
+++ b/packages/auth-providers/auth0/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/auth0/setup/README.md
+++ b/packages/auth-providers/auth0/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/auth0/web/README.md
+++ b/packages/auth-providers/auth0/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/azureActiveDirectory/api/README.md
+++ b/packages/auth-providers/azureActiveDirectory/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/azureActiveDirectory/setup/README.md
+++ b/packages/auth-providers/azureActiveDirectory/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/azureActiveDirectory/web/README.md
+++ b/packages/auth-providers/azureActiveDirectory/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/clerk/api/README.md
+++ b/packages/auth-providers/clerk/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/clerk/setup/README.md
+++ b/packages/auth-providers/clerk/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/clerk/web/README.md
+++ b/packages/auth-providers/clerk/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/custom/setup/README.md
+++ b/packages/auth-providers/custom/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/dbAuth/api/README.md
+++ b/packages/auth-providers/dbAuth/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/dbAuth/setup/README.md
+++ b/packages/auth-providers/dbAuth/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/dbAuth/web/README.md
+++ b/packages/auth-providers/dbAuth/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/firebase/api/README.md
+++ b/packages/auth-providers/firebase/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/firebase/setup/README.md
+++ b/packages/auth-providers/firebase/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/firebase/web/README.md
+++ b/packages/auth-providers/firebase/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/netlify/api/README.md
+++ b/packages/auth-providers/netlify/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/netlify/setup/README.md
+++ b/packages/auth-providers/netlify/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/netlify/web/README.md
+++ b/packages/auth-providers/netlify/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/supabase/api/README.md
+++ b/packages/auth-providers/supabase/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/supabase/setup/README.md
+++ b/packages/auth-providers/supabase/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/supertokens/api/README.md
+++ b/packages/auth-providers/supertokens/api/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/supertokens/setup/README.md
+++ b/packages/auth-providers/supertokens/setup/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth-providers/supertokens/web/README.md
+++ b/packages/auth-providers/supertokens/web/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -21,7 +21,7 @@ both auth service providers and RW apps we recommend you start looking in
 `authFactory.ts` and then continue to `AuthProvider.tsx`. `AuthProvider.tsx`
 has most of our implementation together with all the custom hooks it uses.
 Another file to be accustomed with is `AuthContext.ts`. The interface in there
-has pretty god code comments, and is what will be exposed to RW apps.
+has pretty good code comments, and is what will be exposed to RW apps.
 
 ## getCurrentUser
 


### PR DESCRIPTION
As the title says