### PR TITLE
chore: Update Testing documentation to link to How to Test Email/Mailer

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1975,6 +1975,16 @@ console.log(testCacheClient.storage)
 This is mainly helpful when you are testing for a very specific value, or have edgecases in how the serialization/deserialization works in the cache.
 
 
+## Testing Mailer
+
+If your project uses [RedwoodJS Mailer](./mailer.md) to send emails, you can [also write tests](./mailer.md#testing) to make sure that email:
+
+* is sent to an sandbox inbox
+* renders properly
+* sets the expected to, from, cc, bcc, subject attributes based on the email sending logic
+* checks that the html and text content is set correctly
+
+Since these tests send mail to a sandbox inbox, you can be confident that no emails accidentally get sent into the wild as part of your test or CI runs.
 
 
 ## Wrapping Up


### PR DESCRIPTION
The testing docs include info on how to test service, directives, cells, and more ... but did not link to the "how to test email" with the recent Redwood Mailer package.

This PR adds some short comy introducing the topic and a link to the main Mailer testing section.