### PR TITLE
Mention the you need corepack enabled to run this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ Use `git clone` to get a local copy of the Redwood Framework. If you've already 
 ```terminal
 git clone https://github.com/redwoodjs/redwood.git
 cd redwood
+corepack enable
 yarn install
 ```
 


### PR DESCRIPTION
https://github.com/redwoodjs/redwood/pull/9579 also applies here, took like an hour to get a `yarn build` to succeed because a build was very close to working but didn't