### PR TITLE
fix(studio): Remove unused setting inMemory

### DIFF
--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -94,7 +94,6 @@ describe('getConfig', () => {
             },
             "endpoint": "graphql",
           },
-          "inMemory": false,
         },
         "web": {
           "a11y": true,
@@ -116,7 +115,6 @@ describe('getConfig', () => {
     const config = getConfig(path.join(__dirname, './fixtures/redwood.toml'))
     expect(config.web.port).toEqual(8888)
 
-    expect(config.studio.inMemory).toEqual(false)
     expect(config.studio.graphiql?.endpoint).toEqual('graphql')
   })
 
@@ -126,7 +124,6 @@ describe('getConfig', () => {
         path.join(__dirname, './fixtures/redwood.studio.toml')
       )
 
-      expect(config.studio.inMemory).toEqual(false)
       expect(config.studio.graphiql?.endpoint).toEqual('graphql-endpoint')
     })
 
@@ -134,7 +131,6 @@ describe('getConfig', () => {
       const config = getConfig(
         path.join(__dirname, './fixtures/redwood.studio.dbauth.toml')
       )
-      expect(config.studio.inMemory).toEqual(false)
       expect(config.studio.graphiql?.endpoint).toEqual('graphql')
       expect(config.studio.graphiql?.authImpersonation?.authProvider).toEqual(
         'dbAuth'
@@ -150,7 +146,6 @@ describe('getConfig', () => {
         path.join(__dirname, './fixtures/redwood.studio.supabase.toml')
       )
 
-      expect(config.studio.inMemory).toEqual(false)
       expect(config.studio.graphiql?.endpoint).toEqual('graphql')
       expect(config.studio.graphiql?.authImpersonation?.authProvider).toEqual(
         'supabase'

--- a/packages/project-config/src/__tests__/fixtures/redwood.studio.dbauth.toml
+++ b/packages/project-config/src/__tests__/fixtures/redwood.studio.dbauth.toml
@@ -1,7 +1,6 @@
 [web]
   port = 8888
 [studio]
-  inMemory = false
   [studio.graphiql]
     endpoint = "graphql"
     [studio.graphiql.authImpersonation]

--- a/packages/project-config/src/__tests__/fixtures/redwood.studio.supabase.toml
+++ b/packages/project-config/src/__tests__/fixtures/redwood.studio.supabase.toml
@@ -1,7 +1,6 @@
 [web]
   port = 8888
 [studio]
-  inMemory = false
   [studio.graphiql]
     endpoint = "graphql"
     [studio.graphiql.authImpersonation]

--- a/packages/project-config/src/__tests__/fixtures/redwood.studio.toml
+++ b/packages/project-config/src/__tests__/fixtures/redwood.studio.toml
@@ -1,6 +1,5 @@
 [web]
   port = 8888
 [studio]
-  inMemory = false
   [studio.graphiql]
     endpoint = "graphql-endpoint"

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -76,7 +76,6 @@ interface AuthImpersonationConfig {
 
 interface StudioConfig {
   basePort: number
-  inMemory: boolean
   graphiql?: GraphiQLStudioConfig
 }
 
@@ -165,7 +164,6 @@ const DEFAULT_CONFIG: Config = {
   },
   studio: {
     basePort: 4318,
-    inMemory: false,
     graphiql: {
       endpoint: 'graphql',
       authImpersonation: {


### PR DESCRIPTION
Removes unused `inMemory` setting from Studio config

The database is now always written to disk