### PR TITLE
Update cli tsconfig to reference used packages

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,5 +7,6 @@
     "noEmit": true
   },
   "include": ["src", "./testUtils.d.ts"],
-  "exclude": ["**/__testfixtures__"]
+  "exclude": ["**/__testfixtures__"],
+  "references": [{ "path": "../cli-helpers" }, { "path": "../project-config" }]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,5 +8,14 @@
   },
   "include": ["src", "./testUtils.d.ts"],
   "exclude": ["**/__testfixtures__"],
-  "references": [{ "path": "../cli-helpers" }, { "path": "../project-config" }]
+  "references": [
+    { "path": "../api-server" },
+    { "path": "../cli-helpers" },
+    { "path": "../fastify" },
+    { "path": "../internal" },
+    { "path": "../prerender" },
+    { "path": "../project-config" },
+    { "path": "../structure" },
+    { "path": "../telemetry" }
+  ]
 }


### PR DESCRIPTION
Took the list of used packages from `package.json`

![image](https://github.com/redwoodjs/redwood/assets/30793/c2343bfe-dc00-4f53-a0d2-c7d88ec16f18)

(marking this as "next-release", because tsconfig is introduced in a PR that's not going out until the next release)