### PR TITLE
fix(gitpod): enable corepack to get proper node version

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,6 +21,7 @@ tasks:
       export REDWOOD_DISABLE_TELEMETRY=1
     init: |
       cd /workspace/redwood
+      corepack enable
       yarn install
       yarn run build:test-project ../rw-test-app --typescript --link --verbose
       cd /workspace/rw-test-app && sed -i "s/\(open *= *\).*/\1false/" redwood.toml


### PR DESCRIPTION
this adds `corepack enable` in the gitpod init in order to properly set the node version.

# Recreate the bug
visit https://gitpod.io/#https://github.com/redwoodjs/redwood

# Test
visit gitpod via my branch: https://gitpod.io/#https://github.com/colbywhite/redwood/tree/fix.node.version

Fixes #9731