### PR TITLE
Detect/resolve ambiguous script names

### DIFF
--- a/.changesets/9848.md
+++ b/.changesets/9848.md
@@ -1,0 +1,3 @@
+- Detect/resolve ambiguous script names (#9848) by @codersmith
+
+Detects and resolves ambiguous script name combinations like `[foo.js, foo.ts]` or `[foo.ts, foo.json]` when running `yarn rw exec foo`.

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -9,12 +9,22 @@ import { handler } from '../execHandler'
 vi.mock('envinfo', () => ({ default: { run: () => '' } }))
 vi.mock('@redwoodjs/project-config', () => ({
   getPaths: () => ({
-    scripts: path.join(
-      __dirname,
-      '../../../../../__fixtures__/test-project/scripts',
-    ),
+    scripts: path.join('redwood-app', 'scripts'),
   }),
   resolveFile: (path: string) => path,
+}))
+vi.mock('@redwoodjs/internal/dist/files', () => ({
+  findScripts: () => {
+    const scriptsPath = path.join('redwood-app', 'scripts')
+
+    return [
+      path.join(scriptsPath, 'one', 'two', 'myNestedScript.ts'),
+      path.join(scriptsPath, 'conflicting.js'),
+      path.join(scriptsPath, 'conflicting.ts'),
+      path.join(scriptsPath, 'normalScript.ts'),
+      path.join(scriptsPath, 'secondNormalScript.ts'),
+    ]
+  },
 }))
 
 const mockRedwoodToml = {
@@ -47,6 +57,26 @@ describe('yarn rw exec --list', () => {
       .replaceAll('\\', '\\\\')
     expect(vi.mocked(console).log).toHaveBeenCalledWith(
       expect.stringMatching(new RegExp('\\b' + scriptPath + '\\b')),
+    )
+  })
+
+  it("does not include the file extension if there's no ambiguity", async () => {
+    await handler({ list: true })
+    expect(vi.mocked(console).log).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp('\\bnormalScript\\b')),
+    )
+    expect(vi.mocked(console).log).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp('\\bsecondNormalScript\\b')),
+    )
+  })
+
+  it('includes the file extension if there could be ambiguity', async () => {
+    await handler({ list: true })
+    expect(vi.mocked(console).log).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp('\\bconflicting.js\\b')),
+    )
+    expect(vi.mocked(console).log).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp('\\bconflicting.ts\\b')),
     )
   })
 })

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -1,4 +1,5 @@
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 
 import { context } from '@opentelemetry/api'
 import { suppressTracing } from '@opentelemetry/core'
@@ -17,12 +18,30 @@ import { runScriptFunction } from '../lib/exec'
 import { generatePrismaClient } from '../lib/generatePrismaClient'
 
 const printAvailableScriptsToConsole = () => {
-  console.log('Available scripts:')
-  findScripts(getPaths().scripts).forEach((scriptPath) => {
+  // Loop through all scripts and get their relative path
+  // Also group scripts with the same name but different extensions
+  const scripts = findScripts(getPaths().scripts).reduce((acc, scriptPath) => {
     const relativePath = path.relative(getPaths().scripts, scriptPath)
-    const { ext } = path.parse(relativePath)
-    const relativePathWithoutExt = relativePath.slice(0, -ext.length)
-    console.log(c.info(`- ${relativePathWithoutExt}`))
+    const ext = path.parse(relativePath).ext
+    const pathNoExt = relativePath.slice(0, -ext.length)
+
+    acc[pathNoExt] ||= []
+    acc[pathNoExt].push(relativePath)
+
+    return acc
+  }, {})
+
+  console.log('Available scripts:')
+  Object.entries(scripts).forEach(([name, paths]) => {
+    // If a script name exists with multiple extensions, print them all,
+    // including the extension
+    if (paths.length > 1) {
+      paths.forEach((scriptPath) => {
+        console.log(c.info(`- ${scriptPath}`))
+      })
+    } else {
+      console.log(c.info(`- ${name}`))
+    }
   })
   console.log()
 }
@@ -39,8 +58,6 @@ export const handler = async (args) => {
     printAvailableScriptsToConsole()
     return
   }
-
-  const scriptPath = path.join(getPaths().scripts, name)
 
   const {
     overrides: _overrides,
@@ -101,11 +118,11 @@ export const handler = async (args) => {
     ],
   })
 
-  try {
-    require.resolve(scriptPath)
-  } catch {
+  const scriptPath = resolveScriptPath(name)
+
+  if (!scriptPath) {
     console.error(
-      c.error(`\nNo script called ${c.underline(name)} in ./scripts folder.\n`),
+      c.error(`\nNo script called \`${name}\` in the ./scripts folder.\n`),
     )
 
     printAvailableScriptsToConsole()
@@ -144,4 +161,45 @@ export const handler = async (args) => {
   await context.with(suppressTracing(context.active()), async () => {
     await tasks.run()
   })
+}
+
+function resolveScriptPath(name) {
+  const scriptPath = path.join(getPaths().scripts, name)
+
+  // If scriptPath already has an extension, and it's a valid path, return it
+  // as it is
+  if (fs.existsSync(scriptPath)) {
+    return scriptPath
+  }
+
+  // These extensions match the ones in internal/src/files.ts::findScripts()
+  const extensions = ['.js', '.jsx', '.ts', '.tsx']
+  const matches = []
+
+  for (const extension of extensions) {
+    const p = scriptPath + extension
+
+    if (fs.existsSync(p)) {
+      matches.push(p)
+    }
+  }
+
+  if (matches.length === 1) {
+    return matches[0]
+  } else if (matches.length > 1) {
+    console.error(
+      c.error(
+        `\nMultiple scripts found for \`${name}\`. Please specify the ` +
+          'extension.',
+      ),
+    )
+
+    matches.forEach((match) => {
+      console.log(c.info(`- ${path.relative(getPaths().scripts, match)}`))
+    })
+
+    process.exit(1)
+  }
+
+  return null
 }


### PR DESCRIPTION
Detects and resolves ambiguous script name combinations like `[foo.js, foo.ts]` or `[foo.ts, foo.json]` when running `yarn rw exec foo`.

Fixes #9249

### Problem
#9249 identified that when you have a script file called `scripts/foo.ts` along with a JSON data file with the same name `scripts/foo.json`, that trying to run `yarn rw exec foo` breaks. 

The problem is that when calling `require('foo')`, require finds the JSON file first and loads that vs. loading the `.ts` file.

### Solution
There are two parts to the fix:
1. Resolve any ambiguity ahead of trying to load and run the script. 
   For example, if the script name is fully qualified e.g. `yarn rw exec foo.ts`, then that should work. 
   But if two scripts exist such as `[foo.js, foo.ts]`, and the command is `yarn rw exec foo`, then this is ambiguous and a nice error message should be displayed to help the user clarify their intent.

2. Any non-script files (like JSON files, etc.) should not conflict when resolving a potential script file. Script files are identified with extensions `.{js,jsx,ts,tsx}`
   To do this, we can resolve `foo` into `foo.ts` prior to attempt loading it with `require`. 

---

EDIT (by @Tobbe):

Example output:
![image](https://github.com/user-attachments/assets/7aca2393-a1cd-4146-b072-d5fa0a173572)

Normally it'll just list the names of the scripts. But if there is a conflict between names (two or more files with the same name, only different file extensions) then the file extension is included in the output

`.json` files (or other files that we can't execute) are not included in the list of scripts

![image](https://github.com/user-attachments/assets/2a4a5774-807b-4aaf-99de-55861240e21c)

Running a script by just the name prints an error if there's ambiguity

![image](https://github.com/user-attachments/assets/262dfe9a-07ec-4a99-8115-788cad1e6e4a)

And as for testing, unfortunately we can't unit test actually running the script. The issue is with CJS/ESM (require vs import) and vitest. So for now only the listing of scripts is tested. Running the scripts has only been tested manually.