### PR TITLE
💬 Fixed formatting within the docs

### DIFF
--- a/docs/docs/how-to/oauth.md
+++ b/docs/docs/how-to/oauth.md
@@ -350,7 +350,7 @@ model Identity {
 
 We're also storing the `accessToken` and `scope` that we got back from the last time we retrived them from GitHub, as well as a timestamp for the last time the user logged in. Storing the `scope` is useful because if you ever change them, you may want to notify users that have the previous scope definition to re-login so the new scopes can be authorized.
 
-::: caution
+:::caution
 
 There's no GraphQL SDL tied to the Identity table, so it is not accessible via our API. But, if you ever did create an SDL and service, be sure that `accessToken` is not in the list of fields exposed publicly!
 

--- a/docs/versioned_docs/version-6.0/how-to/oauth.md
+++ b/docs/versioned_docs/version-6.0/how-to/oauth.md
@@ -350,7 +350,7 @@ model Identity {
 
 We're also storing the `accessToken` and `scope` that we got back from the last time we retrived them from GitHub, as well as a timestamp for the last time the user logged in. Storing the `scope` is useful because if you ever change them, you may want to notify users that have the previous scope definition to re-login so the new scopes can be authorized.
 
-::: caution
+:::caution
 
 There's no GraphQL SDL tied to the Identity table, so it is not accessible via our API. But, if you ever did create an SDL and service, be sure that `accessToken` is not in the list of fields exposed publicly!
 


### PR DESCRIPTION
## Feature description

There was a formatting issue within [the docs](https://redwoodjs.com/docs/how-to/oauth#prisma-schema-updates):

<img width="803" alt="CleanShot 2023-11-29 at 01 47 28@2x" src="https://github.com/redwoodjs/redwood/assets/212300/55f4058f-e348-4384-ac33-8496b61eccf0">

## Solution description

There was an extra space between `::: caution`

## Output Screenshots

<img width="991" alt="CleanShot 2023-11-29 at 01 51 23@2x" src="https://github.com/redwoodjs/redwood/assets/212300/b8b7f87c-07b1-41ee-9516-81fb1d498592">
