### PR TITLE
chore(release-tooling): fetch -> pull

### DIFF
--- a/tasks/release/releaseLib.mjs
+++ b/tasks/release/releaseLib.mjs
@@ -126,7 +126,7 @@ export function prompts(promptsObject, promptsOptions) {
 // ─── Branch Statuses ─────────────────────────────────────────────────────────
 
 /**
- * Basically runs `git fetch origin` on branches with safety checks and logging.
+ * Basically runs `git pull upstream` on branches with safety checks and logging.
  *
  * @param {string[]} branches
  */
@@ -149,7 +149,7 @@ export async function resolveBranchStatuses(branches) {
   let result
 
   // We need to run `git remote update ${redwoodRemote}` to `git fetch ${branch}`.
-  // Nine out of ten times, the redwood remote is `origin`. But let's just be sure.
+  // Nine out of ten times, the redwood remote is `upstream`. But let's just be sure.
   result = await getRedwoodRemote()
 
   if (result.error) {
@@ -313,10 +313,10 @@ export async function handleBranchesToCommits(
       if (
         status.commitsExclusiveToRemoteBranch &&
         isYes(
-          await question(`Ok to \`git fetch\` ${chalk.magenta(branch)}? [Y/n] `)
+          await question(`Ok to \`git pull\` ${chalk.magenta(branch)}? [Y/n] `)
         )
       ) {
-        await $`git fetch ${redwoodRemote} ${branch}:${branch}`
+        await $`git pull ${redwoodRemote} ${branch}:${branch}`
       }
     }
   }

--- a/tasks/release/releaseLib.mjs
+++ b/tasks/release/releaseLib.mjs
@@ -126,7 +126,8 @@ export function prompts(promptsObject, promptsOptions) {
 // ─── Branch Statuses ─────────────────────────────────────────────────────────
 
 /**
- * Basically runs `git pull upstream` on branches with safety checks and logging.
+ * Basically runs `git pull upstream` or `git fetch upstream` on branches with
+ * safety checks and logging.
  *
  * @param {string[]} branches
  */
@@ -310,13 +311,17 @@ export async function handleBranchesToCommits(
     ].join('\n')
   } else {
     for (const [branch, status] of Object.entries(branchesToCommits)) {
+      const pullOrFetch = branch === 'main' ? 'pull' : 'fetch'
+
       if (
         status.commitsExclusiveToRemoteBranch &&
         isYes(
-          await question(`Ok to \`git pull\` ${chalk.magenta(branch)}? [Y/n] `)
+          await question(
+            `Ok to \`git ${pullOrFetch}\` ${chalk.magenta(branch)}? [Y/n] `
+          )
         )
       ) {
-        await $`git pull ${redwoodRemote} ${branch}:${branch}`
+        await $`git ${pullOrFetch} ${redwoodRemote} ${branch}:${branch}`
       }
     }
   }


### PR DESCRIPTION
`git fetch` was throwing errors about refusing to fetch

![image](https://github.com/redwoodjs/redwood/assets/30793/65885c7b-8662-46e9-be51-2e8dd370daf3)

The reason is you can't `fetch` the current branch. So if you're currently on `main` you can't fetch main. In that case you should use `pull` instead