### PR TITLE
Update `.vscode/settings.json` files for ESLint setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "workbench.colorCustomizations": {
     "statusBar.background": "#b85833",

--- a/__fixtures__/test-project/.vscode/settings.json
+++ b/__fixtures__/test-project/.vscode/settings.json
@@ -3,7 +3,7 @@
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "[prisma]": {
     "editor.formatOnSave": true

--- a/packages/create-redwood-app/templates/js/.vscode/settings.json
+++ b/packages/create-redwood-app/templates/js/.vscode/settings.json
@@ -3,7 +3,7 @@
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "[prisma]": {
     "editor.formatOnSave": true

--- a/packages/create-redwood-app/templates/ts/.vscode/settings.json
+++ b/packages/create-redwood-app/templates/ts/.vscode/settings.json
@@ -3,7 +3,7 @@
   "files.trimTrailingWhitespace": true,
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "[prisma]": {
     "editor.formatOnSave": true


### PR DESCRIPTION
The `source.fixAll.eslint` setting changed from `true` to `"explicit"`. It will actually correct this automatically on install