### PR TITLE
fix(test): Update createServer test to use a different port to normal

### DIFF
--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -236,7 +236,7 @@ describe('resolveOptions', () => {
           DEFAULT_CREATE_SERVER_OPTIONS.fastifyServerOptions.requestTimeout,
         logger: DEFAULT_CREATE_SERVER_OPTIONS.logger,
       },
-      port: 8911,
+      port: 65501,
       host: '::',
     })
   })

--- a/packages/api-server/src/__tests__/fixtures/redwood-app/redwood.toml
+++ b/packages/api-server/src/__tests__/fixtures/redwood-app/redwood.toml
@@ -7,14 +7,14 @@
 
 [web]
   title = "Redwood App"
-  port = 8910
+  port = 65500
   apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
   includeEnvironmentVariables = [
     # Add any ENV vars that should be available to the web side to this array
     # See https://redwoodjs.com/docs/environment-variables#web
   ]
 [api]
-  port = 8911
+  port = 65501
 [browser]
   open = true
 [notifications]


### PR DESCRIPTION
Just helps when you have another RW server running in the background :) 

I tried mocking with vitest, but it gets complicated because some of the test cases check against `getConfig` - this is good enough