### PR TITLE
e2e: Explain why we're setting package resolutions

### DIFF
--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -68,22 +68,29 @@ const createRedwoodJSApp = ({ typescript, bundler }) => {
       }
     )
 
-    // Add prisma resolutions
+    // Add package resolutions
+    //
+    // This is needed because the test project uses the current stable version
+    // of Redwood when installing, but then when we use rwfw to link, newer
+    // versions of packages might be installed causing conflicts. Setting
+    // resolutions prevents this.
+    // See https://github.com/redwoodjs/redwood/pull/6772 for more info.
+
     const packageJSONPath = path.join(REDWOOD_PROJECT_DIRECTORY, 'package.json')
     const packageJSON = fs.readJSONSync(packageJSONPath)
 
-    const getVersionFrmRwPkg = (dep, pkg) => {
+    const getVersionFromRwPackage = (dep, pkg) => {
       return fs.readJSONSync(
         path.join(REDWOODJS_FRAMEWORK_PATH, 'packages', pkg, 'package.json')
       ).dependencies[dep]
     }
 
     packageJSON.resolutions = {
-      prisma: getVersionFrmRwPkg('prisma', 'cli'),
-      '@prisma/client': getVersionFrmRwPkg('@prisma/client', 'api'),
-      '@prisma/internals': getVersionFrmRwPkg('@prisma/internals', 'cli'),
-      'graphql-yoga': getVersionFrmRwPkg('graphql-yoga', 'graphql-server'),
-      graphql: getVersionFrmRwPkg('graphql', 'graphql-server'),
+      prisma: getVersionFromRwPackage('prisma', 'cli'),
+      '@prisma/client': getVersionFromRwPackage('@prisma/client', 'api'),
+      '@prisma/internals': getVersionFromRwPackage('@prisma/internals', 'cli'),
+      'graphql-yoga': getVersionFromRwPackage('graphql-yoga', 'graphql-server'),
+      graphql: getVersionFromRwPackage('graphql', 'graphql-server'),
     }
 
     fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2))

--- a/tasks/run-e2e
+++ b/tasks/run-e2e
@@ -74,6 +74,9 @@ const createRedwoodJSApp = ({ typescript, bundler }) => {
     // of Redwood when installing, but then when we use rwfw to link, newer
     // versions of packages might be installed causing conflicts. Setting
     // resolutions prevents this.
+    // Note that this isn't limited to any specific versions. It's always
+    // going to be a potential issue when package versions differ between
+    // stable and canary.
     // See https://github.com/redwoodjs/redwood/pull/6772 for more info.
 
     const packageJSONPath = path.join(REDWOOD_PROJECT_DIRECTORY, 'package.json')


### PR DESCRIPTION
I stumbled upon this code and thought I could revert it, because stable version of RW has upgraded Prisma since the code was written. But then I realized this is always going to be a potential issue, so I decided to write some comments explaining what the code does.