### PR TITLE
fix(cli): use fetch instead of `yarn npm info`

### DIFF
--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -225,8 +225,8 @@ async function getAuthHandler(module) {
       version = version.split('+')[0]
     }
 
-    const packumentP = await fetch(`https://registry.npmjs.org/${module}`)
-    const packument = await packumentP.json()
+    const packumentResponse = await fetch(`https://registry.npmjs.org/${module}`)
+    const packument = await packumentResponse.json()
 
     const versionIsPublished = Object.keys(packument.versions).includes(version)
 

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -225,8 +225,23 @@ async function getAuthHandler(module) {
       version = version.split('+')[0]
     }
 
-    const packumentResponse = await fetch(`https://registry.npmjs.org/${module}`)
-    const packument = await packumentResponse.json()
+    let packument
+
+    try {
+      const packumentResponse = await fetch(
+        `https://registry.npmjs.org/${module}`
+      )
+
+      packument = await packumentResponse.json()
+
+      if (packument.error) {
+        throw new Error(packument.error)
+      }
+    } catch (error) {
+      throw new Error(
+        `Couldn't fetch packument for ${module}: ${error.message}`
+      )
+    }
 
     const versionIsPublished = Object.keys(packument.versions).includes(version)
 

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -219,17 +219,16 @@ async function getAuthHandler(module) {
   let { version } = fs.readJSONSync(packageJsonPath)
 
   if (!isInstalled(module)) {
-    const { stdout } = await execa.command(
-      `yarn npm info ${module} --fields versions --json`
-    )
-
     // If the version includes a plus, like '4.0.0-rc.428+dd79f1726'
     // (all @canary, @next, and @rc packages do), get rid of everything after the plus.
     if (version.includes('+')) {
       version = version.split('+')[0]
     }
 
-    const versionIsPublished = JSON.parse(stdout).versions.includes(version)
+    const packumentP = await fetch(`https://registry.npmjs.org/${module}`)
+    const packument = await packumentP.json()
+
+    const versionIsPublished = Object.keys(packument.versions).includes(version)
 
     if (!versionIsPublished) {
       // Fallback to canary. This is most likely because it's a new package

--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -55,8 +55,23 @@ export async function installRedwoodModule(module) {
       version = version.split('+')[0]
     }
 
-    const packumentResponse = await fetch(`https://registry.npmjs.org/${module}`)
-    const packument = await packumentResponse.json()
+    let packument
+
+    try {
+      const packumentResponse = await fetch(
+        `https://registry.npmjs.org/${module}`
+      )
+
+      packument = await packumentResponse.json()
+
+      if (packument.error) {
+        throw new Error(packument.error)
+      }
+    } catch (error) {
+      throw new Error(
+        `Couldn't fetch packument for ${module}: ${error.message}`
+      )
+    }
 
     const versionIsPublished = Object.keys(packument.versions).includes(version)
 

--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -55,8 +55,8 @@ export async function installRedwoodModule(module) {
       version = version.split('+')[0]
     }
 
-    const packumentP = await fetch(`https://registry.npmjs.org/${module}`)
-    const packument = await packumentP.json()
+    const packumentResponse = await fetch(`https://registry.npmjs.org/${module}`)
+    const packument = await packumentResponse.json()
 
     const versionIsPublished = Object.keys(packument.versions).includes(version)
 

--- a/packages/cli/src/lib/packages.js
+++ b/packages/cli/src/lib/packages.js
@@ -49,17 +49,16 @@ export async function installRedwoodModule(module) {
   let { version } = fs.readJSONSync(packageJsonPath)
 
   if (!isModuleInstalled(module)) {
-    const { stdout } = await execa.command(
-      `yarn npm info ${module} --fields versions --json`
-    )
-
     // If the version includes a plus, like '4.0.0-rc.428+dd79f1726'
     // (all @canary, @next, and @rc packages do), get rid of everything after the plus.
     if (version.includes('+')) {
       version = version.split('+')[0]
     }
 
-    const versionIsPublished = JSON.parse(stdout).versions.includes(version)
+    const packumentP = await fetch(`https://registry.npmjs.org/${module}`)
+    const packument = await packumentP.json()
+
+    const versionIsPublished = Object.keys(packument.versions).includes(version)
 
     if (!versionIsPublished) {
       // Fallback to canary. This is most likely because it's a new package


### PR DESCRIPTION
Some time ago I think I made the call to use `yarn npm info` to get information from NPM about a package's version because I didn't want to install yet another dependency. This was the wrong move in hindsight since it meant 1) spawning a child process and 2) while it seemed safe to assume that Redwood projects would have a version of yarn with the `npm` subcommand, this wasn't true in practice.

Now that fetch is in Node.js, we can just use that like @Josh-Walker-GM has elsewhere:

https://github.com/redwoodjs/redwood/blob/019361550736f5ed733c37d7f5241583f26d405b/packages/cli/src/commands/experimental/setupDockerHandler.js#L330-L339

I think this might fix the bug you saw when deploying yesterday.