### PR TITLE
chore(esbuild): dedupe esbuild config

### DIFF
--- a/buildDefaults.mjs
+++ b/buildDefaults.mjs
@@ -1,0 +1,73 @@
+import path from 'node:path'
+
+import * as esbuild from 'esbuild'
+import fg from 'fast-glob'
+import fs from 'fs-extra'
+
+export const defaultBuildOptions = {
+  outdir: 'dist',
+
+  platform: 'node',
+  target: ['node20'],
+
+  format: 'cjs',
+
+  logLevel: 'info',
+
+  // For visualizing dist. See:
+  // - https://esbuild.github.io/api/#metafile
+  // - https://esbuild.github.io/analyze/
+  metafile: true,
+}
+
+export const defaultPatterns = ['./src/**/*.{ts,js}']
+export const defaultIgnorePatterns = ['**/__tests__', '**/*.test.{ts,js}']
+
+/**
+ * @typedef {{
+ *   cwd?: string
+ *   buildOptions?: import('esbuild').BuildOptions
+ *   entryPointOptions?: {
+ *     patterns?: string[]
+ *     ignore?: string[]
+ *   }
+ *   metafileName?: string
+ * }} BuildOptions
+ *
+ * @param {BuildOptions} options
+ */
+export async function build({
+  cwd,
+  buildOptions,
+  entryPointOptions,
+  metafileName,
+} = {}) {
+  // Yarn and Nx both set this to the package's root dir path
+  cwd ??= process.cwd()
+
+  buildOptions ??= defaultBuildOptions
+  metafileName ??= 'meta.json'
+
+  // If the user didn't explicitly provide entryPoints,
+  // then we'll use fg to find all the files in `${cwd}/src`
+  let entryPoints = buildOptions.entryPoints
+
+  if (!entryPoints) {
+    const patterns = entryPointOptions?.patterns ?? defaultPatterns
+    const ignore = entryPointOptions?.ignore ?? defaultIgnorePatterns
+
+    entryPoints = await fg(patterns, {
+      cwd,
+      ignore,
+    })
+  }
+
+  const result = await esbuild.build({
+    entryPoints,
+    ...buildOptions,
+  })
+
+  await fs.writeJSON(path.join(cwd, metafileName), result.metafile, {
+    spaces: 2,
+  })
+}

--- a/packages/babel-config/build.mjs
+++ b/packages/babel-config/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs/promises'
+import { build } from '../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-const sourceFiles = await fg.glob(['./src/**/*.ts'], {
-  ignore: ['./src/**/__tests__'],
-})
-
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing the bundle.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-await fs.writeFile('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -49,7 +49,6 @@
     "@types/babel__core": "7.20.4",
     "@types/node": "20.10.4",
     "babel-plugin-tester": "11.0.4",
-    "esbuild": "0.19.9",
     "jest": "29.7.0"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/cli-packages/dataMigrate/build.mjs
+++ b/packages/cli-packages/dataMigrate/build.mjs
@@ -1,57 +1,27 @@
-import fs from 'node:fs/promises'
+import {
+  build,
+  defaultBuildOptions,
+  defaultIgnorePatterns,
+} from '../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// ─── Package ─────────────────────────────────────────────────────────────────
-//
-// Types don't need to be transformed by esbuild, and the bin is bundled later.
-
-const sourceFiles = await fg.glob(['./src/**/*.ts'], {
-  ignore: ['./src/__tests__', './src/types.ts', './src/bin.ts'],
-})
-
-let result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing the bundle.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-await fs.writeFile('meta.json', JSON.stringify(result.metafile, null, 2))
-
-// ─── Bin ─────────────────────────────────────────────────────────────────────
-//
-// We build the bin differently because it doesn't have to asynchronously import the handler.
-
-result = await esbuild.build({
-  entryPoints: ['./src/bin.ts'],
-  outdir: 'dist',
-
-  banner: {
-    js: '#!/usr/bin/env node',
+// Build the package.
+await build({
+  entryPointOptions: {
+    ignore: [...defaultIgnorePatterns, './src/types.ts', './src/bin.ts'],
   },
-
-  bundle: true,
-  minify: true,
-
-  platform: 'node',
-  target: ['node20'],
-  packages: 'external',
-
-  logLevel: 'info',
-
-  // For visualizing the bundle.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
 })
 
-await fs.writeFile('meta.bins.json', JSON.stringify(result.metafile, null, 2))
+// Build the bin.
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+    bundle: true,
+    entryPoints: ['./src/bin.ts'],
+    minify: true,
+    packages: 'external',
+  },
+  metafileName: 'meta.bin.json',
+})

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -39,8 +39,6 @@
     "@prisma/client": "5.7.0",
     "@types/fs-extra": "11.0.4",
     "@types/yargs": "17.0.32",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "jest": "29.7.0",
     "memfs": "4.6.0",
     "typescript": "5.3.3"

--- a/packages/cli-packages/storybook/build.mjs
+++ b/packages/cli-packages/storybook/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/cli-packages/storybook/package.json
+++ b/packages/cli-packages/storybook/package.json
@@ -19,11 +19,6 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@redwoodjs/cli-helpers": "6.0.7",
     "@redwoodjs/project-config": "6.0.7",
@@ -40,9 +35,6 @@
   },
   "devDependencies": {
     "@types/yargs": "17.0.32",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
-    "jest": "29.7.0",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/context/.babelrc.js
+++ b/packages/context/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/context/build.mjs
+++ b/packages/context/build.mjs
@@ -1,27 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'], {
-  ignore: ['**/*.test.ts'],
-})
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node18'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -19,15 +19,7 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "devDependencies": {
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
-    "jest": "29.7.0",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -37,7 +37,6 @@
     "check-node-version": "4.2.1",
     "ci-info": "4.0.0",
     "envinfo": "7.11.0",
-    "esbuild": "0.19.9",
     "execa": "5.1.1",
     "fs-extra": "11.2.0",
     "jest": "29.7.0",

--- a/packages/create-redwood-app/scripts/build.js
+++ b/packages/create-redwood-app/scripts/build.js
@@ -1,7 +1,4 @@
-/* eslint-env node */
-
-import * as esbuild from 'esbuild'
-import fs from 'fs-extra'
+import { build, defaultBuildOptions } from '../../../buildDefaults.mjs'
 
 const jsBanner = `\
 #!/usr/bin/env node
@@ -11,24 +8,15 @@ const __filename = (await import("node:url")).fileURLToPath(import.meta.url);
 const __dirname = (await import("node:path")).dirname(__filename);
 `
 
-const result = await esbuild.build({
-  entryPoints: ['src/create-redwood-app.js'],
-  outdir: 'dist',
-
-  platform: 'node',
-  target: ['node20'],
-  format: 'esm',
-  bundle: true,
-  banner: {
-    js: jsBanner,
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    banner: {
+      js: jsBanner,
+    },
+    bundle: true,
+    entryPoints: ['src/create-redwood-app.js'],
+    format: 'esm',
+    minify: true,
   },
-
-  minify: true,
-
-  logLevel: 'info',
-  metafile: true,
-})
-
-await fs.writeJSON(new URL('./meta.json', import.meta.url), result.metafile, {
-  spaces: 2,
 })

--- a/packages/eslint-plugin/build.mjs
+++ b/packages/eslint-plugin/build.mjs
@@ -1,23 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-const sourceFiles = fg.sync(['./src/**/*.ts'], { ignore: ['./src/__tests__'] })
-
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -29,8 +29,6 @@
     "@types/eslint": "8",
     "@types/estree": "1.0.5",
     "@typescript-eslint/parser": "5.62.0",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "glob": "10.3.10",
     "tsx": "4.6.2",
     "typescript": "5.3.3"

--- a/packages/fastify/build.mjs
+++ b/packages/fastify/build.mjs
@@ -1,19 +1,3 @@
-import * as esbuild from 'esbuild'
+import { build } from '../../buildDefaults.mjs'
 
-await esbuild.build({
-  entryPoints: [
-    'src/api.ts',
-    'src/config.ts',
-    'src/index.ts',
-    'src/types.ts',
-    'src/web.ts',
-    'src/lambda/index.ts',
-  ],
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-})
+await build()

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -35,7 +35,6 @@
     "@types/aws-lambda": "8.10.126",
     "@types/lodash": "4.14.201",
     "@types/qs": "6.9.11",
-    "esbuild": "0.19.9",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/core/build.mjs
+++ b/packages/mailer/core/build.mjs
@@ -1,27 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'], {
-  ignore: ['**/*.test.ts'],
-})
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -21,15 +21,8 @@
     "test": "vitest run src",
     "test:watch": "vitest watch src"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "devDependencies": {
     "@redwoodjs/api": "6.0.7",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3",
     "vitest": "1.2.1"
   },

--- a/packages/mailer/handlers/in-memory/build.mjs
+++ b/packages/mailer/handlers/in-memory/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -19,17 +19,10 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@redwoodjs/mailer-core": "6.0.7"
   },
   "devDependencies": {
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/handlers/nodemailer/build.mjs
+++ b/packages/mailer/handlers/nodemailer/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -19,19 +19,12 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@redwoodjs/mailer-core": "6.0.7",
     "nodemailer": "6.9.7"
   },
   "devDependencies": {
     "@types/nodemailer": "^6",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/handlers/resend/build.mjs
+++ b/packages/mailer/handlers/resend/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -19,18 +19,11 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@redwoodjs/mailer-core": "6.0.7",
     "resend": "1.1.0"
   },
   "devDependencies": {
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/handlers/studio/build.mjs
+++ b/packages/mailer/handlers/studio/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -19,19 +19,12 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@redwoodjs/mailer-core": "6.0.7",
     "@redwoodjs/mailer-handler-nodemailer": "6.0.7"
   },
   "devDependencies": {
     "@types/nodemailer": "^6",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/renderers/mjml-react/build.mjs
+++ b/packages/mailer/renderers/mjml-react/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -19,11 +19,6 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@faire/mjml-react": "3.3.0",
     "@redwoodjs/mailer-core": "6.0.7",
@@ -31,8 +26,6 @@
   },
   "devDependencies": {
     "@types/mjml": "4",
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/renderers/react-email/build.mjs
+++ b/packages/mailer/renderers/react-email/build.mjs
@@ -1,25 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-// Get source files
-const sourceFiles = fg.sync(['./src/**/*.ts'])
-
-// Build general source files
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -19,18 +19,11 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@react-email/render": "0.0.10",
     "@redwoodjs/mailer-core": "6.0.7"
   },
   "devDependencies": {
-    "esbuild": "0.19.9",
-    "fast-glob": "3.3.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/project-config/build.js
+++ b/packages/project-config/build.js
@@ -1,28 +1,25 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
-import * as esbuild from 'esbuild'
+import { build, defaultBuildOptions } from '../../buildDefaults.mjs'
 
 const options = {
-  entryPoints: ['./src/index.ts'],
-  outdir: 'dist',
-
-  platform: 'node',
-  target: ['node20'],
+  ...defaultBuildOptions,
   bundle: true,
+  entryPoints: ['./src/index.ts'],
   packages: 'external',
-
-  logLevel: 'info',
-  metafile: true,
 }
 
-await esbuild.build({
-  ...options,
-  format: 'esm',
-  outExtension: { '.js': '.mjs' },
+// ESM build.
+await build({
+  buildOptions: {
+    ...options,
+    format: 'esm',
+    outExtension: { '.js': '.mjs' },
+  },
 })
 
-await esbuild.build({
-  ...options,
-  format: 'cjs',
-  outExtension: { '.js': '.cjs' },
+// CJS build.
+await build({
+  buildOptions: {
+    ...options,
+    outExtension: { '.js': '.cjs' },
+  },
 })

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -33,7 +33,6 @@
     "string-env-interpolation": "1.0.1"
   },
   "devDependencies": {
-    "esbuild": "0.19.9",
     "rimraf": "5.0.5",
     "typescript": "5.3.3",
     "vitest": "1.2.1"

--- a/packages/realtime/build.mjs
+++ b/packages/realtime/build.mjs
@@ -1,22 +1,10 @@
-import fs from 'node:fs'
+import { build, defaultBuildOptions } from '../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-
-const result = await esbuild.build({
-  entryPoints: ['src/index.ts'],
-  outdir: 'dist',
-
-  bundle: true,
-
-  platform: 'node',
-  target: ['node20'],
-  packages: 'external',
-
-  logLevel: 'info',
-
-  // For visualizing the bundle.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    bundle: true,
+    entryPoints: ['src/index.ts'],
+    packages: 'external',
+  },
 })
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile))

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -40,7 +40,6 @@
     "@envelop/core": "5.0.0",
     "@envelop/testing": "6.0.3",
     "@envelop/types": "4.0.1",
-    "esbuild": "0.19.9",
     "jest": "29.7.0",
     "nodemon": "3.0.2",
     "typescript": "5.3.3"

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -22,11 +22,6 @@
     "test": "vitest run src",
     "test:watch": "vitest watch src"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@babel/runtime-corejs3": "7.23.6",
     "@prisma/client": "5.7.0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -21,11 +21,6 @@
     "test": "vitest run src",
     "test:watch": "vitest watch src"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "@babel/runtime-corejs3": "7.23.6",
     "@redwoodjs/project-config": "6.0.7",

--- a/packages/tui/build.mjs
+++ b/packages/tui/build.mjs
@@ -1,19 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-
-// Since this is a library, there's no bundling going on here by design.
-// Instead we plan for this library to be bundled by leaf packages so-to-speak like create-redwood-app.
-const result = await esbuild.build({
-  entryPoints: ['src/index.ts'],
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-  outfile: 'dist/index.js',
-
-  // For visualizing the bundle.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile))
+await build()

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -19,11 +19,6 @@
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
-  "jest": {
-    "testPathIgnorePatterns": [
-      "/dist/"
-    ]
-  },
   "dependencies": {
     "boxen": "5.1.2",
     "chalk": "4.1.2",
@@ -31,7 +26,6 @@
     "stdout-update": "1.6.8"
   },
   "devDependencies": {
-    "esbuild": "0.19.9",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/web-server/.babelrc.js
+++ b/packages/web-server/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/web-server/build.mjs
+++ b/packages/web-server/build.mjs
@@ -1,23 +1,3 @@
-import fs from 'node:fs'
+import { build } from '../../buildDefaults.mjs'
 
-import * as esbuild from 'esbuild'
-import fg from 'fast-glob'
-
-const sourceFiles = fg.sync(['./src/**/*.ts'], { ignore: ['./src/__tests__'] })
-
-const result = await esbuild.build({
-  entryPoints: sourceFiles,
-  outdir: 'dist',
-
-  format: 'cjs',
-  platform: 'node',
-  target: ['node20'],
-
-  logLevel: 'info',
-
-  // For visualizing dist.
-  // See https://esbuild.github.io/api/#metafile and https://esbuild.github.io/analyze/.
-  metafile: true,
-})
-
-fs.writeFileSync('meta.json', JSON.stringify(result.metafile, null, 2))
+await build()

--- a/yarn.lock
+++ b/yarn.lock
@@ -8059,7 +8059,6 @@ __metadata:
     babel-plugin-module-resolver: "npm:5.0.0"
     babel-plugin-tester: "npm:11.0.4"
     core-js: "npm:3.34.0"
-    esbuild: "npm:0.19.9"
     fast-glob: "npm:3.3.2"
     graphql: "npm:16.8.1"
     jest: "npm:29.7.0"
@@ -8078,9 +8077,7 @@ __metadata:
     "@types/yargs": "npm:17.0.32"
     chalk: "npm:4.1.2"
     dotenv-defaults: "npm:5.0.2"
-    esbuild: "npm:0.19.9"
     execa: "npm:5.1.1"
-    fast-glob: "npm:3.3.2"
     fs-extra: "npm:11.2.0"
     jest: "npm:29.7.0"
     listr2: "npm:6.6.1"
@@ -8135,10 +8132,7 @@ __metadata:
     "@storybook/react-webpack5": "npm:7.6.4"
     "@types/yargs": "npm:17.0.32"
     chalk: "npm:4.1.2"
-    esbuild: "npm:0.19.9"
     execa: "npm:5.1.1"
-    fast-glob: "npm:3.3.2"
-    jest: "npm:29.7.0"
     storybook: "npm:7.6.4"
     terminal-link: "npm:2.1.1"
     typescript: "npm:5.3.3"
@@ -8261,9 +8255,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/context@workspace:packages/context"
   dependencies:
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
-    jest: "npm:29.7.0"
     typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
@@ -8365,9 +8356,7 @@ __metadata:
     "@types/estree": "npm:1.0.5"
     "@typescript-eslint/parser": "npm:5.62.0"
     "@typescript-eslint/utils": "npm:5.62.0"
-    esbuild: "npm:0.19.9"
     eslint: "npm:8.55.0"
-    fast-glob: "npm:3.3.2"
     glob: "npm:10.3.10"
     tsx: "npm:4.6.2"
     typescript: "npm:5.3.3"
@@ -8387,7 +8376,6 @@ __metadata:
     "@types/lodash": "npm:4.14.201"
     "@types/qs": "npm:6.9.11"
     ansi-colors: "npm:4.1.3"
-    esbuild: "npm:0.19.9"
     fast-glob: "npm:3.3.2"
     fastify: "npm:4.24.3"
     fastify-raw-body: "npm:4.3.0"
@@ -8527,8 +8515,6 @@ __metadata:
   resolution: "@redwoodjs/mailer-core@workspace:packages/mailer/core"
   dependencies:
     "@redwoodjs/api": "npm:6.0.7"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     typescript: "npm:5.3.3"
     vitest: "npm:1.2.1"
   languageName: unknown
@@ -8539,8 +8525,6 @@ __metadata:
   resolution: "@redwoodjs/mailer-handler-in-memory@workspace:packages/mailer/handlers/in-memory"
   dependencies:
     "@redwoodjs/mailer-core": "npm:6.0.7"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
@@ -8551,8 +8535,6 @@ __metadata:
   dependencies:
     "@redwoodjs/mailer-core": "npm:6.0.7"
     "@types/nodemailer": "npm:^6"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     nodemailer: "npm:6.9.7"
     typescript: "npm:5.3.3"
   languageName: unknown
@@ -8563,8 +8545,6 @@ __metadata:
   resolution: "@redwoodjs/mailer-handler-resend@workspace:packages/mailer/handlers/resend"
   dependencies:
     "@redwoodjs/mailer-core": "npm:6.0.7"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     resend: "npm:1.1.0"
     typescript: "npm:5.3.3"
   languageName: unknown
@@ -8577,8 +8557,6 @@ __metadata:
     "@redwoodjs/mailer-core": "npm:6.0.7"
     "@redwoodjs/mailer-handler-nodemailer": "npm:6.0.7"
     "@types/nodemailer": "npm:^6"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
@@ -8590,8 +8568,6 @@ __metadata:
     "@faire/mjml-react": "npm:3.3.0"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     "@types/mjml": "npm:4"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     mjml: "npm:4.14.1"
     typescript: "npm:5.3.3"
   languageName: unknown
@@ -8603,8 +8579,6 @@ __metadata:
   dependencies:
     "@react-email/render": "npm:0.0.10"
     "@redwoodjs/mailer-core": "npm:6.0.7"
-    esbuild: "npm:0.19.9"
-    fast-glob: "npm:3.3.2"
     typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
@@ -8644,7 +8618,6 @@ __metadata:
   dependencies:
     "@iarna/toml": "npm:2.2.5"
     deepmerge: "npm:4.3.1"
-    esbuild: "npm:0.19.9"
     fast-glob: "npm:3.3.2"
     rimraf: "npm:5.0.5"
     string-env-interpolation: "npm:1.0.1"
@@ -8669,7 +8642,6 @@ __metadata:
     "@graphql-yoga/subscription": "npm:4.0.0"
     "@n1ru4l/graphql-live-query": "npm:0.10.0"
     "@n1ru4l/in-memory-live-query-store": "npm:0.10.0"
-    esbuild: "npm:0.19.9"
     graphql: "npm:16.8.1"
     ioredis: "npm:^5.3.2"
     jest: "npm:29.7.0"
@@ -8829,7 +8801,6 @@ __metadata:
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     enquirer: "npm:2.4.1"
-    esbuild: "npm:0.19.9"
     stdout-update: "npm:1.6.8"
     typescript: "npm:5.3.3"
   languageName: unknown
@@ -15984,7 +15955,6 @@ __metadata:
     check-node-version: "npm:4.2.1"
     ci-info: "npm:4.0.0"
     envinfo: "npm:7.11.0"
-    esbuild: "npm:0.19.9"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.2.0"
     jest: "npm:29.7.0"


### PR DESCRIPTION
This PR cleans up duplicated esbuild config.

Any package using esbuild to build can import `build` from `buildDefaults.mjs` in the root of the framework and call it which should more often than not just work. It builds all source files the way babel currently does. It doesn't do any bundling or polyfilling or anything fancy by default. It can take a few options though to do fancy things. See these examples here for packages that are bundled and have dual exports:

- https://github.com/redwoodjs/redwood/blob/0c61531e8ed0f89b7210a6816b97d8c34cde2340/packages/project-config/build.js
- https://github.com/redwoodjs/redwood/blob/0c61531e8ed0f89b7210a6816b97d8c34cde2340/packages/cli-packages/dataMigrate/build.mjs

The goal here was to start cleaning up tech debt and duplicated code before it gets out of hand. I'm sure more patterns will arise or better ways of doing this as we migrate more packages away from Babel and to ESM.

I tested by checking in the dist from main by removing the `dist` line in the `.gitignore` and compared all of the changes against that.