### PR TITLE
Only watch inside web/ and api/

### DIFF
--- a/packages/internal/src/generate/watch.ts
+++ b/packages/internal/src/generate/watch.ts
@@ -35,7 +35,7 @@ import {
 
 const rwjsPaths = getPaths()
 
-const watcher = chokidar.watch('**/src/**/*.{ts,js,jsx,tsx}', {
+const watcher = chokidar.watch('(web|api)/src/**/*.{ts,js,jsx,tsx}', {
   persistent: true,
   ignored: ['node_modules', '.redwood'],
   ignoreInitial: true,


### PR DESCRIPTION
I got this error when working on the new Studio

![image](https://github.com/redwoodjs/redwood/assets/30793/7174a690-3a60-4125-ab4c-82e78d40b6f8)

The problem is that we're watching for file changes inside `__fixtures__/test-project/`. There's no need to do that!

We solved a similar issue a couple of months ago in this PR: https://github.com/redwoodjs/redwood/pull/9079. So I just copied the solution from there.