### PR TITLE
fix(docker): corepack permissions fix and style updates

### DIFF
--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -7,7 +7,7 @@ description: Redwood's Dockerfile
 :::note The Dockerfile is experimental
 
 Redwood's Dockerfile is the collective effort of several hard-working community members.
-We've worked hard to optimize the it, but expect changes as we collaborate with users and deploy providers.
+We've worked hard to optimize it, but expect changes as we collaborate with users and deploy providers.
 
 :::
 
@@ -136,6 +136,7 @@ The important thing is that they're all here, before the `yarn install` step:
 
 ```Dockerfile
 RUN mkdir -p /home/node/.yarn/berry/index
+RUN mkdir -p /home/node/.cache
 
 RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,uid=1000 \
     --mount=type=cache,target=/home/node/.cache,uid=1000 \
@@ -146,7 +147,7 @@ This step installs all your project's dependencies—production and dev.
 Since we use multi-stage builds, your production images won't pay for the dev dependencies installed in this step.
 The build stages need the dev dependencies.
 
-The `mkdir` step is a workaround for a permission error. We're working on removing it, but for now if you remove it the install step will probably fail.
+The `mkdir` steps are a workaround for a permission error. We're working on removing them, but for now if you remove them the install step will probably fail.
 
 This step is a bit more involved than the others.
 It uses a [cache mount](https://docs.docker.com/build/cache/#use-your-package-manager-wisely).
@@ -190,10 +191,10 @@ FROM base as api_build
 # ARG MY_BUILD_TIME_ENV_VAR
 
 COPY --chown=node:node api api
-RUN yarn redwood build api
+RUN yarn rw build api
 ```
 
-After the work we did in the base stage, building the api side amounts to copying in the api directory and running `yarn redwood build api`.
+After the work we did in the base stage, building the api side amounts to copying in the api directory and running `yarn rw build api`.
 
 ### The `api_serve` stage
 
@@ -228,6 +229,7 @@ Like other `COPY` instructions, ordering these files with care enables layering 
 
 ```Dockerfile
 RUN mkdir -p /home/node/.yarn/berry/index
+RUN mkdir -p /home/node/.cache
 
 RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,uid=1000 \
     --mount=type=cache,target=/home/node/.cache,uid=1000 \
@@ -277,10 +279,10 @@ This `web_build` builds the web side:
 FROM base as web_build
 
 COPY --chown=node:node web web
-RUN yarn redwood build web --no-prerender
+RUN yarn rw build web --no-prerender
 ```
 
-After the work we did in the base stage, building the web side amounts to copying in the web directory and running `yarn redwood build web`.
+After the work we did in the base stage, building the web side amounts to copying in the web directory and running `yarn rw build web`.
 
 This stage is a bit of a simplification.
 It foregoes Redwood's prerendering (SSG) capability.
@@ -297,7 +299,7 @@ The `web_prerender_build` stage builds the web side with prerender.
 FROM api_build as web_build_with_prerender
 
 COPY --chown=node:node web web
-RUN yarn redwood build web
+RUN yarn rw build web
 ```
 
 Building the web side with prerendering poses a challenge.
@@ -320,6 +322,7 @@ COPY --chown=node:node web/package.json web/
 COPY --chown=node:node yarn.lock .
 
 RUN mkdir -p /home/node/.yarn/berry/index
+RUN mkdir -p /home/node/.cache
 
 RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,uid=1000 \
     --mount=type=cache,target=/home/node/.cache,uid=1000 \
@@ -332,9 +335,9 @@ COPY --chown=node:node .env.defaults .env.defaults
 COPY --chown=node:node --from=web_build /home/node/app/web/dist /home/node/app/web/dist
 
 ENV NODE_ENV=production \
-    API_HOST=http://api:8911
+    API_PROXY_TARGET=http://api:8911
 
-CMD "node_modules/.bin/rw-web-server" "--apiHost" "$API_HOST"
+CMD "node_modules/.bin/rw-web-server" "--api-proxy-target" "$API_PROXY_TARGET"
 ```
 
 Most of this stage is similar to the `api_serve` stage, except that we're copying from the `web_build` stage instead of the `api_build`.

--- a/packages/cli/src/commands/experimental/templates/docker/Dockerfile
+++ b/packages/cli/src/commands/experimental/templates/docker/Dockerfile
@@ -1,5 +1,5 @@
 # base
-# ------------------------------------------------
+# ----
 FROM node:20-bookworm-slim as base
 
 RUN corepack enable
@@ -22,6 +22,7 @@ COPY --chown=node:node web/package.json web/
 COPY --chown=node:node yarn.lock .
 
 RUN mkdir -p /home/node/.yarn/berry/index
+RUN mkdir -p /home/node/.cache
 
 RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,uid=1000 \
     --mount=type=cache,target=/home/node/.cache,uid=1000 \
@@ -32,7 +33,7 @@ COPY --chown=node:node graphql.config.js .
 COPY --chown=node:node .env.defaults .env.defaults
 
 # api build
-# ------------------------------------------------
+# ---------
 FROM base as api_build
 
 # If your api side build relies on build-time environment variables,
@@ -41,24 +42,24 @@ FROM base as api_build
 # ARG MY_BUILD_TIME_ENV_VAR
 
 COPY --chown=node:node api api
-RUN yarn redwood build api
+RUN yarn rw build api
 
 # web prerender build
-# ------------------------------------------------
+# -------------------
 FROM api_build as web_build_with_prerender
 
 COPY --chown=node:node web web
-RUN yarn redwood build web
+RUN yarn rw build web
 
 # web build
-# ------------------------------------------------
+# ---------
 FROM base as web_build
 
 COPY --chown=node:node web web
-RUN yarn redwood build web --no-prerender
+RUN yarn rw build web --no-prerender
 
-# serve api
-# ------------------------------------------------
+# api serve
+# ---------
 FROM node:20-bookworm-slim as api_serve
 
 RUN corepack enable
@@ -77,6 +78,7 @@ COPY --chown=node:node api/package.json api/
 COPY --chown=node:node yarn.lock .
 
 RUN mkdir -p /home/node/.yarn/berry/index
+RUN mkdir -p /home/node/.cache
 
 RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,uid=1000 \
     --mount=type=cache,target=/home/node/.cache,uid=1000 \
@@ -92,10 +94,10 @@ COPY --chown=node:node --from=api_build /home/node/app/node_modules/.prisma /hom
 
 ENV NODE_ENV=production
 
-CMD [ "node_modules/.bin/rw-server", "api", "--load-env-files" ]
+CMD [ "node_modules/.bin/rw-server", "api" ]
 
-# serve web
-# ------------------------------------------------
+# web serve
+# ---------
 FROM node:20-bookworm-slim as web_serve
 
 RUN corepack enable
@@ -109,6 +111,7 @@ COPY --chown=node:node web/package.json web/
 COPY --chown=node:node yarn.lock .
 
 RUN mkdir -p /home/node/.yarn/berry/index
+RUN mkdir -p /home/node/.cache
 
 RUN --mount=type=cache,target=/home/node/.yarn/berry/cache,uid=1000 \
     --mount=type=cache,target=/home/node/.cache,uid=1000 \
@@ -127,7 +130,7 @@ ENV NODE_ENV=production \
 CMD "node_modules/.bin/rw-web-server" "--api-proxy-target" "$API_PROXY_TARGET"
 
 # console
-# ------------------------------------------------
+# -------
 FROM base as console
 
 # To add more packages:

--- a/packages/cli/src/commands/experimental/templates/docker/docker-compose.prod.yml
+++ b/packages/cli/src/commands/experimental/templates/docker/docker-compose.prod.yml
@@ -25,7 +25,7 @@ services:
     depends_on:
       - api
     environment:
-      - API_HOST=http://api:8911
+      - API_PROXY_TARGET=http://api:8911
 
   db:
     image: postgres:16-bookworm


### PR DESCRIPTION
PRing some fixes @Josh-Walker-GM tipped me off to:

- We need to add the `RUN mkdir -p /home/node/.cache` instruction after `RUN mkdir -p /home/node/.yarn/berry/index`. I still can't reliably reproduce this one, but have seen it fail reliably before too for sure and this seems to fix it
- I forgot to remove `--load-env-files` when I did the api-server work. It's a no-op now
- I forgot to change `API_HOST` to `API_PROXY_TARGET`

Adding a few style tweaks while I'm here:

- I guess I used `yarn redwood`? This isn't the tutorial
- Fixed a typo in the docs