### PR TITLE
chore(RSC): update RSC test projects to latest canary

### DIFF
--- a/__fixtures__/test-project-rsa/api/package.json
+++ b/__fixtures__/test-project-rsa/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "7.0.0-canary.348",
-    "@redwoodjs/graphql-server": "7.0.0-canary.348"
+    "@redwoodjs/api": "7.0.0-canary.717",
+    "@redwoodjs/graphql-server": "7.0.0-canary.717"
   }
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "7.0.0-canary.348"
+    "@redwoodjs/core": "7.0.0-canary.717"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/test-project-rsa/web/package.json
+++ b/__fixtures__/test-project-rsa/web/package.json
@@ -11,13 +11,13 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "7.0.0-canary.404",
-    "@redwoodjs/router": "7.0.0-canary.404",
-    "@redwoodjs/web": "7.0.0-canary.404",
+    "@redwoodjs/forms": "7.0.0-canary.717",
+    "@redwoodjs/router": "7.0.0-canary.717",
+    "@redwoodjs/web": "7.0.0-canary.717",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "7.0.0-canary.404"
+    "@redwoodjs/vite": "7.0.0-canary.717"
   }
 }

--- a/__fixtures__/test-project-rsc-external-packages/api/package.json
+++ b/__fixtures__/test-project-rsc-external-packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "7.0.0-canary.413",
-    "@redwoodjs/graphql-server": "7.0.0-canary.413"
+    "@redwoodjs/api": "7.0.0-canary.717",
+    "@redwoodjs/graphql-server": "7.0.0-canary.717"
   }
 }

--- a/__fixtures__/test-project-rsc-external-packages/package.json
+++ b/__fixtures__/test-project-rsc-external-packages/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "7.0.0-canary.413"
+    "@redwoodjs/core": "7.0.0-canary.717"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/test-project-rsc-external-packages/web/package.json
+++ b/__fixtures__/test-project-rsc-external-packages/web/package.json
@@ -11,9 +11,9 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "7.0.0-canary.413",
-    "@redwoodjs/router": "7.0.0-canary.413",
-    "@redwoodjs/web": "7.0.0-canary.413",
+    "@redwoodjs/forms": "7.0.0-canary.717",
+    "@redwoodjs/router": "7.0.0-canary.717",
+    "@redwoodjs/web": "7.0.0-canary.717",
     "@tobbe.dev/rsc-test": "0.0.3",
     "client-only": "0.0.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
@@ -21,7 +21,7 @@
     "server-only": "0.0.1"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "7.0.0-canary.413",
+    "@redwoodjs/vite": "7.0.0-canary.717",
     "@types/react": "18.2.37",
     "@types/react-dom": "18.2.15"
   }


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/9701. We needed to wait for a canary to be published.