### PR TITLE
docker.md: Fix web path

### DIFF
--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -316,7 +316,7 @@ WORKDIR /home/node/app
 
 COPY --chown=node:node .yarnrc.yml .
 COPY --chown=node:node package.json .
-COPY --chown=node:node web/package.json .
+COPY --chown=node:node web/package.json web/
 COPY --chown=node:node yarn.lock .
 
 RUN mkdir -p /home/node/.yarn/berry/index


### PR DESCRIPTION
The docker docs were updated in https://github.com/redwoodjs/redwood/pull/9764 but one broken path snuck in there. This PR fixes that