### PR TITLE
chore(vite): switch to vitest

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -60,9 +60,8 @@
     "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\"",
     "build:pack": "yarn pack -o redwoodjs-vite.tgz",
     "build:types": "tsc --build --verbose",
-    "test": "yarn test:node && echo",
-    "test:node": "glob './src/**/__tests__/*.test.mts' --cmd='tsx --no-warnings --test'",
-    "test:watch": "glob './src/**/__tests__/*.test.mts' --cmd='tsx --no-warnings --test --watch'"
+    "test": "vitest run src",
+    "test:watch": "vitest watch src"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.23.6",
@@ -94,7 +93,8 @@
     "glob": "10.3.10",
     "jest": "29.7.0",
     "rollup": "3.29.4",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vitest": "1.2.1"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -91,7 +91,6 @@
     "@types/react": "18.2.37",
     "@types/yargs-parser": "21.0.3",
     "glob": "10.3.10",
-    "jest": "29.7.0",
     "rollup": "3.29.4",
     "typescript": "5.3.3",
     "vitest": "1.2.1"

--- a/packages/vite/src/__tests__/viteNestedPages.test.mts
+++ b/packages/vite/src/__tests__/viteNestedPages.test.mts
@@ -229,9 +229,9 @@ describe('User specified imports, with static imports', () => {
   })
 
   it('Handles when imports from a page include non-default imports too', () => {
-     // Because we import import EditJobPage, 👉 { NonDefaultExport } from 'src/pages/Jobs/EditJobPage'
+    // Because we import import EditJobPage, 👉 { NonDefaultExport } from 'src/pages/Jobs/EditJobPage'
 
-     expect(outputWithStaticImports).toContain(
+    expect(outputWithStaticImports).toContain(
       'import { NonDefaultExport } from "'
     )
 

--- a/packages/vite/src/plugins/__tests__/remove-from-bundle.test.mts
+++ b/packages/vite/src/plugins/__tests__/remove-from-bundle.test.mts
@@ -1,21 +1,16 @@
-import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
+import { describe, it, expect } from 'vitest'
 
-import * as vitePluginRemoveFromBundle from '../vite-plugin-remove-from-bundle.js'
-
-// @ts-expect-error We have to write it this way to appease node:test, but TS doesn't seem to like it.
-// node:test needs to be configured correctly, I imagine.
-const { excludeOnMatch } = vitePluginRemoveFromBundle.default
+import { excludeOnMatch } from '../vite-plugin-remove-from-bundle'
 
 describe('excludeModule', () => {
   it('should return true if idToExclude matches id', () => {
     const loadOutput = excludeOnMatch([{
       id: /router\/dist\/splash-page/,
     }],
-    '/Users/dac09/Experiments/splash-page-null-loader/node_modules/@redwoodjs/router/dist/splash-page.js?commonjs-exports',
+      '/Users/dac09/Experiments/splash-page-null-loader/node_modules/@redwoodjs/router/dist/splash-page.js?commonjs-exports',
     )
 
-    assert.notStrictEqual(loadOutput, {
+    expect(loadOutput).not.toEqual({
       code: 'module.exports = null'
     })
   })
@@ -24,8 +19,8 @@ describe('excludeModule', () => {
     const loadOutput = excludeOnMatch([{
       id: /bazinga-page/,
     }],
-    '/Users/dac09/Experiments/splash-page-null-loader/node_modules/@redwoodjs/router/dist/params.js')
+      '/Users/dac09/Experiments/splash-page-null-loader/node_modules/@redwoodjs/router/dist/params.js')
 
-    assert.equal(loadOutput, null)
+    expect(loadOutput).toEqual(null)
   })
 })

--- a/packages/vite/src/plugins/__tests__/swap-apollo-provider.test.mts
+++ b/packages/vite/src/plugins/__tests__/swap-apollo-provider.test.mts
@@ -1,18 +1,14 @@
-import assert from 'node:assert/strict'
-import { describe, it } from 'node:test'
 
-import plugin from '../vite-plugin-swap-apollo-provider.js'
-
-// @ts-expect-error node test not configured correctly
-const swapApolloProvider = plugin.default
-
+import swapApolloProvider from '../vite-plugin-swap-apollo-provider'
+import { describe, it, expect } from 'vitest'
 
 describe('excludeModule', () => {
-  it('should swap the import', async() => {
+  it('should swap the import', async () => {
     const plugin = swapApolloProvider()
 
-   const output = await plugin.transform(`import ApolloProvider from '@redwoodjs/web/apollo'`, '/Users/dac09/Experiments/ssr-2354/web/src/App.tsx')
+    // @ts-expect-error The PluginOption type is 'false | Plugin_2 | PluginOption[] | Promise<false | Plugin_2 | PluginOption[] | null | undefined>' which does not gaurentee that the transform method exists.
+    const output = await plugin.transform(`import ApolloProvider from '@redwoodjs/web/apollo'`, '/Users/dac09/Experiments/ssr-2354/web/src/App.tsx')
 
-   assert.strictEqual(output, "import ApolloProvider from '@redwoodjs/web/dist/apollo/suspense'")
-})
+    expect(output).toEqual("import ApolloProvider from '@redwoodjs/web/dist/apollo/suspense'")
+  })
 })

--- a/packages/vite/vitest.config.mts
+++ b/packages/vite/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '**/fixtures', '**/dist'],
+  },
+})

--- a/packages/vite/vitest.config.mts
+++ b/packages/vite/vitest.config.mts
@@ -2,6 +2,6 @@ import { defineConfig, configDefaults } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    exclude: [...configDefaults.exclude, '**/fixtures', '**/dist'],
+    exclude: [...configDefaults.exclude, '**/fixtures'],
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8869,6 +8869,7 @@ __metadata:
     rollup: "npm:3.29.4"
     typescript: "npm:5.3.3"
     vite: "npm:4.5.1"
+    vitest: "npm:1.2.1"
     yargs-parser: "npm:21.1.1"
   bin:
     rw-dev-fe: ./dist/devFeServer.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -8863,7 +8863,6 @@ __metadata:
     glob: "npm:10.3.10"
     http-proxy-middleware: "npm:2.0.6"
     isbot: "npm:3.7.1"
-    jest: "npm:29.7.0"
     react: "npm:0.0.0-experimental-e5205658f-20230913"
     react-server-dom-webpack: "npm:0.0.0-experimental-e5205658f-20230913"
     rollup: "npm:3.29.4"


### PR DESCRIPTION
The vite package used the node test runner. This PR switches it over to vitest.

The transition was not difficult.
1. `before` and `after` for the node test runner have their vitest equivalents in `beforeAll` and `afterAll`. See: https://nodejs.org/api/test.html#afterfn-options where `after` is described as acting like `afterAll`.
2. Usage of `assert` was not too difficult to transition as they could be switched to `.toEqual` and `.not.toEqual`
3. Mocking of `fs` was achieved using spys and `mockImplementationOnce`. There was no clear need to use `Once` but it felt safer to assume that rather than continue to return the mock value for eternity.

@dac09 As requested I've switched this one out. One of the ts expect error comments is gone but one remains. From what I can see it seems to be a valid complaint - the type of `PluginOption` looks pretty funky. 