### PR TITLE
fix(internal): Remove unused import

### DIFF
--- a/packages/internal/src/__tests__/__snapshots__/typeDefinitions.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/typeDefinitions.test.ts.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generates global page imports source maps 1`] = `
+"{
+  "version": 3,
+  "sources": [
+    "../../../web/src/pages/BarPage/BarPage.tsx",
+    "../../../web/src/pages/FatalErrorPage/FatalErrorPage.js",
+    "../../../web/src/pages/FooPage/FooPage.tsx",
+    "../../../web/src/pages/HomePage/HomePage.tsx",
+    "../../../web/src/pages/NotFoundPage/NotFoundPage.js",
+    "../../../web/src/pages/PrivatePage/PrivatePage.tsx",
+    "../../../web/src/pages/TypeScriptPage/TypeScriptPage.tsx",
+    "../../../web/src/pages/admin/EditUserPage/EditUserPage.jsx"
+  ],
+  "names": [],
+  "mappings": ";;;;;;;;;;;;AAAA;ACQA;ACRA;ACKA;ACLA;ACAA;ACAA;ACAA",
+  "file": "web-routesPages.d.ts"
+}"
+`;
+
+exports[`generates source maps for the router routes 1`] = `
+"{
+  "version": 3,
+  "sources": [
+    "../../../web/src/Routes.js"
+  ],
+  "names": [],
+  "mappings": ";;;;;;IAiBM;IACA;IACA;IAEE;IACA;IAGA",
+  "file": "web-routerRoutes.d.ts"
+}"
+`;
+
 exports[`mirror path for directory named modules 1`] = `".redwood/types/mirror/web/src/graphql"`;
 
 exports[`mirror path for directory named modules 2`] = `"../../packages/internal/index.d.ts"`;

--- a/packages/internal/src/__tests__/__snapshots__/typeDefinitions.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/typeDefinitions.test.ts.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generates global page imports source maps 1`] = `
-"{
-  "version": 3,
+{
+  "file": "web-routesPages.d.ts",
+  "mappings": ";;;;;;;;;;;;AAAA;ACQA;ACRA;ACKA;ACLA;ACAA;ACAA;ACAA",
+  "names": [],
   "sources": [
     "../../../web/src/pages/BarPage/BarPage.tsx",
     "../../../web/src/pages/FatalErrorPage/FatalErrorPage.js",
@@ -11,24 +13,22 @@ exports[`generates global page imports source maps 1`] = `
     "../../../web/src/pages/NotFoundPage/NotFoundPage.js",
     "../../../web/src/pages/PrivatePage/PrivatePage.tsx",
     "../../../web/src/pages/TypeScriptPage/TypeScriptPage.tsx",
-    "../../../web/src/pages/admin/EditUserPage/EditUserPage.jsx"
+    "../../../web/src/pages/admin/EditUserPage/EditUserPage.jsx",
   ],
-  "names": [],
-  "mappings": ";;;;;;;;;;;;AAAA;ACQA;ACRA;ACKA;ACLA;ACAA;ACAA;ACAA",
-  "file": "web-routesPages.d.ts"
-}"
+  "version": 3,
+}
 `;
 
 exports[`generates source maps for the router routes 1`] = `
-"{
-  "version": 3,
-  "sources": [
-    "../../../web/src/Routes.js"
-  ],
-  "names": [],
+{
+  "file": "web-routerRoutes.d.ts",
   "mappings": ";;;;;;IAiBM;IACA;IACA;IAEE;IACA;IAGA",
-  "file": "web-routerRoutes.d.ts"
-}"
+  "names": [],
+  "sources": [
+    "../../../web/src/Routes.js",
+  ],
+  "version": 3,
+}
 `;
 
 exports[`mirror path for directory named modules 1`] = `".redwood/types/mirror/web/src/graphql"`;

--- a/packages/internal/src/__tests__/typeDefinitions.test.ts
+++ b/packages/internal/src/__tests__/typeDefinitions.test.ts
@@ -136,7 +136,10 @@ declare global {
 
 test('generates global page imports source maps', () => {
   const paths = generateTypeDefRouterPages()
-  const sourceMap = fs.readFileSync(paths[0] + '.map', 'utf-8')
+  const sourceMap = fs
+    .readFileSync(paths[0] + '.map', 'utf-8')
+    // Handle Windows paths
+    .replace(/\.\.\\\\/g, '../')
   expect(sourceMap).toMatchSnapshot()
 })
 
@@ -165,7 +168,10 @@ test('generates the router routes', () => {
 
 test('generates source maps for the router routes', () => {
   const paths = generateTypeDefRouterRoutes()
-  const sourceMap = fs.readFileSync(paths[0] + '.map', 'utf-8')
+  const sourceMap = fs
+    .readFileSync(paths[0] + '.map', 'utf-8')
+    // Handle Windows paths
+    .replace(/\.\.\\\\/g, '../')
   expect(sourceMap).toMatchSnapshot()
 })
 

--- a/packages/internal/src/__tests__/typeDefinitions.test.ts
+++ b/packages/internal/src/__tests__/typeDefinitions.test.ts
@@ -136,10 +136,8 @@ declare global {
 
 test('generates global page imports source maps', () => {
   const paths = generateTypeDefRouterPages()
-  const sourceMap = fs
-    .readFileSync(paths[0] + '.map', 'utf-8')
-    // Handle Windows paths
-    .replace(/\.\.\\\\/g, '../')
+  const sourceMap = JSON.parse(fs.readFileSync(paths[0] + '.map', 'utf-8'))
+  sourceMap.sources = sourceMap.sources.map((source) => ensurePosixPath(source))
   expect(sourceMap).toMatchSnapshot()
 })
 
@@ -168,10 +166,10 @@ test('generates the router routes', () => {
 
 test('generates source maps for the router routes', () => {
   const paths = generateTypeDefRouterRoutes()
-  const sourceMap = fs
-    .readFileSync(paths[0] + '.map', 'utf-8')
-    // Handle Windows paths
-    .replace(/\.\.\\\\/g, '../')
+  const sourceMap = JSON.parse(fs.readFileSync(paths[0] + '.map', 'utf-8'))
+  sourceMap.sources = sourceMap.sources.map((source: string) =>
+    ensurePosixPath(source)
+  )
   expect(sourceMap).toMatchSnapshot()
 })
 

--- a/packages/internal/src/__tests__/typeDefinitions.test.ts
+++ b/packages/internal/src/__tests__/typeDefinitions.test.ts
@@ -134,6 +134,12 @@ declare global {
 }`)
 })
 
+test('generates global page imports source maps', () => {
+  const paths = generateTypeDefRouterPages()
+  const sourceMap = fs.readFileSync(paths[0] + '.map', 'utf-8')
+  expect(sourceMap).toMatchSnapshot()
+})
+
 test('generate current user ', () => {
   const paths = generateTypeDefCurrentUser()
   const p = paths.map(cleanPaths)
@@ -155,6 +161,12 @@ test('generates the router routes', () => {
     barPage: (params?: RouteParams<"/bar"> & QueryParams) => "/bar"
     privatePage: (params?: RouteParams<"/private-page"> & QueryParams) => "/private-page"
 `)
+})
+
+test('generates source maps for the router routes', () => {
+  const paths = generateTypeDefRouterRoutes()
+  const sourceMap = fs.readFileSync(paths[0] + '.map', 'utf-8')
+  expect(sourceMap).toMatchSnapshot()
 })
 
 test('generate glob imports', () => {

--- a/packages/internal/src/generate/templates/web-routerRoutes.d.ts.template
+++ b/packages/internal/src/generate/templates/web-routerRoutes.d.ts.template
@@ -1,6 +1,4 @@
 import { RouteParams, QueryParams } from '@redwoodjs/router'
-import { A } from 'ts-toolbelt'
-
 
 declare module '@redwoodjs/router' {
   interface AvailableRoutes {

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -260,8 +260,10 @@ export const generateTypeDefRouterRoutes = () => {
       file: 'web-routerRoutes.d.ts',
     })
 
-    // Start line is based on where in the template the `    ${name}: (params?: RouteParams<"${path}"> & QueryParams) => "${path}"` are defined
-    const startLine = 9
+    // Start line is based on where in the template the
+    // `    ${name}: (params?: RouteParams<"${path}"> & QueryParams) => "${path}"`
+    // line is defined
+    const startLine = 7
 
     // Map the location of the default export for each page
     for (let i = 0; i < routes.length; i++) {


### PR DESCRIPTION
We generate `.redwood/types/includes/web-routerRoutes.d.ts` to provide proper types for `routes` that users import from `@redwoodjs/router`. 

This file used to be a lot more complicated, but was greatly simplified in https://github.com/redwoodjs/redwood/pull/6364. However, we forgot to remove an import that's no longer used. This PR cleans that up

![image](https://github.com/redwoodjs/redwood/assets/30793/1dced6e9-b2f9-4054-8f3d-0def91adb80a)
