### PR TITLE
fix(crwa): remove yarn install preference

### DIFF
--- a/packages/create-redwood-app/src/create-redwood-app.js
+++ b/packages/create-redwood-app/src/create-redwood-app.js
@@ -38,21 +38,6 @@ const { telemetry } = Parser(hideBin(process.argv), {
 
 const tui = new RedwoodTUI()
 
-// Credit to esbuild: https://github.com/rtsao/esbuild/blob/c35a4cebf037237559213abc684504658966f9d6/lib/install.ts#L190-L199
-function isYarnBerryOrNewer() {
-  const { npm_config_user_agent: npmConfigUserAgent } = process.env
-
-  if (npmConfigUserAgent) {
-    const match = npmConfigUserAgent.match(/yarn\/(\d+)/)
-
-    if (match && match[1]) {
-      return parseInt(match[1], 10) >= 2
-    }
-  }
-
-  return false
-}
-
 const USE_GITPOD_TEXT = [
   `  As an alternative solution, you can launch a Redwood project using GitPod instead. GitPod is a an online IDE.`,
   `  See: ${terminalLink(
@@ -237,94 +222,6 @@ async function createProjectFiles(appDir, { templateDir, overwrite }) {
   tui.stopReactive()
 
   return newAppDir
-}
-
-async function installNodeModules(newAppDir) {
-  const tuiContent = new ReactiveTUIContent({
-    mode: 'text',
-    header: 'Installing node modules',
-    content: '  ⏱ This could take a while...',
-    spinner: {
-      enabled: true,
-    },
-  })
-  tui.startReactive(tuiContent)
-
-  const yarnInstallSubprocess = execa('yarn install', {
-    shell: true,
-    cwd: newAppDir,
-  })
-
-  try {
-    await yarnInstallSubprocess
-  } catch (error) {
-    tui.stopReactive(true)
-    tui.displayError(
-      "Couldn't install node modules",
-      [
-        `We couldn't install node modules via ${RedwoodStyling.info(
-          "'yarn install'"
-        )}. Please see below for the full error message.`,
-        '',
-        error,
-      ].join('\n')
-    )
-    recordErrorViaTelemetry(error)
-    await shutdownTelemetry()
-    process.exit(1)
-  }
-
-  tuiContent.update({
-    header: '',
-    content: `${RedwoodStyling.green('✔')} Installed node modules`,
-    spinner: {
-      enabled: false,
-    },
-  })
-  tui.stopReactive()
-}
-
-async function generateTypes(newAppDir) {
-  const tuiContent = new ReactiveTUIContent({
-    mode: 'text',
-    content: 'Generating types',
-    spinner: {
-      enabled: true,
-    },
-  })
-  tui.startReactive(tuiContent)
-
-  const generateSubprocess = execa('yarn rw-gen', {
-    shell: true,
-    cwd: newAppDir,
-  })
-
-  try {
-    await generateSubprocess
-  } catch (error) {
-    tui.stopReactive(true)
-    tui.displayError(
-      "Couldn't generate types",
-      [
-        `We could not generate types using ${RedwoodStyling.info(
-          "'yarn rw-gen'"
-        )}. Please see below for the full error message.`,
-        '',
-        error,
-      ].join('\n')
-    )
-    recordErrorViaTelemetry(error)
-    await shutdownTelemetry()
-    process.exit(1)
-  }
-
-  tuiContent.update({
-    content: `${RedwoodStyling.green('✔')} Generated types`,
-    spinner: {
-      enabled: false,
-    },
-  })
-  tui.stopReactive()
 }
 
 async function initializeGit(newAppDir, commitMessage) {
@@ -606,33 +503,6 @@ async function handleCommitMessagePreference(commitMessageFlag) {
 }
 
 /**
- * @param {boolean?} yarnInstallFlag
- */
-async function handleYarnInstallPreference(yarnInstallFlag) {
-  // Handle case where flag is set
-  if (yarnInstallFlag !== null) {
-    return yarnInstallFlag
-  }
-
-  // Prompt user for preference
-  try {
-    const response = await tui.prompt({
-      type: 'Toggle',
-      name: 'yarnInstall',
-      message: 'Do you want to run yarn install?',
-      enabled: 'Yes',
-      disabled: 'no',
-      initial: 'Yes',
-    })
-    return response.yarnInstall
-  } catch (_error) {
-    recordErrorViaTelemetry('User cancelled install at yarn install prompt')
-    await shutdownTelemetry()
-    process.exit(1)
-  }
-}
-
-/**
  * This function creates a new RedwoodJS app.
  *
  * It performs the following actions:
@@ -692,22 +562,9 @@ async function createRedwoodApp() {
     ].join('\n')
   )
 
-  const _isYarnBerryOrNewer = isYarnBerryOrNewer()
-
-  // Only permit the yarn install flag on yarn 1.
-  if (!_isYarnBerryOrNewer) {
-    cli.option('yarn-install', {
-      default: null,
-      type: 'boolean',
-      describe: 'Install node modules. Skip via --no-yarn-install.',
-    })
-  }
-
   // Extract the args as provided by the user in the command line
   // TODO: Make all flags have the 'flag' suffix
   const args = parsedFlags._
-  const yarnInstallFlag =
-    parsedFlags['yarn-install'] ?? !_isYarnBerryOrNewer ? parsedFlags.yes : null
   const typescriptFlag = parsedFlags.typescript ?? parsedFlags.yes
   const overwrite = parsedFlags.overwrite
   const gitInitFlag = parsedFlags['git-init'] ?? parsedFlags.yes
@@ -716,7 +573,6 @@ async function createRedwoodApp() {
     (parsedFlags.yes ? INITIAL_COMMIT_MESSAGE : null)
 
   // Record some of the arguments for telemetry
-  trace.getActiveSpan()?.setAttribute('yarn-install', yarnInstallFlag)
   trace.getActiveSpan()?.setAttribute('overwrite', overwrite)
 
   // Get the directory for installation from the args
@@ -745,35 +601,11 @@ async function createRedwoodApp() {
     commitMessage = await handleCommitMessagePreference(commitMessageFlag)
   }
 
-  let yarnInstall = false
-
-  if (!_isYarnBerryOrNewer) {
-    yarnInstall = await handleYarnInstallPreference(yarnInstallFlag)
-  }
-
   let newAppDir = path.resolve(process.cwd(), targetDir)
 
   // Create project files
   // if this directory already exists then createProjectFiles may set a new directory name
   newAppDir = await createProjectFiles(newAppDir, { templateDir, overwrite })
-
-  // Install the node packages
-  if (yarnInstall) {
-    const yarnInstallStart = Date.now()
-    await installNodeModules(newAppDir)
-    trace
-      .getActiveSpan()
-      ?.setAttribute('yarn-install-time', Date.now() - yarnInstallStart)
-  } else {
-    if (!_isYarnBerryOrNewer) {
-      tui.drawText(`${RedwoodStyling.info('ℹ')} Skipped yarn install step`)
-    }
-  }
-
-  // Generate types
-  if (yarnInstall) {
-    await generateTypes(newAppDir)
-  }
 
   // Initialize git repo
   if (useGit) {
@@ -798,10 +630,6 @@ async function createRedwoodApp() {
             `cd ${path.relative(process.cwd(), newAppDir)}`
           )}`
         )}`,
-        !yarnInstall &&
-          `${RedwoodStyling.redwood(
-            ` > ${RedwoodStyling.green(`yarn install`)}`
-          )}`,
         `${RedwoodStyling.redwood(
           ` > ${RedwoodStyling.green(`yarn rw dev`)}`
         )}`,

--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -76,7 +76,6 @@ describe('create-redwood-app', () => {
       Fire it up! 🚀
 
        > cd redwood-app
-       > yarn install
        > yarn rw dev
 
       [?25l✔ Initialized a git repo with commit message "Initial commit"


### PR DESCRIPTION
@Tobbe told me he couldn't run `yarn create redwood-app` with yarn v1. I was able to reproduce and so was @Josh-Walker-GM:

```
$ yarn create redwood-app test
yarn create v1.22.21
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Installed "create-redwood-app@6.6.2" with binaries:
      - create-redwood-app
[########################################################################################] 88/88------------------------------------------------------------------
                🌲⚡️ Welcome to RedwoodJS! ⚡️🌲
------------------------------------------------------------------
✔ Compatibility checks passed
✔ Creating your Redwood app in test based on command line argument
✔ Select your preferred language · TypeScript
✔ Do you want to initialize a git repo? · no / Yes
✔ Enter a commit message · Initial commit
✔ Do you want to run yarn install? · no / Yes
✔ Project files created
✔ Installed node modules
✔ Generated types
✔ Initialized a git repo with commit message "Initial commit"

Thanks for trying out Redwood!

 ⚡️ Get up and running fast with this Quick Start guide: https://redwoodjs.com/quick-start

Fire it up! 🚀

 > cd test
 > yarn rw dev

✨  Done in 100.70s.
$ cd test
$ yarn rw dev
Internal Error: root-workspace-0b6124@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile
    ...
```

I'm not sure if this is new as of yarn v4 or not, but I think it's time we removed the yarn install preference in CRWA; I brought it up before in https://github.com/redwoodjs/redwood/pull/9786#discussion_r1438986336 but we held off at the time.

@Tobbe I'm happy to cherry pick this into the next branch and release a patch.