### PR TITLE
feat(gql): Codemod existing projects to get newest gql config

### DIFF
--- a/packages/cli/src/testUtils/matchFolderTransform.ts
+++ b/packages/cli/src/testUtils/matchFolderTransform.ts
@@ -21,7 +21,7 @@ type Options = {
 
 type MatchFolderTransformFunction = (
   transformFunctionOrName: (() => any) | string,
-  fixtureName: string,
+  fixtureName?: string,
   options?: Options
 ) => Promise<void>
 
@@ -53,7 +53,7 @@ export const matchFolderTransform: MatchFolderTransformFunction = async (
   const fixtureFolder = path.join(
     testPath,
     '../../__testfixtures__',
-    fixtureName
+    fixtureName || ''
   )
 
   const fixtureInputDir = path.join(fixtureFolder, 'input')

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/README.md
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/README.md
@@ -1,0 +1,8 @@
+# Update graphql.config.js
+
+Replaces the root `graphql.config.js` file with one that includes types and gql
+documents support.
+
+Fetches the file from the create-redwood-app template files on GitHub
+
+No jscodeshift is involved.

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__testfixtures__/input/graphql.config.js
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__testfixtures__/input/graphql.config.js
@@ -1,0 +1,5 @@
+const { getPaths } = require('@redwoodjs/internal')
+
+module.exports = {
+  schema: getPaths().generated.schema,
+}

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__testfixtures__/output/graphql.config.js
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__testfixtures__/output/graphql.config.js
@@ -1,0 +1,11 @@
+// This file is used by the VSCode GraphQL extension
+
+const { getPaths } = require('@redwoodjs/project-config')
+
+/** @type {import('graphql-config').IGraphQLConfig} */
+const config = {
+  schema: getPaths().generated.schema,
+  documents: './web/src/**/!(*.d).{ts,tsx,js,jsx}',
+}
+
+module.exports = config

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__tests__/updateGraphqlConfig.test.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__tests__/updateGraphqlConfig.test.ts
@@ -1,0 +1,7 @@
+import { updateGraphqlConfig } from '../updateGraphqlConfig'
+
+describe('updateGraphQLConfig', () => {
+  it('Replaces the JS FatalErrorPage with a new version that includes development info', async () => {
+    await matchFolderTransform(updateGraphqlConfig, 'javascript')
+  })
+})

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__tests__/updateGraphqlConfig.test.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__tests__/updateGraphqlConfig.test.ts
@@ -2,6 +2,6 @@ import { updateGraphqlConfig } from '../updateGraphqlConfig'
 
 describe('updateGraphQLConfig', () => {
   it('Replaces the JS FatalErrorPage with a new version that includes development info', async () => {
-    await matchFolderTransform(updateGraphqlConfig, 'javascript')
+    await matchFolderTransform(updateGraphqlConfig)
   })
 })

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__tests__/updateGraphqlConfig.test.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/__tests__/updateGraphqlConfig.test.ts
@@ -1,7 +1,7 @@
 import { updateGraphqlConfig } from '../updateGraphqlConfig'
 
 describe('updateGraphQLConfig', () => {
-  it('Replaces the JS FatalErrorPage with a new version that includes development info', async () => {
+  it('Replaces graphql.config.js with a new version downloaded from GH', async () => {
     await matchFolderTransform(updateGraphqlConfig)
   })
 })

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
@@ -7,7 +7,10 @@ import { getPaths } from '@redwoodjs/project-config'
 
 export const updateGraphqlConfig = async () => {
   const res = await fetch(
-    'https://raw.githubusercontent.com/redwoodjs/redwood/release/major/v7.0.0/packages/create-redwood-app/templates/ts/graphql.config.js'
+    // TODO: Have to come back here to update the URL when we have a more
+    // stable location than main
+    // 'https://raw.githubusercontent.com/redwoodjs/redwood/release/major/v7.0.0/packages/create-redwood-app/templates/ts/graphql.config.js'
+    'https://raw.githubusercontent.com/redwoodjs/redwood/main/packages/create-redwood-app/templates/ts/graphql.config.js'
   )
   const text = await res.text()
   fs.writeFileSync(path.join(getPaths().base, 'graphql.config.js'), text)

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.ts
@@ -1,0 +1,14 @@
+import fs from 'fs'
+import path from 'path'
+
+import { fetch } from '@whatwg-node/fetch'
+
+import { getPaths } from '@redwoodjs/project-config'
+
+export const updateGraphqlConfig = async () => {
+  const res = await fetch(
+    'https://raw.githubusercontent.com/redwoodjs/redwood/release/major/v7.0.0/packages/create-redwood-app/templates/ts/graphql.config.js'
+  )
+  const text = await res.text()
+  fs.writeFileSync(path.join(getPaths().base, 'graphql.config.js'), text)
+}

--- a/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.yargs.ts
+++ b/packages/codemods/src/codemods/v7.x.x/updateGraphQLConfig/updateGraphqlConfig.yargs.ts
@@ -1,0 +1,13 @@
+import task from 'tasuku'
+
+import { updateGraphqlConfig } from './updateGraphqlConfig'
+
+export const command = 'update-graphql-config'
+export const description =
+  '(v6.x->v7.x) Update graphql.config.js from the create-redwood-app template'
+
+export const handler = () => {
+  task('Update root graphql.config.js file', async () => {
+    await updateGraphqlConfig()
+  })
+}

--- a/packages/codemods/src/testUtils/matchFolderTransform.ts
+++ b/packages/codemods/src/testUtils/matchFolderTransform.ts
@@ -19,7 +19,7 @@ type Options = {
 
 type MatchFolderTransformFunction = (
   transformFunctionOrName: (() => any) | string,
-  fixtureName: string,
+  fixtureName?: string,
   options?: Options
 ) => Promise<void>
 
@@ -47,7 +47,7 @@ export const matchFolderTransform: MatchFolderTransformFunction = async (
   const fixtureFolder = path.join(
     testPath,
     '../../__testfixtures__',
-    fixtureName
+    fixtureName || ''
   )
 
   const fixtureInputDir = path.join(fixtureFolder, 'input')


### PR DESCRIPTION
Replaces the root `graphql.config.js` file with one that includes types and gql
documents support.

Fetches the file from the create-redwood-app template files on GitHub

No jscodeshift is involved.

