### PR TITLE
RSC: Default entry.server and more standard App.tsx

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -251,7 +251,6 @@ export const handler = async ({ force, verbose }) => {
           indexHtml = indexHtml.replace(
             'href="/favicon.png" />',
             'href="/favicon.png" />\n' +
-              '  <link rel="stylesheet" href="index.css" />\n' +
               '  <script type="module" src="entry.client.tsx"></script>'
           )
 
@@ -286,18 +285,6 @@ export const handler = async ({ force, verbose }) => {
             rwPaths.web.app ?? path.join(rwPaths.web.src, 'App.tsx')
 
           writeFile(appPath, appTemplate, {
-            overwriteExisting: true,
-          })
-        },
-      },
-      {
-        title: 'Updating entry.server.tsx...',
-        task: async () => {
-          let entryServer = fs.readFileSync(rwPaths.web.entryServer, 'utf-8')
-
-          entryServer = entryServer.replaceAll('App', 'HomePage')
-
-          writeFile(rwPaths.web.entryServer, entryServer, {
             overwriteExisting: true,
           })
         },

--- a/packages/cli/src/commands/experimental/templates/rsc/App.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/App.tsx.template
@@ -1,11 +1,15 @@
-import { FatalErrorBoundary } from '@redwoodjs/web'
+import { FatalErrorBoundary, RedwoodProvider } from '@redwoodjs/web'
 
 import FatalErrorPage from './pages/FatalErrorPage/FatalErrorPage'
 import Routes from './Routes'
 
+import './index.css'
+
 const App = () => (
   <FatalErrorBoundary page={FatalErrorPage}>
-    <Routes />
+    <RedwoodProvider titleTemplate="%PageTitle | %AppTitle">
+      <Routes />
+    </RedwoodProvider>
   </FatalErrorBoundary>
 )
 


### PR DESCRIPTION
Continuing on from #9654 we now also don't need to have any special entry.server file. And we can bring back more functionality into App.tsx from a standard RW app. 
For example, now with `<RedwoodProvider>` in App.tsx it's possible to set the App title just like in a regular RW app

From my browser tab bar:
![image](https://github.com/redwoodjs/redwood/assets/30793/968dc670-767d-4cdc-bba2-71b2f93d5958)
And my redwood.toml:
![image](https://github.com/redwoodjs/redwood/assets/30793/f97c6cc0-191e-43af-bf89-df4adf119853)
And App.tsx
![image](https://github.com/redwoodjs/redwood/assets/30793/4e55564b-e456-4ab7-b2a5-db555dd688cc)


