### PR TITLE
chore(framework-tools): .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ blog-test-project/*
 *.code-workspace
 .nova
 packages/**/redwoodjs-*.tgz
-packages/**/create-redwood-app.tgz
+packages/create-redwood-app/create-redwood-app.tgz
 
 # For esbuild.
 **/meta.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ blog-test-project/*
 .pnp.*
 *.code-workspace
 .nova
+packages/**/redwoodjs-*.tgz
+packages/**/create-redwood-app.tgz
 
 # For esbuild.
 **/meta.json


### PR DESCRIPTION
When running the new `yarn:pack` command (added in https://github.com/redwoodjs/redwood/pull/9766) you end up with a bunch of .tgz files. They should not be committed to git, so I'm adding them to our .gitignore