### PR TITLE
fix(gql): Add back gql global type

### DIFF
--- a/packages/internal/src/generate/trustedDocuments.ts
+++ b/packages/internal/src/generate/trustedDocuments.ts
@@ -52,8 +52,14 @@ export const replaceGqlTagWithTrustedDocumentGraphql = (
   const gqlFile = gqlFileOutput[0]
 
   if (gqlFile && gqlFile.content) {
-    gqlFile.content +=
-      'export function gql(source: string) { return graphql(source); }'
+    gqlFile.content += `\n
+      export function gql(source: string | TemplateStringsArray) {
+        if (typeof source === 'string') {
+          return graphql(source)
+        }
+
+        return graphql(source.join('\\n'))
+      }`
 
     const content = format(gqlFile.content, {
       trailingComma: 'es5',

--- a/packages/web/src/global.web-auto-imports.ts
+++ b/packages/web/src/global.web-auto-imports.ts
@@ -1,12 +1,17 @@
 import type _React from 'react'
 
-import type _gql from 'graphql-tag'
+import type { DocumentNode } from 'graphql'
 
 // These are the global types exposed to a user's project
 // For "internal" global types see ambient.d.ts
 
 declare global {
-  // const gql: typeof _gql
+  // This type is used for both regular RW projects and projects that have
+  // enabled Trusted Documents. For regular RW projects, this could have been
+  // typed just by importing gql from `graphql-tag`. But for Trusted Documents
+  // the type should be imported from `web/src/graphql/gql` in the user's
+  // project. The type here is generic enough to cover both cases.
+  const gql: (source: string | TemplateStringsArray) => DocumentNode
 
   // Having this as a type instead of a const allows us to augment/override it
   // in other packages


### PR DESCRIPTION
When Trusted Documents were introduced in https://github.com/redwoodjs/redwood/pull/9416 we accidentally lost the type for the global `gql` tagged template literal function.

This PR adds the global type back, and also improves the function we generate to handle matching `gql` for both regular RW projects and for TD-enabled RW projects.

New projects created with `yarn create redwood-app` currently gives you this for the `gql` tagged template literal function

![image](https://github.com/redwoodjs/redwood/assets/30793/bddab14c-616d-43cf-95d2-1f39e3dfd3c1)

Switching to canary, to get the code that enables support for TDs (with or without actually enabling them) makes it look like this

![image](https://github.com/redwoodjs/redwood/assets/30793/f808e703-3c53-4365-abf9-207103f8259f)

With this PR in place you'd instead see this, which is obviously better than red squiggles, but also better than what we've ever had before, imo

![image](https://github.com/redwoodjs/redwood/assets/30793/44d351f7-c528-4d57-852f-de2571979b71)
