### PR TITLE
Fix sshExec() errors not displaying

### DIFF
--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -131,8 +131,8 @@ export const builder = (yargs) => {
   )
 }
 
-// Executes a single command via SSH connection. Displays an error and will
-// exit() with the same code returned from the SSH command.
+// Executes a single command via SSH connection. Throws an error and sets
+// the exit code with the same code returned from the SSH command.
 const sshExec = async (ssh, path, command, args) => {
   let sshCommand = command
 
@@ -145,18 +145,9 @@ const sshExec = async (ssh, path, command, args) => {
   })
 
   if (result.code !== 0) {
-    console.error(c.error(`\nDeploy failed!`))
-    console.error(
-      c.error(`Error while running command \`${command} ${args.join(' ')}\`:`)
-    )
-    console.error(
-      boxen(result.stderr, {
-        padding: { top: 0, bottom: 0, right: 1, left: 1 },
-        margin: 0,
-        borderColor: 'red',
-      })
-    )
-    process.exit(result.code)
+    const error = new Error(`Error while running command \`${command} ${args.join(' ')}\``);
+    error.exitCode = result.code;
+    throw error;
   }
 
   return result

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -145,9 +145,11 @@ const sshExec = async (ssh, path, command, args) => {
   })
 
   if (result.code !== 0) {
-    const error = new Error(`Error while running command \`${command} ${args.join(' ')}\``);
-    error.exitCode = result.code;
-    throw error;
+    const error = new Error(
+      `Error while running command \`${command} ${args.join(' ')}\``
+    )
+    error.exitCode = result.code
+    throw error
   }
 
   return result


### PR DESCRIPTION
sshExec errors were not printing to console when running `yarn rw deploy baremetal production`. I had errors both in update and install stages which both just exited without the console.error printing the error message. 

To reproduce the issue, in the deploy.toml change the name of "branch" to something incorrect as this will trigger an error. Then run `yarn rw deploy baremetal production` and the command will exit without displaying an error. You can also just put a console.log() in the async task: callbacks which also don't seem to fire.

To fix the issue I just replaced the console.errors() with a throw new Error() which gets caught by the handler and displays the message as it should.

My system environment while having the problem:
System:
    OS: Windows 11 10.0.22621
Binaries:
    Node: 21.5.0 - ~\AppData\Local\Temp\xfs-71f3a1eb\node.CMD
    Yarn: 3.7.0 - ~\AppData\Local\Temp\xfs-71f3a1eb\yarn.CMD
Browsers:
    Edge: Chromium (120.0.2210.77)
npmPackages:
    @redwoodjs/core: 6.5.1 => 6.5.1

I was also using the terminal in VSCode if that matters.