### PR TITLE
chore(ts): Remove src alias and baseUrl from all tsconfigs

### DIFF
--- a/__fixtures__/test-project/api/tsconfig.json
+++ b/__fixtures__/test-project/api/tsconfig.json
@@ -7,7 +7,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": false,
-    "baseUrl": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/api/src"

--- a/__fixtures__/test-project/scripts/tsconfig.json
+++ b/__fixtures__/test-project/scripts/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
     "paths": {
       "$api/*": [
         "../api/*"

--- a/__fixtures__/test-project/web/tsconfig.json
+++ b/__fixtures__/test-project/web/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,7 +1,4 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  }
 }

--- a/packages/adapters/fastify/web/tsconfig.json
+++ b/packages/adapters/fastify/web/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/api-server/tsconfig.build.json
+++ b/packages/api-server/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/api-server/tsconfig.json
+++ b/packages/api-server/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
     "emitDeclarationOnly": false,

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/auth-providers/auth0/api/tsconfig.json
+++ b/packages/auth-providers/auth0/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/auth0/setup/tsconfig.json
+++ b/packages/auth-providers/auth0/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/auth0/web/tsconfig.json
+++ b/packages/auth-providers/auth0/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/azureActiveDirectory/web/tsconfig.json
+++ b/packages/auth-providers/azureActiveDirectory/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/clerk/api/tsconfig.json
+++ b/packages/auth-providers/clerk/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/clerk/setup/tsconfig.json
+++ b/packages/auth-providers/clerk/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/clerk/web/tsconfig.json
+++ b/packages/auth-providers/clerk/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/custom/setup/tsconfig.json
+++ b/packages/auth-providers/custom/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/dbAuth/api/tsconfig.json
+++ b/packages/auth-providers/dbAuth/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/dbAuth/setup/tsconfig.json
+++ b/packages/auth-providers/dbAuth/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/dbAuth/web/tsconfig.json
+++ b/packages/auth-providers/dbAuth/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/api/tsconfig.json
+++ b/packages/auth-providers/firebase/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/setup/tsconfig.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/setup/tsconfig.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/setup/tsconfig.json
+++ b/packages/auth-providers/firebase/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/web/tsconfig.json
+++ b/packages/auth-providers/firebase/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/web/tsconfig.json
+++ b/packages/auth-providers/firebase/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/firebase/web/tsconfig.json
+++ b/packages/auth-providers/firebase/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/api/tsconfig.json
+++ b/packages/auth-providers/netlify/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/api/tsconfig.json
+++ b/packages/auth-providers/netlify/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/api/tsconfig.json
+++ b/packages/auth-providers/netlify/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/setup/tsconfig.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/setup/tsconfig.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/setup/tsconfig.json
+++ b/packages/auth-providers/netlify/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/web/tsconfig.json
+++ b/packages/auth-providers/netlify/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/web/tsconfig.json
+++ b/packages/auth-providers/netlify/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/netlify/web/tsconfig.json
+++ b/packages/auth-providers/netlify/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/api/tsconfig.json
+++ b/packages/auth-providers/supabase/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/api/tsconfig.json
+++ b/packages/auth-providers/supabase/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/api/tsconfig.json
+++ b/packages/auth-providers/supabase/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/setup/tsconfig.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/setup/tsconfig.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/setup/tsconfig.json
+++ b/packages/auth-providers/supabase/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/web/tsconfig.json
+++ b/packages/auth-providers/supabase/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/web/tsconfig.json
+++ b/packages/auth-providers/supabase/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supabase/web/tsconfig.json
+++ b/packages/auth-providers/supabase/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/api/tsconfig.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/api/tsconfig.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/api/tsconfig.json
+++ b/packages/auth-providers/supertokens/api/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/setup/tsconfig.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/setup/tsconfig.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/setup/tsconfig.json
+++ b/packages/auth-providers/supertokens/setup/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/web/tsconfig.json
+++ b/packages/auth-providers/supertokens/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/web/tsconfig.json
+++ b/packages/auth-providers/supertokens/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth-providers/supertokens/web/tsconfig.json
+++ b/packages/auth-providers/supertokens/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/babel-config/tsconfig.json
+++ b/packages/babel-config/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node", "jest"],

--- a/packages/babel-config/tsconfig.json
+++ b/packages/babel-config/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node", "jest"],

--- a/packages/babel-config/tsconfig.json
+++ b/packages/babel-config/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
     "types": ["node", "jest"],

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-packages/dataMigrate/tsconfig.json
+++ b/packages/cli-packages/dataMigrate/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-packages/dataMigrate/tsconfig.json
+++ b/packages/cli-packages/dataMigrate/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-packages/dataMigrate/tsconfig.json
+++ b/packages/cli-packages/dataMigrate/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-packages/storybook/tsconfig.json
+++ b/packages/cli-packages/storybook/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-packages/storybook/tsconfig.json
+++ b/packages/cli-packages/storybook/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli-packages/storybook/tsconfig.json
+++ b/packages/cli-packages/storybook/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "emitDeclarationOnly": false,
     "noEmit": true

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "emitDeclarationOnly": false,
     "noEmit": true

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "emitDeclarationOnly": false,
     "noEmit": true

--- a/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/input/web/tsconfig.json
+++ b/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/input/web/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
+    "": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/web/src",

--- a/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/input/web/tsconfig.json
+++ b/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/input/web/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/web/src",

--- a/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/output/web/tsconfig.json
+++ b/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/output/web/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
+    "": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/web/src",

--- a/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/output/web/tsconfig.json
+++ b/packages/codemods/src/codemods/v2.3.x/tsconfigForRouteHooks/__testfixtures__/default/output/web/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/web/src",

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "emitDeclarationOnly": false,
     "noEmit": true

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "emitDeclarationOnly": false,
     "noEmit": true

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "emitDeclarationOnly": false,
     "noEmit": true

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "outDir": "dist",

--- a/packages/create-redwood-app/templates/js/api/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/api/jsconfig.json
@@ -6,7 +6,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": false,
-    "baseUrl": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/api/src"

--- a/packages/create-redwood-app/templates/js/scripts/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/scripts/jsconfig.json
@@ -5,7 +5,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
     "paths": {
       "$api/*": [
         "../api/*"

--- a/packages/create-redwood-app/templates/js/web/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/web/jsconfig.json
@@ -5,7 +5,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",

--- a/packages/create-redwood-app/templates/ts/api/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/api/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": false,
-    "baseUrl": "./",
+    "": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/api/src"

--- a/packages/create-redwood-app/templates/ts/api/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/api/tsconfig.json
@@ -7,7 +7,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": false,
-    "": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/api/src"

--- a/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
+    "": "./",
     "paths": {
       "$api/*": [
         "../api/*"

--- a/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "": "./",
     "paths": {
       "$api/*": [
         "../api/*"

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
+    "": "./",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "": "./",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/fastify/tsconfig.json
+++ b/packages/fastify/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/fastify/tsconfig.json
+++ b/packages/fastify/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/fastify/tsconfig.json
+++ b/packages/fastify/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
+++ b/packages/graphql-server/src/plugins/useRedwoodOpenTelemetry.ts
@@ -6,7 +6,7 @@ import { SpanKind } from '@opentelemetry/api'
 import * as opentelemetry from '@opentelemetry/api'
 import { print } from 'graphql'
 
-import type { RedwoodOpenTelemetryConfig } from 'src/types'
+import type { RedwoodOpenTelemetryConfig } from '../types'
 
 export enum AttributeName {
   EXECUTION_ERROR = 'graphql.execute.error',

--- a/packages/graphql-server/src/types.ts
+++ b/packages/graphql-server/src/types.ts
@@ -13,8 +13,7 @@ import type { AuthContextPayload, Decoder } from '@redwoodjs/api'
 import type { CorsConfig } from '@redwoodjs/api'
 import type { RedwoodRealtimeOptions } from '@redwoodjs/realtime'
 
-import type { DirectiveGlobImports } from 'src/directives/makeDirectives'
-
+import type { DirectiveGlobImports } from './directives/makeDirectives'
 import type {
   useRedwoodDirectiveReturn,
   DirectivePluginOptions,

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/core/tsconfig.json
+++ b/packages/mailer/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/core/tsconfig.json
+++ b/packages/mailer/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/core/tsconfig.json
+++ b/packages/mailer/core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/in-memory/tsconfig.json
+++ b/packages/mailer/handlers/in-memory/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/in-memory/tsconfig.json
+++ b/packages/mailer/handlers/in-memory/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/in-memory/tsconfig.json
+++ b/packages/mailer/handlers/in-memory/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/nodemailer/tsconfig.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/nodemailer/tsconfig.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/nodemailer/tsconfig.json
+++ b/packages/mailer/handlers/nodemailer/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/resend/tsconfig.json
+++ b/packages/mailer/handlers/resend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/resend/tsconfig.json
+++ b/packages/mailer/handlers/resend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/resend/tsconfig.json
+++ b/packages/mailer/handlers/resend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/studio/tsconfig.json
+++ b/packages/mailer/handlers/studio/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/studio/tsconfig.json
+++ b/packages/mailer/handlers/studio/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/handlers/studio/tsconfig.json
+++ b/packages/mailer/handlers/studio/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/renderers/mjml-react/tsconfig.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/renderers/mjml-react/tsconfig.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/renderers/mjml-react/tsconfig.json
+++ b/packages/mailer/renderers/mjml-react/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/renderers/react-email/tsconfig.json
+++ b/packages/mailer/renderers/react-email/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/renderers/react-email/tsconfig.json
+++ b/packages/mailer/renderers/react-email/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/mailer/renderers/react-email/tsconfig.json
+++ b/packages/mailer/renderers/react-email/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
     "allowJs": true

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
-    "paths": {
-      "src/*": ["./src/*"]
-    },
     "allowJs": true
   },
   "include": ["./src/**/*", "ambient.d.ts"],

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
     "allowJs": true

--- a/packages/project-config/tsconfig.json
+++ b/packages/project-config/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/project-config/tsconfig.json
+++ b/packages/project-config/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/project-config/tsconfig.json
+++ b/packages/project-config/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/realtime/tsconfig.json
+++ b/packages/realtime/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/realtime/tsconfig.json
+++ b/packages/realtime/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/realtime/tsconfig.json
+++ b/packages/realtime/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
-    "paths": {
-      "src/*": ["./src/*"]
-    }
   },
   "include": ["src", "./ambient.d.ts"],
   "references": [

--- a/packages/structure/tsconfig.json
+++ b/packages/structure/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
     "experimentalDecorators": true,

--- a/packages/structure/tsconfig.json
+++ b/packages/structure/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
     "experimentalDecorators": true,

--- a/packages/structure/tsconfig.json
+++ b/packages/structure/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
     "experimentalDecorators": true,

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
-    "paths": {
-      "src/*": ["./src/*"],
-    },
   },
   "include": [
     "src",

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/web-server/tsconfig.json
+++ b/packages/web-server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "": ".",
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "": ".",
+
     "rootDir": "src",
     "outDir": "dist"
   },


### PR DESCRIPTION
As title. 

### Rationale

**1. Prevent incorrect auto imports**
VSCode often auto imports from `src/xxx.ts` instead of using relative imports `../../xxx.ts` - in the framework. When the code is compiled, this leads to runtime errors (even though no ts errors during dev time). This is caused by the `baseUrl` option. For example:

```
╰─ yarn tsc -traceResolution | grep invoke
'baseUrl' option is set to '/Users/dac09/Code/redwood/packages/vite', using this value to resolve non-relative module name 'src/middleware/invokeMiddleware'.
``` 

If they are just type imports, usually a non-issue, because its only relevant during dev (rather than compilation with babel)

**2. `baseUrl` isn't necessary or recommended to configure according TS docs**

> This feature was designed for use in conjunction with AMD module loaders in the browser, and is not recommended in any other context. As of TypeScript 4.1, baseUrl is no longer required to be set when using paths.

source: https://www.typescriptlang.org/tsconfig#baseUrl