### PR TITLE
docs: auth - Clerk - Corrects Home Page generation instructions

### DIFF
--- a/docs/docs/auth/clerk.md
+++ b/docs/docs/auth/clerk.md
@@ -56,10 +56,15 @@ Lastly, in your project's `redwood.toml` file, include `CLERK_PUBLISHABLE_KEY` i
 ```
 
 That should be enough; now, things should just work.
-Let's make sure: if this is a brand new project, generate a home page.
+Let's make sure: if this is a brand new project, generate a home page:
+
+```bash
+yarn rw g page Home /
+```
+
 There we'll try to sign up by destructuring `signUp` from the `useAuth` hook (import that from `'src/auth'`). We'll also destructure and display `isAuthenticated` to see if it worked:
 
-```tsx title="web/src/pages/HomePage.tsx"
+```tsx title="web/src/pages/HomePage/HomePage.tsx"
 import { useAuth } from 'src/auth'
 
 const HomePage = () => {
@@ -76,11 +81,8 @@ const HomePage = () => {
 }
 ```
 
-Clicking sign up should open a sign-up box:
+Clicking sign up should open a sign-up box and after you sign up, you should see `{"isAuthenticated":true}` on the page.
 
-<img width="1522" alt="image" src="https://user-images.githubusercontent.com/32992335/208342825-b380f8f8-7b76-4be9-a0a5-e64740a03bd3.png" />
-
-After you sign up, you should see `{"isAuthenticated":true}` on the page.
 
 ## Customizing the session token
 


### PR DESCRIPTION
See issue https://github.com/redwoodjs/redwood/issues/9658

In the issue above, @swrichards found that if one places a Page.tsx in just the `pages` directory (ie, not /pages/PageName/PageName.tsx` and routes to it, one gets the following error building web / starting dev:

![image](https://github.com/redwoodjs/redwood/assets/1051633/2246778f-424e-44f7-9e91-7c4ed10b2b89)

The found this while following the Clerk auth documentation -- and that said to make the HomePage in just the `pages` directory:

![image](https://github.com/redwoodjs/redwood/assets/1051633/83bca047-0f31-4340-8ad3-bcf03000143f)

While this perhaps worked in the past, it doesn't seem to with the new site builds.

This PR updates the documentation to:

* say to use the page generator
* corrects filepath
* removes outdated screenshot of old Clerk widget

The issue of the error will be assigned and resolved in a future PR.



