### PR TITLE
data migrate: Clean up upHandler test

### DIFF
--- a/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
@@ -8,6 +8,25 @@ import { handler, NO_PENDING_MIGRATIONS_MESSAGE } from '../commands/upHandler'
 
 const redwoodProjectPath = '/redwood-app'
 
+let consoleLogMock: jest.SpyInstance
+let consoleInfoMock: jest.SpyInstance
+let consoleErrorMock: jest.SpyInstance
+let consoleWarnMock: jest.SpyInstance
+
+beforeEach(() => {
+  consoleLogMock = jest.spyOn(console, 'log').mockImplementation()
+  consoleInfoMock = jest.spyOn(console, 'info').mockImplementation()
+  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
+  consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation()
+})
+
+afterEach(() => {
+  consoleLogMock.mockRestore()
+  consoleInfoMock.mockRestore()
+  consoleErrorMock.mockRestore()
+  consoleWarnMock.mockRestore()
+})
+
 jest.mock('fs', () => require('memfs').fs)
 
 const mockDataMigrations: { current: any[] } = { current: [] }
@@ -146,8 +165,6 @@ const ranDataMigration = {
 
 describe('upHandler', () => {
   it("noops if there's no data migrations directory", async () => {
-    console.info = jest.fn()
-
     vol.fromNestedJSON(
       {
         'redwood.toml': '',
@@ -174,7 +191,9 @@ describe('upHandler', () => {
       distPath: getPaths().api.dist,
     })
 
-    expect(console.info.mock.calls[0][0]).toMatch(NO_PENDING_MIGRATIONS_MESSAGE)
+    expect(consoleInfoMock.mock.calls[0][0]).toMatch(
+      NO_PENDING_MIGRATIONS_MESSAGE
+    )
   })
 
   it("noops if there's no pending migrations", async () => {
@@ -199,21 +218,17 @@ describe('upHandler', () => {
       redwoodProjectPath
     )
 
-    console.info = jest.fn()
-
     await handler({
       importDbClientFromDist: true,
       distPath: getPaths().api.dist,
     })
 
-    expect(console.info.mock.calls[0][0]).toMatch(NO_PENDING_MIGRATIONS_MESSAGE)
+    expect(consoleInfoMock.mock.calls[0][0]).toMatch(
+      NO_PENDING_MIGRATIONS_MESSAGE
+    )
   })
 
   it('runs pending migrations', async () => {
-    console.info = jest.fn()
-    console.error = jest.fn()
-    console.warn = jest.fn()
-
     mockDataMigrations.current = [
       {
         version: '20230822075441',
@@ -253,13 +268,13 @@ describe('upHandler', () => {
     // or test suite itself will fail.
     process.exitCode = 0
 
-    expect(console.info.mock.calls[0][0]).toMatch(
+    expect(consoleInfoMock.mock.calls[0][0]).toMatch(
       '1 data migration(s) completed successfully.'
     )
-    expect(console.error.mock.calls[1][0]).toMatch(
+    expect(consoleErrorMock.mock.calls[1][0]).toMatch(
       '1 data migration(s) exited with errors.'
     )
-    expect(console.warn.mock.calls[0][0]).toMatch(
+    expect(consoleWarnMock.mock.calls[0][0]).toMatch(
       '1 data migration(s) skipped due to previous error'
     )
   })


### PR DESCRIPTION
Running the upHandler tests you'd see this in your console
![image](https://github.com/redwoodjs/redwood/assets/30793/2a495b4f-ad79-42d4-b875-9c982402cbf4)

This PR cleans that up by mocking out console.log

It also fixes TS errors in the test code:

![image](https://github.com/redwoodjs/redwood/assets/30793/b4aa5e1b-6269-41d2-9ffd-bfd3e8c0b909)
