### PR TITLE
fix(docker): compose dev and prod

### DIFF
--- a/packages/cli/src/commands/experimental/templates/docker/docker-compose.dev.yml
+++ b/packages/cli/src/commands/experimental/templates/docker/docker-compose.dev.yml
@@ -20,6 +20,7 @@ services:
       - SESSION_SECRET=super_secret_session_key_change_me_in_production_please
       - CI=
       - NODE_ENV=development
+      - REDWOOD_API_HOST=0.0.0.0
 
   db:
     image: postgres:16-bookworm

--- a/packages/web-server/package.json
+++ b/packages/web-server/package.json
@@ -30,6 +30,7 @@
     "chalk": "4.1.2",
     "dotenv-defaults": "5.0.2",
     "fastify": "4.25.2",
+    "fs-extra": "11.2.0",
     "yargs": "17.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8805,6 +8805,7 @@ __metadata:
     chalk: "npm:4.1.2"
     dotenv-defaults: "npm:5.0.2"
     fastify: "npm:4.25.2"
+    fs-extra: "npm:11.2.0"
     tsx: "npm:4.6.2"
     typescript: "npm:5.3.3"
     yargs: "npm:17.7.2"


### PR DESCRIPTION
**Problem**
By default when once you have run the experimental setup command for docker, the compose setup for dev and prod doesn't quite work. 

**Changes**
1. We add missing `fs-extra` dependency for the `@redwoodjs/web-server`, it is a runtime dependency.
2. We add a `REDWOOD_API_HOST=0.0.0.0` env var for the dev setup. This is required for the vite dev server to proxy requests correctly. 

**Notes**
@jtoar I'm not overly sure how to test the compose with the updated dependency of the web-server package. Adding the dependency to the web side itself did work so I would imagine this works fine too. 