### PR TITLE
fix: Fixes way OpenTelemetry setup template uses project-config for port setting

### DIFF
--- a/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
+++ b/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
@@ -15,7 +15,7 @@ const {
 } = require('@opentelemetry/semantic-conventions')
 const { PrismaInstrumentation } = require ('@prisma/instrumentation')
 
-const { getConfig } from '@redwoodjs/project-config'
+const { getConfig } = require('@redwoodjs/project-config')
 
 // You may wish to set this to DiagLogLevel.DEBUG when you need to debug opentelemetry itself
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO)


### PR DESCRIPTION
Fixes PR https://github.com/redwoodjs/redwood/pull/9709/files where way `getConfig` is imported from `project-config` when setting up OpenTelemetry for use with RedwoodJS Studio.

Need to `require` and not import.
