### PR TITLE
Tweak graphiql setup messages

### DIFF
--- a/packages/cli/src/commands/setup/graphiql/__tests__/graphiqlHandler.test.js
+++ b/packages/cli/src/commands/setup/graphiql/__tests__/graphiqlHandler.test.js
@@ -57,7 +57,7 @@ describe('Graphiql generator tests', () => {
     try {
       await graphiqlHelpers.generatePayload('dbAuth')
     } catch (e) {
-      expect(e.message).toBe('Require an unique id to generate session cookie')
+      expect(e.message).toBe('Require a unique id to generate session cookie')
     }
   })
 
@@ -67,7 +67,10 @@ describe('Graphiql generator tests', () => {
       await graphiqlHelpers.generatePayload('dbAuth', 'user-id-123')
     } catch (e) {
       expect(e.message).toBe(
-        'dbAuth requires a SESSION_SECRET environment variable that is used to encrypt session cookies. Use `yarn rw g secret` to create one, then add to your `.env` file. DO NOT check this variable in your version control system!!'
+        'dbAuth requires a SESSION_SECRET environment variable that is used ' +
+          'to encrypt session cookies. Use `yarn rw g secret` to create ' +
+          'one, then add to your `.env` file. DO NOT check this variable in ' +
+          'to your version control system!!'
       )
     }
   })

--- a/packages/cli/src/commands/setup/graphiql/graphiqlHandler.js
+++ b/packages/cli/src/commands/setup/graphiql/graphiqlHandler.js
@@ -64,6 +64,8 @@ const printHeaders = async () => {
 export const handler = async ({ provider, id, token, expiry, view }) => {
   let payload
 
+  const ext = isTypeScriptProject() ? 'ts' : 'js'
+
   const tasks = new Listr(
     [
       {
@@ -73,7 +75,7 @@ export const handler = async ({ provider, id, token, expiry, view }) => {
         },
       },
       {
-        title: 'Generating file in src/lib/generateGraphiQLHeader.{js,ts}...',
+        title: `Generating file in src/lib/generateGraphiQLHeader.${ext}...`,
         task: () => {
           const fileName =
             token || provider === 'dbAuth'

--- a/packages/cli/src/commands/setup/graphiql/supportedProviders.js
+++ b/packages/cli/src/commands/setup/graphiql/supportedProviders.js
@@ -11,12 +11,15 @@ const getExpiryTime = (expiry) => {
 
 const getDBAuthHeader = async (userId) => {
   if (!userId) {
-    throw new Error('Require an unique id to generate session cookie')
+    throw new Error('Require a unique id to generate session cookie')
   }
 
   if (!process.env.SESSION_SECRET) {
     throw new Error(
-      'dbAuth requires a SESSION_SECRET environment variable that is used to encrypt session cookies. Use `yarn rw g secret` to create one, then add to your `.env` file. DO NOT check this variable in your version control system!!'
+      'dbAuth requires a SESSION_SECRET environment variable that is used ' +
+        'to encrypt session cookies. Use `yarn rw g secret` to create one, ' +
+        'then add to your `.env` file. DO NOT check this variable in to ' +
+        'your version control system!!'
     )
   }
 


### PR DESCRIPTION
Fix grammar in setup messages for graphiql. And print correct/exact filename