### PR TITLE
graphql setup fragments: Move telemetry to main handler

### DIFF
--- a/packages/cli/src/commands/setup/graphql/features/fragments/fragments.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/fragments.ts
@@ -1,5 +1,7 @@
 import type { Argv } from 'yargs'
 
+import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
+
 export const command = 'fragments'
 export const description = 'Set up Fragments for GraphQL'
 
@@ -17,6 +19,11 @@ export interface Args {
 }
 
 export async function handler({ force }: Args) {
+  recordTelemetryAttributes({
+    command: 'setup graphql fragments',
+    force,
+  })
+
   const { handler } = await import('./fragmentsHandler.js')
   return handler({ force })
 }

--- a/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
@@ -6,11 +6,7 @@ import execa from 'execa'
 import { Listr } from 'listr2'
 import { format } from 'prettier'
 
-import {
-  colors,
-  recordTelemetryAttributes,
-  prettierOptions,
-} from '@redwoodjs/cli-helpers'
+import { colors, prettierOptions } from '@redwoodjs/cli-helpers'
 import { getConfigPath, getPaths } from '@redwoodjs/project-config'
 
 import type { Args } from './fragments'
@@ -20,11 +16,6 @@ export const command = 'fragments'
 export const description = 'Set up Fragments for GraphQL'
 
 export async function handler({ force }: Args) {
-  recordTelemetryAttributes({
-    command: 'setup graphql fragments',
-    force,
-  })
-
   const redwoodTomlPath = getConfigPath()
   const redwoodTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
   // Can't type toml.parse because this PR has not been included in a released yet


### PR DESCRIPTION
Fix for #8911 

Telemetry reporting should be done in the main handler, not the async imported one.