### PR TITLE
chore(ci): retry detectChanges on error

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -47,10 +47,11 @@ async function getChangedFiles(page = 1, retries = 0) {
   // Query the GitHub API to get the changed files in the PR
   const githubToken = process.env.GITHUB_TOKEN
   const url = `https://api.github.com/repos/redwoodjs/redwood/pulls/${prNumber}/files?per_page=100&page=${page}`
+  let resp
   let files
 
   try {
-    const resp = await fetch(url, {
+    resp = await fetch(url, {
       headers: {
         Authorization: githubToken ? `Bearer ${githubToken}` : undefined,
         ['X-GitHub-Api-Version']: '2022-11-28',

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -31,26 +31,48 @@ const getPrNumber = (githubRef) => {
   return prNumber
 }
 
-async function getChangedFiles(page = 1) {
+async function getChangedFiles(page = 1, retries = 0) {
   const prNumber = getPrNumber()
 
-  console.log(`Getting changed files for PR ${prNumber} (page ${page})`)
+  if (retries) {
+    console.log(
+      `Retry ${retries}: Getting changed files for PR ${prNumber} (page ${page})`
+    )
+  } else {
+    console.log(`Getting changed files for PR ${prNumber} (page ${page})`)
+  }
 
   let changedFiles = []
 
   // Query the GitHub API to get the changed files in the PR
   const githubToken = process.env.GITHUB_TOKEN
   const url = `https://api.github.com/repos/redwoodjs/redwood/pulls/${prNumber}/files?per_page=100&page=${page}`
-  const resp = await fetch(url, {
-    headers: {
-      Authorization: githubToken ? `Bearer ${githubToken}` : undefined,
-      ['X-GitHub-Api-Version']: '2022-11-28',
-      Accept: 'application/vnd.github+json',
-    },
-  })
+  let files
 
-  const json = await resp.json()
-  const files = json?.map((file) => file.filename) || []
+  try {
+    const resp = await fetch(url, {
+      headers: {
+        Authorization: githubToken ? `Bearer ${githubToken}` : undefined,
+        ['X-GitHub-Api-Version']: '2022-11-28',
+        Accept: 'application/vnd.github+json',
+      },
+    })
+
+    const json = await resp.json()
+    files = json.map((file) => file.filename) || []
+  } catch (e) {
+    if (retries >= 3) {
+      console.error(e)
+
+      console.log()
+      console.log('Too many retries, giving up.')
+
+      return []
+    } else {
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+      getChangedFiles(page, ++retries)
+    }
+  }
 
   changedFiles = changedFiles.concat(files)
 


### PR DESCRIPTION
![image](https://github.com/redwoodjs/redwood/assets/30793/2e3a0105-e11e-4ef1-a637-e565a4ca6c8b)


I thought I already fixed this in [a previous PR (#9762)](https://github.com/redwoodjs/redwood/pull/9762), but I guess not... Trying again!