### PR TITLE
chore(crwa): set `REDWOOD_CI` and `REDWOOD_DISABLE_TELEMETRY`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -811,6 +811,10 @@ jobs:
     name: 🌲 Create Redwood App
     runs-on: ubuntu-latest
 
+    env:
+      REDWOOD_CI: 1
+      REDWOOD_DISABLE_TELEMETRY: 1
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Forgot to set `REDWOOD_CI` and `REDWOOD_DISABLE_TELEMETRY` when I added e2e tests for CRWA in https://github.com/redwoodjs/redwood/pull/9783. It may be better to just set `REDWOOD_CI` at the very top of the workflow file but I wasn't sure if we're testing for its absence sometimes like we do for `REDWOOD_DISABLE_TELEMETRY` I think.