### PR TITLE
chore(crwa): switch to vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,7 +848,7 @@ jobs:
           git config --global user.name "Your Name"
 
       - name: e2e test
-        run: yarn test e2e
+        run: yarn test:e2e
         working-directory: ./packages/create-redwood-app
         env:
           PROJECT_PATH: ${{ env.PROJECT_PATH }}

--- a/packages/create-redwood-app/jest.config.js
+++ b/packages/create-redwood-app/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('jest').Config} */
-export default {
-  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/templates/'],
-  transform: {},
-}

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -19,8 +19,9 @@
     "build:watch": "nodemon --watch src --ignore dist,template --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "set-up-test-project": "node ./scripts/setUpTestProject.js",
-    "test": "node --experimental-vm-modules $(yarn bin jest) templates",
-    "test:e2e": "node --experimental-vm-modules $(yarn bin jest) e2e",
+    "test": "vitest run templates",
+    "test:watch": "vitest watch templates",
+    "test:e2e": "vitest --pool=forks run e2e",
     "ts-to-js": "yarn node ./scripts/tsToJS.js"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "terminal-link": "2.1.1",
     "untildify": "4.0.0",
     "uuid": "9.0.1",
+    "vitest": "1.2.1",
     "yargs": "17.7.2"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -20,7 +20,6 @@
     "prepublishOnly": "NODE_ENV=production yarn build",
     "set-up-test-project": "node ./scripts/setUpTestProject.js",
     "test": "vitest run templates",
-    "test:watch": "vitest watch templates",
     "test:e2e": "vitest --pool=forks run e2e",
     "ts-to-js": "yarn node ./scripts/tsToJS.js"
   },

--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -1,7 +1,11 @@
 /* eslint-env node */
 
+import { describe, test, expect, it } from 'vitest'
 import { cd, fs, $ } from 'zx'
 
+if (!process.env.PROJECT_PATH) {
+  throw new Error('PROJECT_PATH environment variable is not set')
+}
 const projectPath = await fs.realpath(process.env.PROJECT_PATH)
 
 cd(projectPath)
@@ -83,7 +87,7 @@ describe('create-redwood-app', () => {
     await fs.rm('./redwood-app', { recursive: true, force: true })
   })
 
-  it.failing('fails on unknown options', async () => {
+  it.fails('fails on unknown options', async () => {
     try {
       await $`yarn create-redwood-app --unknown-options`.timeout(2500)
       // Fail the test if the function didn't throw.

--- a/packages/create-redwood-app/tests/templates.test.ts
+++ b/packages/create-redwood-app/tests/templates.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import klawSync from 'klaw-sync'
+import { describe, it, expect } from 'vitest'
 
 const TS_TEMPLATE_DIR = fileURLToPath(
   new URL('../templates/ts', import.meta.url)
@@ -192,7 +193,7 @@ describe('JS template', () => {
  * @returns string[]
  */
 function getDirectoryStructure(dir) {
-  let fileStructure = klawSync(dir)
+  const fileStructure = klawSync(dir)
 
   return fileStructure
     .filter(

--- a/packages/create-redwood-app/vitest.config.mts
+++ b/packages/create-redwood-app/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, 'templates/**'],
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -15992,6 +15992,7 @@ __metadata:
     terminal-link: "npm:2.1.1"
     untildify: "npm:4.0.0"
     uuid: "npm:9.0.1"
+    vitest: "npm:1.2.1"
     yargs: "npm:17.7.2"
   bin:
     create-redwood-app: ./dist/create-redwood-app.js


### PR DESCRIPTION
Continuing the exploration of switching packages over to vitest.

Notes:
1. The `test:e2e` required a small change to the default vitest options. We have to add `--pool=forks` (see: https://vitest.dev/config/#pool-1-0-0 for the pool option). This is because we're using zx to do things like change directories. This is not possible with the default `threads` pool. See: https://github.com/vitest-dev/vitest/issues/566 for more information related to the specific error that I encountered.