### PR TITLE
fix(createServer): use addHook instead of ready

### DIFF
--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -115,7 +115,7 @@ export async function redwoodFastifyGraphQLServer(
       })
     }
 
-    fastify.ready(() => {
+    fastify.addHook('onReady', (done) => {
       console.info(`GraphQL Yoga Server endpoint at ${yoga.graphqlEndpoint}`)
       console.info(
         `GraphQL Yoga Server Health Check endpoint at ${yoga.graphqlEndpoint}/health`
@@ -123,6 +123,8 @@ export async function redwoodFastifyGraphQLServer(
       console.info(
         `GraphQL Yoga Server Readiness endpoint at ${yoga.graphqlEndpoint}/readiness`
       )
+
+      done()
     })
 
     done()


### PR DESCRIPTION
Fixes the issue @Tobbe and I were seeing in studio:

```
~/redwood-project/node_modules/avvio/boot.js:244
    throw new AVV_ERR_ROOT_PLG_BOOTED()
          ^
AvvioError [Error]: Root plugin has already booted
  ...
```

`fastify.ready` actually starts the server. All this is doing is logging. We want to use `addHook` instead. Follow up to https://github.com/redwoodjs/redwood/pull/9845.