### PR TITLE
fix(crwa): use `fs.renameSync` instead of `fs.rename`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,13 +756,9 @@ jobs:
           sudo apt-get install expect
 
           ./tests/e2e_prompts.sh
-          sleep 1
           ./tests/e2e_prompts_git.sh
-          sleep 1
           ./tests/e2e_prompts_m.sh
-          sleep 1
           ./tests/e2e_prompts_ts.sh
-          sleep 1
           ./tests/e2e_prompts_overwrite.sh
         working-directory: ./packages/create-redwood-app
         env:

--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -251,7 +251,7 @@ async function createProjectFiles(appDir, { templateDir, overwrite }) {
   fs.copySync(templateDir, newAppDir, { overwrite })
 
   // .gitignore is renamed here to force file inclusion during publishing
-  fs.rename(
+  fs.renameSync(
     path.join(newAppDir, 'gitignore.template'),
     path.join(newAppDir, '.gitignore')
   )


### PR DESCRIPTION
I thought the prompt tests for CRWA introduced in https://github.com/redwoodjs/redwood/pull/9783 needed a little time between them to avoid flakiness so I added sleep statements, but @Tobbe showed me a failing run where the first test fails: https://github.com/redwoodjs/redwood/actions/runs/7370512212/job/20056962003?pr=9785.

@Josh-Walker-GM and I had a look at the code around the gitignore renaming step because that file starts as `gitignore.template` and gets renamed to `.gitignore` and we found an async `fs` method that wasn't being awaited. Changed it sync here.

We've had it this for quite a while now! Over two and a half years (see https://github.com/redwoodjs/redwood/pull/2752). I can't say I've ever seen it fail locally, but it's more likely in a resource constrained environment like CI I guess.