### PR TITLE
fix(studio): Fix windows path issues

### DIFF
--- a/packages/studio/api/mail/index.ts
+++ b/packages/studio/api/mail/index.ts
@@ -127,7 +127,7 @@ export async function updateMailTemplates() {
     (file) => {
       const correspondingDistEntry =
         file
-          .replace('api/src', 'api/dist')
+          .replace(path.join('api', 'src'), path.join('api', 'dist'))
           .substring(0, file.lastIndexOf('.') + 1) + '.js'
       return distFiles.includes(correspondingDistEntry)
     }

--- a/packages/studio/api/services/mail.ts
+++ b/packages/studio/api/services/mail.ts
@@ -97,7 +97,7 @@ export async function getRenderedMail(
     // Import the template component
     const templateComponentDistPath =
       template.path
-        .replace('api/src', 'api/dist')
+        .replace(path.join('api', 'src'), path.join('api', 'dist'))
         .substring(0, template.path.lastIndexOf('.') + 1) + '.js'
 
     const templateImportPath = templateComponentDistPath.replace(


### PR DESCRIPTION
**Problem**
#9545 Highlights some compatibility issues with studio on windows.

**Changes**
1. Removes some assumptions of `/` as the path separator.

**Fixes**
Fixes #9545 in combination with #9639