### PR TITLE
feat(crwa): Make the seed template idempotent

### DIFF
--- a/__fixtures__/test-project/scripts/seed.ts
+++ b/__fixtures__/test-project/scripts/seed.ts
@@ -83,17 +83,21 @@ export default async () => {
       "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
     )
 
-    // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
-    // @see: https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany
-    await Promise.all(
-      //
-      // Change to match your data model and seeding needs
-      //
-      data.map(async (data: Prisma.UserExampleCreateArgs['data']) => {
-        const record = await db.userExample.create({ data })
-        console.log(record)
-      })
-    )
+    if ((await db.userExample.count()) === 0) {
+      // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
+      // @see: https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany
+      await Promise.all(
+        //
+        // Change to match your data model and seeding needs
+        //
+        data.map(async (data: Prisma.UserExampleCreateArgs['data']) => {
+          const record = await db.userExample.create({ data })
+          console.log(record)
+        })
+      )
+    } else {
+      console.log('Users already seeded')
+    }
 
     // If using dbAuth and seeding users, you'll need to add a `hashedPassword`
     // and associated `salt` to their record. Here's how to create them using

--- a/packages/create-redwood-app/templates/js/scripts/seed.js
+++ b/packages/create-redwood-app/templates/js/scripts/seed.js
@@ -21,17 +21,21 @@ export default async () => {
       "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
     )
 
-    // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
-    // @see: https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany
-    await Promise.all(
-      //
-      // Change to match your data model and seeding needs
-      //
-      data.map(async (data) => {
-        const record = await db.userExample.create({ data })
-        console.log(record)
-      })
-    )
+    if ((await db.userExample.count()) === 0) {
+      // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
+      // @see: https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany
+      await Promise.all(
+        //
+        // Change to match your data model and seeding needs
+        //
+        data.map(async (data) => {
+          const record = await db.userExample.create({ data })
+          console.log(record)
+        })
+      )
+    } else {
+      console.log('Users already seeded')
+    }
 
     // If using dbAuth and seeding users, you'll need to add a `hashedPassword`
     // and associated `salt` to their record. Here's how to create them using

--- a/packages/create-redwood-app/templates/ts/scripts/seed.ts
+++ b/packages/create-redwood-app/templates/ts/scripts/seed.ts
@@ -22,17 +22,21 @@ export default async () => {
       "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
     )
 
-    // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
-    // @see: https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany
-    await Promise.all(
-      //
-      // Change to match your data model and seeding needs
-      //
-      data.map(async (data: Prisma.UserExampleCreateArgs['data']) => {
-        const record = await db.userExample.create({ data })
-        console.log(record)
-      })
-    )
+    if ((await db.userExample.count()) === 0) {
+      // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster
+      // @see: https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#createmany
+      await Promise.all(
+        //
+        // Change to match your data model and seeding needs
+        //
+        data.map(async (data: Prisma.UserExampleCreateArgs['data']) => {
+          const record = await db.userExample.create({ data })
+          console.log(record)
+        })
+      )
+    } else {
+      console.log('Users already seeded')
+    }
 
     // If using dbAuth and seeding users, you'll need to add a `hashedPassword`
     // and associated `salt` to their record. Here's how to create them using


### PR DESCRIPTION
Makes it so that the default seed script we ship with our templates are safe to run multiple times. It'll now just skip updating the DB if it already has records in there.

This also makes the template more closely match what we have for our CI tests