### PR TITLE
Add trusted-documents to fragments CI smoke-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,6 +779,18 @@ jobs:
           REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
           REDWOOD_DISABLE_TELEMETRY: 1
 
+      - name: Enable trusted-documents in Fragments test project
+        run: npx -y tsx ./tasks/test-project/set-up-trusted-documents ${{ steps.set-up-test-project.outputs.test-project-path }}
+        env:
+          REDWOOD_DISABLE_TELEMETRY: 1
+
+      - name: 📄 Run prerender smoke tests against Fragments test project (with trusted-documents enabled)
+        working-directory: tasks/smoke-tests/prerender
+        run: npx playwright test
+        env:
+          REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-test-project.outputs.test-project-path }}
+          REDWOOD_DISABLE_TELEMETRY: 1
+
   fragments-smoke-tests-skip:
     needs: detect-changes
 

--- a/tasks/test-project/set-up-trusted-documents.ts
+++ b/tasks/test-project/set-up-trusted-documents.ts
@@ -1,0 +1,76 @@
+/* eslint-env node, es6*/
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { hideBin } from 'yargs/helpers'
+import yargs from 'yargs/yargs'
+
+import { exec, getExecaOptions } from './util'
+
+const args = yargs(hideBin(process.argv))
+  .usage('Usage: $0 <project directory>')
+  .parseSync()
+
+/**
+ * This script takes a regular test-project, and adds some extra files/config
+ * so we can run e2e tests for fragments
+ */
+async function runCommand() {
+  const OUTPUT_PROJECT_PATH = path.resolve(String(args._))
+
+  await exec(
+    'yarn rw setup graphql trusted-documents',
+    [],
+    getExecaOptions(OUTPUT_PROJECT_PATH)
+  )
+
+  const redwoodTomlPath = path.join(OUTPUT_PROJECT_PATH, 'redwood.toml')
+  const redwoodTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
+
+  // NOTE: The checks we do here are very specific. This would never be enough
+  // for a user's project. But since we're in full control of the generation of
+  // the project here, we can get away with these simpler checks
+
+  if (!redwoodTomlContent.includes('trustedDocuments = true')) {
+    console.error(
+      'Failed to set up trusted-documents in fragments test-project'
+    )
+    console.error('trustedDocuments = true not set in redwood.toml')
+    console.error()
+    console.error('Please run this command locally to make sure it works')
+    throw new Error('Failed to set up trusted-document')
+  }
+
+  const graphqlHandlerPath = path.join(
+    OUTPUT_PROJECT_PATH,
+    'api/src/functions/graphql.ts'
+  )
+  const graphqlHandlerContent = fs.readFileSync(graphqlHandlerPath, 'utf-8')
+  const storeImport = "import { store } from 'src/lib/trustedDocumentsStore'"
+
+  if (!graphqlHandlerContent.includes(storeImport)) {
+    console.error(
+      'Failed to set up trusted-documents in fragments test-project'
+    )
+    console.error('`store` is not imported in the graphql handler')
+    console.error()
+    console.error('Please run this command locally to make sure it works')
+    throw new Error('Failed to set up trusted-document')
+  }
+
+  if (!graphqlHandlerContent.includes('trustedDocuments: {')) {
+    console.error(
+      'Failed to set up trusted-documents in fragments test-project'
+    )
+    console.error(
+      'The trustedDocuments store is not used in the graphql handler'
+    )
+    console.error()
+    console.error('Please run this command locally to make sure it works')
+    throw new Error('Failed to set up trusted-document')
+  }
+
+  await exec('yarn rw build', [], getExecaOptions(OUTPUT_PROJECT_PATH))
+}
+
+runCommand()


### PR DESCRIPTION
Enable trusted-documents, then build (including prerender), and then run the prerender smoke tests.