### PR TITLE
fix(server): don't mix async and callback styles

### DIFF
--- a/packages/adapters/fastify/web/src/web.ts
+++ b/packages/adapters/fastify/web/src/web.ts
@@ -5,12 +5,7 @@ import httpProxy from '@fastify/http-proxy'
 import fastifyStatic from '@fastify/static'
 import fastifyUrlData from '@fastify/url-data'
 import fg from 'fast-glob'
-import type {
-  FastifyInstance,
-  FastifyReply,
-  FastifyRequest,
-  HookHandlerDoneFunction,
-} from 'fastify'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -22,8 +17,7 @@ export { coerceRootPath, RedwoodFastifyWebOptions }
 
 export async function redwoodFastifyWeb(
   fastify: FastifyInstance,
-  opts: RedwoodFastifyWebOptions,
-  done: HookHandlerDoneFunction
+  opts: RedwoodFastifyWebOptions
 ) {
   const { redwoodOptions, flags } = resolveOptions(opts)
 
@@ -53,8 +47,6 @@ export async function redwoodFastifyWeb(
   // but TS doesn't know that so it complains about `apiUrl` being undefined
   // in `fastify.all(...)` below. So we have to do this check for now
   if (redwoodOptions.apiUrl && flags.shouldRegisterApiUrl) {
-    fastify.log.warn("apiUrl is relative but there's no proxy target")
-
     const apiUrlHandler = (_req: FastifyRequest, reply: FastifyReply) => {
       reply.code(200)
       reply.send({
@@ -113,6 +105,4 @@ export async function redwoodFastifyWeb(
     reply.code(404)
     return reply.send('Not Found')
   })
-
-  done()
 }

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -11,7 +11,6 @@ import type {
   FastifyListenOptions,
   FastifyServerOptions,
   FastifyInstance,
-  HookHandlerDoneFunction,
 } from 'fastify'
 import fastifyRawBody from 'fastify-raw-body'
 
@@ -312,8 +311,7 @@ export interface RedwoodFastifyAPIOptions {
 
 export async function redwoodFastifyFunctions(
   fastify: FastifyInstance,
-  opts: RedwoodFastifyAPIOptions,
-  done: HookHandlerDoneFunction
+  opts: RedwoodFastifyAPIOptions
 ) {
   fastify.register(fastifyUrlData)
   await fastify.register(fastifyRawBody)
@@ -332,6 +330,4 @@ export async function redwoodFastifyFunctions(
       ignore: ['**/dist/functions/graphql.js'],
     },
   })
-
-  done()
 }

--- a/packages/api-server/src/plugins/graphql.ts
+++ b/packages/api-server/src/plugins/graphql.ts
@@ -3,7 +3,6 @@ import fg from 'fast-glob'
 import type {
   FastifyInstance,
   HTTPMethods,
-  HookHandlerDoneFunction,
   FastifyReply,
   FastifyRequest,
 } from 'fastify'
@@ -35,8 +34,7 @@ export interface RedwoodFastifyGraphQLOptions {
  */
 export async function redwoodFastifyGraphQLServer(
   fastify: FastifyInstance,
-  options: RedwoodFastifyGraphQLOptions,
-  done: HookHandlerDoneFunction
+  options: RedwoodFastifyGraphQLOptions
 ) {
   // These two plugins are needed to transform a Fastify Request to a Lambda event
   // which is used by the RedwoodGraphQLContext and mimics the behavior of the
@@ -126,8 +124,6 @@ export async function redwoodFastifyGraphQLServer(
 
       done()
     })
-
-    done()
   } catch (e) {
     console.log(e)
   }

--- a/packages/fastify/src/api.ts
+++ b/packages/fastify/src/api.ts
@@ -1,5 +1,5 @@
 import fastifyUrlData from '@fastify/url-data'
-import type { FastifyInstance, HookHandlerDoneFunction } from 'fastify'
+import type { FastifyInstance } from 'fastify'
 import fastifyRawBody from 'fastify-raw-body'
 
 import type { GlobalContext } from '@redwoodjs/context'
@@ -11,8 +11,7 @@ import type { RedwoodFastifyAPIOptions } from './types'
 
 export async function redwoodFastifyAPI(
   fastify: FastifyInstance,
-  opts: RedwoodFastifyAPIOptions,
-  done: HookHandlerDoneFunction
+  opts: RedwoodFastifyAPIOptions
 ) {
   if (!fastify.hasPlugin('@fastify/url-data')) {
     await fastify.register(fastifyUrlData)
@@ -41,6 +40,4 @@ export async function redwoodFastifyAPI(
   fastify.all(`${apiRootPath}:routeName`, lambdaRequestHandler)
   fastify.all(`${apiRootPath}:routeName/*`, lambdaRequestHandler)
   await loadFunctionsFromDist()
-
-  done()
 }


### PR DESCRIPTION
Running `yarn rw serve` in the v7 RC emits two warnings:

```
$ yarn rw serve                                         
...
(node:69556) [FSTWRN002] FastifyWarning: The redwoodFastifyWeb plugin being registered mixes async and callback styles, which will result in an error in `fastify@5`
(Use `node --trace-warnings ...` to show where the warning was created)
(node:69556) [FSTWRN002] FastifyWarning: The redwoodFastifyAPI plugin being registered mixes async and callback styles, which will result in an error in `fastify@5`
```

These seem to be because the fastify plugins are async but use the `done` param, which is the callback style. This PR removes the callback style in favor of the async. 

I'm also removing this warn log which we've already handled on the frontend by registering a warning route for. Right now there's no correct configuration for it when both plugins are registered on the same instance, which is what we've been doing since forever, and I don't want logs to become meaningless:

```
{"level":40,"time":1706557821043,"pid":69556,"hostname":"evaM1.local","msg":"apiUrl is relative but there's no proxy target"}
```