### PR TITLE
Updates OAuth how-to to use new cookie encryption function, use user service for creation

### DIFF
--- a/docs/versioned_docs/version-6.3/how-to/oauth.md
+++ b/docs/versioned_docs/version-6.3/how-to/oauth.md
@@ -350,7 +350,7 @@ model Identity {
 
 We're also storing the `accessToken` and `scope` that we got back from the last time we retrived them from GitHub, as well as a timestamp for the last time the user logged in. Storing the `scope` is useful because if you ever change them, you may want to notify users that have the previous scope definition to re-login so the new scopes can be authorized.
 
-::: caution
+:::caution
 
 There's no GraphQL SDL tied to the Identity table, so it is not accessible via our API. But, if you ever did create an SDL and service, be sure that `accessToken` is not in the list of fields exposed publicly!
 
@@ -390,8 +390,10 @@ Be sure to import `db` at the top of the file if you haven't already!
 :::
 
 ```js title="/api/src/functions/oauth/oauth.js"
-// highlight-next-line
+// highlight-start
 import { db } from 'src/lib/db'
+import { user, createUser } from 'src/services/users'
+// highlight-end
 
 const callback = async (event) => {
   const { code } = event.queryStringParameters
@@ -450,29 +452,27 @@ const findOrCreateUser = async (providerUser) => {
 
   if (identity) {
     // identity exists, return the user
-    const user = await db.user.findUnique({ where: { id: identity.userId }})
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
   // identity not found, need to create it and the user
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    }
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString()
-      }
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString()
+    }
+  })
+
+  return { user, identity }
 }
 // highlight-end
 ```
@@ -512,7 +512,7 @@ const findOrCreateUser = async (providerUser) => {
   })
 
   if (identity) {
-    const user = await db.user.findUnique({ where: { id: identity.userId }})
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
@@ -520,34 +520,32 @@ const findOrCreateUser = async (providerUser) => {
 }
 ```
 
-If the user already exists, great! Return it, and the attached `identity` so that we can update the details. If the user doesn't exist already:
+Note we're using the `user()` function defined in our service, re-using any business logic you may have added around looking up a user. If the user already exists, great! Return it, and the attached `identity` so that we can update the details. If the user doesn't exist already:
 
 ```js
 const findOrCreateUser = async (providerUser) => {
   // ...
 
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    }
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString()
-      }
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString()
+    }
+  })
+
+  return { user, identity }
 }
 ```
 
-We create the `user` and the `identity` records inside a transaction so that if something goes wrong, both records fail to create. The error would bubble up to the try/catch inside `callback()`. (The Redwood test project has a required `fullName` field that we fill with the `name` attribute from GitHub.)
+We create the `user` via the existing `createUser()` service, but the `identity` directly in the database. For this particular usecase we have no need of allowing access to the `Identity` data via GraphQL, so there's no reason to create and SDL or underlying service. If you did make them available via GraphQL, it would make sense to replace this create with the `createIdentity()` service. Any error raised during creation would bubble up to the try/catch inside `callback()`. (The Redwood test project has a required `fullName` field that we fill with the `name` attribute from GitHub.)
 
 :::info
 Don't forget the `toString()` calls whenever we read or write the `providerUser.id` since we made the `uid` of type `String`.
@@ -573,11 +571,13 @@ In order to let dbAuth do the work of actually considering us logged in (and han
 
 Setting a cookie in the browser is a matter of returning a `Set-Cookie` header in the response from the server. We've been responding with a dump of the user object, but now we'll do a real return, including the cookie and a `Location` header to redirect us back to the site.
 
-Don't forget the new `CryptoJS` import at the top!
+Redwood provides the cookie encryption helper as a function that you can use in your own code, as well as the function that returns the cookie name based on what you set in your auth config:
 
 ```js title="/api/src/functions/oauth/oauth.js"
-// highlight-next-line
-import CryptoJS from 'crypto-js'
+// highlight-start
+import { cookieName, encryptSession } from '@redwoodjs/auth-dbauth-api'
+import { cookieName as sessionCookieName } from 'src/lib/auth'
+// highlight-end
 
 const callback = async (event) => {
   const { code } = event.queryStringParameters
@@ -638,13 +638,11 @@ const secureCookie = (user) => {
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
+  const encrypted = encryptSession(data)
 
-  const encrypted = CryptoJS.AES.encrypt(
-    data,
-    process.env.SESSION_SECRET
-  ).toString()
-
-  return [`session=${encrypted}`, ...cookieAttrs].join('; ')
+  return [`${cookieName(sessionCookieName)}=${encrypted}`, ...cookieAttrs].join(
+    '; '
+  )
 }
 // highlight-end
 ```
@@ -660,8 +658,10 @@ Try it out, and as long as you have an indication on your site that a user is lo
 Here's the `oauth` function in its entirety:
 
 ```jsx title="/api/src/functions/oauth/oauth.js"
-import CryptoJS from 'crypto-js'
+import { cookieName, encryptSession } from '@redwoodjs/auth-dbauth-api'
 
+import { cookieName as sessionCookieName } from 'src/lib/auth'
+import { user, createUser } from 'src/services/users'
 import { db } from 'src/lib/db'
 
 export const handler = async (event, _context) => {
@@ -732,13 +732,11 @@ const secureCookie = (user) => {
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
+  const encrypted = encryptSession(data)
 
-  const encrypted = CryptoJS.AES.encrypt(
-    data,
-    process.env.SESSION_SECRET
-  ).toString()
-
-  return [`session=${encrypted}`, ...cookieAttrs].join('; ')
+  return [`${cookieName(sessionCookieName)}=${encrypted}`, ...cookieAttrs].join(
+    '; '
+  )
 }
 
 const getProviderUser = async (token) => {
@@ -768,29 +766,27 @@ const findOrCreateUser = async (providerUser) => {
 
   if (identity) {
     // identity exists, return the user
-    const user = await db.user.findUnique({ where: { id: identity.userId } })
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
   // identity not found, need to create it and the user
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    })
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString(),
-      },
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString(),
+    },
+  })
+
+  return { user, identity }
 }
 ```
 

--- a/docs/versioned_docs/version-6.4/how-to/oauth.md
+++ b/docs/versioned_docs/version-6.4/how-to/oauth.md
@@ -350,7 +350,7 @@ model Identity {
 
 We're also storing the `accessToken` and `scope` that we got back from the last time we retrived them from GitHub, as well as a timestamp for the last time the user logged in. Storing the `scope` is useful because if you ever change them, you may want to notify users that have the previous scope definition to re-login so the new scopes can be authorized.
 
-::: caution
+:::caution
 
 There's no GraphQL SDL tied to the Identity table, so it is not accessible via our API. But, if you ever did create an SDL and service, be sure that `accessToken` is not in the list of fields exposed publicly!
 
@@ -390,8 +390,10 @@ Be sure to import `db` at the top of the file if you haven't already!
 :::
 
 ```js title="/api/src/functions/oauth/oauth.js"
-// highlight-next-line
+// highlight-start
 import { db } from 'src/lib/db'
+import { user, createUser } from 'src/services/users'
+// highlight-end
 
 const callback = async (event) => {
   const { code } = event.queryStringParameters
@@ -450,29 +452,27 @@ const findOrCreateUser = async (providerUser) => {
 
   if (identity) {
     // identity exists, return the user
-    const user = await db.user.findUnique({ where: { id: identity.userId }})
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
   // identity not found, need to create it and the user
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    }
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString()
-      }
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString()
+    }
+  })
+
+  return { user, identity }
 }
 // highlight-end
 ```
@@ -512,7 +512,7 @@ const findOrCreateUser = async (providerUser) => {
   })
 
   if (identity) {
-    const user = await db.user.findUnique({ where: { id: identity.userId }})
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
@@ -520,34 +520,32 @@ const findOrCreateUser = async (providerUser) => {
 }
 ```
 
-If the user already exists, great! Return it, and the attached `identity` so that we can update the details. If the user doesn't exist already:
+Note we're using the `user()` function defined in our service, re-using any business logic you may have added around looking up a user. If the user already exists, great! Return it, and the attached `identity` so that we can update the details. If the user doesn't exist already:
 
 ```js
 const findOrCreateUser = async (providerUser) => {
   // ...
 
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    }
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString()
-      }
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString()
+    }
+  })
+
+  return { user, identity }
 }
 ```
 
-We create the `user` and the `identity` records inside a transaction so that if something goes wrong, both records fail to create. The error would bubble up to the try/catch inside `callback()`. (The Redwood test project has a required `fullName` field that we fill with the `name` attribute from GitHub.)
+We create the `user` via the existing `createUser()` service, but the `identity` directly in the database. For this particular usecase we have no need of allowing access to the `Identity` data via GraphQL, so there's no reason to create and SDL or underlying service. If you did make them available via GraphQL, it would make sense to replace this create with the `createIdentity()` service. Any error raised during creation would bubble up to the try/catch inside `callback()`. (The Redwood test project has a required `fullName` field that we fill with the `name` attribute from GitHub.)
 
 :::info
 Don't forget the `toString()` calls whenever we read or write the `providerUser.id` since we made the `uid` of type `String`.
@@ -573,11 +571,13 @@ In order to let dbAuth do the work of actually considering us logged in (and han
 
 Setting a cookie in the browser is a matter of returning a `Set-Cookie` header in the response from the server. We've been responding with a dump of the user object, but now we'll do a real return, including the cookie and a `Location` header to redirect us back to the site.
 
-Don't forget the new `CryptoJS` import at the top!
+Redwood provides the cookie encryption helper as a function that you can use in your own code, as well as the function that returns the cookie name based on what you set in your auth config:
 
 ```js title="/api/src/functions/oauth/oauth.js"
-// highlight-next-line
-import CryptoJS from 'crypto-js'
+// highlight-start
+import { cookieName, encryptSession } from '@redwoodjs/auth-dbauth-api'
+import { cookieName as sessionCookieName } from 'src/lib/auth'
+// highlight-end
 
 const callback = async (event) => {
   const { code } = event.queryStringParameters
@@ -638,13 +638,11 @@ const secureCookie = (user) => {
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
+  const encrypted = encryptSession(data)
 
-  const encrypted = CryptoJS.AES.encrypt(
-    data,
-    process.env.SESSION_SECRET
-  ).toString()
-
-  return [`session=${encrypted}`, ...cookieAttrs].join('; ')
+  return [`${cookieName(sessionCookieName)}=${encrypted}`, ...cookieAttrs].join(
+    '; '
+  )
 }
 // highlight-end
 ```
@@ -660,8 +658,10 @@ Try it out, and as long as you have an indication on your site that a user is lo
 Here's the `oauth` function in its entirety:
 
 ```jsx title="/api/src/functions/oauth/oauth.js"
-import CryptoJS from 'crypto-js'
+import { cookieName, encryptSession } from '@redwoodjs/auth-dbauth-api'
 
+import { cookieName as sessionCookieName } from 'src/lib/auth'
+import { user, createUser } from 'src/services/users'
 import { db } from 'src/lib/db'
 
 export const handler = async (event, _context) => {
@@ -732,13 +732,11 @@ const secureCookie = (user) => {
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
+  const encrypted = encryptSession(data)
 
-  const encrypted = CryptoJS.AES.encrypt(
-    data,
-    process.env.SESSION_SECRET
-  ).toString()
-
-  return [`session=${encrypted}`, ...cookieAttrs].join('; ')
+  return [`${cookieName(sessionCookieName)}=${encrypted}`, ...cookieAttrs].join(
+    '; '
+  )
 }
 
 const getProviderUser = async (token) => {
@@ -768,29 +766,27 @@ const findOrCreateUser = async (providerUser) => {
 
   if (identity) {
     // identity exists, return the user
-    const user = await db.user.findUnique({ where: { id: identity.userId } })
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
   // identity not found, need to create it and the user
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    })
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString(),
-      },
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString(),
+    },
+  })
+
+  return { user, identity }
 }
 ```
 

--- a/docs/versioned_docs/version-6.5/how-to/oauth.md
+++ b/docs/versioned_docs/version-6.5/how-to/oauth.md
@@ -350,7 +350,7 @@ model Identity {
 
 We're also storing the `accessToken` and `scope` that we got back from the last time we retrived them from GitHub, as well as a timestamp for the last time the user logged in. Storing the `scope` is useful because if you ever change them, you may want to notify users that have the previous scope definition to re-login so the new scopes can be authorized.
 
-::: caution
+:::caution
 
 There's no GraphQL SDL tied to the Identity table, so it is not accessible via our API. But, if you ever did create an SDL and service, be sure that `accessToken` is not in the list of fields exposed publicly!
 
@@ -390,8 +390,10 @@ Be sure to import `db` at the top of the file if you haven't already!
 :::
 
 ```js title="/api/src/functions/oauth/oauth.js"
-// highlight-next-line
+// highlight-start
 import { db } from 'src/lib/db'
+import { user, createUser } from 'src/services/users'
+// highlight-end
 
 const callback = async (event) => {
   const { code } = event.queryStringParameters
@@ -450,29 +452,27 @@ const findOrCreateUser = async (providerUser) => {
 
   if (identity) {
     // identity exists, return the user
-    const user = await db.user.findUnique({ where: { id: identity.userId }})
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
   // identity not found, need to create it and the user
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    }
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString()
-      }
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString()
+    }
+  })
+
+  return { user, identity }
 }
 // highlight-end
 ```
@@ -512,7 +512,7 @@ const findOrCreateUser = async (providerUser) => {
   })
 
   if (identity) {
-    const user = await db.user.findUnique({ where: { id: identity.userId }})
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
@@ -520,34 +520,32 @@ const findOrCreateUser = async (providerUser) => {
 }
 ```
 
-If the user already exists, great! Return it, and the attached `identity` so that we can update the details. If the user doesn't exist already:
+Note we're using the `user()` function defined in our service, re-using any business logic you may have added around looking up a user. If the user already exists, great! Return it, and the attached `identity` so that we can update the details. If the user doesn't exist already:
 
 ```js
 const findOrCreateUser = async (providerUser) => {
   // ...
 
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    }
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString()
-      }
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString()
+    }
+  })
+
+  return { user, identity }
 }
 ```
 
-We create the `user` and the `identity` records inside a transaction so that if something goes wrong, both records fail to create. The error would bubble up to the try/catch inside `callback()`. (The Redwood test project has a required `fullName` field that we fill with the `name` attribute from GitHub.)
+We create the `user` via the existing `createUser()` service, but the `identity` directly in the database. For this particular usecase we have no need of allowing access to the `Identity` data via GraphQL, so there's no reason to create and SDL or underlying service. If you did make them available via GraphQL, it would make sense to replace this create with the `createIdentity()` service. Any error raised during creation would bubble up to the try/catch inside `callback()`. (The Redwood test project has a required `fullName` field that we fill with the `name` attribute from GitHub.)
 
 :::info
 Don't forget the `toString()` calls whenever we read or write the `providerUser.id` since we made the `uid` of type `String`.
@@ -573,11 +571,13 @@ In order to let dbAuth do the work of actually considering us logged in (and han
 
 Setting a cookie in the browser is a matter of returning a `Set-Cookie` header in the response from the server. We've been responding with a dump of the user object, but now we'll do a real return, including the cookie and a `Location` header to redirect us back to the site.
 
-Don't forget the new `CryptoJS` import at the top!
+Redwood provides the cookie encryption helper as a function that you can use in your own code, as well as the function that returns the cookie name based on what you set in your auth config:
 
 ```js title="/api/src/functions/oauth/oauth.js"
-// highlight-next-line
-import CryptoJS from 'crypto-js'
+// highlight-start
+import { cookieName, encryptSession } from '@redwoodjs/auth-dbauth-api'
+import { cookieName as sessionCookieName } from 'src/lib/auth'
+// highlight-end
 
 const callback = async (event) => {
   const { code } = event.queryStringParameters
@@ -638,13 +638,11 @@ const secureCookie = (user) => {
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
+  const encrypted = encryptSession(data)
 
-  const encrypted = CryptoJS.AES.encrypt(
-    data,
-    process.env.SESSION_SECRET
-  ).toString()
-
-  return [`session=${encrypted}`, ...cookieAttrs].join('; ')
+  return [`${cookieName(sessionCookieName)}=${encrypted}`, ...cookieAttrs].join(
+    '; '
+  )
 }
 // highlight-end
 ```
@@ -660,8 +658,10 @@ Try it out, and as long as you have an indication on your site that a user is lo
 Here's the `oauth` function in its entirety:
 
 ```jsx title="/api/src/functions/oauth/oauth.js"
-import CryptoJS from 'crypto-js'
+import { cookieName, encryptSession } from '@redwoodjs/auth-dbauth-api'
 
+import { cookieName as sessionCookieName } from 'src/lib/auth'
+import { user, createUser } from 'src/services/users'
 import { db } from 'src/lib/db'
 
 export const handler = async (event, _context) => {
@@ -732,13 +732,11 @@ const secureCookie = (user) => {
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
+  const encrypted = encryptSession(data)
 
-  const encrypted = CryptoJS.AES.encrypt(
-    data,
-    process.env.SESSION_SECRET
-  ).toString()
-
-  return [`session=${encrypted}`, ...cookieAttrs].join('; ')
+  return [`${cookieName(sessionCookieName)}=${encrypted}`, ...cookieAttrs].join(
+    '; '
+  )
 }
 
 const getProviderUser = async (token) => {
@@ -768,29 +766,27 @@ const findOrCreateUser = async (providerUser) => {
 
   if (identity) {
     // identity exists, return the user
-    const user = await db.user.findUnique({ where: { id: identity.userId } })
+    const user = await user({ id: identity.userId })
     return { user, identity }
   }
 
   // identity not found, need to create it and the user
-  return await db.$transaction(async (tx) => {
-    const user = await tx.user.create({
-      data: {
-        email: providerUser.email,
-        fullName: providerUser.name,
-      },
-    })
-
-    const identity = await tx.identity.create({
-      data: {
-        userId: user.id,
-        provider: 'github',
-        uid: providerUser.id.toString(),
-      },
-    })
-
-    return { user, identity }
+  const user = await createUser({
+    input: {
+      email: providerUser.email,
+      fullName: providerUser.name,
+    },
   })
+
+  const identity = await tx.identity.create({
+    data: {
+      userId: user.id,
+      provider: 'github',
+      uid: providerUser.id.toString(),
+    },
+  })
+
+  return { user, identity }
 }
 ```
 


### PR DESCRIPTION
Went to add OAuth to one of my apps and realized that this had the old, manual method of encrypting the cookie. dbAuth now exports a shared function that you can use instead (which uses the new, more secure encryption algorithm).

Also realized I should have been following good Redwood practice and reuse the existing user creation service function rather than creating the user via Prisma directly.

The docs have been backported to 6.3 and up since the new algorithm was released in 6.3.3.