### PR TITLE
fix(web): import helmet from node_modules

### DIFF
--- a/packages/web/src/components/Metadata.tsx
+++ b/packages/web/src/components/Metadata.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Head as HelmetHead } from '../index'
+import { Helmet as HelmetHead } from 'react-helmet-async'
 
 // Ideally we wouldn't include this for non experiment builds
 // But.... not worth the effort to remove it from bundle atm


### PR DESCRIPTION
We can import this straight from node_modules instead of loading all the index which imports a bunch of other files and node_modules first. 