### PR TITLE
Fix(crwa): Exit 0 after Quit install

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -173,7 +173,7 @@ async function executeCompatibilityCheck(templateDir) {
       if (response['override-engine-error'] === 'Quit install') {
         recordErrorViaTelemetry('User quit after engine check error')
         await shutdownTelemetry()
-        process.exit(1)
+        process.exit(0)
       }
     } catch (error) {
       recordErrorViaTelemetry('User cancelled install at engine check error')


### PR DESCRIPTION
![image](https://github.com/redwoodjs/redwood/assets/30793/84c6a795-fec9-41f8-8a29-fd906075f06c)

It successfully completed my command (quitting the install), so should exit with a successful exit code