### PR TITLE
Fastify config: Use exact file extension in log message

### DIFF
--- a/packages/fastify/src/config.ts
+++ b/packages/fastify/src/config.ts
@@ -36,14 +36,16 @@ let serverConfigFile: {
 }
 
 export function loadFastifyConfig() {
-  const serverFileExists =
-    fs.existsSync(path.join(getPaths().api.src, 'server.js')) ||
-    fs.existsSync(path.join(getPaths().api.src, 'server.ts'))
+  const serverTsFileExists = fs.existsSync(
+    path.join(getPaths().api.src, 'server.ts')
+  )
+  const serverJsFileExists =
+    !serverTsFileExists &&
+    fs.existsSync(path.join(getPaths().api.src, 'server.js'))
 
-  if (serverFileExists) {
-    console.log(
-      "Ignoring Fastify config inside 'api/src/server.config.(js|ts)'"
-    )
+  if (serverTsFileExists || serverJsFileExists) {
+    const ext = serverTsFileExists ? 'ts' : 'js'
+    console.log(`Ignoring Fastify config inside 'api/src/server.config.${ext}`)
 
     return {
       config: {},


### PR DESCRIPTION
We know the file extension, so we might as well use the exact file extension in the log message. Makes it nicer to read imho 🙂 

This is what it used to look like
![image](https://github.com/redwoodjs/redwood/assets/30793/b7e56b17-aefb-43b2-8395-c6eea47bb5aa)

And I'm sure you can imagine what it'll look like with this change 😉 