### PR TITLE
cli: add missing dep jscodeshift

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
     "fast-glob": "3.3.2",
     "fs-extra": "11.2.0",
     "humanize-string": "2.1.0",
+    "jscodeshift": "0.15.0",
     "latest-version": "5.1.0",
     "listr2": "6.6.1",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8794,6 +8794,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     humanize-string: "npm:2.1.0"
     jest: "npm:29.7.0"
+    jscodeshift: "npm:0.15.0"
     latest-version: "npm:5.1.0"
     listr2: "npm:6.6.1"
     lodash: "npm:4.17.21"


### PR DESCRIPTION
The setup commands for gql fragments and trusted documents use jscodeshift for more robust codemods than simple string regexes. So need to add jscodeshift as a package dependency