### PR TITLE
fix(docusaurus): Make {jsx,tsx} file extensions switch properly

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,8 +1,8 @@
 import type * as PresetClassic from '@docusaurus/preset-classic'
 import type { Config } from '@docusaurus/types'
 
-import autoImportTabs from './src/remark/auto-import-tabs'
-import fileExtSwitcher from './src/remark/file-ext-switcher'
+import autoImportTabs from './src/remark/auto-import-tabs.mjs'
+import fileExtSwitcher from './src/remark/file-ext-switcher.mjs'
 
 const config: Config = {
   customFields: {

--- a/docs/src/components/FileExtSwitcher.tsx
+++ b/docs/src/components/FileExtSwitcher.tsx
@@ -7,17 +7,18 @@ interface Props {
 }
 
 /**
- * Takes a path on the form web/src/layouts/BlogLayout/BlogLayout.{js,tsx} and
- * replaces the end part, {js,tsx}, with the correct file extension depending
- * on what language the user has selected for the code blocks
+ * Takes a path on the form web/src/layouts/BlogLayout/BlogLayout.{jsx,tsx} and
+ * replaces the end part, {jsx,tsx}, with the correct file extension depending
+ * on what language the user has selected for the code blocks.
+ * Supports js, jsx, ts and tsx file extensions
  */
 export default function FileExtSwitcher({ path }: Props) {
   const [jsTs] = useStorageSlot('docusaurus.tab.js-ts')
 
   const extensionStart = path.lastIndexOf('{')
   const extensions = path.slice(extensionStart + 1, path.length - 1)
-  const ts = extensions.split(',')[1]
+  const [js, ts] = extensions.split(',')
   const pathWithoutExt = path.slice(0, extensionStart)
 
-  return <code>{pathWithoutExt + (jsTs === 'js' ? 'js' : ts)}</code>
+  return <code>{pathWithoutExt + (jsTs === 'js' ? js : ts)}</code>
 }

--- a/docs/src/remark/file-ext-switcher.mjs
+++ b/docs/src/remark/file-ext-switcher.mjs
@@ -5,7 +5,7 @@ const plugin = () => {
 
   return (tree, _file) => {
     visit(tree, (node, _index, parent) => {
-      if (node.type === 'inlineCode' && /\w\.\{js,tsx?}$/.test(node.value)) {
+      if (node.type === 'inlineCode' && /\w\.\{jsx?,tsx?}$/.test(node.value)) {
         needImport = true
         const pathValue = `${node.value}`
 


### PR DESCRIPTION
This should show the correct file extension depending on what language you have selected, not both of them
![image](https://github.com/redwoodjs/redwood/assets/30793/65c77306-cb14-431f-93ca-567af6f9d121)

This PR fixes that