### PR TITLE
mapPrismaScalarToPagePropTsType: Fix Decimal test case

### DIFF
--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -534,7 +534,7 @@ describe('mapPrismaScalarToPagePropTsType', () => {
   })
 
   it('maps scalar type Decimal to TS type number', () => {
-    expect(helpers.mapPrismaScalarToPagePropTsType('Float')).toBe('number')
+    expect(helpers.mapPrismaScalarToPagePropTsType('Decimal')).toBe('number')
   })
 
   it('maps scalar type DateTime to TS type string', () => {


### PR DESCRIPTION
We've been testing the wrong thing the whole time 😅 
Lucky us nothing broke without us noticing 😀 

Now actually testing `Decimal` and not `Float`!