### PR TITLE
chore(ci): retry detectChanges on error, and await result

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -5,7 +5,7 @@ import { hasCodeChanges } from './cases/code_changes.mjs'
 import { rscChanged } from './cases/rsc.mjs'
 import { ssrChanged } from './cases/ssr.mjs'
 
-const getPrNumber = (githubRef) => {
+const getPrNumber = () => {
   // Example GITHUB_REF refs/pull/9544/merge
   const result = /refs\/pull\/(\d+)\/merge/g.exec(process.env.GITHUB_REF)
 
@@ -48,7 +48,7 @@ async function getChangedFiles(page = 1, retries = 0) {
   const githubToken = process.env.GITHUB_TOKEN
   const url = `https://api.github.com/repos/redwoodjs/redwood/pulls/${prNumber}/files?per_page=100&page=${page}`
   let resp
-  let files
+  let files = []
 
   try {
     resp = await fetch(url, {
@@ -71,7 +71,7 @@ async function getChangedFiles(page = 1, retries = 0) {
       return []
     } else {
       await new Promise((resolve) => setTimeout(resolve, 3000))
-      getChangedFiles(page, ++retries)
+      files = await getChangedFiles(page, ++retries)
     }
   }
 

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -59,6 +59,12 @@ async function getChangedFiles(page = 1, retries = 0) {
       },
     })
 
+    if (!resp.ok) {
+      console.log()
+      console.error('Response not ok')
+      console.log('resp', resp)
+    }
+
     const json = await resp.json()
     files = json.map((file) => file.filename) || []
   } catch (e) {
@@ -103,8 +109,8 @@ async function main() {
 
   if (changedFiles.length === 0) {
     console.log(
-      'No changed files found. Something must have gone wrong. Fall back to ' +
-        'running all tests.'
+      'No changed files found. Something must have gone wrong. Falling back ' +
+        'to running all tests.'
     )
     core.setOutput('onlydocs', false)
     core.setOutput('rsc', true)

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -70,7 +70,7 @@ async function getChangedFiles(page = 1, retries = 0) {
 
       return []
     } else {
-      await new Promise((resolve) => setTimeout(resolve, 3000))
+      await new Promise((resolve) => setTimeout(resolve, 3000 * retries))
       files = await getChangedFiles(page, ++retries)
     }
   }


### PR DESCRIPTION
Fix for issue with #9769

![image](https://github.com/redwoodjs/redwood/assets/30793/d26c7a61-8d03-4b48-bdf7-15d9161705f5)

Also saw this:

![image](https://github.com/redwoodjs/redwood/assets/30793/9608409a-c3eb-44ff-8172-3156fbce9e2a)

