### PR TITLE
chore(cli): More robust isAwaitable

### DIFF
--- a/tasks/test-project/typing.ts
+++ b/tasks/test-project/typing.ts
@@ -17,5 +17,10 @@ export interface TuiTaskDef {
 }
 
 export function isAwaitable(promise: unknown): promise is Promise<unknown> {
-  return typeof promise !== 'undefined' && 'then' in promise
+  return (
+    !!promise &&
+    typeof promise === 'object' &&
+    'then' in promise &&
+    typeof promise.then === 'function'
+  )
 }


### PR DESCRIPTION
Don't just check that `then` exists, also make sure it's a function

Also fixes this TS error
![image](https://github.com/redwoodjs/redwood/assets/30793/075ab121-53e9-4135-86a0-5f8e0fe00b8d)
