### PR TITLE
fragments setup: newline fix + refactor->rename

### DIFF
--- a/packages/cli/src/commands/setup/graphql/features/fragments/__tests__/fragmentsHandler.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__tests__/fragmentsHandler.test.ts
@@ -138,7 +138,7 @@ test('redwood.toml is updated even if `fragments = true` exists for other sectio
   await handler({ force: false })
 
   expect(vol.toJSON()[FIXTURE_PATH + '/redwood.toml']).toEqual(
-    toml + '\n\n[graphql]\n  fragments = true'
+    toml + '\n[graphql]\n  fragments = true'
   )
 })
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
@@ -54,7 +54,8 @@ export async function handler({ force }: Args) {
           const hasExistingGraphqlSection = !!redwoodTomlObject?.graphql
 
           let newTomlContent =
-            originalTomlContent + '\n\n[graphql]\n  fragments = true'
+            originalTomlContent.replace(/\n$/, '') +
+            '\n\n[graphql]\n  fragments = true'
 
           if (hasExistingGraphqlSection) {
             const existingGraphqlSetting = Object.keys(

--- a/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
@@ -121,13 +121,13 @@ export async function handler({ force }: Args) {
       {
         title: 'Add possibleTypes to the GraphQL cache config',
         task: async () => {
-          const result = await runTransform({
+          const transformResult = await runTransform({
             transformPath: path.join(__dirname, 'appGqlConfigTransform.js'),
             targetPaths: [getPaths().web.app],
           })
 
-          if (result.error) {
-            throw new Error(result.error)
+          if (transformResult.error) {
+            throw new Error(transformResult.error)
           }
 
           const appPath = getPaths().web.app


### PR DESCRIPTION
Remove extra newline that was sometimes inserted in redwood.toml

Also rename a variable to make it clearer what it is