### PR TITLE
chore: update rsc fixture

### DIFF
--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@redwoodjs/vite": "7.0.0-canary.966",
-    "@types/react": "18.2.37",
-    "@types/react-dom": "18.2.15"
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.19"
   }
 }


### PR DESCRIPTION
I missed updating a few fixtures in https://github.com/redwoodjs/redwood/pull/9727 and this is the test that’s failing in https://github.com/redwoodjs/redwood/pull/9985.