### PR TITLE
fix(dbAuth): Correct hardcoded DB column

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -970,8 +970,9 @@ export class DbAuthHandler<
 
       const existingDevice = await this.dbCredentialAccessor.findFirst({
         where: {
-          id: plainCredentialId,
-          userId: user[this.options.authFields.id],
+          [this.options.webAuthn.credentialFields.id]: plainCredentialId,
+          [this.options.webAuthn.credentialFields.userId]:
+            user[this.options.authFields.id],
         },
       })
 


### PR DESCRIPTION
**Problem**
Logging in with webauthn enabled was broken when you had customised your schema to use different column names than the default.

See #8743 for details. 

**Changes**
1. Alters the where clause to use the same column names as the create a few lines below. See: https://github.com/redwoodjs/redwood/blob/c7ae669e36c5e1b7edcd4ee5436558831bad94b8/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts#L979-L983

**Fixes**
Fixes #8743