### PR TITLE
fix(clerk auth): remove errant comma in post-setup notes

### DIFF
--- a/packages/auth-providers/clerk/setup/src/setupHandler.ts
+++ b/packages/auth-providers/clerk/setup/src/setupHandler.ts
@@ -33,7 +33,7 @@ export const handler = async ({ force: forceArg }: Args) => {
       '',
       '```toml title="redwood.toml"',
       'includeEnvironmentVariables = [',
-      '  "CLERK_PUBLISHABLE_KEY,"',
+      '  "CLERK_PUBLISHABLE_KEY"',
       ']',
       '```',
       '',


### PR DESCRIPTION
Corrects the `packages/auth-providers/clerk/setup/src/setupHandler.ts` for errant comma in the post setup notes of the clerk setup command.