### PR TITLE
Add cli-helpers util to update redwood.toml

### DIFF
--- a/packages/cli-helpers/src/lib/__tests__/project.test.ts
+++ b/packages/cli-helpers/src/lib/__tests__/project.test.ts
@@ -1,10 +1,11 @@
-import fs from 'fs'
-
-import toml from '@iarna/toml'
-
-import { updateTomlConfig, addEnvVar } from '../project' // Replace with the correct path to your module
-
 jest.mock('fs')
+jest.mock('node:fs')
+
+import * as fs from 'node:fs'
+
+import * as toml from '@iarna/toml'
+
+import { updateTomlConfig, addEnvVar } from '../project'
 
 const defaultRedwoodToml = {
   web: {

--- a/packages/cli-helpers/src/lib/project.ts
+++ b/packages/cli-helpers/src/lib/project.ts
@@ -1,10 +1,11 @@
-import fs from 'fs'
-import path from 'path'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
 
 import type { JsonMap } from '@iarna/toml'
 import toml from '@iarna/toml'
 import dotenv from 'dotenv'
 
+import type { Config } from '@redwoodjs/project-config'
 import {
   findUp,
   getConfigPath,
@@ -188,4 +189,137 @@ export const setRedwoodCWD = (cwd?: string) => {
   }
 
   process.env.RWJS_CWD = cwd
+}
+
+/**
+ * Create or update the given setting, in the given section, with the given value.
+ *
+ * If the section already exists it adds the new setting last
+ * If the section, and the setting, already exists, the setting is updated
+ * If the section does not exist it is created at the end of the file and the setting is added
+ * If the setting exists in the section, but is commented out, it will be uncommented and updated
+ */
+export function setTomlSetting(
+  section: keyof Config,
+  setting: string,
+  value: string | boolean | number
+) {
+  const redwoodTomlPath = getConfigPath()
+  const originalTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
+
+  // Can't type toml.parse because this PR has not been included in a released yet
+  // https://github.com/iarna/iarna-toml/commit/5a89e6e65281e4544e23d3dbaf9e8428ed8140e9
+  const redwoodTomlObject = toml.parse(originalTomlContent) as any
+
+  const existingValue = redwoodTomlObject?.[section]?.[setting]
+
+  // If the setting already exists in the given section, and has the given
+  // value already, just return
+  if (existingValue === value) {
+    return
+  }
+
+  // By default we create the new section at the end of the file, and set the
+  // new value for the given setting. If the section already exists, we'll
+  // disregard this update and use the existing section instead
+  let newTomlContent =
+    originalTomlContent.replace(/\n$/, '') +
+    `\n\n[${section}]\n  ${setting} = ${value}`
+
+  const hasExistingSettingSection = !!redwoodTomlObject?.[section]
+
+  if (hasExistingSettingSection) {
+    const existingSectionSettings = Object.keys(redwoodTomlObject[section])
+
+    let inSection = false
+    let indentation = ''
+    let insertionIndex = 1
+    let updateExistingValue = false
+    let updateExistingCommentedValue = false
+
+    const tomlLines = originalTomlContent.split('\n')
+
+    // Loop over all lines looking for either the given setting in the given
+    // section (preferred), or the given setting, but commented out, in the
+    // given section
+    tomlLines.forEach((line: string, index) => {
+      // Assume all sections start with [sectionName] un-indented. This might
+      // prove to be too simplistic, but it's all we support right now. Feel
+      // free to add support for more complicated scenarios as needed.
+      if (line.startsWith(`[${section}]`)) {
+        inSection = true
+        insertionIndex = index + 1
+      } else {
+        // The section ends as soon as we find a line that starts with a [
+        if (/^\s*\[/.test(line)) {
+          inSection = false
+        }
+
+        // If we're in the section, and we haven't found the setting yet, keep
+        // looking
+        if (inSection && !updateExistingValue) {
+          for (const existingSectionSetting of existingSectionSettings) {
+            const matches = line.match(
+              new RegExp(`^(\\s*)${existingSectionSetting}\\s*=`, 'i')
+            )
+
+            if (!updateExistingValue && matches) {
+              if (!updateExistingCommentedValue) {
+                indentation = matches[1]
+              }
+
+              if (existingSectionSetting === setting) {
+                updateExistingValue = true
+                insertionIndex = index
+                indentation = matches[1]
+              }
+            }
+
+            // As long as we find existing settings in the section we keep
+            // pushing the insertion index forward, unless we've already found
+            // an existing setting that matches the one we're adding.
+            if (
+              !updateExistingValue &&
+              !updateExistingCommentedValue &&
+              /^\s*\w+\s*=/.test(line)
+            ) {
+              insertionIndex = index + 1
+            }
+          }
+
+          // If we haven't found an existing value to update, see if we can
+          // find a commented value instead
+          if (!updateExistingValue) {
+            const matchesComment = line.match(
+              new RegExp(`^(\\s*)#(\\s*)${setting}\\s*=`, 'i')
+            )
+
+            if (matchesComment) {
+              const commentIndentation =
+                matchesComment[1].length > matchesComment[2].length
+                  ? matchesComment[1]
+                  : matchesComment[2]
+
+              if (commentIndentation.length - 1 > indentation.length) {
+                indentation = commentIndentation
+              }
+
+              updateExistingCommentedValue = true
+              insertionIndex = index
+            }
+          }
+        }
+      }
+    })
+
+    tomlLines.splice(
+      insertionIndex,
+      updateExistingValue || updateExistingCommentedValue ? 1 : 0,
+      `${indentation}${setting} = ${value}`
+    )
+
+    newTomlContent = tomlLines.join('\n')
+  }
+
+  fs.writeFileSync(redwoodTomlPath, newTomlContent)
 }

--- a/packages/cli/src/commands/setup/graphql/features/fragments/__tests__/fragmentsHandler.test.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/__tests__/fragmentsHandler.test.ts
@@ -58,16 +58,6 @@ afterAll(() => {
   jest.resetModules()
 })
 
-test('`fragments = true` is added to redwood.toml', async () => {
-  vol.fromJSON({ 'redwood.toml': '', 'web/src/App.tsx': '' }, FIXTURE_PATH)
-
-  await handler({ force: false })
-
-  expect(vol.toJSON()[FIXTURE_PATH + '/redwood.toml']).toMatch(
-    /fragments = true/
-  )
-})
-
 test('all tasks are being called', async () => {
   vol.fromJSON({ 'redwood.toml': '', 'web/src/App.tsx': '' }, FIXTURE_PATH)
 

--- a/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
@@ -1,13 +1,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import toml from '@iarna/toml'
 import execa from 'execa'
 import { Listr } from 'listr2'
 import { format } from 'prettier'
 
-import { colors, prettierOptions } from '@redwoodjs/cli-helpers'
-import { getConfigPath, getPaths } from '@redwoodjs/project-config'
+import { colors, prettierOptions, setTomlSetting } from '@redwoodjs/cli-helpers'
+import { getConfig, getPaths } from '@redwoodjs/project-config'
 
 import type { Args } from './fragments'
 import { runTransform } from './runTransform'
@@ -16,12 +15,6 @@ export const command = 'fragments'
 export const description = 'Set up Fragments for GraphQL'
 
 export async function handler({ force }: Args) {
-  const redwoodTomlPath = getConfigPath()
-  const redwoodTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
-  // Can't type toml.parse because this PR has not been included in a released yet
-  // https://github.com/iarna/iarna-toml/commit/5a89e6e65281e4544e23d3dbaf9e8428ed8140e9
-  const redwoodTomlObject = toml.parse(redwoodTomlContent) as any
-
   const tasks = new Listr(
     [
       {
@@ -33,66 +26,15 @@ export async function handler({ force }: Args) {
             return false
           }
 
-          if (redwoodTomlObject?.graphql?.fragments) {
+          const config = getConfig()
+          if (config.graphql.fragments) {
             return 'GraphQL Fragments are already enabled.'
           }
 
           return false
         },
         task: () => {
-          const redwoodTomlPath = getConfigPath()
-          const originalTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
-          const hasExistingGraphqlSection = !!redwoodTomlObject?.graphql
-
-          let newTomlContent =
-            originalTomlContent.replace(/\n$/, '') +
-            '\n\n[graphql]\n  fragments = true'
-
-          if (hasExistingGraphqlSection) {
-            const existingGraphqlSetting = Object.keys(
-              redwoodTomlObject.graphql
-            )
-
-            let inGraphqlSection = false
-            let indentation = ''
-            let lastGraphqlSettingIndex = 0
-
-            const tomlLines = originalTomlContent.split('\n')
-            tomlLines.forEach((line, index) => {
-              if (line.startsWith('[graphql]')) {
-                inGraphqlSection = true
-                lastGraphqlSettingIndex = index
-              } else {
-                if (/^\s*\[/.test(line)) {
-                  inGraphqlSection = false
-                }
-              }
-
-              if (inGraphqlSection) {
-                const matches = line.match(
-                  new RegExp(`^(\\s*)(${existingGraphqlSetting})\\s*=`, 'i')
-                )
-
-                if (matches) {
-                  indentation = matches[1]
-                }
-
-                if (/^\s*\w+\s*=/.test(line)) {
-                  lastGraphqlSettingIndex = index
-                }
-              }
-            })
-
-            tomlLines.splice(
-              lastGraphqlSettingIndex + 1,
-              0,
-              `${indentation}fragments = true`
-            )
-
-            newTomlContent = tomlLines.join('\n')
-          }
-
-          fs.writeFileSync(redwoodTomlPath, newTomlContent)
+          setTomlSetting('graphql', 'fragments', true)
         },
       },
       {


### PR DESCRIPTION
This PR adds a utility function to set/create/update a setting in `redwood.toml`. 

It's intended mainly to be used by our setup commands to enable features or change configurations. It's made to handle comments, indentation, duplicated setting names in different sections, etc. Writing and testing this code is something pretty much all setup commands have done before. That's just duplicated unnecessary work. Especially since we want community members to write their own plugins it'd be nice if there was a standardized way to do this, and now there is! 🙂 

Here's a snippet of a usage example:

```typescript
import { colors, prettierOptions, setTomlSetting } from '@redwoodjs/cli-helpers'

// ...

export async function handler({ force }: Args) {
  const tasks = new Listr(
    [
      {
        title:
          'Update Redwood Project Configuration to enable GraphQL Fragments',
        skip: () => {
          // ...
        },
        task: () => {
          setTomlSetting('graphql', 'fragments', true)
        },
      },
```

It will add this to the user's `redwood.toml`:
```toml
[graphql]
  fragments = true
```

And if the user already had

```toml
[graphql]
  # Turn on/off support for GraphQL Fragments
  # fragments = false
  trustedDocuments = true
```

It'll be changed to
```toml
[graphql]
  # Turn on/off support for GraphQL Fragments
  fragments = true
  trustedDocuments = true
```