### PR TITLE
chore(unit tests): Use side-effect import to fix TS errors

### DIFF
--- a/packages/forms/jest.config.js
+++ b/packages/forms/jest.config.js
@@ -1,4 +1,5 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
 }

--- a/packages/forms/jest.setup.ts
+++ b/packages/forms/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/packages/forms/src/__tests__/form.test.tsx
+++ b/packages/forms/src/__tests__/form.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import '@testing-library/jest-dom'
 import {
   screen,
   render,

--- a/packages/forms/src/__tests__/form.test.tsx
+++ b/packages/forms/src/__tests__/form.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react'
 
-import {
-  toHaveFocus,
-  toHaveClass,
-  toBeInTheDocument,
-} from '@testing-library/jest-dom/matchers'
+import '@testing-library/jest-dom'
 import {
   screen,
   render,
@@ -27,7 +23,6 @@ import {
   FieldError,
   Label,
 } from '../index'
-expect.extend({ toHaveFocus, toHaveClass, toBeInTheDocument })
 
 describe('Form', () => {
   const TestComponent = ({ onSubmit = () => {} }) => {

--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  setupFilesAfterEnv: ['./jest.setup.js'],
+  setupFilesAfterEnv: ['./jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   testMatch: ['**/*.test.+(ts|tsx|js|jsx)', '!**/__typetests__/*.ts'],
 }

--- a/packages/router/jest.setup.js
+++ b/packages/router/jest.setup.js
@@ -1,1 +1,0 @@
-globalThis.scrollTo = jest.fn()

--- a/packages/router/jest.setup.ts
+++ b/packages/router/jest.setup.ts
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom'
+
+globalThis.scrollTo = jest.fn()

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
 
 import { NavLink, useMatch, Link } from '../links'

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
 
-import { toHaveClass, toHaveStyle } from '@testing-library/jest-dom/matchers'
+import '@testing-library/jest-dom'
 import { render } from '@testing-library/react'
-
-// TODO: Remove when jest configs are in place
-// @ts-expect-error - Issue with TS and jest-dom
-expect.extend({ toHaveClass, toHaveStyle })
 
 import { NavLink, useMatch, Link } from '../links'
 import { LocationProvider } from '../location'


### PR DESCRIPTION
![image](https://github.com/redwoodjs/redwood/assets/30793/fb2e7212-35c6-4d15-9723-03f7e737725e)

We had a bunch of TypeScript errors like the one above. This PR fixes those by changing what import we use.

Trying to more closely follow https://github.com/testing-library/jest-dom#usage
Except we keep our config and setup files outside of TS `root`, so we can't include them. But it seems to work anyways.