### PR TITLE
chore(cli): Move coerceRootPath()

### DIFF
--- a/packages/adapters/fastify/web/build.mjs
+++ b/packages/adapters/fastify/web/build.mjs
@@ -1,10 +1,19 @@
 import { build, defaultBuildOptions } from '../../../../buildDefaults.mjs'
 
+// Build the main entry point
 await build({
   buildOptions: {
     ...defaultBuildOptions,
     bundle: true,
     entryPoints: ['./src/web.ts'],
     packages: 'external',
+  },
+})
+
+// Build the helpers entry point
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    entryPoints: ['./src/helpers.ts'],
   },
 })

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/web.d.ts",
       "default": "./dist/web.js"
+    },
+    "./helpers": {
+      "types": "./dist/helpers.d.ts",
+      "default": "./dist/helpers.js"
     }
   },
   "types": "./dist/web.d.ts",

--- a/packages/adapters/fastify/web/src/helpers.ts
+++ b/packages/adapters/fastify/web/src/helpers.ts
@@ -1,0 +1,7 @@
+/** Ensures that `path` starts and ends with a slash ('/') */
+export function coerceRootPath(path: string) {
+  const prefix = path.charAt(0) !== '/' ? '/' : ''
+  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
+
+  return `${prefix}${path}${suffix}`
+}

--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -122,3 +122,12 @@ export async function redwoodFastifyWeb(
 
   done()
 }
+
+// Note that Studio depends on this export
+/** Ensures that `path` starts and ends with a slash ('/') */
+export function coerceRootPath(path: string) {
+  const prefix = path.charAt(0) !== '/' ? '/' : ''
+  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
+
+  return `${prefix}${path}${suffix}`
+}

--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -14,10 +14,11 @@ import type {
 
 import { getPaths } from '@redwoodjs/project-config'
 
+import { coerceRootPath } from './helpers'
 import { resolveOptions } from './resolveOptions'
 import type { RedwoodFastifyWebOptions } from './types'
 
-export { RedwoodFastifyWebOptions }
+export { coerceRootPath, RedwoodFastifyWebOptions }
 
 export async function redwoodFastifyWeb(
   fastify: FastifyInstance,
@@ -114,13 +115,4 @@ export async function redwoodFastifyWeb(
   })
 
   done()
-}
-
-// Note that Studio depends on this export
-/** Ensures that `path` starts and ends with a slash ('/') */
-export function coerceRootPath(path: string) {
-  const prefix = path.charAt(0) !== '/' ? '/' : ''
-  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
-
-  return `${prefix}${path}${suffix}`
 }

--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -70,14 +70,7 @@ export async function redwoodFastifyWeb(
       })
     }
 
-    // Make sure apiUrl starts and ends with a slash
-    const prefix = redwoodOptions.apiUrl.charAt(0) !== '/' ? '/' : ''
-    const suffix =
-      redwoodOptions.apiUrl.charAt(redwoodOptions.apiUrl.length - 1) !== '/'
-        ? '/'
-        : ''
-
-    const apiUrlWarningPath = `${prefix}${redwoodOptions.apiUrl}${suffix}`
+    const apiUrlWarningPath = coerceRootPath(redwoodOptions.apiUrl)
 
     fastify.all(apiUrlWarningPath, apiUrlHandler)
     fastify.all(`${apiUrlWarningPath}*`, apiUrlHandler)

--- a/packages/api-server/src/cliHandlers.ts
+++ b/packages/api-server/src/cliHandlers.ts
@@ -1,6 +1,6 @@
 import c from 'ansi-colors'
 
-import { redwoodFastifyWeb } from '@redwoodjs/fastify-web'
+import { redwoodFastifyWeb, coerceRootPath } from '@redwoodjs/fastify-web'
 import { getConfig } from '@redwoodjs/project-config'
 
 import createFastifyInstance from './fastify'
@@ -99,14 +99,6 @@ export const bothServerHandler = async (options: BothServerArgs) => {
     console.log(`GraphQL endpoint at ${graphqlEnd}`)
     sendProcessReady()
   })
-}
-
-function coerceRootPath(path: string) {
-  // Make sure that we create a root path that starts and ends with a slash (/)
-  const prefix = path.charAt(0) !== '/' ? '/' : ''
-  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
-
-  return `${prefix}${path}${suffix}`
 }
 
 // Temporarily here till we refactor server code

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "@redwoodjs/api-server": "6.0.7",
     "@redwoodjs/cli-helpers": "6.0.7",
     "@redwoodjs/fastify": "6.0.7",
+    "@redwoodjs/fastify-web": "6.0.7",
     "@redwoodjs/internal": "6.0.7",
     "@redwoodjs/prerender": "6.0.7",
     "@redwoodjs/project-config": "6.0.7",

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -206,9 +206,9 @@ export const builder = async (yargs) => {
 }
 
 // We'll clean this up later, but for now note that this function is
-// duplicated between this package and @redwoodjs/fastify
-// to avoid importing @redwoodjs/fastify when the CLI starts.
-export function coerceRootPath(path) {
+// duplicated between this package and @redwoodjs/fastify-web
+// to avoid importing @redwoodjs/fastify-web when the CLI starts.
+function coerceRootPath(path) {
   // Make sure that we create a root path that starts and ends with a slash (/)
   const prefix = path.charAt(0) !== '/' ? '/' : ''
   const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -4,6 +4,7 @@ import fs from 'fs-extra'
 import terminalLink from 'terminal-link'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
+import { coerceRootPath } from '@redwoodjs/fastify-web/helpers'
 import * as webServerCLIConfig from '@redwoodjs/web-server'
 
 import { getPaths, getConfig } from '../lib'
@@ -203,15 +204,4 @@ export const builder = async (yargs) => {
         'https://redwoodjs.com/docs/cli-commands#serve'
       )}`
     )
-}
-
-// We'll clean this up later, but for now note that this function is
-// duplicated between this package and @redwoodjs/fastify-web
-// to avoid importing @redwoodjs/fastify-web when the CLI starts.
-function coerceRootPath(path) {
-  // Make sure that we create a root path that starts and ends with a slash (/)
-  const prefix = path.charAt(0) !== '/' ? '/' : ''
-  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
-
-  return `${prefix}${path}${suffix}`
 }

--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -4,12 +4,8 @@ import chalk from 'chalk'
 import concurrently from 'concurrently'
 import execa from 'execa'
 
-import {
-  coerceRootPath,
-  createFastifyInstance,
-  redwoodFastifyAPI,
-} from '@redwoodjs/fastify'
-import { redwoodFastifyWeb } from '@redwoodjs/fastify-web'
+import { createFastifyInstance, redwoodFastifyAPI } from '@redwoodjs/fastify'
+import { redwoodFastifyWeb, coerceRootPath } from '@redwoodjs/fastify-web'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 import { errorTelemetry } from '@redwoodjs/telemetry'
 

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -14,13 +14,3 @@ export { redwoodFastifyAPI } from './api.js'
 export type * from './types.js'
 
 export { DEFAULT_REDWOOD_FASTIFY_CONFIG } from './config.js'
-
-/**
- * Ensures that `path` starts and ends with a slash ('/')
- */
-export function coerceRootPath(path: string) {
-  const prefix = path.charAt(0) !== '/' ? '/' : ''
-  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
-
-  return `${prefix}${path}${suffix}`
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8155,6 +8155,7 @@ __metadata:
     "@redwoodjs/api-server": "npm:6.0.7"
     "@redwoodjs/cli-helpers": "npm:6.0.7"
     "@redwoodjs/fastify": "npm:6.0.7"
+    "@redwoodjs/fastify-web": "npm:6.0.7"
     "@redwoodjs/internal": "npm:6.0.7"
     "@redwoodjs/prerender": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"


### PR DESCRIPTION
Move `coerceRootPath()` to the new `@redwoodjs/fastify-web` package.
It was previously exported from `@redwoodjs/fastify`, but everyone who imported it from there uses it together with `redwoodFastifyWeb`, which is exported from `@redwoodjs/fastify-web`, so I thought it made sense this function also lives there.

Also managed to remove a duplicated implementation from another package.