### PR TITLE
chore(fwtools): handle existing resolutions in tarsync

### DIFF
--- a/tasks/framework-tools/tarsync.mjs
+++ b/tasks/framework-tools/tarsync.mjs
@@ -90,7 +90,10 @@ async function main() {
     projectPackageJsonPath,
     {
       ...projectPackageJson,
-      resolutions,
+      resolutions: {
+        ...projectPackageJson.resolutions,
+        ...resolutions,
+      },
     },
     {
       spaces: 2,


### PR DESCRIPTION
Currently there's a `@graphql-codegen` package in canary that doesn't exist at the published version we have to set a resolution for (see https://github.com/dotansimha/graphql-code-generator/issues/9808). `yarn rwfw project:tarsync` overwrites the resolutions, so you have to add it back after running the command which is annoying. This just makes it add the tarball resolutions to the existing ones:

```json5
  "resolutions": {
    // This is now preserved
    "@graphql-codegen/visitor-plugin-common": "4.0.1",
    "@redwoodjs/fastify-plugin-streaming": "./tarballs/redwoodjs-fastify-plugin-streaming.tgz",
    "@redwoodjs/api": "./tarballs/redwoodjs-api.tgz",
    "@redwoodjs/api-server": "./tarballs/redwoodjs-api-server.tgz",
    // ...
  }
```