### PR TITLE
docs(#9006) - Update redwoodjs cli to include correct forum url

### DIFF
--- a/packages/cli/src/commands/experimental/setupSentryHandler.js
+++ b/packages/cli/src/commands/experimental/setupSentryHandler.js
@@ -178,7 +178,7 @@ export const handler = async ({ force }) => {
           )
         } else {
           notes.push(
-            "Check out RedwoodJS' docs for more: https://redwoodjs.com/docs/cli-commands#setup-sentry"
+            "Check out RedwoodJS forums' for more: https://community.redwoodjs.com/t/sentry-error-and-performance-monitoring-experimental/4880"
           )
         }
       },


### PR DESCRIPTION
Updated the cli url to point to the forum instead of the non-existent documentation based on the ticket open here. https://github.com/redwoodjs/redwood/issues/9006