### PR TITLE
chore(project-config): switch to vitest

### DIFF
--- a/packages/project-config/.babelrc.js
+++ b/packages/project-config/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/project-config/jest.config.js
+++ b/packages/project-config/jest.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/*.test.[jt]s?(x)'],
-  testPathIgnorePatterns: ['fixtures', 'dist'],
-  moduleNameMapper: {
-    'src/(.*)': '<rootDir>/src/$1',
-  },
-  testTimeout: 15000,
-}

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -20,8 +20,8 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
-    "test:watch": "run test --watch"
+    "test": "vitest run src",
+    "test:watch": "vitest watch src"
   },
   "dependencies": {
     "@iarna/toml": "2.2.5",
@@ -33,7 +33,8 @@
     "esbuild": "0.19.9",
     "jest": "29.7.0",
     "rimraf": "5.0.5",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vitest": "1.2.1"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "esbuild": "0.19.9",
-    "jest": "29.7.0",
     "rimraf": "5.0.5",
     "typescript": "5.3.3",
     "vitest": "1.2.1"

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -1,5 +1,7 @@
 import path from 'path'
 
+import { describe, it, expect } from 'vitest'
+
 import { getConfig, getRawConfig } from '../config'
 
 describe('getRawConfig', () => {

--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -1,5 +1,7 @@
 import path from 'path'
 
+import { describe, beforeAll, afterAll, it, expect, test } from 'vitest'
+
 import {
   processPagesDir,
   resolveFile,
@@ -226,7 +228,7 @@ describe('paths', () => {
       })
     })
 
-    describe('resolveFile', () => {
+    test('resolveFile', () => {
       const p = resolveFile(path.join(FIXTURE_BASEDIR, 'web', 'src', 'App'))
       expect(path.extname(p)).toEqual('.tsx')
 
@@ -547,7 +549,7 @@ describe('paths', () => {
       })
     })
 
-    describe('resolveFile', () => {
+    test('resolveFile', () => {
       const p = resolveFile(path.join(FIXTURE_BASEDIR, 'web', 'src', 'App'))
       expect(path.extname(p)).toEqual('.js')
 
@@ -826,7 +828,7 @@ describe('paths', () => {
       })
     })
 
-    describe('resolveFile', () => {
+    test('resolveFile', () => {
       const p = resolveFile(path.join(FIXTURE_BASEDIR, 'web', 'src', 'index'))
       expect(path.extname(p)).toEqual('.js')
 
@@ -1158,7 +1160,7 @@ describe('paths', () => {
       })
     })
 
-    describe('resolveFile', () => {
+    test('resolveFile', () => {
       const p = resolveFile(path.join(FIXTURE_BASEDIR, 'web', 'src', 'Routes'))
       expect(path.extname(p)).toEqual('.tsx')
 

--- a/packages/project-config/vitest.config.mts
+++ b/packages/project-config/vitest.config.mts
@@ -1,0 +1,12 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    testTimeout: 15_000,
+    include: ['**/__tests__/**/*.[jt]s?(x)', '**/*.test.[jt]s?(x)'],
+    exclude: [...configDefaults.exclude, '**/fixtures', '**/dist'],
+    alias: {
+      'src/(.*)': '<rootDir>/src/$1',
+    }
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8652,6 +8652,7 @@ __metadata:
     rimraf: "npm:5.0.5"
     string-env-interpolation: "npm:1.0.1"
     typescript: "npm:5.3.3"
+    vitest: "npm:1.2.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8648,7 +8648,6 @@ __metadata:
     deepmerge: "npm:4.3.1"
     esbuild: "npm:0.19.9"
     fast-glob: "npm:3.3.2"
-    jest: "npm:29.7.0"
     rimraf: "npm:5.0.5"
     string-env-interpolation: "npm:1.0.1"
     typescript: "npm:5.3.3"


### PR DESCRIPTION
Switches our tests in `@redwoodjs/project-config` over to vitest.