### PR TITLE
Use regex to make test pass in VSCode

### DIFF
--- a/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
@@ -30,9 +30,17 @@ describe('install', () => {
 
     installCommand.builder(yargs)
 
+    // The epilogue is a string that contains a link to the docs. The string
+    // contains special control characters when rendered in a terminal that
+    // supports clickable links. We use regular expressions and wildcards here
+    // to avoid having to match control characters that might not even always
+    // be there
+    expect(yargs.epilogue).toHaveBeenCalledWith(
+      expect.stringMatching(/Also see the .*Redwood CLI Reference.*/)
+    )
     expect(yargs.epilogue).toHaveBeenCalledWith(
       expect.stringMatching(
-        /:\/\/redwoodjs\.com\/docs\/cli-commands#datamigrate-install/
+        /https:\/\/redwoodjs\.com\/docs\/cli-commands#datamigrate-install/
       )
     )
   })

--- a/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
@@ -26,6 +26,8 @@ describe('install', () => {
   })
 
   it('`builder` has an epilogue', () => {
+    // The typecasting here is to make TS happy when calling `builder(yargs)`
+    // further down. We know that only `epilogue` will be called.
     const yargs = { epilogue: jest.fn() } as unknown as yargs.Argv
 
     installCommand.builder(yargs)

--- a/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
@@ -1,3 +1,5 @@
+import type yargs from 'yargs'
+
 import * as installCommand from '../commands/install'
 import { handler as dataMigrateInstallHandler } from '../commands/installHandler.js'
 
@@ -24,12 +26,14 @@ describe('install', () => {
   })
 
   it('`builder` has an epilogue', () => {
-    const yargs = { epilogue: jest.fn() }
-    // @ts-expect-error this is a test file; epilogue is the only thing `builder` calls right now
+    const yargs = { epilogue: jest.fn() } as unknown as yargs.Argv
+
     installCommand.builder(yargs)
-    expect(yargs.epilogue).toBeCalledWith(
-      // eslint-disable-next-line no-irregular-whitespace
-      'Also see the Redwood CLI Reference (​https://redwoodjs.com/docs/cli-commands#datamigrate-install​)'
+
+    expect(yargs.epilogue).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /:\/\/redwoodjs\.com\/docs\/cli-commands#datamigrate-install/
+      )
     )
   })
 


### PR DESCRIPTION
I was seeing this test fail when running in VSCode

![image](https://github.com/redwoodjs/redwood/assets/30793/354f52c3-e242-40f6-a842-3b3dfa933204)

Even the editor part of VSCode gets confused about the control characters used in the string we're trying to match

![image](https://github.com/redwoodjs/redwood/assets/30793/4a7226a0-7832-4b8f-ab9c-9b419d7e8385)
(notice how you can't see the "https" part, and how the last control character is rendered after the end of the string (after `'`))