### PR TITLE
docs(typo): correct grammar in realtime docs

### DIFF
--- a/docs/docs/realtime.md
+++ b/docs/docs/realtime.md
@@ -260,7 +260,7 @@ subscription CountdownFromInterval {
 }
 ```
 
-This example showcases how a subscription can yields its own response.
+This example showcases how a subscription yields its own response.
 
 ## Live Queries
 


### PR DESCRIPTION
i believe it's either _a subscription can yield_ or _a subscription yields_