### PR TITLE
chore(CI): add RSC fixtures to detect changes list

### DIFF
--- a/.github/actions/detect-changes/cases/rsc.mjs
+++ b/.github/actions/detect-changes/cases/rsc.mjs
@@ -20,7 +20,9 @@ export function rscChanged(changedFiles){
       changedFile.startsWith('packages/internal/') ||
       changedFile.startsWith('packages/project-config/') ||
       changedFile.startsWith('packages/web/') ||
-      changedFile.startsWith('packages/vite/')
+      changedFile.startsWith('packages/vite/') ||
+      changedFile.startsWith('__fixtures__/test-project-rsa') ||
+      changedFile.startsWith('__fixtures__/test-project-rsc-external-packages')
     ) {
       console.log('RSC change detected:', changedFile)
       return true


### PR DESCRIPTION
Currently the RSC smoke tests seem to be failing consistently on https://github.com/redwoodjs/redwood/pull/9649. In debugging, I noticed that the RSC smoke tests didn't actually run for https://github.com/redwoodjs/redwood/pull/9666 which changed the RSC fixtures. That's because those files weren't listed in the detect changes list. Adding them here.