### PR TITLE
DT types for jest-dom should not be used

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -37,7 +37,6 @@
     "@types/pascalcase": "1.0.3",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
-    "@types/testing-library__jest-dom": "5.14.9",
     "graphql": "16.8.1",
     "jest": "29.7.0",
     "nodemon": "3.0.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -56,7 +56,6 @@
     "@testing-library/react": "14.1.2",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15",
-    "@types/testing-library__jest-dom": "5.14.9",
     "jest": "29.7.0",
     "nodemon": "3.0.2",
     "react": "0.0.0-experimental-e5205658f-20230913",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9043,7 +9043,6 @@ __metadata:
     "@types/pascalcase": 1.0.3
     "@types/react": 18.2.37
     "@types/react-dom": 18.2.15
-    "@types/testing-library__jest-dom": 5.14.9
     core-js: 3.34.0
     graphql: 16.8.1
     jest: 29.7.0
@@ -9623,7 +9622,6 @@ __metadata:
     "@testing-library/react": 14.1.2
     "@types/react": 18.2.37
     "@types/react-dom": 18.2.15
-    "@types/testing-library__jest-dom": 5.14.9
     core-js: 3.34.0
     graphql: 16.8.1
     graphql-sse: 2.4.0
@@ -11983,7 +11981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:*, @types/jest@npm:29.5.8":
+"@types/jest@npm:29.5.8":
   version: 29.5.8
   resolution: "@types/jest@npm:29.5.8"
   dependencies:
@@ -12578,15 +12576,6 @@ __metadata:
   dependencies:
     "@types/estree": "*"
   checksum: 1d30ccfbb84362fe7a7edeea3ba5268f5a7a0965d504147c6b701092f0ea3f0833799ee753e2059a535ca06590f91dd2416e4bd94a6e8ad51eea127a0607c617
-  languageName: node
-  linkType: hard
-
-"@types/testing-library__jest-dom@npm:5.14.9":
-  version: 5.14.9
-  resolution: "@types/testing-library__jest-dom@npm:5.14.9"
-  dependencies:
-    "@types/jest": "*"
-  checksum: 91f7b15e8813b515912c54da44464fb60ecf21162b7cae2272fcb3918074f4e1387dc2beca1f5041667e77b76b34253c39675ea4e0b3f28f102d8cc87fdba9fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With the update to @testing-library/jest-dom v6 in #9673 types are built-in, and so https://www.npmjs.com/package/@types/testing-library__jest-dom should not be used anymore

Marking this as breaking since it requires #9673 which is breaking