### PR TITLE
fix(cell-suspense): pass through variables if passed to refetch

### DIFF
--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -212,26 +212,6 @@ export interface SuspenseCellQueryResult<
 > extends UseBackgroundQueryResult {
   client: ApolloClient<any>
   // fetchMore & refetch  come from UseBackgroundQueryResult
-
-  // not supplied in Error and Failure
-  // because it's implicit in these components, but the one edgecase is showing a different loader when refetching
   networkStatus?: NetworkStatus
-  called: boolean // can we assume if we have a queryRef its called?
-
-  // Stuff not here compared to useQuery:
-  // observable: ObservableQuery<TData, TVariables> // Lenz: internal implementation detail, should not be required anymore
-  // previousData?: TData,  // emulating suspense, not required in the new Suspense model
-
-  // ObservableQueryFields 👇
-  //  subscribeToMore ~ returned from useSuspenseQuery but not useReadQuery. Apollo team **may** expose from useReadQuery.
-  //  updateQuery <~ May not be necessary in the Suspense model
-  //  refetch ~ <~ refetch signature is different in useQuery vs useSuspenseQuery. Apollo team need an internal discussion.
-  //  reobserve <~ avoid
-  //  variables <~ variables passed to the query, useful if you updated the variables using updateQuery or refetch. Apollo team need an internal discussion.
-
-  // Polling: Apollo team are not ready to expose Polling yet. Unlikely to be shipped in the next few months.
-  // But possible to re-implement this in a different way using setInternal or client.startPolling
-  //  startPolling
-  //  stopPolling
-  // ~~~
+  called: boolean // set if queryRef present
 }

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 
-import type { QueryReference } from '@apollo/client'
+import type { OperationVariables, QueryReference } from '@apollo/client'
 import { useApolloClient } from '@apollo/client'
 
 import { useBackgroundQuery, useReadQuery } from '../GraphQLHooksProvider'
@@ -112,9 +112,9 @@ export function createSuspendingCell<
 
       const queryResultWithErrorReset = {
         ...suspenseQueryResult,
-        refetch: () => {
+        refetch: (variables: Partial<OperationVariables> | undefined) => {
           resetErrorBoundary()
-          return suspenseQueryResult.refetch?.()
+          return suspenseQueryResult.refetch?.(variables)
         },
       }
 


### PR DESCRIPTION
1. Cleans up some of the comments
2. Makes sure we pass variables passed to refetch, when we wrap it for the failure component