### PR TITLE
chore(cli): make fs modules used in the CLI consistent

### DIFF
--- a/packages/cli/src/__tests__/fs.test.js
+++ b/packages/cli/src/__tests__/fs.test.js
@@ -1,7 +1,8 @@
 jest.mock('fs')
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 const INITIAL_FS = {
   file_a: 'content_a',

--- a/packages/cli/src/__tests__/plugin.test.js
+++ b/packages/cli/src/__tests__/plugin.test.js
@@ -1,5 +1,4 @@
-import fs from 'fs'
-
+import fs from 'fs-extra'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 

--- a/packages/cli/src/commands/buildHandler.js
+++ b/packages/cli/src/commands/buildHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import { rimraf } from 'rimraf'
 import terminalLink from 'terminal-link'

--- a/packages/cli/src/commands/consoleHandler.js
+++ b/packages/cli/src/commands/consoleHandler.js
@@ -1,6 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 import repl from 'repl'
+
+import fs from 'fs-extra'
 
 import { registerApiSideBabelHook } from '@redwoodjs/babel-config'
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/deploy/__tests__/nftPack.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/nftPack.test.js
@@ -1,5 +1,6 @@
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { buildApi } from '@redwoodjs/internal/dist/build/api'
 import { findApiDistFunctions } from '@redwoodjs/internal/dist/files'

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import toml from '@iarna/toml'
 import boxen from 'boxen'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import { env as envInterpolation } from 'string-env-interpolation'
 import terminalLink from 'terminal-link'

--- a/packages/cli/src/commands/deploy/serverless.js
+++ b/packages/cli/src/commands/deploy/serverless.js
@@ -1,10 +1,10 @@
-import fs from 'fs'
 import path from 'path'
 
 import boxen from 'boxen'
 import chalk from 'chalk'
 import { config } from 'dotenv-defaults'
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import prompts from 'prompts'
 import terminalLink from 'terminal-link'

--- a/packages/cli/src/commands/destroy/cell/__tests__/cell.test.js
+++ b/packages/cli/src/commands/destroy/cell/__tests__/cell.test.js
@@ -16,7 +16,7 @@ jest.mock('@redwoodjs/structure', () => {
   }
 })
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/component/__tests__/component.test.js
+++ b/packages/cli/src/commands/destroy/component/__tests__/component.test.js
@@ -7,7 +7,7 @@ jest.mock('../../../../lib', () => {
   }
 })
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/directive/__tests__/directive.test.js
+++ b/packages/cli/src/commands/destroy/directive/__tests__/directive.test.js
@@ -8,7 +8,7 @@ jest.mock('../../../../lib', () => {
   }
 })
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/function/__tests__/function.test.js
+++ b/packages/cli/src/commands/destroy/function/__tests__/function.test.js
@@ -7,7 +7,7 @@ jest.mock('../../../../lib', () => {
   }
 })
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/layout/__tests__/layout.test.js
+++ b/packages/cli/src/commands/destroy/layout/__tests__/layout.test.js
@@ -7,7 +7,7 @@ jest.mock('../../../../lib', () => {
   }
 })
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/destroy/page/__tests__/page.test.js
@@ -7,7 +7,7 @@ jest.mock('../../../../lib', () => {
   }
 })
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffold.test.js
@@ -1,7 +1,8 @@
 globalThis.__dirname = __dirname
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
@@ -1,7 +1,8 @@
 globalThis.__dirname = __dirname
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/sdl/__tests__/sdl.test.js
+++ b/packages/cli/src/commands/destroy/sdl/__tests__/sdl.test.js
@@ -1,6 +1,6 @@
 globalThis.__dirname = __dirname
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/destroy/service/__tests__/service.test.js
+++ b/packages/cli/src/commands/destroy/service/__tests__/service.test.js
@@ -1,5 +1,5 @@
 globalThis.__dirname = __dirname
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 

--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import { argv } from 'process'
 
 import concurrently from 'concurrently'
+import fs from 'fs-extra'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
 import { shutdownPort } from '@redwoodjs/internal/dist/dev'

--- a/packages/cli/src/commands/experimental/setupOpentelemetryHandler.js
+++ b/packages/cli/src/commands/experimental/setupOpentelemetryHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addApiPackages } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { prettify } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/experimental/setupSentryHandler.js
+++ b/packages/cli/src/commands/experimental/setupSentryHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import {

--- a/packages/cli/src/commands/experimental/setupServerFileHandler.js
+++ b/packages/cli/src/commands/experimental/setupServerFileHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addApiPackages } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/experimental/setupStreamingSsrHandler.js
+++ b/packages/cli/src/commands/experimental/setupStreamingSsrHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addWebPackages } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/experimental/studioHandler.js
+++ b/packages/cli/src/commands/experimental/studioHandler.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import { getConfigPath } from '@redwoodjs/project-config'
 

--- a/packages/cli/src/commands/experimental/util.js
+++ b/packages/cli/src/commands/experimental/util.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
+import fs from 'fs-extra'
 import terminalLink from 'terminal-link'
 
 import { getPaths } from '../../lib'

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -1,5 +1,6 @@
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 // Setup test mocks
 globalThis.__dirname = __dirname

--- a/packages/cli/src/commands/generate/dataMigration/dataMigration.js
+++ b/packages/cli/src/commands/generate/dataMigration/dataMigration.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import { paramCase } from 'param-case'
 import terminalLink from 'terminal-link'

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
@@ -2,7 +2,6 @@ global.__dirname = __dirname
 
 jest.mock('fs')
 
-import fs from 'fs'
 import path from 'path'
 
 // Load mocks
@@ -10,6 +9,7 @@ import '../../../../lib/test'
 
 const realfs = jest.requireActual('fs')
 import Enquirer from 'enquirer'
+import fs from 'fs-extra'
 
 import { getPaths } from '../../../../lib'
 import * as dbAuth from '../dbAuth'

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import { camelCase } from 'camel-case'
 import Enquirer from 'enquirer'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import terminalLink from 'terminal-link'
 import { titleCase } from 'title-case'

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import { paramCase } from 'param-case'
 import pascalcase from 'pascalcase'

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -36,8 +36,9 @@ jest.mock('fs', () => {
   }
 })
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 // Load mocks
 import '../../../../lib/test'

--- a/packages/cli/src/commands/generate/scaffold/__tests__/shouldUseTailwindCSS.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/shouldUseTailwindCSS.test.js
@@ -1,6 +1,6 @@
 globalThis.__dirname = __dirname
 
-import fs from 'fs'
+import fs from 'fs-extra'
 
 import '../../../../lib/test'
 import { shouldUseTailwindCSS } from '../scaffold'

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import camelcase from 'camelcase'
 import execa from 'execa'
+import fs from 'fs-extra'
 import humanize from 'humanize-string'
 import { Listr } from 'listr2'
 import { paramCase } from 'param-case'

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import terminalLink from 'terminal-link'
 

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.js
@@ -24,9 +24,9 @@ jest.mock('fs', () => {
   }
 })
 
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import prompts from 'prompts'
 
 // Load mocks

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -1,6 +1,5 @@
-import fs from 'fs'
-
 import execa from 'execa'
+import fs from 'fs-extra'
 import terminalLink from 'terminal-link'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/prerenderHandler.js
+++ b/packages/cli/src/commands/prerenderHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/prismaHandler.js
+++ b/packages/cli/src/commands/prismaHandler.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import boxen from 'boxen'
 import execa from 'execa'
+import fs from 'fs-extra'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
 import { errorTelemetry } from '@redwoodjs/telemetry'

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import terminalLink from 'terminal-link'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/cache/cacheHandler.js
+++ b/packages/cli/src/commands/setup/cache/cacheHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addEnvVarTask } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/custom-web-index/custom-web-index-handler.js
+++ b/packages/cli/src/commands/setup/custom-web-index/custom-web-index-handler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { errorTelemetry } from '@redwoodjs/telemetry'

--- a/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.js
+++ b/packages/cli/src/commands/setup/deploy/__tests__/netlify.test.js
@@ -1,8 +1,9 @@
 // Automock fs using ../..../__mocks__/fs
 jest.mock('fs')
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { getPaths } from '../../../../lib'
 import { updateApiURLTask } from '../helpers'

--- a/packages/cli/src/commands/setup/deploy/helpers/index.js
+++ b/packages/cli/src/commands/setup/deploy/helpers/index.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { getPaths, writeFilesTask } from '../../../../lib'

--- a/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import toml from '@iarna/toml'
 import { getSchema, getConfig } from '@prisma/internals'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import {

--- a/packages/cli/src/commands/setup/deploy/providers/edgio.js
+++ b/packages/cli/src/commands/setup/deploy/providers/edgio.js
@@ -1,5 +1,4 @@
-import fs from 'fs'
-
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/deploy/providers/flightcontrol.js
+++ b/packages/cli/src/commands/setup/deploy/providers/flightcontrol.js
@@ -1,9 +1,9 @@
 // import terminalLink from 'terminal-link'
-import fs from 'fs'
 import { EOL } from 'os'
 import path from 'path'
 
 import { getSchema, getConfig } from '@prisma/internals'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/deploy/providers/render.js
+++ b/packages/cli/src/commands/setup/deploy/providers/render.js
@@ -1,8 +1,8 @@
 // import terminalLink from 'terminal-link'
-import fs from 'fs'
 import path from 'path'
 
 import { getSchema, getConfig } from '@prisma/internals'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/deploy/providers/serverless.js
+++ b/packages/cli/src/commands/setup/deploy/providers/serverless.js
@@ -1,7 +1,7 @@
 // import terminalLink from 'terminal-link'
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/deploy/templates/serverless/api.js
+++ b/packages/cli/src/commands/setup/deploy/templates/serverless/api.js
@@ -1,5 +1,6 @@
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { getPaths } from '../../../../../lib'
 

--- a/packages/cli/src/commands/setup/generator/generator.js
+++ b/packages/cli/src/commands/setup/generator/generator.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import terminalLink from 'terminal-link'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/graphiql/graphiqlHandler.js
+++ b/packages/cli/src/commands/setup/graphiql/graphiqlHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { registerApiSideBabelHook } from '@redwoodjs/babel-config'

--- a/packages/cli/src/commands/setup/i18n/i18nHandler.js
+++ b/packages/cli/src/commands/setup/i18n/i18nHandler.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { errorTelemetry } from '@redwoodjs/telemetry'

--- a/packages/cli/src/commands/setup/mailer/mailerHandler.js
+++ b/packages/cli/src/commands/setup/mailer/mailerHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addApiPackages } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/package/__tests__/packageHandler.test.js
+++ b/packages/cli/src/commands/setup/package/__tests__/packageHandler.test.js
@@ -34,10 +34,10 @@ jest.mock('enquirer', () => {
   }
 })
 
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 
 import { getCompatibilityData } from '@redwoodjs/cli-helpers'
 

--- a/packages/cli/src/commands/setup/realtime/realtimeHandler.js
+++ b/packages/cli/src/commands/setup/realtime/realtimeHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addApiPackages } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import { outputFileSync } from 'fs-extra'
 import { Listr } from 'listr2'
 import terminalLink from 'terminal-link'

--- a/packages/cli/src/commands/setup/vite/viteHandler.js
+++ b/packages/cli/src/commands/setup/vite/viteHandler.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { addWebPackages } from '@redwoodjs/cli-helpers'

--- a/packages/cli/src/commands/setup/webpack/webpackHandler.js
+++ b/packages/cli/src/commands/setup/webpack/webpackHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { errorTelemetry } from '@redwoodjs/telemetry'

--- a/packages/cli/src/commands/testHandler.js
+++ b/packages/cli/src/commands/testHandler.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
 import { ensurePosixPath } from '@redwoodjs/project-config'

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import execa from 'execa'
+import fs from 'fs-extra'
 import latestVersion from 'latest-version'
 import { Listr } from 'listr2'
 import terminalLink from 'terminal-link'

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import fs from 'fs'
 import path from 'path'
 
 import { trace, SpanStatusCode } from '@opentelemetry/api'
 import { config } from 'dotenv-defaults'
+import fs from 'fs-extra'
 import { hideBin, Parser } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 

--- a/packages/cli/src/lib/__tests__/index.test.js
+++ b/packages/cli/src/lib/__tests__/index.test.js
@@ -15,8 +15,9 @@ jest.mock('@redwoodjs/project-config', () => {
   }
 })
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import * as index from '../index'
 

--- a/packages/cli/src/lib/__tests__/locking.test.js
+++ b/packages/cli/src/lib/__tests__/locking.test.js
@@ -13,8 +13,9 @@ jest.mock('@redwoodjs/project-config', () => {
 })
 jest.mock('fs')
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { setLock, unsetLock, isLockSet, clearLocks } from '../locking'
 

--- a/packages/cli/src/lib/__tests__/rollback.test.js
+++ b/packages/cli/src/lib/__tests__/rollback.test.js
@@ -1,6 +1,6 @@
-import fs from 'fs'
 import path from 'path'
 
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 jest.mock('fs')

--- a/packages/cli/src/lib/__tests__/updateCheck.test.js
+++ b/packages/cli/src/lib/__tests__/updateCheck.test.js
@@ -17,8 +17,7 @@ jest.mock('@redwoodjs/project-config', () => {
   }
 })
 
-import fs from 'fs'
-
+import fs from 'fs-extra'
 import latestVersion from 'latest-version'
 
 import { getConfig } from '@redwoodjs/project-config'

--- a/packages/cli/src/lib/extendFile.js
+++ b/packages/cli/src/lib/extendFile.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'fs-extra'
 
 /**
  * Convenience function to check if a file includes a particular string.

--- a/packages/cli/src/lib/generatePrismaClient.js
+++ b/packages/cli/src/lib/generatePrismaClient.js
@@ -1,7 +1,8 @@
 // helper used in Dev and Build commands
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { runCommandTask, getPaths } from '../lib'
 

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -1,5 +1,4 @@
 import { execSync } from 'child_process'
-import fs from 'fs'
 import https from 'https'
 import path from 'path'
 
@@ -8,6 +7,7 @@ import boxen from 'boxen'
 import camelcase from 'camelcase'
 import decamelize from 'decamelize'
 import execa from 'execa'
+import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import { memoize, template } from 'lodash'
 import { paramCase } from 'param-case'

--- a/packages/cli/src/lib/locking.js
+++ b/packages/cli/src/lib/locking.js
@@ -1,5 +1,6 @@
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { getPaths } from './index'
 

--- a/packages/cli/src/lib/plugin.js
+++ b/packages/cli/src/lib/plugin.js
@@ -1,7 +1,7 @@
-import fs from 'fs'
 import path from 'path'
 
 import chalk from 'chalk'
+import fs from 'fs-extra'
 
 import { getCompatibilityData } from '@redwoodjs/cli-helpers'
 

--- a/packages/cli/src/lib/project.js
+++ b/packages/cli/src/lib/project.js
@@ -1,5 +1,6 @@
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import { getPaths } from '.'
 

--- a/packages/cli/src/lib/rollback.js
+++ b/packages/cli/src/lib/rollback.js
@@ -1,5 +1,6 @@
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 // The stack containing rollback actions
 let rollback = []

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -1,6 +1,5 @@
-import fs from 'fs'
-
 import { getConfig, getDMMF } from '@prisma/internals'
+import fs from 'fs-extra'
 
 import { ensureUniquePlural } from './pluralHelpers'
 import { singularize, isPlural } from './rwPluralize'

--- a/packages/cli/src/lib/test.js
+++ b/packages/cli/src/lib/test.js
@@ -8,8 +8,9 @@
 //   expect('some output').toEqual(loadComponentFixture('component', 'filename.js'))
 // })
 
-import fs from 'fs'
 import path from 'path'
+
+import fs from 'fs-extra'
 
 import './mockTelemetry'
 

--- a/packages/cli/src/lib/updateCheck.js
+++ b/packages/cli/src/lib/updateCheck.js
@@ -1,8 +1,8 @@
-import fs from 'fs'
 import path from 'path'
 
 import boxen from 'boxen'
 import chalk from 'chalk'
+import fs from 'fs-extra'
 import latestVersion from 'latest-version'
 import semver from 'semver'
 

--- a/packages/cli/src/rwfw.js
+++ b/packages/cli/src/rwfw.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import fs from 'fs'
 import path from 'path'
 
 import Configstore from 'configstore/index'
 import execa from 'execa'
+import fs from 'fs-extra'
 import TerminalLink from 'terminal-link'
 
 import { getConfigPath } from '@redwoodjs/project-config'


### PR DESCRIPTION
I was sizing up the CLI code as part of ESM work. Since I was looking at it wholesale, @Josh-Walker-GM and I were exchanging notes on what we'd like to improve about it. While a lot of what we talked about was out of scope, there were a few things that are low hanging fruit, one of which is this one, which amounted to a simple search and replace. We just figured if we're using `fs-extra` half the time in the CLI, we may as well use it everywhere to remove the overhead of why it'd be different in one place vs another.