### PR TITLE
chore(ci): Fix CRWA telemetry check

### DIFF
--- a/.github/actions/telemetry_check/check.mjs
+++ b/.github/actions/telemetry_check/check.mjs
@@ -37,7 +37,7 @@ try {
   switch (mode) {
     case 'crwa':
       exitCode = await exec(
-        `yarn node ./packages/create-redwood-app/dist/create-redwood-app.js ../project-for-telemetry --typescript true --git false`
+        `yarn node ./packages/create-redwood-app/dist/create-redwood-app.js ../project-for-telemetry --typescript true --git false --no-yarn-install`
       )
       if (exitCode) {
         process.exit(1)


### PR DESCRIPTION
The check is currently running indefinitely as it is waiting for the result of a prompt. This PR passes the `--no-yarn-install` flag to prevent this. That flag was introduced in #9861