### PR TITLE
chore(crwa): update e2e test to handle yarn install patch

### DIFF
--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "node ./scripts/build.js",
-    "build:pack": "yarn pack -o create-redwood-app.tgz",
+    "build:pack": "node ./scripts/buildPack.js",
     "build:watch": "nodemon --watch src --ignore dist,template --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "set-up-test-project": "node ./scripts/setUpTestProject.js",

--- a/packages/create-redwood-app/scripts/buildPack.js
+++ b/packages/create-redwood-app/scripts/buildPack.js
@@ -1,0 +1,31 @@
+/* eslint-env node */
+
+import { fileURLToPath } from 'node:url'
+
+import { cd, path, within, $ } from 'zx'
+
+const tsTemplatePath = fileURLToPath(
+  new URL('../templates/ts', import.meta.url)
+)
+const jsTemplatePath = fileURLToPath(
+  new URL('../templates/js', import.meta.url)
+)
+
+await within(async () => {
+  cd(tsTemplatePath)
+
+  await $`touch yarn.lock`
+  await $`yarn`
+})
+
+await within(async () => {
+  cd(jsTemplatePath)
+
+  await $`touch yarn.lock`
+  await $`yarn`
+})
+
+await $`yarn pack -o create-redwood-app.tgz`
+
+await $`rm ${path.join(tsTemplatePath, 'yarn.lock')}`
+await $`rm ${path.join(jsTemplatePath, 'yarn.lock')}`

--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -18,8 +18,8 @@
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
+    "@redwoodjs/vite": "6.0.7",
     "@types/react": "18.2.37",
-    "@types/react-dom": "18.2.15",
-    "@redwoodjs/vite": "6.0.7"
+    "@types/react-dom": "18.2.15"
   }
 }

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -18,8 +18,8 @@
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
+    "@redwoodjs/vite": "6.0.7",
     "@types/react": "18.2.37",
-    "@types/react-dom": "18.2.15",
-    "@redwoodjs/vite": "6.0.7"
+    "@types/react-dom": "18.2.15"
   }
 }

--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -53,8 +53,12 @@ describe('create-redwood-app', () => {
     expect(p.stderr).toMatchInlineSnapshot(`"[?25l[?25h"`)
   })
 
-  test.skip('--yes, -y', async () => {
-    const p = await $`yarn create-redwood-app ./redwood-app --yes`
+  test('--yes, -y', async () => {
+    // Running `yarn install` in Jest test times out  and the subsequent step,
+    // generating types, is also flakey since `yarn pack` seems to skip `.yarnrc.yml`
+    // which is necessary for configuring a proper install.
+    const p =
+      await $`yarn create-redwood-app ./redwood-app --no-yarn-install --yes`
 
     expect(p.exitCode).toEqual(0)
     expect(p.stdout).toMatchInlineSnapshot(`
@@ -66,10 +70,11 @@ describe('create-redwood-app', () => {
       [?25h✔ Creating your Redwood app in ./redwood-app based on command line argument
       ✔ Using TypeScript based on command line flag
       ✔ Will initialize a git repo based on command line flag
-      ✔ Will run yarn install based on command line flag
+      ✔ Will not run yarn install based on command line flag
       [?25l⠋ Creating project files
       [?25h[?25l✔ Project files created
-      [?25h[?25l⠋ Initializing a git repo
+      [?25hℹ Skipped yarn install step
+      [?25l⠋ Initializing a git repo
       [?25h[?25l✔ Initialized a git repo with commit message "Initial commit"
       [?25h
       Thanks for trying out Redwood!

--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -53,7 +53,7 @@ describe('create-redwood-app', () => {
     expect(p.stderr).toMatchInlineSnapshot(`"[?25l[?25h"`)
   })
 
-  test('--yes, -y', async () => {
+  test.skip('--yes, -y', async () => {
     const p = await $`yarn create-redwood-app ./redwood-app --yes`
 
     expect(p.exitCode).toEqual(0)

--- a/packages/create-redwood-app/tests/e2e_prompts.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts.sh
@@ -27,9 +27,6 @@ send "\n"
 expect "Enter a commit message"
 send "first\n"
 
-expect "Do you want to run yarn install?"
-send "\n"
-
 expect eof
 catch wait result
 set exitStatus [lindex $result 3]

--- a/packages/create-redwood-app/tests/e2e_prompts.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts.sh
@@ -11,7 +11,7 @@ cd $projectPath
 
 set projectDirectory "redwood-app-prompt-test"
 
-spawn yarn create-redwood-app
+spawn yarn create-redwood-app --no-yarn-install
 
 expect "Where would you like to create your Redwood app?"
 send "$projectDirectory\n"
@@ -26,6 +26,9 @@ send "\n"
 
 expect "Enter a commit message"
 send "first\n"
+
+expect "Do you want to run yarn install?"
+send "\n"
 
 expect eof
 catch wait result

--- a/packages/create-redwood-app/tests/e2e_prompts_git.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts_git.sh
@@ -11,7 +11,7 @@ cd $projectPath
 
 set projectDirectory "redwood-app-prompt-git-test"
 
-spawn yarn create-redwood-app --git
+spawn yarn create-redwood-app --no-yarn-install --git
 
 expect "Where would you like to create your Redwood app?"
 send "$projectDirectory\n"

--- a/packages/create-redwood-app/tests/e2e_prompts_m.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts_m.sh
@@ -11,7 +11,7 @@ cd $projectPath
 
 set projectDirectory "redwood-app-prompt-m-test"
 
-spawn yarn create-redwood-app -m "first"
+spawn yarn create-redwood-app --no-yarn-install -m "first"
 
 expect "Where would you like to create your Redwood app?"
 send "$projectDirectory\n"

--- a/packages/create-redwood-app/tests/e2e_prompts_node_greater.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts_node_greater.sh
@@ -13,7 +13,7 @@ cd $projectPath
 
 set projectDirectory "redwood-app-prompt-node-greater-test"
 
-spawn yarn create-redwood-app
+spawn yarn create-redwood-app --no-yarn-install
 
 expect "How would you like to proceed?"
 # ❯ Override error and continue install

--- a/packages/create-redwood-app/tests/e2e_prompts_node_less.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts_node_less.sh
@@ -13,7 +13,7 @@ cd $projectPath
 
 set projectDirectory "redwood-app-prompt-node-less-test"
 
-spawn yarn create-redwood-app
+spawn yarn create-redwood-app --no-yarn-install
 
 expect eof
 catch wait result

--- a/packages/create-redwood-app/tests/e2e_prompts_overwrite.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts_overwrite.sh
@@ -14,7 +14,7 @@ set projectDirectory "redwood-app-prompt-overwrite-test"
 exec mkdir $projectDirectory
 exec touch $projectDirectory/README.md
 
-spawn yarn create-redwood-app
+spawn yarn create-redwood-app --no-yarn-install
 
 expect "Where would you like to create your Redwood app?"
 send "$projectDirectory\n"

--- a/packages/create-redwood-app/tests/e2e_prompts_ts.sh
+++ b/packages/create-redwood-app/tests/e2e_prompts_ts.sh
@@ -11,7 +11,7 @@ cd $projectPath
 
 set projectDirectory "redwood-app-prompt-ts-test"
 
-spawn yarn create-redwood-app --ts
+spawn yarn create-redwood-app --no-yarn-install --ts
 
 expect "Where would you like to create your Redwood app?"
 send "$projectDirectory\n"


### PR DESCRIPTION
This PR fixes the CRWA e2e tests after the functionality introduced in https://github.com/redwoodjs/redwood/pull/9861.

For now I'm skipping `yarn install` since it's prone to timeouts in CI, and the subsequent step, generating types, is also flakey since `yarn pack` seems to skip the `.yarnrc.yml` which is necessary for configuring a proper install.