### PR TITLE
Make it easier to find useMatch docs

### DIFF
--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -246,7 +246,9 @@ More granular match, `page` key only and `tab=tutorial`
 activeMatchParams={[{ tab: 'tutorial' }, 'page' ]}
 ```
 
-You can `useMatch` to create your own component with active styles.
+### useMatch
+
+You can use `useMatch` to create your own component with active styles.
 
 > `NavLink` uses it internally!
 


### PR DESCRIPTION
Adds a heading to the router docs for the `useMatch` hook to make it easier to find the docs for it (useParams and useLocation already had their own headings). Also fixes a grammatical mistake