### PR TITLE
Keep testing `<Private>`

### DIFF
--- a/packages/internal/src/__tests__/fixtures/nestedPages/web/src/Routes.js
+++ b/packages/internal/src/__tests__/fixtures/nestedPages/web/src/Routes.js
@@ -7,7 +7,7 @@
 // 'src/pages/HomePage/HomePage.js'         -> HomePage
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
-import { PrivateSet, Route, Router, Set } from '@redwoodjs/router'
+import { Private, Route, Router, Set } from '@redwoodjs/router'
 
 import AdminLayout from 'src/layouts/AdminLayout/AdminLayout'
 import MainLayout from 'src/layouts/MainLayout/MainLayout'
@@ -44,7 +44,7 @@ const Routes = () => {
         <Route notfound page={NotFoundPage} />
       </Set>
 
-      <PrivateSet unauthenticated={'home'}>
+      <Private unauthenticated={'home'}>
         <Set wrap={[AdminLayout]} role={'admin'}>
           <Route path="/admin/users/new" page={AdminUserNewUserPage} name="newUser" />
           <Route path="/admin/users/{id:Int}/edit" page={AdminUserEditUserPage} name="editUser" />
@@ -52,7 +52,7 @@ const Routes = () => {
           <Route path="/admin/users" page={AdminUserUsersPage} name="users" />
         </Set>
 
-      </PrivateSet>
+      </Private>
     </Router>
   )
 }

--- a/packages/testing/src/web/__tests__/MockRouter.test.tsx
+++ b/packages/testing/src/web/__tests__/MockRouter.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { render } from '@testing-library/react'
 
-import { Route, PrivateSet } from '@redwoodjs/router'
+import { Route, Private } from '@redwoodjs/router'
 
 import { routes, Router } from '../MockRouter'
 
@@ -14,10 +14,10 @@ describe('MockRouter', () => {
       <Router>
         <Route name="a" path="/a" page={FakePage} />
         <Route name="b" path="/b" page={FakePage} />
-        <PrivateSet unauthenticated="a">
+        <Private unauthenticated="a">
           <Route name="c" path="/c" page={FakePage} />
           <Route name="d" path="/d" page={FakePage} />
-        </PrivateSet>
+        </Private>
       </Router>
     )
 

--- a/packages/vite/src/__tests__/fixtures/nestedPages/web/src/Routes.js
+++ b/packages/vite/src/__tests__/fixtures/nestedPages/web/src/Routes.js
@@ -7,7 +7,7 @@
 // 'src/pages/HomePage/HomePage.js'         -> HomePage
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
-import { PrivateSet, Route, Router, Set } from '@redwoodjs/router'
+import { Private, Route, Router, Set } from '@redwoodjs/router'
 
 import AdminLayout from 'src/layouts/AdminLayout/AdminLayout'
 import MainLayout from 'src/layouts/MainLayout/MainLayout'
@@ -44,7 +44,7 @@ const Routes = () => {
         <Route notfound page={NotFoundPage} />
       </Set>
 
-      <PrivateSet unauthenticated={'home'}>
+      <Private unauthenticated={'home'}>
         <Set wrap={[AdminLayout]} role={'admin'}>
           <Route path="/admin/users/new" page={AdminUserNewUserPage} name="newUser" />
           <Route path="/admin/users/{id:Int}/edit" page={AdminUserEditUserPage} name="editUser" />
@@ -52,7 +52,7 @@ const Routes = () => {
           <Route path="/admin/users" page={AdminUserUsersPage} name="users" />
         </Set>
 
-      </PrivateSet>
+      </Private>
     </Router>
   )
 }


### PR DESCRIPTION
This PR reverts some of the changes in https://github.com/redwoodjs/redwood/pull/9575 because we want to keep testing `<Private>` until we've gotten rid of it, so that we don't have any regressions on it.