### PR TITLE
SSR smoke-test: Use <Metadata />

### DIFF
--- a/.github/actions/detect-changes/cases/ssr.mjs
+++ b/.github/actions/detect-changes/cases/ssr.mjs
@@ -8,7 +8,8 @@ export function ssrChanged(changedFiles){
   for (const changedFile of changedFiles) {
     if (
       changedFile.startsWith('tasks/smoke-tests/streaming-ssr') ||
-      changedFile.startsWith('tasks/smoke-tests/basePlaywright.config.ts') ||
+      changedFile === 'tasks/smoke-tests/basePlaywright.config.ts' ||
+      changedFile === 'tasks/test-project/codemods/delayedPage.js' ||
       changedFile.startsWith('packages/internal/') ||
       changedFile.startsWith('packages/project-config/') ||
       changedFile.startsWith('packages/web/') ||

--- a/tasks/test-project/codemods/delayedPage.js
+++ b/tasks/test-project/codemods/delayedPage.js
@@ -63,7 +63,7 @@ const body = `
 {
  return (
   <>
-  <MetaTags title="Delayed" description="Delayed page" />
+  <Metadata title="Delayed" description="Delayed page" />
 
   <h1>DelayedPage</h1>
   <p>The following component will render over 4 seconds...</p>


### PR DESCRIPTION
Fixes this error in our CI

![image](https://github.com/redwoodjs/redwood/assets/30793/29ae8ce8-53b9-4982-990f-a012025c0f17)

```
web | transporting incomingBackgroundQueries []
  ✓  1 [chromium] › progressiveRendering.spec.ts:25:5 › Check that homepage has content rendered from the server (progressively) (924ms)
[WebServer] web | 🔻 Caught error outside shell
[WebServer] web | ReferenceError: MetaTags is not defined
web |     at DelayedPage (/home/runner/work/redwood/test-project/web/src/pages/DelayedPage/DelayedPage.tsx:70:4)
web |     at renderWithHooks (/home/runner/work/redwood/test-project/node_modules/react-dom/cjs/react-dom-server.edge.development.js:8654:16)
```

https://github.com/redwoodjs/redwood/actions/runs/7337050830/job/19977328836?pr=9758