### PR TITLE
@redwoodjs/framework-tools for buildDefaults

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,7 +10,6 @@
       "!{projectRoot}/**/*.test.{js,jsx,ts,tsx}",
       "{workspaceRoot}/babel.config.js",
       "{workspaceRoot}/tsconfig.json",
-      "{workspaceRoot}/buildDefaults.mjs",
       {
         "runtime": "node -v"
       },

--- a/packages/adapters/fastify/web/build.mjs
+++ b/packages/adapters/fastify/web/build.mjs
@@ -1,4 +1,4 @@
-import { build, defaultBuildOptions } from '../../../../buildDefaults.mjs'
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 // Build the main entry point
 await build({

--- a/packages/adapters/fastify/web/package.json
+++ b/packages/adapters/fastify/web/package.json
@@ -37,6 +37,7 @@
     "fast-glob": "3.3.2"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "fastify": "4.25.2",
     "typescript": "5.3.3",
     "vitest": "1.2.2"

--- a/packages/babel-config/build.mjs
+++ b/packages/babel-config/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/babel-config/package.json
+++ b/packages/babel-config/package.json
@@ -45,6 +45,7 @@
     "typescript": "5.3.3"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/babel-plugin-tester": "9.0.9",
     "@types/babel__core": "7.20.4",
     "@types/node": "20.11.10",

--- a/packages/cli-packages/dataMigrate/build.mjs
+++ b/packages/cli-packages/dataMigrate/build.mjs
@@ -2,7 +2,7 @@ import {
   build,
   defaultBuildOptions,
   defaultIgnorePatterns,
-} from '../../../buildDefaults.mjs'
+} from '@redwoodjs/framework-tools'
 
 // Build the package.
 await build({

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@prisma/client": "5.9.0",
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/fs-extra": "11.0.4",
     "@types/yargs": "17.0.32",
     "jest": "29.7.0",

--- a/packages/cli-packages/storybook/build.mjs
+++ b/packages/cli-packages/storybook/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/cli-packages/storybook/package.json
+++ b/packages/cli-packages/storybook/package.json
@@ -34,6 +34,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/yargs": "17.0.32",
     "typescript": "5.3.3"
   },

--- a/packages/context/build.mjs
+++ b/packages/context/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -20,6 +20,7 @@
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -31,6 +31,7 @@
     "@opentelemetry/resources": "1.18.1",
     "@opentelemetry/sdk-trace-node": "1.18.1",
     "@opentelemetry/semantic-conventions": "1.18.1",
+    "@redwoodjs/framework-tools": "6.0.7",
     "@redwoodjs/tui": "6.0.7",
     "@types/babel__core": "7.20.4",
     "chalk": "4.1.2",

--- a/packages/create-redwood-app/scripts/build.js
+++ b/packages/create-redwood-app/scripts/build.js
@@ -1,4 +1,4 @@
-import { build, defaultBuildOptions } from '../../../buildDefaults.mjs'
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 const jsBanner = `\
 #!/usr/bin/env node

--- a/packages/eslint-plugin/build.mjs
+++ b/packages/eslint-plugin/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -26,6 +26,7 @@
     "eslint": "8.55.0"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/eslint": "8",
     "@types/estree": "1.0.5",
     "@typescript-eslint/parser": "5.62.0",

--- a/packages/fastify/build.mjs
+++ b/packages/fastify/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -32,6 +32,7 @@
     "qs": "6.11.2"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/aws-lambda": "8.10.126",
     "@types/lodash": "4.14.201",
     "@types/qs": "6.9.11",

--- a/packages/framework-tools/README.md
+++ b/packages/framework-tools/README.md
@@ -1,0 +1,3 @@
+# Framework Tools
+
+Tooling etc used internally by the Redwood framework

--- a/packages/framework-tools/README.md
+++ b/packages/framework-tools/README.md
@@ -1,3 +1,4 @@
 # Framework Tools
 
-Tooling etc used internally by the Redwood framework
+Tooling used internally by the Redwood framework.
+This package isn't published to NPM.

--- a/packages/framework-tools/build.ts
+++ b/packages/framework-tools/build.ts
@@ -1,16 +1,11 @@
 import { build, defaultBuildOptions } from './src/buildDefaults'
 
-const options = {
-  ...defaultBuildOptions,
-  bundle: true,
-  entryPoints: ['./src/buildDefaults.ts'],
-  packages: 'external',
-}
-
 // ESM build.
 await build({
   buildOptions: {
-    ...options,
+    ...defaultBuildOptions,
+    entryPoints: ['./src/buildDefaults.ts'],
+    packages: 'external',
     format: 'esm',
     outExtension: { '.js': '.mjs' },
   },

--- a/packages/framework-tools/build.ts
+++ b/packages/framework-tools/build.ts
@@ -1,12 +1,8 @@
 import { build, defaultBuildOptions } from './src/buildDefaults'
 
-// ESM build.
 await build({
   buildOptions: {
     ...defaultBuildOptions,
-    entryPoints: ['./src/buildDefaults.ts'],
-    packages: 'external',
     format: 'esm',
-    outExtension: { '.js': '.mjs' },
   },
 })

--- a/packages/framework-tools/build.ts
+++ b/packages/framework-tools/build.ts
@@ -1,0 +1,25 @@
+import { build, defaultBuildOptions } from './src/buildDefaults'
+
+const options = {
+  ...defaultBuildOptions,
+  bundle: true,
+  entryPoints: ['./src/buildDefaults.ts'],
+  packages: 'external',
+}
+
+// ESM build.
+await build({
+  buildOptions: {
+    ...options,
+    format: 'esm',
+    outExtension: { '.js': '.mjs' },
+  },
+})
+
+// CJS build.
+await build({
+  buildOptions: {
+    ...options,
+    outExtension: { '.js': '.cjs' },
+  },
+})

--- a/packages/framework-tools/build.ts
+++ b/packages/framework-tools/build.ts
@@ -15,11 +15,3 @@ await build({
     outExtension: { '.js': '.mjs' },
   },
 })
-
-// CJS build.
-await build({
-  buildOptions: {
-    ...options,
-    outExtension: { '.js': '.cjs' },
-  },
-})

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redwoodjs/framework-tools",
-  "private": true,
   "version": "6.0.7",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/redwoodjs/redwood.git",
@@ -9,7 +9,10 @@
   },
   "license": "MIT",
   "type": "module",
-  "exports": "./dist/buildDefaults.mjs",
+  "exports": {
+    "types": "./dist/buildDefaults.d.ts",
+    "default": "./dist/buildDefaults.js"
+  },
   "types": "./dist/buildDefaults.d.ts",
   "files": [
     "dist"
@@ -18,15 +21,15 @@
     "build": "tsx ./build.ts && run build:types",
     "build:types": "tsc --build --verbose"
   },
+  "dependencies": {
+    "esbuild": "0.20.0",
+    "fast-glob": "3.3.2",
+    "fs-extra": "11.2.0"
+  },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
     "tsx": "4.6.2",
     "typescript": "5.3.3"
   },
-  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
-  "dependencies": {
-    "esbuild": "0.20.0",
-    "fast-glob": "3.3.2",
-    "fs-extra": "11.2.0"
-  }
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@redwoodjs/framework-tools",
+  "version": "6.0.7",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/redwoodjs/redwood.git",
+    "directory": "packages/framework-tools"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "types": "./dist/buildDefaults.d.ts",
+    "import": "./dist/buildDefaults.mjs",
+    "default": "./dist/buildDefaults.cjs"
+  },
+  "types": "./dist/buildDefaults.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsx ./build.ts && run build:types",
+    "build:types": "tsc --build --verbose"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "11.0.4",
+    "esbuild": "0.20.0",
+    "tsx": "4.6.2",
+    "typescript": "5.3.3"
+  },
+  "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
+  "dependencies": {
+    "fast-glob": "3.3.2",
+    "fs-extra": "11.2.0"
+  }
+}

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@redwoodjs/framework-tools",
+  "private": true,
   "version": "6.0.7",
   "repository": {
     "type": "git",
@@ -8,11 +9,7 @@
   },
   "license": "MIT",
   "type": "module",
-  "exports": {
-    "types": "./dist/buildDefaults.d.ts",
-    "import": "./dist/buildDefaults.mjs",
-    "default": "./dist/buildDefaults.cjs"
-  },
+  "exports": "./dist/buildDefaults.mjs",
   "types": "./dist/buildDefaults.d.ts",
   "files": [
     "dist"

--- a/packages/framework-tools/package.json
+++ b/packages/framework-tools/package.json
@@ -23,12 +23,12 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "esbuild": "0.20.0",
     "tsx": "4.6.2",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1",
   "dependencies": {
+    "esbuild": "0.20.0",
     "fast-glob": "3.3.2",
     "fs-extra": "11.2.0"
   }

--- a/packages/framework-tools/src/buildDefaults.ts
+++ b/packages/framework-tools/src/buildDefaults.ts
@@ -1,10 +1,11 @@
 import path from 'node:path'
 
 import * as esbuild from 'esbuild'
+import type { BuildOptions as ESBuildOptions } from 'esbuild'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 
-export const defaultBuildOptions = {
+export const defaultBuildOptions: ESBuildOptions = {
   outdir: 'dist',
 
   platform: 'node',
@@ -27,25 +28,22 @@ export const defaultIgnorePatterns = [
   '**/__fixtures__',
 ]
 
-/**
- * @typedef {{
- *   cwd?: string
- *   buildOptions?: import('esbuild').BuildOptions
- *   entryPointOptions?: {
- *     patterns?: string[]
- *     ignore?: string[]
- *   }
- *   metafileName?: string
- * }} BuildOptions
- *
- * @param {BuildOptions} options
- */
+interface BuildOptions {
+  cwd?: string
+  buildOptions?: ESBuildOptions
+  entryPointOptions?: {
+    patterns?: string[]
+    ignore?: string[]
+  }
+  metafileName?: string
+}
+
 export async function build({
   cwd,
   buildOptions,
   entryPointOptions,
   metafileName,
-} = {}) {
+}: BuildOptions = {}) {
   // Yarn and Nx both set this to the package's root dir path
   cwd ??= process.cwd()
 

--- a/packages/framework-tools/tsconfig.json
+++ b/packages/framework-tools/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.compilerOption.json",
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+  },
+  "include": ["src"],
+}

--- a/packages/mailer/core/build.mjs
+++ b/packages/mailer/core/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/core/package.json
+++ b/packages/mailer/core/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@redwoodjs/api": "6.0.7",
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3",
     "vitest": "1.2.2"
   },

--- a/packages/mailer/handlers/in-memory/build.mjs
+++ b/packages/mailer/handlers/in-memory/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/handlers/in-memory/package.json
+++ b/packages/mailer/handlers/in-memory/package.json
@@ -23,6 +23,7 @@
     "@redwoodjs/mailer-core": "6.0.7"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/handlers/nodemailer/build.mjs
+++ b/packages/mailer/handlers/nodemailer/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/handlers/nodemailer/package.json
+++ b/packages/mailer/handlers/nodemailer/package.json
@@ -24,6 +24,7 @@
     "nodemailer": "6.9.7"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/nodemailer": "^6",
     "typescript": "5.3.3"
   },

--- a/packages/mailer/handlers/resend/build.mjs
+++ b/packages/mailer/handlers/resend/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/handlers/resend/package.json
+++ b/packages/mailer/handlers/resend/package.json
@@ -24,6 +24,7 @@
     "resend": "1.1.0"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/mailer/handlers/studio/build.mjs
+++ b/packages/mailer/handlers/studio/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/handlers/studio/package.json
+++ b/packages/mailer/handlers/studio/package.json
@@ -24,6 +24,7 @@
     "@redwoodjs/mailer-handler-nodemailer": "6.0.7"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/nodemailer": "^6",
     "typescript": "5.3.3"
   },

--- a/packages/mailer/renderers/mjml-react/build.mjs
+++ b/packages/mailer/renderers/mjml-react/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/renderers/mjml-react/package.json
+++ b/packages/mailer/renderers/mjml-react/package.json
@@ -25,6 +25,7 @@
     "mjml": "4.14.1"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "@types/mjml": "4",
     "typescript": "5.3.3"
   },

--- a/packages/mailer/renderers/react-email/build.mjs
+++ b/packages/mailer/renderers/react-email/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/mailer/renderers/react-email/package.json
+++ b/packages/mailer/renderers/react-email/package.json
@@ -24,6 +24,7 @@
     "@redwoodjs/mailer-core": "6.0.7"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/project-config/build.js
+++ b/packages/project-config/build.js
@@ -1,4 +1,4 @@
-import { build, defaultBuildOptions } from '../../buildDefaults.mjs'
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 const options = {
   ...defaultBuildOptions,

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -33,6 +33,7 @@
     "string-env-interpolation": "1.0.1"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "rimraf": "5.0.5",
     "typescript": "5.3.3",
     "vitest": "1.2.2"

--- a/packages/realtime/build.mjs
+++ b/packages/realtime/build.mjs
@@ -1,4 +1,4 @@
-import { build, defaultBuildOptions } from '../../buildDefaults.mjs'
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 await build({
   buildOptions: {

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -40,6 +40,7 @@
     "@envelop/core": "5.0.0",
     "@envelop/testing": "7.0.0",
     "@envelop/types": "5.0.0",
+    "@redwoodjs/framework-tools": "6.0.7",
     "jest": "29.7.0",
     "nodemon": "3.0.2",
     "typescript": "5.3.3"

--- a/packages/tui/build.mjs
+++ b/packages/tui/build.mjs
@@ -1,3 +1,3 @@
-import { build } from '../../buildDefaults.mjs'
+import { build } from '@redwoodjs/framework-tools'
 
 await build()

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -26,6 +26,7 @@
     "stdout-update": "1.6.8"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/web-server/build.mjs
+++ b/packages/web-server/build.mjs
@@ -4,7 +4,7 @@ import {
   build,
   defaultBuildOptions,
   defaultIgnorePatterns,
-} from '../../buildDefaults.mjs'
+} from '@redwoodjs/framework-tools'
 
 // This package uses the name of the bin as `scriptName` for Yargs to keep things in sync.
 // There should only be one bin entry for this to work.

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -39,6 +39,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "6.0.7",
     "typescript": "5.3.3"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7984,6 +7984,7 @@ __metadata:
     "@babel/register": "npm:^7.22.15"
     "@babel/runtime-corejs3": "npm:7.23.9"
     "@babel/traverse": "npm:^7.22.20"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"
     "@types/babel-plugin-tester": "npm:9.0.9"
     "@types/babel__core": "npm:7.20.4"
@@ -8006,6 +8007,7 @@ __metadata:
   dependencies:
     "@prisma/client": "npm:5.9.0"
     "@redwoodjs/babel-config": "npm:6.0.7"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"
     "@types/fs-extra": "npm:11.0.4"
     "@types/yargs": "npm:17.0.32"
@@ -8055,6 +8057,7 @@ __metadata:
   resolution: "@redwoodjs/cli-storybook@workspace:packages/cli-packages/storybook"
   dependencies:
     "@redwoodjs/cli-helpers": "npm:6.0.7"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"
     "@redwoodjs/telemetry": "npm:6.0.7"
     "@storybook/addon-a11y": "npm:7.6.10"
@@ -8189,6 +8192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/context@workspace:packages/context"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
@@ -8286,6 +8290,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/eslint-plugin@workspace:packages/eslint-plugin"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@types/eslint": "npm:8"
     "@types/estree": "npm:1.0.5"
     "@typescript-eslint/parser": "npm:5.62.0"
@@ -8304,6 +8309,7 @@ __metadata:
     "@fastify/http-proxy": "npm:9.3.0"
     "@fastify/static": "npm:6.12.0"
     "@fastify/url-data": "npm:5.4.0"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"
     fast-glob: "npm:3.3.2"
     fastify: "npm:4.25.2"
@@ -8320,6 +8326,7 @@ __metadata:
     "@fastify/static": "npm:6.12.0"
     "@fastify/url-data": "npm:5.4.0"
     "@redwoodjs/context": "npm:6.0.7"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"
     "@types/aws-lambda": "npm:8.10.126"
     "@types/lodash": "npm:4.14.201"
@@ -8360,6 +8367,19 @@ __metadata:
   peerDependencies:
     graphql: 16.8.1
     react: 0.0.0-experimental-e5205658f-20230913
+  languageName: unknown
+  linkType: soft
+
+"@redwoodjs/framework-tools@npm:6.0.7, @redwoodjs/framework-tools@workspace:packages/framework-tools":
+  version: 0.0.0-use.local
+  resolution: "@redwoodjs/framework-tools@workspace:packages/framework-tools"
+  dependencies:
+    "@types/fs-extra": "npm:11.0.4"
+    esbuild: "npm:0.20.0"
+    fast-glob: "npm:3.3.2"
+    fs-extra: "npm:11.2.0"
+    tsx: "npm:4.6.2"
+    typescript: "npm:5.3.3"
   languageName: unknown
   linkType: soft
 
@@ -8464,6 +8484,7 @@ __metadata:
   resolution: "@redwoodjs/mailer-core@workspace:packages/mailer/core"
   dependencies:
     "@redwoodjs/api": "npm:6.0.7"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     typescript: "npm:5.3.3"
     vitest: "npm:1.2.2"
   languageName: unknown
@@ -8473,6 +8494,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/mailer-handler-in-memory@workspace:packages/mailer/handlers/in-memory"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     typescript: "npm:5.3.3"
   languageName: unknown
@@ -8482,6 +8504,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/mailer-handler-nodemailer@workspace:packages/mailer/handlers/nodemailer"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     "@types/nodemailer": "npm:^6"
     nodemailer: "npm:6.9.7"
@@ -8493,6 +8516,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/mailer-handler-resend@workspace:packages/mailer/handlers/resend"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     resend: "npm:1.1.0"
     typescript: "npm:5.3.3"
@@ -8503,6 +8527,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/mailer-handler-studio@workspace:packages/mailer/handlers/studio"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     "@redwoodjs/mailer-handler-nodemailer": "npm:6.0.7"
     "@types/nodemailer": "npm:^6"
@@ -8515,6 +8540,7 @@ __metadata:
   resolution: "@redwoodjs/mailer-renderer-mjml-react@workspace:packages/mailer/renderers/mjml-react"
   dependencies:
     "@faire/mjml-react": "npm:3.3.0"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     "@types/mjml": "npm:4"
     mjml: "npm:4.14.1"
@@ -8527,6 +8553,7 @@ __metadata:
   resolution: "@redwoodjs/mailer-renderer-react-email@workspace:packages/mailer/renderers/react-email"
   dependencies:
     "@react-email/render": "npm:0.0.10"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/mailer-core": "npm:6.0.7"
     typescript: "npm:5.3.3"
   languageName: unknown
@@ -8566,6 +8593,7 @@ __metadata:
   resolution: "@redwoodjs/project-config@workspace:packages/project-config"
   dependencies:
     "@iarna/toml": "npm:2.2.5"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     deepmerge: "npm:4.3.1"
     fast-glob: "npm:3.3.2"
     rimraf: "npm:5.0.5"
@@ -8591,6 +8619,7 @@ __metadata:
     "@graphql-yoga/subscription": "npm:5.0.0"
     "@n1ru4l/graphql-live-query": "npm:0.10.0"
     "@n1ru4l/in-memory-live-query-store": "npm:0.10.0"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     graphql: "npm:16.8.1"
     ioredis: "npm:^5.3.2"
     jest: "npm:29.7.0"
@@ -8747,6 +8776,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/tui@workspace:packages/tui"
   dependencies:
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     boxen: "npm:5.1.2"
     chalk: "npm:4.1.2"
     enquirer: "npm:2.4.1"
@@ -8804,6 +8834,7 @@ __metadata:
   resolution: "@redwoodjs/web-server@workspace:packages/web-server"
   dependencies:
     "@redwoodjs/fastify-web": "npm:6.0.7"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/project-config": "npm:6.0.7"
     chalk: "npm:4.1.2"
     dotenv-defaults: "npm:5.0.2"
@@ -15944,6 +15975,7 @@ __metadata:
     "@opentelemetry/resources": "npm:1.18.1"
     "@opentelemetry/sdk-trace-node": "npm:1.18.1"
     "@opentelemetry/semantic-conventions": "npm:1.18.1"
+    "@redwoodjs/framework-tools": "npm:6.0.7"
     "@redwoodjs/tui": "npm:6.0.7"
     "@types/babel__core": "npm:7.20.4"
     chalk: "npm:4.1.2"


### PR DESCRIPTION
Move `buildDefaults` from project root into a package.

This is in preparation of hopefully moving more files/scripts and packages over to TS