### PR TITLE
usePathMatch

### DIFF
--- a/packages/router/src/__tests__/usePathMatch.test.tsx
+++ b/packages/router/src/__tests__/usePathMatch.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+
+import * as testingLibraryReact from '@testing-library/react'
+
+import { LocationProvider } from '..'
+import { usePathMatch } from '../usePathMatch'
+
+function createDummyLocation(pathname: string, search = '') {
+  return {
+    pathname,
+    hash: '',
+    host: '',
+    hostname: '',
+    href: '',
+    ancestorOrigins: null,
+    assign: () => null,
+    reload: () => null,
+    replace: () => null,
+    origin: '',
+    port: '',
+    protocol: '',
+    search,
+  }
+}
+
+describe('usePathMatch', () => {
+  let locationPathname = '/dummy-location'
+  let locationSearch = ''
+
+  function createLocationWrapper() {
+    const mockLocation = createDummyLocation(locationPathname, locationSearch)
+    return ({ children }) => (
+      <LocationProvider location={mockLocation}>{children}</LocationProvider>
+    )
+  }
+
+  type CallbackType = Parameters<typeof testingLibraryReact.renderHook>[0]
+  function renderHook(cb: CallbackType) {
+    return testingLibraryReact.renderHook(cb, {
+      wrapper: createLocationWrapper(),
+    })
+  }
+
+  function setLocation(pathname: string, search = '') {
+    locationPathname = pathname
+    locationSearch = search
+  }
+
+  beforeAll(() => {})
+
+  afterEach(() => {
+    setLocation('/dummy-location')
+  })
+
+  it('matches on identical url and path', () => {
+    const { result } = renderHook(() => usePathMatch('/about', '/about'))
+
+    expect(result.current).toBeTruthy()
+  })
+
+  it('matches on location', () => {
+    setLocation('/test-path')
+
+    const { result } = renderHook(() => usePathMatch('/test-path'))
+
+    expect(result.current).toBeTruthy()
+  })
+
+  it('matches a path with given param value', () => {
+    const { result } = renderHook(() =>
+      usePathMatch('/posts/uuid-string', '/posts/{id}', {
+        paramValues: { id: 'uuid-string' },
+      })
+    )
+
+    expect(result.current).toBeTruthy()
+  })
+
+  it('matches a path with given param value, using location', () => {
+    setLocation('/posts/uuid-string')
+
+    const { result } = renderHook(() =>
+      usePathMatch('/posts/{id}', { paramValues: { id: 'uuid-string' } })
+    )
+
+    expect(result.current).toBeTruthy()
+  })
+
+  it('matches a path with default param type', () => {
+    const { result } = renderHook(() =>
+      usePathMatch('/posts/123', '/posts/{id}', {
+        paramValues: { id: '123' },
+      })
+    )
+
+    expect(result.current).toBeTruthy()
+  })
+
+  it('matches a path with a specified param type', () => {
+    const { result } = renderHook(() =>
+      usePathMatch('/posts/123', '/posts/{id:Int}', {
+        paramValues: { id: 123 },
+      })
+    )
+
+    expect(result.current).toBeTruthy()
+  })
+
+  it("doesn't match a path with a specified param type with different value", () => {
+    const { result } = renderHook(() =>
+      usePathMatch('/posts/123', '/posts/{id:Int}', {
+        paramValues: { id: '0' },
+      })
+    )
+
+    expect(result.current).toBeFalsy()
+  })
+})

--- a/packages/router/src/__tests__/usePathMatch.test.tsx
+++ b/packages/router/src/__tests__/usePathMatch.test.tsx
@@ -27,17 +27,14 @@ describe('usePathMatch', () => {
   let locationPathname = '/dummy-location'
   let locationSearch = ''
 
-  function createLocationWrapper() {
-    const mockLocation = createDummyLocation(locationPathname, locationSearch)
-    return ({ children }) => (
-      <LocationProvider location={mockLocation}>{children}</LocationProvider>
-    )
-  }
-
   type CallbackType = Parameters<typeof testingLibraryReact.renderHook>[0]
   function renderHook(cb: CallbackType) {
+    const mockLocation = createDummyLocation(locationPathname, locationSearch)
+
     return testingLibraryReact.renderHook(cb, {
-      wrapper: createLocationWrapper(),
+      wrapper: ({ children }) => (
+        <LocationProvider location={mockLocation}>{children}</LocationProvider>
+      ),
     })
   }
 
@@ -45,8 +42,6 @@ describe('usePathMatch', () => {
     locationPathname = pathname
     locationSearch = search
   }
-
-  beforeAll(() => {})
 
   afterEach(() => {
     setLocation('/dummy-location')

--- a/packages/router/src/useMatch.ts
+++ b/packages/router/src/useMatch.ts
@@ -1,3 +1,4 @@
+import type { LocationContextType } from './location'
 import { useLocation } from './location'
 import { matchPath } from './util'
 import type { FlattenSearchParams } from './util'
@@ -32,9 +33,16 @@ type UseMatchOptions = {
  * const match = useMatch('/product', { matchSubPaths: true })
  */
 export const useMatch = (pathname: string, options?: UseMatchOptions) => {
-  const location = useLocation()
+  return useLocationMatch(useLocation(), pathname, options)
+}
+
+export const useLocationMatch = (
+  location: LocationContextType,
+  pathname: string,
+  options?: UseMatchOptions
+) => {
   if (!location) {
-    return { match: false }
+    return { match: false, params: undefined }
   }
 
   if (options?.searchParams) {
@@ -50,7 +58,7 @@ export const useMatch = (pathname: string, options?: UseMatchOptions) => {
     })
 
     if (hasUnmatched) {
-      return { match: false }
+      return { match: false, params: undefined }
     }
   }
 

--- a/packages/router/src/useMatch.ts
+++ b/packages/router/src/useMatch.ts
@@ -42,7 +42,7 @@ export const useLocationMatch = (
   options?: UseMatchOptions
 ) => {
   if (!location) {
-    return { match: false, params: undefined }
+    return { match: false }
   }
 
   if (options?.searchParams) {
@@ -58,7 +58,7 @@ export const useLocationMatch = (
     })
 
     if (hasUnmatched) {
-      return { match: false, params: undefined }
+      return { match: false }
     }
   }
 

--- a/packages/router/src/usePathMatch.ts
+++ b/packages/router/src/usePathMatch.ts
@@ -6,8 +6,8 @@ interface UsePathMatchOptions {
 }
 
 /**
- * Will match the current location against the given path, making any
- * replacements as provided in the options.
+ * Will match the current location against the given path, also matching all
+ * supplied param values
  *
  * @param path The path as defined in your Routes file
  * @param options {UsePathMatchOptions}
@@ -18,6 +18,9 @@ export function usePathMatch(
   options?: UsePathMatchOptions
 ): boolean
 /**
+ * Will match the given url against the given path, also matching all supplied
+ * param values
+ *
  * @param url The url to match against
  * @param path The path as defined in your Routes file
  * @param options {UsePathMatchOptions}

--- a/packages/router/src/usePathMatch.ts
+++ b/packages/router/src/usePathMatch.ts
@@ -1,0 +1,66 @@
+import { useLocation } from './location'
+import { useLocationMatch } from './useMatch'
+
+interface UsePathMatchOptions {
+  paramValues?: Record<string, any>
+}
+
+/**
+ * Will match the current location against the given path, making any
+ * replacements as provided in the options.
+ *
+ * @param path The path as defined in your Routes file
+ * @param options {UsePathMatchOptions}
+ * @param options.paramValues An map of param names and their values
+ */
+export function usePathMatch(
+  path: string,
+  options?: UsePathMatchOptions
+): boolean
+/**
+ * @param url The url to match against
+ * @param path The path as defined in your Routes file
+ * @param options {UsePathMatchOptions}
+ * @param options.paramValues An map of param names and their values
+ */
+export function usePathMatch(
+  url: string,
+  path: string,
+  options?: UsePathMatchOptions
+): boolean
+export function usePathMatch(
+  urlOrPath: string,
+  pathOrOptions?: string | UsePathMatchOptions,
+  opts?: UsePathMatchOptions
+): boolean {
+  const location = useLocation()
+
+  const url = typeof pathOrOptions !== 'string' ? location.pathname : urlOrPath
+  const path = typeof pathOrOptions === 'string' ? pathOrOptions : urlOrPath
+  const options = typeof pathOrOptions !== 'string' ? pathOrOptions : opts
+
+  const match = useLocationMatch({ pathname: url }, path)
+
+  if (!match.match) {
+    return false
+  }
+
+  const paramValues = Object.entries(options?.paramValues || {})
+
+  if (paramValues.length > 0) {
+    if (!isMatchWithParams(match) || !match.params) {
+      return false
+    }
+
+    // If paramValues were given, they must all match
+    return paramValues.every(([key, value]) => {
+      return match.params[key] === value
+    })
+  }
+
+  return true
+}
+
+function isMatchWithParams(match: unknown): match is { params: any } {
+  return match !== null && typeof match === 'object' && 'params' in match
+}

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -149,7 +149,7 @@ export function matchPath(
   const matches = [...pathname.matchAll(matchRegex)]
 
   if (matches.length === 0) {
-    return { match: false, params: undefined }
+    return { match: false }
   }
   // Map extracted values to their param name, casting the value if needed
   const providedParams = matches[0].slice(1)
@@ -177,7 +177,7 @@ export function matchPath(
     return { match: true, params }
   }
 
-  return { match: true, params: undefined }
+  return { match: true }
 }
 
 interface GetRouteRegexOptions {

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -149,7 +149,7 @@ export function matchPath(
   const matches = [...pathname.matchAll(matchRegex)]
 
   if (matches.length === 0) {
-    return { match: false }
+    return { match: false, params: undefined }
   }
   // Map extracted values to their param name, casting the value if needed
   const providedParams = matches[0].slice(1)
@@ -177,7 +177,7 @@ export function matchPath(
     return { match: true, params }
   }
 
-  return { match: true }
+  return { match: true, params: undefined }
 }
 
 interface GetRouteRegexOptions {


### PR DESCRIPTION
**Finally** have a solution to matching route paths

This PR and #9755 together provides a solution for the use case outlined in #7469

Here's the example from #7469 as it could be solved with the code in this PR

```jsx
const Navbar () => {
  const { project } = useParams()
  const routePaths = useRoutePaths()

  const modes = [
    {
      name: "Info",
      route: routes.info({ project }),
      match: usePathMatch(routePaths.info), // using the new hook together with routePaths
    },
    {
      name: "Compare",
      route: routes.compare({ project, id: "1" }),
      match: usePathMatch(useRoutePath('compare')), // alternative to the above
    },
    // ...
  ]

  return (
    <>
      {modes.map((x) => <Button as={Link} to={x.route} isActive={x.match} />)}
    </>
  )
}
```

TODO:
- [ ] More tests
- [ ] Docs
- [ ] Discuss with @jtoar 
- [ ] Better types
- [ ] Make it possible to pass the same options as for `useMatch`