### PR TITLE
RSC: Take full control over the env vars

### DIFF
--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -30,6 +30,7 @@ export async function rscBuildClient(
     root: rwPaths.web.src,
     envPrefix: 'REDWOOD_ENV_',
     publicDir: path.join(rwPaths.web.base, 'public'),
+    envFile: false,
     define: {
       RWJS_ENV: {
         __REDWOOD__APP_TITLE: rwConfig.web.title || path.basename(rwPaths.base),

--- a/packages/vite/src/rsc/rscBuildServer.ts
+++ b/packages/vite/src/rsc/rscBuildServer.ts
@@ -40,6 +40,7 @@ export async function rscBuildServer(
     root: rwPaths.web.base,
     envPrefix: 'REDWOOD_ENV_',
     publicDir: path.join(rwPaths.web.base, 'public'),
+    envFile: false,
     define: {
       RWJS_ENV: {
         // @NOTE we're avoiding process.env here, unlike webpack


### PR DESCRIPTION
We load env files on our own, and set extra env variables etc. So don't want Vite to conflict with that.

We already have this setting configured in `rw-vite-dev.mjs`, `internal/src/build/web.ts` and out main vite plugin in `vite/src/index.ts`