### PR TITLE
feat(crwa): Always install using yarn v4

### DIFF
--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -28,6 +28,8 @@ describe('create-redwood-app', () => {
             --git-init, --git   Initialize a git repository  [boolean] [default: null]
         -m, --commit-message    Commit message for the initial commit
                                                               [string] [default: null]
+            --yarn-install      Install node modules. Skip via --no-yarn-install.
+                                                             [boolean] [default: null]
             --telemetry         Enables sending telemetry events for this create
                                 command and all Redwood CLI commands
                                 https://telemetry.redwoodjs.com
@@ -64,6 +66,7 @@ describe('create-redwood-app', () => {
       [?25h✔ Creating your Redwood app in ./redwood-app based on command line argument
       ✔ Using TypeScript based on command line flag
       ✔ Will initialize a git repo based on command line flag
+      ✔ Will run yarn install based on command line flag
       [?25l⠋ Creating project files
       [?25h[?25l✔ Project files created
       [?25h[?25l⠋ Initializing a git repo


### PR DESCRIPTION
By cd-ing into the new rw app directory we make sure `yarn install` is executed by yarn v4 (or whatever version is set in the root package.json)