### PR TITLE
fix(otel): Fix OTel sdk loading

### DIFF
--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -84,21 +84,26 @@ const rebuildApiServer = () => {
 
     // OpenTelemetry SDK Setup
     if (getConfig().experimental.opentelemetry.enabled) {
-      const opentelemetrySDKScriptPath =
-        getConfig().experimental.opentelemetry.apiSdk
-      if (opentelemetrySDKScriptPath) {
-        console.log(
-          `Setting up OpenTelemetry using the setup file: ${opentelemetrySDKScriptPath}`
+      // We expect the OpenTelemetry SDK setup file to be in a specific location
+      const opentelemetrySDKScriptPath = path.join(
+        getPaths().api.dist,
+        'opentelemetry.js'
+      )
+      const opentelemetrySDKScriptPathRelative = path.relative(
+        getPaths().base,
+        opentelemetrySDKScriptPath
+      )
+      console.log(
+        `Setting up OpenTelemetry using the setup file: ${opentelemetrySDKScriptPathRelative}`
+      )
+      if (fs.existsSync(opentelemetrySDKScriptPath)) {
+        forkOpts.execArgv = forkOpts.execArgv.concat([
+          `--require=${opentelemetrySDKScriptPath}`,
+        ])
+      } else {
+        console.error(
+          `OpenTelemetry setup file does not exist at ${opentelemetrySDKScriptPathRelative}`
         )
-        if (fs.existsSync(opentelemetrySDKScriptPath)) {
-          forkOpts.execArgv = forkOpts.execArgv.concat([
-            `--require=${opentelemetrySDKScriptPath}`,
-          ])
-        } else {
-          console.error(
-            `OpenTelemetry setup file does not exist at ${opentelemetrySDKScriptPath}`
-          )
-        }
       }
     }
 

--- a/packages/cli/src/commands/experimental/setupOpentelemetryHandler.js
+++ b/packages/cli/src/commands/experimental/setupOpentelemetryHandler.js
@@ -69,7 +69,7 @@ export const handler = async ({ force, verbose }) => {
           writeFile(
             redwoodTomlPath,
             configContent.concat(
-              `\n[experimental.opentelemetry]\n\tenabled = true\n\twrapApi = true\n\tapiSdk = "${opentelemetryScriptPath}"`
+              `\n[experimental.opentelemetry]\n\tenabled = true\n\twrapApi = true`
             ),
             {
               overwriteExisting: true, // redwood.toml always exists

--- a/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
+++ b/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
@@ -29,6 +29,7 @@ const exporter = new OTLPTraceExporter({
   // The redwood development studio (`yarn rw exp studio`) can collect your
   // telemetry at `http://127.0.0.1:<PORT>/v1/traces` (default PORT is 4318)
   url: `http://127.0.0.1:${studioPort}/v1/traces`,
+  concurrencyLimit: 64,
 })
 
 // You may wish to switch to BatchSpanProcessor in production as it is the recommended choice for performance reasons

--- a/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
+++ b/packages/cli/src/commands/experimental/templates/opentelemetry.ts.template
@@ -1,21 +1,17 @@
-const { diag, DiagConsoleLogger, DiagLogLevel } = require('@opentelemetry/api')
-const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
-const { registerInstrumentations } = require('@opentelemetry/instrumentation')
-const {
-  FastifyInstrumentation,
-} = require('@opentelemetry/instrumentation-fastify')
-const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http')
-const { Resource } = require('@opentelemetry/resources')
-const {
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
+import { registerInstrumentations } from '@opentelemetry/instrumentation'
+import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify'
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
+import { Resource } from '@opentelemetry/resources'
+import {
   NodeTracerProvider,
   SimpleSpanProcessor,
-} = require('@opentelemetry/sdk-trace-node')
-const {
-  SemanticResourceAttributes,
-} = require('@opentelemetry/semantic-conventions')
-const { PrismaInstrumentation } = require ('@prisma/instrumentation')
+} from '@opentelemetry/sdk-trace-node'
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { PrismaInstrumentation } from '@prisma/instrumentation'
 
-const { getConfig } = require('@redwoodjs/project-config')
+import { getConfig } from '@redwoodjs/project-config'
 
 // You may wish to set this to DiagLogLevel.DEBUG when you need to debug opentelemetry itself
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO)
@@ -51,7 +47,7 @@ registerInstrumentations({
     new FastifyInstrumentation(),
     new PrismaInstrumentation({
       middleware: true,
-    })
+    }),
   ],
 })
 

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -55,7 +55,6 @@ describe('getConfig', () => {
             ],
           },
           "opentelemetry": {
-            "apiSdk": undefined,
             "enabled": false,
             "wrapApi": true,
           },

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -169,7 +169,6 @@ const DEFAULT_CONFIG: Config = {
     opentelemetry: {
       enabled: false,
       wrapApi: true,
-      apiSdk: undefined,
     },
     studio: {
       basePort: 4318,


### PR DESCRIPTION
**Problem**
The toml config value that was supported for the experimental OpenTelemetry support points to the source file. It was however being used as if it were pointing to the transpiled version of the file.

**Changes**
1. Switches the `opentelemetry.ts` file to use `import` over `require` syntax.
2. Removes the `apiSdk` toml option and now assumes the file exists at `api/src/opentelemetry.ts` such that it then also exists at `api/dist/opentelemetry.js`.
3. Adds a large `concurrencyLimit` option to the OTel trace exporter. This fixes a limitation of the current redwood studio. This config will be removed in an upcoming change to the redwood studio which will better support the `BatchSpanProcessor` instead. 

---

This is a breaking change for OTel, but since our OTel support is still experimental we can release this in a patch-release.