### PR TITLE
RSC: Enable babel plugins to get client Cell support

### DIFF
--- a/packages/babel-config/src/plugins/babel-plugin-redwood-cell.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-cell.ts
@@ -60,10 +60,13 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
       },
       Program: {
         exit(path) {
-          // Validate that this file has exports which are "cell-like":
-          // If the user is not exporting `QUERY` and has a default export then
-          // it's likely not a cell.
-          if (hasDefaultExport && !exportNames.includes('QUERY')) {
+          // If the file already has a default export then
+          //   1. It's likely not a cell, or it's a cell that's already been
+          //      wrapped in `createCell`
+          //   2. If we added another default export we'd be breaking JS module
+          //      rules. There can only be one default export.
+          // If there's no QUERY export it's not a valid cell
+          if (hasDefaultExport || !exportNames.includes('QUERY')) {
             return
           }
 

--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { build as viteBuild } from 'vite'
 
+import { getWebSideDefaultBabelConfig } from '@redwoodjs/babel-config'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 
 import { onWarn } from '../lib/onWarn'
@@ -74,7 +75,16 @@ export async function rscBuildClient(
         {}
       ),
     },
-    plugins: [react(), rscIndexPlugin()],
+    plugins: [
+      react({
+        babel: {
+          ...getWebSideDefaultBabelConfig({
+            forVite: true,
+          }),
+        },
+      }),
+      rscIndexPlugin(),
+    ],
     build: {
       outDir: webDist,
       emptyOutDir: true, // Needed because `outDir` is not inside `root`

--- a/packages/vite/src/rsc/rscBuildServer.ts
+++ b/packages/vite/src/rsc/rscBuildServer.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { build as viteBuild } from 'vite'
 
+import { getWebSideDefaultBabelConfig } from '@redwoodjs/babel-config'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 
 import { onWarn } from '../lib/onWarn'
@@ -125,7 +126,15 @@ export async function rscBuildServer(
         externalConditions: ['react-server'],
       },
     },
-    plugins: [react()],
+    plugins: [
+      react({
+        babel: {
+          ...getWebSideDefaultBabelConfig({
+            forVite: true,
+          }),
+        },
+      }),
+    ],
     build: {
       ssr: true,
       ssrEmitAssets: true,


### PR DESCRIPTION
Slightly modified the logic for when RW inserts `export default createCell(...` at the end of cells to make it work with how RSC builds everything.

Enabled the web babel plugins when building for client and server

On the app side of things what you'll have to do is add `"use client"` to the top of your cell 