### PR TITLE
chore: switch some more packages to vitest

### DIFF
--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -18,8 +18,8 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
-    "test:watch": "yarn test --watch"
+    "test": "vitest run src",
+    "test:watch": "vitest watch src"
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -30,8 +30,8 @@
     "@redwoodjs/api": "6.0.7",
     "esbuild": "0.19.9",
     "fast-glob": "3.3.2",
-    "jest": "29.7.0",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vitest": "1.2.1"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/mailer/core/src/__tests__/mailer.test.ts
+++ b/packages/mailer/core/src/__tests__/mailer.test.ts
@@ -1,3 +1,14 @@
+import {
+  vi,
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from 'vitest'
+
 import { AbstractMailHandler } from '../handler'
 import { Mailer } from '../mailer'
 import { AbstractMailRenderer } from '../renderer'
@@ -61,13 +72,13 @@ describe('Uses the correct modes', () => {
 
   beforeAll(() => {
     // prevent console output
-    jest.spyOn(console, 'log').mockImplementation(() => {})
-    jest.spyOn(console, 'warn').mockImplementation(() => {})
-    jest.spyOn(console, 'debug').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
   })
 
   afterAll(() => {
-    jest.restoreAllMocks()
+    vi.restoreAllMocks()
   })
 
   describe('starts in test mode', () => {
@@ -131,7 +142,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid 'when' configuration for test mode"`
+        `[Error: Invalid 'when' configuration for test mode]`
       )
 
       expect(() => {
@@ -143,7 +154,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid 'when' configuration for test mode"`
+        `[Error: Invalid 'when' configuration for test mode]`
       )
     })
   })
@@ -224,7 +235,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid 'when' configuration for development mode"`
+        `[Error: Invalid 'when' configuration for development mode]`
       )
 
       expect(() => {
@@ -239,7 +250,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid 'when' configuration for development mode"`
+        `[Error: Invalid 'when' configuration for development mode]`
       )
     })
   })
@@ -310,7 +321,7 @@ describe('Uses the correct modes', () => {
 
   describe('warns about null handlers', () => {
     beforeAll(() => {
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
     })
 
     test('test', () => {
@@ -344,7 +355,7 @@ describe('Uses the correct modes', () => {
 
   describe('attempts to use fallback handlers', () => {
     beforeAll(() => {
-      jest.spyOn(console, 'warn').mockImplementation(() => {})
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
     })
 
     test('test', () => {
@@ -388,7 +399,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"The specified test handler 'handlerC' is not defined"`
+        `[Error: The specified test handler 'handlerC' is not defined]`
       )
     })
     test('development', () => {
@@ -402,7 +413,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"The specified development handler 'handlerC' is not defined"`
+        `[Error: The specified development handler 'handlerC' is not defined]`
       )
     })
     test('production', () => {
@@ -422,7 +433,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"The specified default handler 'handlerC' is not defined"`
+        `[Error: The specified default handler 'handlerC' is not defined]`
       )
     })
   })
@@ -442,7 +453,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"The specified default renderer 'rendererC' is not defined"`
+        `[Error: The specified default renderer 'rendererC' is not defined]`
       )
     })
     test('development', () => {
@@ -459,7 +470,7 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"The specified default renderer 'rendererC' is not defined"`
+        `[Error: The specified default renderer 'rendererC' is not defined]`
       )
     })
     test('production', () => {
@@ -479,13 +490,13 @@ describe('Uses the correct modes', () => {
           },
         })
       }).toThrowErrorMatchingInlineSnapshot(
-        `"The specified default renderer 'rendererC' is not defined"`
+        `[Error: The specified default renderer 'rendererC' is not defined]`
       )
     })
   })
 
   describe('calls the correct handler and renderer function', () => {
-    jest.spyOn(console, 'debug').mockImplementation(() => {})
+    vi.spyOn(console, 'debug').mockImplementation(() => {})
 
     describe('test', () => {
       const testHandler = new MockMailHandler()
@@ -522,12 +533,12 @@ describe('Uses the correct modes', () => {
         const handlerKeys = Object.keys(mailer.handlers)
         for (let i = 0; i < handlerKeys.length; i++) {
           const key = handlerKeys[i]
-          jest.spyOn(mailer.handlers[key], 'send')
+          vi.spyOn(mailer.handlers[key], 'send')
         }
         const rendererKeys = Object.keys(mailer.renderers)
         for (let i = 0; i < rendererKeys.length; i++) {
           const key = rendererKeys[i]
-          jest.spyOn(mailer.renderers[key], 'render')
+          vi.spyOn(mailer.renderers[key], 'render')
         }
       })
 
@@ -622,12 +633,12 @@ describe('Uses the correct modes', () => {
         const handlerKeys = Object.keys(mailer.handlers)
         for (let i = 0; i < handlerKeys.length; i++) {
           const key = handlerKeys[i]
-          jest.spyOn(mailer.handlers[key], 'send')
+          vi.spyOn(mailer.handlers[key], 'send')
         }
         const rendererKeys = Object.keys(mailer.renderers)
         for (let i = 0; i < rendererKeys.length; i++) {
           const key = rendererKeys[i]
-          jest.spyOn(mailer.renderers[key], 'render')
+          vi.spyOn(mailer.renderers[key], 'render')
         }
       })
 
@@ -723,12 +734,12 @@ describe('Uses the correct modes', () => {
         const handlerKeys = Object.keys(mailer.handlers)
         for (let i = 0; i < handlerKeys.length; i++) {
           const key = handlerKeys[i]
-          jest.spyOn(mailer.handlers[key], 'send')
+          vi.spyOn(mailer.handlers[key], 'send')
         }
         const rendererKeys = Object.keys(mailer.renderers)
         for (let i = 0; i < rendererKeys.length; i++) {
           const key = rendererKeys[i]
-          jest.spyOn(mailer.renderers[key], 'render')
+          vi.spyOn(mailer.renderers[key], 'render')
         }
       })
 

--- a/packages/mailer/core/src/__tests__/utils.test.ts
+++ b/packages/mailer/core/src/__tests__/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, test, expect } from 'vitest'
+
 import type { MailerDefaults } from '../types'
 import {
   constructCompleteSendOptions,
@@ -120,7 +122,7 @@ describe('constructCompleteSendOptions', () => {
         },
         blankDefaults
       )
-    }).toThrowErrorMatchingInlineSnapshot(`"Missing from address"`)
+    }).toThrowErrorMatchingInlineSnapshot(`[Error: Missing from address]`)
 
     expect(() => {
       constructCompleteSendOptions(
@@ -153,7 +155,7 @@ describe('constructCompleteSendOptions', () => {
         },
         blankDefaults
       )
-    }).toThrowErrorMatchingInlineSnapshot(`"Missing to address"`)
+    }).toThrowErrorMatchingInlineSnapshot(`[Error: Missing to address]`)
 
     expect(() => {
       constructCompleteSendOptions(
@@ -176,7 +178,7 @@ describe('constructCompleteSendOptions', () => {
         },
         blankDefaults
       )
-    }).toThrowErrorMatchingInlineSnapshot(`"Missing subject"`)
+    }).toThrowErrorMatchingInlineSnapshot(`[Error: Missing subject]`)
 
     expect(() => {
       constructCompleteSendOptions(

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -19,8 +19,8 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "datamodel:parse": "node src/scripts/parse.js",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
-    "test:watch": "yarn test --watch"
+    "test": "vitest run src",
+    "test:watch": "vitest watch src"
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -38,7 +38,7 @@
     "@babel/core": "^7.22.20",
     "@prisma/internals": "5.7.0",
     "esbuild": "0.19.9",
-    "jest": "29.7.0"
+    "vitest": "1.2.1"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/record/src/redwoodrecord/__tests__/Core.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/Core.test.js
@@ -1,9 +1,11 @@
+import { vi, afterEach, describe, it, expect } from 'vitest'
+
 import * as Errors from '../../errors'
 import datamodel from '../__fixtures__/datamodel.js'
 import Core from '../Core'
 
 // Mock Prisma
-const db = { user: jest.fn() }
+const db = { user: vi.fn() }
 
 // Setup Core
 Core.schema = datamodel
@@ -98,7 +100,7 @@ describe('User subclass', () => {
 
     describe('where', () => {
       it('returns an array of User records', async () => {
-        db.user.findMany = jest.fn(() => [
+        db.user.findMany = vi.fn(() => [
           {
             id: 1,
             email: 'rob@redwoodjs.com',
@@ -114,7 +116,7 @@ describe('User subclass', () => {
 
     describe('all', () => {
       it('calls where with an empty first argument', async () => {
-        db.user.findMany = jest.fn(() => [])
+        db.user.findMany = vi.fn(() => [])
         await User.all()
 
         expect(db.user.findMany).toHaveBeenCalledWith({
@@ -123,7 +125,7 @@ describe('User subclass', () => {
       })
 
       it('is an alias for where', async () => {
-        db.user.findMany = jest.fn(() => [
+        db.user.findMany = vi.fn(() => [
           {
             id: 1,
             email: 'rob@redwoodjs.com',
@@ -142,7 +144,7 @@ describe('User subclass', () => {
           hashedPassword: 'abc',
           salt: 'abc',
         }
-        db.user.create = jest.fn(() => ({ id: 1, ...attributes }))
+        db.user.create = vi.fn(() => ({ id: 1, ...attributes }))
 
         const user = await User.create(attributes)
 
@@ -157,7 +159,7 @@ describe('User subclass', () => {
     describe('find', () => {
       it('finds a user by ID', async () => {
         const id = 1
-        db.user.findFirst = jest.fn(() => ({
+        db.user.findFirst = vi.fn(() => ({
           id,
           email: 'rob@redwoodjs.com',
         }))
@@ -168,7 +170,7 @@ describe('User subclass', () => {
       })
 
       it('throws RedwoodRecordNotFound if ID is not found', async () => {
-        db.user.findFirst = jest.fn(() => null)
+        db.user.findFirst = vi.fn(() => null)
 
         try {
           await User.find(999999999)
@@ -183,7 +185,7 @@ describe('User subclass', () => {
     describe('findBy', () => {
       it('returns the first record if no arguments', async () => {
         const id = 1
-        db.user.findFirst = jest.fn(() => ({
+        db.user.findFirst = vi.fn(() => ({
           id,
           email: 'rob@redwoodjs.com',
         }))
@@ -196,7 +198,7 @@ describe('User subclass', () => {
 
       it('returns the first record that matches the given attributes', async () => {
         const id = 1
-        db.user.findFirst = jest.fn(() => ({
+        db.user.findFirst = vi.fn(() => ({
           id,
           email: 'tom@redwoodjs.com',
         }))
@@ -210,7 +212,7 @@ describe('User subclass', () => {
       })
 
       it('returns null if no records', async () => {
-        db.user.findFirst = jest.fn(() => null)
+        db.user.findFirst = vi.fn(() => null)
 
         expect(await User.findBy()).toEqual(null)
       })
@@ -219,7 +221,7 @@ describe('User subclass', () => {
     describe('first', () => {
       it('is an alias for findBy', async () => {
         const id = 1
-        db.user.findFirst = jest.fn(() => ({
+        db.user.findFirst = vi.fn(() => ({
           id,
           email: 'tom@redwoodjs.com',
         }))
@@ -238,7 +240,7 @@ describe('User subclass', () => {
     describe('destroy', () => {
       it('deletes a record', async () => {
         const data = { id: 1, email: 'tom@redwoodjs.com' }
-        db.user.delete = jest.fn(() => data)
+        db.user.delete = vi.fn(() => data)
         const user = User.build(data)
 
         await user.destroy()
@@ -250,7 +252,7 @@ describe('User subclass', () => {
 
       it('returns the record that was deleted', async () => {
         const data = { id: 1, email: 'tom@redwoodjs.com' }
-        db.user.delete = jest.fn(() => data)
+        db.user.delete = vi.fn(() => data)
         const user = User.build(data)
         const result = await user.destroy()
 
@@ -258,7 +260,7 @@ describe('User subclass', () => {
       })
 
       it('returns false if record not found', async () => {
-        db.user.delete = jest.fn(() => {
+        db.user.delete = vi.fn(() => {
           throw new Error('Record to delete does not exist')
         })
         const user = User.build({ id: 99999999 })
@@ -267,7 +269,7 @@ describe('User subclass', () => {
       })
 
       it('throws an error if record not found', async () => {
-        db.user.delete = jest.fn(() => {
+        db.user.delete = vi.fn(() => {
           throw new Error('Record to delete does not exist')
         })
         const user = User.build({ id: 99999999 })
@@ -287,7 +289,7 @@ describe('User subclass', () => {
             hashedPassword: 'abc',
             salt: 'abc',
           }
-          db.user.create = jest.fn(() => ({ id: 1, ...attributes }))
+          db.user.create = vi.fn(() => ({ id: 1, ...attributes }))
           const user = await User.build(attributes)
 
           const result = await user.save()
@@ -297,7 +299,7 @@ describe('User subclass', () => {
         })
 
         it('returns false if create fails', async () => {
-          db.user.create = jest.fn(() => {
+          db.user.create = vi.fn(() => {
             throw new Error()
           })
           const user = await User.build({ email: 'foo@bar.com' })
@@ -310,7 +312,7 @@ describe('User subclass', () => {
         })
 
         it('throws error for missing attribute', async () => {
-          db.user.create = jest.fn(() => {
+          db.user.create = vi.fn(() => {
             throw new Error('Argument email is missing')
           })
           const user = await User.build({})
@@ -326,7 +328,7 @@ describe('User subclass', () => {
         })
 
         it('throws error for null attribute', async () => {
-          db.user.create = jest.fn(() => {
+          db.user.create = vi.fn(() => {
             throw new Error('Argument email must not be null')
           })
           const user = await User.build({ email: null })
@@ -342,7 +344,7 @@ describe('User subclass', () => {
         })
 
         it('throws for otherwise uncaught error', async () => {
-          db.user.create = jest.fn(() => {
+          db.user.create = vi.fn(() => {
             throw new Error('Something bad happened')
           })
           const user = await User.build({ email: null })
@@ -364,7 +366,7 @@ describe('User subclass', () => {
             hashedPassword: 'abc',
             salt: 'abc',
           }
-          db.user.update = jest.fn(() => attributes)
+          db.user.update = vi.fn(() => attributes)
           const user = await User.build({ id: 1, ...attributes })
           const result = await user.save()
 
@@ -383,7 +385,7 @@ describe('User subclass', () => {
             hashedPassword: 'abc',
             salt: 'abc',
           }
-          db.user.update = jest.fn(() => attributes)
+          db.user.update = vi.fn(() => attributes)
           const user = await User.build({ userId: 1, ...attributes })
           await user.save()
 
@@ -394,7 +396,7 @@ describe('User subclass', () => {
         })
 
         it('returns false if update fails', async () => {
-          db.user.update = jest.fn(() => {
+          db.user.update = vi.fn(() => {
             throw new Error('Record to update not found')
           })
           const user = await User.build({ id: 99999999 })
@@ -404,7 +406,7 @@ describe('User subclass', () => {
         })
 
         it('throws if record not found', async () => {
-          db.user.update = jest.fn(() => {
+          db.user.update = vi.fn(() => {
             throw new Error('Record to update not found')
           })
           const user = await User.build({ id: 99999999 })
@@ -419,7 +421,7 @@ describe('User subclass', () => {
         })
 
         it('throws on null required field if given the option', async () => {
-          db.user.update = jest.fn(() => {
+          db.user.update = vi.fn(() => {
             throw new Error('Argument email must not be null')
           })
           const user = await User.build({ id: 99999999 })
@@ -446,7 +448,7 @@ describe('User subclass', () => {
           hashedPassword: 'abc',
           salt: 'abc',
         }
-        db.user.update = jest.fn(() => attributes)
+        db.user.update = vi.fn(() => attributes)
         const user = await User.build({ id: 1, ...attributes })
         const _result = await user.update({ name: 'Robert Cameron' })
 

--- a/packages/record/src/redwoodrecord/__tests__/RedwoodRecord.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/RedwoodRecord.test.js
@@ -1,3 +1,5 @@
+import { vi, describe, it, expect } from 'vitest'
+
 import * as ValidationErrors from '@redwoodjs/api'
 
 import datamodel from '../__fixtures__/datamodel.js'
@@ -5,7 +7,7 @@ import RedwoodRecord from '../RedwoodRecord'
 import Reflection from '../Reflection'
 import RelationProxy from '../RelationProxy'
 
-const db = { user: jest.fn() }
+const db = { user: vi.fn() }
 
 describe('reflect()', () => {
   it('returns instance of Reflection', () => {
@@ -87,7 +89,7 @@ describe('_onSaveError()', () => {
   User.db = db
 
   it('returns false if save fails', async () => {
-    db.user.update = jest.fn(() => {
+    db.user.update = vi.fn(() => {
       throw new Error('Argument email must not be null')
     })
     const user = User.build({ id: 1, email: null })
@@ -96,7 +98,7 @@ describe('_onSaveError()', () => {
   })
 
   it('adds an error if save fails', async () => {
-    db.user.update = jest.fn(() => {
+    db.user.update = vi.fn(() => {
       throw new Error('Argument email must not be null')
     })
     const user = User.build({ id: 1, email: null })

--- a/packages/record/src/redwoodrecord/__tests__/Reflection.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/Reflection.test.js
@@ -18,6 +18,8 @@
 //   title  String
 // }
 
+import { describe, it, expect } from 'vitest'
+
 import datamodel from '../__fixtures__/datamodel.js'
 import RedwoodRecord from '../RedwoodRecord'
 import Reflection from '../Reflection'

--- a/packages/record/src/redwoodrecord/__tests__/RelationProxy.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/RelationProxy.test.js
@@ -1,8 +1,10 @@
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest'
+
 import datamodel from '../__fixtures__/datamodel.js'
 import RedwoodRecord from '../RedwoodRecord'
 import RelationProxy from '../RelationProxy'
 
-const db = { user: jest.fn() }
+const db = { user: vi.fn() }
 
 class Post extends RedwoodRecord {}
 class User extends RedwoodRecord {}
@@ -17,7 +19,7 @@ Comment.schema = datamodel
 Category.db = db
 Category.schema = datamodel
 
-globalThis.console.warn = jest.fn()
+globalThis.console.warn = vi.fn()
 
 beforeEach(() => {
   db.user.mockClear()
@@ -28,7 +30,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.console.warn.mockClear()
-  jest.restoreAllMocks()
+  vi.restoreAllMocks()
 })
 
 describe('belongsTo', () => {
@@ -50,9 +52,9 @@ describe('belongsTo', () => {
   })
 
   it('created method returns a belongsTo a record', async () => {
-    jest
-      .spyOn(User, 'findBy')
-      .mockImplementation(() => User.build({ id: 1, name: 'Rob' }))
+    vi.spyOn(User, 'findBy').mockImplementation(() =>
+      User.build({ id: 1, name: 'Rob' })
+    )
     const record = new Post()
     record.userId = 1
 
@@ -95,10 +97,10 @@ describe('hasMany', () => {
   })
 
   it('create hasMany record linked by foreign key', async () => {
-    jest.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
-    jest
-      .spyOn(Post, 'create')
-      .mockImplementation(() => User.build({ id: 1, userId: 1 }))
+    vi.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
+    vi.spyOn(Post, 'create').mockImplementation(() =>
+      User.build({ id: 1, userId: 1 })
+    )
 
     const user = await User.find(1)
     const newPost = await user.posts.create({
@@ -116,8 +118,8 @@ describe('hasMany', () => {
   })
 
   it('fetches related records with find()', async () => {
-    jest.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
-    jest.spyOn(Post, 'findBy').mockImplementation(() => Post.build({ id: 2 }))
+    vi.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
+    vi.spyOn(Post, 'findBy').mockImplementation(() => Post.build({ id: 2 }))
 
     const record = await User.find(1)
     const post = await record.posts.find(2)
@@ -127,10 +129,10 @@ describe('hasMany', () => {
   })
 
   it('fetches related records with findBy()', async () => {
-    jest.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
-    jest
-      .spyOn(Post, 'findBy')
-      .mockImplementation(() => Post.build({ id: 2, title: 'New' }))
+    vi.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
+    vi.spyOn(Post, 'findBy').mockImplementation(() =>
+      Post.build({ id: 2, title: 'New' })
+    )
 
     const record = await User.find(1)
     const post = await record.posts.findBy({ title: 'New' })
@@ -140,8 +142,8 @@ describe('hasMany', () => {
   })
 
   it('fetches related records with where()', async () => {
-    jest.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
-    jest.spyOn(Post, 'where').mockImplementation(() => [Post.build({ id: 2 })])
+    vi.spyOn(User, 'find').mockImplementation(() => User.build({ id: 1 }))
+    vi.spyOn(Post, 'where').mockImplementation(() => [Post.build({ id: 2 })])
 
     const record = await User.find(1)
     const posts = await record.posts.where()
@@ -169,10 +171,10 @@ describe('implicit many-to-many', () => {
   })
 
   it('create connects manyToMany record', async () => {
-    jest.spyOn(Post, 'find').mockImplementation(() => Post.build({ id: 1 }))
-    jest
-      .spyOn(Category, 'create')
-      .mockImplementation(() => Category.build({ id: 2, name: 'Sample' }))
+    vi.spyOn(Post, 'find').mockImplementation(() => Post.build({ id: 1 }))
+    vi.spyOn(Category, 'create').mockImplementation(() =>
+      Category.build({ id: 2, name: 'Sample' })
+    )
 
     const post = await Post.find(1)
     const newCategory = await post.categories.create({ name: 'Sample' })
@@ -191,10 +193,10 @@ describe('implicit many-to-many', () => {
   })
 
   it('fetches related records with find()', async () => {
-    jest.spyOn(Post, 'find').mockImplementation(() => Post.build({ id: 1 }))
-    jest
-      .spyOn(Category, 'findBy')
-      .mockImplementation(() => Category.build({ id: 2, name: 'Cat' }))
+    vi.spyOn(Post, 'find').mockImplementation(() => Post.build({ id: 1 }))
+    vi.spyOn(Category, 'findBy').mockImplementation(() =>
+      Category.build({ id: 2, name: 'Cat' })
+    )
 
     const record = await Post.find(1)
     const category = await record.categories.find(2)
@@ -212,10 +214,10 @@ describe('implicit many-to-many', () => {
   })
 
   it('fetches related records with where()', async () => {
-    jest.spyOn(Post, 'find').mockImplementation(() => Post.build({ id: 1 }))
-    jest
-      .spyOn(Category, 'where')
-      .mockImplementation(() => [Category.build({ id: 2, name: 'Cat' })])
+    vi.spyOn(Post, 'find').mockImplementation(() => Post.build({ id: 1 }))
+    vi.spyOn(Category, 'where').mockImplementation(() => [
+      Category.build({ id: 2, name: 'Cat' }),
+    ])
 
     const record = await Post.find(1)
     const categories = await record.categories.where()

--- a/packages/record/src/redwoodrecord/__tests__/Validation.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/Validation.test.js
@@ -11,7 +11,7 @@ beforeEach(() => {
   TestClass.validates = {}
 })
 
-describe.only('hasError', () => {
+describe('hasError', () => {
   it('defaults to false', () => {
     const record = new TestClass()
 
@@ -42,7 +42,7 @@ describe.only('hasError', () => {
   })
 })
 
-describe.only('isValid', () => {
+describe('isValid', () => {
   it('returns true if record has no validations', () => {
     const record = new TestClass()
 
@@ -72,7 +72,7 @@ describe.only('isValid', () => {
   })
 })
 
-describe.only('validate', () => {
+describe('validate', () => {
   it('returns true if record has no validations', () => {
     const record = new TestClass()
 

--- a/packages/record/src/redwoodrecord/__tests__/Validation.test.js
+++ b/packages/record/src/redwoodrecord/__tests__/Validation.test.js
@@ -1,3 +1,5 @@
+import { beforeEach, describe, it, expect } from 'vitest'
+
 import { PresenceValidationError } from '@redwoodjs/api'
 
 import Validation from '../ValidationMixin'

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -18,8 +18,8 @@
     "build:pack": "yarn pack -o redwoodjs-telemetry.tgz",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
-    "test:watch": "yarn test --watch"
+    "test": "vitest run src",
+    "test:watch": "vitest watch src"
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -44,7 +44,7 @@
     "@types/envinfo": "7.8.3",
     "@types/uuid": "9.0.7",
     "@types/yargs": "17.0.32",
-    "jest": "29.7.0"
+    "vitest": "1.2.1"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/telemetry/src/__tests__/sendTelemetry.test.js
+++ b/packages/telemetry/src/__tests__/sendTelemetry.test.js
@@ -1,4 +1,6 @@
-const { sanitizeArgv } = require('../sendTelemetry')
+import { describe, it, expect } from 'vitest'
+
+import { sanitizeArgv } from '../sendTelemetry'
 
 describe('sanitizeArgv', () => {
   it('ignores commands with no replacements', () => {

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -17,9 +17,7 @@
     "build:pack": "yarn pack -o redwoodjs-tui.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
-    "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
-    "test:watch": "yarn test --watch"
+    "prepublishOnly": "NODE_ENV=production yarn build"
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -34,7 +32,6 @@
   },
   "devDependencies": {
     "esbuild": "0.19.9",
-    "jest": "29.7.0",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/tui/src/__tests__/index.test.js
+++ b/packages/tui/src/__tests__/index.test.js
@@ -1,1 +1,0 @@
-test.todo('implement tests')

--- a/yarn.lock
+++ b/yarn.lock
@@ -8533,6 +8533,7 @@ __metadata:
     fast-glob: "npm:3.3.2"
     jest: "npm:29.7.0"
     typescript: "npm:5.3.3"
+    vitest: "npm:1.2.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8697,7 +8697,7 @@ __metadata:
     "@redwoodjs/project-config": "npm:6.0.7"
     core-js: "npm:3.34.0"
     esbuild: "npm:0.19.9"
-    jest: "npm:29.7.0"
+    vitest: "npm:1.2.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8531,7 +8531,6 @@ __metadata:
     "@redwoodjs/api": "npm:6.0.7"
     esbuild: "npm:0.19.9"
     fast-glob: "npm:3.3.2"
-    jest: "npm:29.7.0"
     typescript: "npm:5.3.3"
     vitest: "npm:1.2.1"
   languageName: unknown
@@ -8780,9 +8779,9 @@ __metadata:
     ci-info: "npm:4.0.0"
     core-js: "npm:3.34.0"
     envinfo: "npm:7.11.0"
-    jest: "npm:29.7.0"
     systeminformation: "npm:5.21.20"
     uuid: "npm:9.0.1"
+    vitest: "npm:1.2.1"
     yargs: "npm:17.7.2"
   languageName: unknown
   linkType: soft
@@ -8833,7 +8832,6 @@ __metadata:
     chalk: "npm:4.1.2"
     enquirer: "npm:2.4.1"
     esbuild: "npm:0.19.9"
-    jest: "npm:29.7.0"
     stdout-update: "npm:1.6.8"
     typescript: "npm:5.3.3"
   languageName: unknown


### PR DESCRIPTION
This PR:
1. Switches `@redwoodjs/mailer-core` to vitest
2. Removes the blank test and testing deps for `@redwoodjs/tui`
3. Switches `@redwoodjs/telemetry` to vitest
4. Switched `@redwoodjs/record` to vitest

These changes have been made because the were relatively easy to do. They're not any particular priority. 