### PR TITLE
fix(studio): Bump minimum RW canary version

### DIFF
--- a/packages/cli/src/commands/studioHandler.js
+++ b/packages/cli/src/commands/studioHandler.js
@@ -11,7 +11,7 @@ export const handler = async (options) => {
   try {
     // Check the module is installed
     if (!isModuleInstalled('@redwoodjs/studio')) {
-      const minVersions = ['7.0.0-canary.874', '7.x', '8.0.0-0']
+      const minVersions = ['7.0.0-canary.889', '7.x', '8.0.0-0']
       assertRedwoodVersion(minVersions)
 
       console.log(


### PR DESCRIPTION
Studio now imports from `@redwoodjs/fastify-web` which was introduced in a newer canary than what our min version was previously set to. So need to update it, or you'll get runtime errors when trying to start Studio if your canary version is too old