### PR TITLE
fix(cli): Skip Studio when running `rw upgrade`

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -224,8 +224,8 @@ function updatePackageJsonVersion(pkgPath, version, { dryRun, verbose }) {
   )
 
   if (pkg.dependencies) {
-    for (const depName of Object.keys(pkg.dependencies).filter((x) =>
-      x.startsWith('@redwoodjs/')
+    for (const depName of Object.keys(pkg.dependencies).filter(
+      (x) => x.startsWith('@redwoodjs/') && x !== '@redwoodjs/studio'
     )) {
       if (verbose || dryRun) {
         console.log(` - ${depName}: ${pkg.dependencies[depName]} => ${version}`)
@@ -234,8 +234,8 @@ function updatePackageJsonVersion(pkgPath, version, { dryRun, verbose }) {
     }
   }
   if (pkg.devDependencies) {
-    for (const depName of Object.keys(pkg.devDependencies).filter((x) =>
-      x.startsWith('@redwoodjs/')
+    for (const depName of Object.keys(pkg.devDependencies).filter(
+      (x) => x.startsWith('@redwoodjs/') && x !== '@redwoodjs/studio'
     )) {
       if (verbose || dryRun) {
         console.log(


### PR DESCRIPTION
Studio is versioned separately. It's a separate project with it's own versions. So it should not be included in the packages that `yarn rw upgrade` tries to upgrade.