### PR TITLE
chore(data-migration): Fix test exit code 

### DIFF
--- a/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
@@ -248,7 +248,9 @@ describe('upHandler', () => {
       importDbClientFromDist: true,
       distPath: getPaths().api.dist,
     })
-    // The handler will error and set the exit code to 1, we must revert that or test suite itself will fail.
+
+    // The handler will error and set the exit code to 1, we must revert that
+    // or test suite itself will fail.
     process.exitCode = 0
 
     expect(console.info.mock.calls[0][0]).toMatch(

--- a/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
@@ -248,6 +248,8 @@ describe('upHandler', () => {
       importDbClientFromDist: true,
       distPath: getPaths().api.dist,
     })
+    // The handler will error and set the exit code to 1, we must revert that or test suite itself will fail.
+    process.exitCode = 0
 
     expect(console.info.mock.calls[0][0]).toMatch(
       '1 data migration(s) completed successfully.'


### PR DESCRIPTION
**Problem**
Running `yarn test` would fail for the cli data migrate package. This is because the code itself sets the exit code to 1 when an error occurs. We deliberately test the case where an error occurs so the exit code is indeed set 1. Even though the jest expect cases pass the test suite thinks something when wrong due to the non-zero exit code. 

**Changes**
1. Resets the exit code to 0 for the test case we expect to set it to 1. 