### PR TITLE
fix(crwa): Use actual filename in seed file template

### DIFF
--- a/__fixtures__/fragment-test-project/scripts/seed.ts
+++ b/__fixtures__/fragment-test-project/scripts/seed.ts
@@ -151,7 +151,7 @@ export default async () => {
       // { name: 'bob', email: 'bob@example.com' },
     ]
     console.log(
-      "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
+      "\nUsing the default './scripts/seed.ts' template\nEdit the file to add seed data\n"
     )
 
     // Note: if using PostgreSQL, using `createMany` to insert multiple records is much faster

--- a/__fixtures__/test-project/scripts/seed.ts
+++ b/__fixtures__/test-project/scripts/seed.ts
@@ -80,7 +80,7 @@ export default async () => {
       // { name: 'bob', email: 'bob@example.com' },
     ]
     console.log(
-      "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
+      "\nUsing the default './scripts/seed.ts' template\nEdit the file to add seed data\n"
     )
 
     if ((await db.userExample.count()) === 0) {

--- a/packages/create-redwood-app/scripts/tsToJS.js
+++ b/packages/create-redwood-app/scripts/tsToJS.js
@@ -111,3 +111,13 @@ for (const tsConfigFilePath of tsConfigFilePaths) {
 }
 
 console.groupEnd()
+
+console.group('Updating file extension in seed.js')
+
+const seedFilePath = path.join(JS_TEMPLATE_PATH, 'scripts', 'seed.js')
+const seedFile = fs
+  .readFileSync(seedFilePath, 'utf-8')
+  .replace('seed.ts', 'seed.js')
+fs.writeFileSync(seedFilePath, seedFile)
+
+console.groupEnd()

--- a/packages/create-redwood-app/templates/js/scripts/seed.js
+++ b/packages/create-redwood-app/templates/js/scripts/seed.js
@@ -18,7 +18,7 @@ export default async () => {
       // { name: 'bob', email: 'bob@example.com' },
     ]
     console.log(
-      "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
+      "\nUsing the default './scripts/seed.js' template\nEdit the file to add seed data\n"
     )
 
     if ((await db.userExample.count()) === 0) {

--- a/packages/create-redwood-app/templates/ts/scripts/seed.ts
+++ b/packages/create-redwood-app/templates/ts/scripts/seed.ts
@@ -19,7 +19,7 @@ export default async () => {
       // { name: 'bob', email: 'bob@example.com' },
     ]
     console.log(
-      "\nUsing the default './scripts/seed.{js,ts}' template\nEdit the file to add seed data\n"
+      "\nUsing the default './scripts/seed.ts' template\nEdit the file to add seed data\n"
     )
 
     if ((await db.userExample.count()) === 0) {


### PR DESCRIPTION
Tidy up the output when running the seed script. We know the exact name of the file – so let's use that 🙂 

Before
![image](https://github.com/redwoodjs/redwood/assets/30793/e4179a1b-a1d0-4bea-8550-d089af647d8a)

After
![image](https://github.com/redwoodjs/redwood/assets/30793/9c77fb43-1a1d-4908-a7fb-6eec4805f248)

And running the ts-to-js script looks like this (see the new output at the end)
![image](https://github.com/redwoodjs/redwood/assets/30793/4ff27e73-6f4a-4520-aa52-6bdf73d0640b)
