### PR TITLE
fix(fastify): Prevent duplicate `@fastify/url-data` registration

### DIFF
--- a/packages/api-server/src/plugins/withFunctions.ts
+++ b/packages/api-server/src/plugins/withFunctions.ts
@@ -14,7 +14,7 @@ const withFunctions = async (
   const { apiRootPath } = options
   // Add extra fastify plugins
   if (!fastify.hasPlugin('@fastify/url-data')) {
-    fastify.register(fastifyUrlData)
+    await fastify.register(fastifyUrlData)
   }
 
   // Fastify v4 must await the fastifyRawBody plugin

--- a/packages/api-server/src/plugins/withFunctions.ts
+++ b/packages/api-server/src/plugins/withFunctions.ts
@@ -13,7 +13,9 @@ const withFunctions = async (
 ) => {
   const { apiRootPath } = options
   // Add extra fastify plugins
-  fastify.register(fastifyUrlData)
+  if (!fastify.hasPlugin('@fastify/url-data')) {
+    fastify.register(fastifyUrlData)
+  }
 
   // Fastify v4 must await the fastifyRawBody plugin
   // registration to ensure the plugin is ready

--- a/packages/api-server/src/plugins/withWebServer.ts
+++ b/packages/api-server/src/plugins/withWebServer.ts
@@ -29,7 +29,7 @@ const withWebServer = async (
   options: WebServerArgs
 ) => {
   if (!fastify.hasPlugin('@fastify/url-data')) {
-    fastify.register(fastifyUrlData)
+    await fastify.register(fastifyUrlData)
   }
 
   const prerenderedFiles = findPrerenderedHtml()

--- a/packages/api-server/src/plugins/withWebServer.ts
+++ b/packages/api-server/src/plugins/withWebServer.ts
@@ -28,7 +28,9 @@ const withWebServer = async (
   fastify: FastifyInstance,
   options: WebServerArgs
 ) => {
-  fastify.register(fastifyUrlData)
+  if (!fastify.hasPlugin('@fastify/url-data')) {
+    fastify.register(fastifyUrlData)
+  }
 
   const prerenderedFiles = findPrerenderedHtml()
   const indexPath = getFallbackIndexPath()

--- a/packages/fastify/src/api.ts
+++ b/packages/fastify/src/api.ts
@@ -14,7 +14,9 @@ export async function redwoodFastifyAPI(
   opts: RedwoodFastifyAPIOptions,
   done: HookHandlerDoneFunction
 ) {
-  fastify.register(fastifyUrlData)
+  if (!fastify.hasPlugin('@fastify/url-data')) {
+    await fastify.register(fastifyUrlData)
+  }
   await fastify.register(fastifyRawBody)
 
   // TODO: This should be refactored to only be defined once and it might not live here

--- a/packages/fastify/src/graphql.ts
+++ b/packages/fastify/src/graphql.ts
@@ -34,7 +34,9 @@ export async function redwoodFastifyGraphQLServer(
   // These two plugins are needed to transform a Fastify Request to a Lambda event
   // which is used by the RedwoodGraphQLContext and mimics the behavior of the
   // api-server withFunction plugin
-  fastify.register(fastifyUrlData)
+  if (!fastify.hasPlugin('@fastify/url-data')) {
+    await fastify.register(fastifyUrlData)
+  }
   await fastify.register(fastifyRawBody)
 
   try {

--- a/packages/fastify/src/web.ts
+++ b/packages/fastify/src/web.ts
@@ -21,7 +21,9 @@ export async function redwoodFastifyWeb(
   opts: RedwoodFastifyWebOptions,
   done: HookHandlerDoneFunction
 ) {
-  fastify.register(fastifyUrlData)
+  if (!fastify.hasPlugin('@fastify/url-data')) {
+    await fastify.register(fastifyUrlData)
+  }
   const prerenderedFiles = findPrerenderedHtml()
 
   // Serve prerendered HTML directly, instead of the index.

--- a/packages/web-server/src/web.ts
+++ b/packages/web-server/src/web.ts
@@ -27,7 +27,9 @@ export async function redwoodFastifyWeb(
   opts: RedwoodFastifyWebOptions,
   done: HookHandlerDoneFunction
 ) {
-  fastify.register(fastifyUrlData)
+  if (!fastify.hasPlugin('@fastify/url-data')) {
+    await fastify.register(fastifyUrlData)
+  }
   const prerenderedFiles = findPrerenderedHtml()
 
   // Serve prerendered HTML directly, instead of the index.


### PR DESCRIPTION
**Problem**
A recent change in #9714 introduced a small issue where the `@fastify/url-data` plugin would register twice and on the second registration would throw an uncaught error. 

See: #9789 for more information.

**Changes**
1. I have introduced simple checks before registering the plugin to ensure it has not already been registered.
2. I have consistently awaited registration for the `@fastify/url-data` plugin.

**Fixes**
Fixes #9789