### PR TITLE
fix(server): spelling, fix deploy handler imports, dedupe server builder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "peacock.color": "#b85833",
   "cSpell.words": [
+    "execa",
     "Fastify",
     "pino",
     "redwoodjs",

--- a/packages/cli/src/commands/__tests__/serve.test.js
+++ b/packages/cli/src/commands/__tests__/serve.test.js
@@ -52,7 +52,7 @@ vi.mock('fs-extra', async (importOriginal) => {
 vi.mock('@redwoodjs/api-server/dist/apiCLIConfig', async (importOriginal) => {
   const originalAPICLIConfig = await importOriginal()
   return {
-    description: originalAPICLIConfig.desciption,
+    description: originalAPICLIConfig.description,
     builder: originalAPICLIConfig.builder,
     handler: vi.fn(),
   }
@@ -60,7 +60,7 @@ vi.mock('@redwoodjs/api-server/dist/apiCLIConfig', async (importOriginal) => {
 vi.mock('@redwoodjs/api-server/dist/bothCLIConfig', async (importOriginal) => {
   const originalBothCLIConfig = await importOriginal()
   return {
-    description: originalBothCLIConfig.desciption,
+    description: originalBothCLIConfig.description,
     builder: originalBothCLIConfig.builder,
     handler: vi.fn(),
   }

--- a/packages/cli/src/commands/deploy/flightcontrol.js
+++ b/packages/cli/src/commands/deploy/flightcontrol.js
@@ -65,7 +65,7 @@ export const handler = async ({ side, serve, prisma, dm: dataMigrate }) => {
   async function runApiCommands() {
     if (serve) {
       console.log('\nStarting api...')
-      await apiServerHandler.handler({
+      await apiServerHandler({
         port: getConfig().api?.port || 8911,
         apiRootPath: '/',
       })

--- a/packages/cli/src/commands/deploy/render.js
+++ b/packages/cli/src/commands/deploy/render.js
@@ -70,7 +70,7 @@ export const handler = async ({ side, prisma, dm: dataMigrate }) => {
         execaConfig
       )
     dataMigrate && execa.sync('yarn rw dataMigrate up', execaConfig)
-    await apiServerHandler.handler({
+    await apiServerHandler({
       port: getConfig().api?.port || 8911,
       apiRootPath: '/',
     })

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -27,36 +27,7 @@ export const builder = async (yargs) => {
     .command({
       command: '$0',
       description: bothServerCLIConfig.description,
-      builder: (yargs) => {
-        if (hasServerFile()) {
-          yargs.options({
-            webPort: {
-              description: 'The port for the web server to listen on',
-              type: 'number',
-              alias: ['web-port'],
-            },
-            webHost: {
-              description:
-                "The host for the web server to listen on. Note that you most likely want this to be '0.0.0.0' in production",
-              type: 'string',
-              alias: ['web-host'],
-            },
-            apiPort: {
-              description: 'The port for the api server to listen on',
-              type: 'number',
-              alias: ['api-port'],
-            },
-            apiHost: {
-              description:
-                "The host for the api server to listen on. Note that you most likely want this to be '0.0.0.0' in production",
-              type: 'string',
-              alias: ['api-host'],
-            },
-          })
-        }
-
-        bothServerCLIConfig.builder(yargs)
-      },
+      builder: bothServerCLIConfig.builder(yargs),
       handler: async (argv) => {
         recordTelemetryAttributes({
           command: 'serve',

--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -47,7 +47,7 @@ export const bothServerFileHandler = async (argv) => {
           name: 'api',
           command: `yarn node ${path.join('dist', 'server.js')} --port ${
             argv.apiPort
-          } --host ${argv.apiHost}`,
+          } --host ${argv.apiHost} --api-root-path ${argv.apiRootPath}`,
           cwd: getPaths().api.base,
           prefixColor: 'cyan',
         },


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/9948; missed a few things at the end there:

- misspelled "description" in a test mock
- the server file and both server handlers take the same options, so I deduped them
- related, I wasn't passing apiRootPath through to the server file handler
- I incorrectly accessed `.handler` on `apiServerHandler` in flightcontrol and render