### PR TITLE
fix(api-server): Remove duplicate command alias

### DIFF
--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -87,7 +87,6 @@ export function resolveOptions(
       options: {
         host: {
           type: 'string',
-          short: 'p',
         },
         port: {
           type: 'string',


### PR DESCRIPTION
Both `--host` and `--port` can't use the `-p` alias (or "short").
Didn't want to use `-h` for `--host`, because `-h` should mean "help".
So I decided to just get rid for the alias. People will have to use the long-form arg