### PR TITLE
chore(fixtures): Update gql file content as a result of trusted documents fix

### DIFF
--- a/__fixtures__/example-todo-main/web/src/graphql/gql.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/gql.ts
@@ -68,6 +68,11 @@ export function graphql(source: string) {
 
 export type DocumentType<TDocumentNode extends DocumentNode<any, any>> =
   TDocumentNode extends DocumentNode<infer TType, any> ? TType : never;
-export function gql(source: string) {
-  return graphql(source);
+
+export function gql(source: string | TemplateStringsArray) {
+  if (typeof source === "string") {
+    return graphql(source);
+  }
+
+  return graphql(source.join("\n"));
 }


### PR DESCRIPTION
@Tobbe This looks to have failed publishing the canary/rc due to the uncommited changes that result after running `yarn test`. This was only file that changed for me but perhaps you have some more context on others that might also need updating.