### PR TITLE
RSC: Keep aligning test project with CRWA template

### DIFF
--- a/__fixtures__/test-project-rsc-external-packages-and-cells/.redwood/README.md
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/.redwood/README.md
@@ -18,7 +18,6 @@ You don't need to commit any other contents of this directory to your version co
 | :---------------- | :------- |
 | commandCache.json | This file contains mappings to assist the Redwood CLI in efficiently executing commands. |
 | schema.graphql    | This is the GraphQL schema which has been automatically generated from your Redwood project. |
-| studio.db         | The sqlite database used by the experimental `rw exp studio` feature. |
 | telemetry.txt     | Contains a unique ID used for telemetry. This value is rotated every 24 hours to protect your project's anonymity. |
 | test.db           | The sqlite database used when running tests. |
 
@@ -32,6 +31,7 @@ You don't need to commit any other contents of this directory to your version co
 | telemetry   | Stores the recent telemetry that the Redwood CLI has generated. You may inspect these files to see everything Redwood is anonymously collecting. |
 | types       | Stores the results of type generation. |
 | updateCheck | Stores a file which contains the results of checking for Redwood updates. |
+| studio      | Used to store data for `rw studio` |
 
 We try to keep this README up to date but you may, from time to time, find other files or directories in this `.redwood` directory that have not yet been documented here. This is likely nothing to worry about but feel free to let us know and we'll update this list.
 

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/.vscode/launch.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "configurations": [
     {
-      "command": "yarn redwood dev --apiDebugPort 18911",
+      "command": "yarn redwood dev --apiDebugPort 18911", // you can add --fwd='--open=false' to prevent the browser from opening
       "name": "Run Dev Server",
       "request": "launch",
       "type": "node-terminal"
@@ -18,7 +18,16 @@
       "localRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
       "remoteRoot": "${workspaceFolder}/node_modules/@redwoodjs/api-server/dist",
       "sourceMaps": true,
-      "restart": true
+      "restart": true,
+      "preLaunchTask": "WaitForDevServer",
+    },
+    {
+      "name": "Launch Web debugger",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:8910",
+      "webRoot": "${workspaceRoot}/web/src",
+      "preLaunchTask": "WaitForDevServer",
     },
     {
       "command": "yarn redwood test api",
@@ -32,5 +41,16 @@
       "request": "launch",
       "type": "node-terminal"
     },
+  ],
+  "compounds": [
+    {
+      "name": "Start Debug",
+      "configurations": [
+        "Run Dev Server",
+        "Attach API debugger",
+        "Launch Web debugger"
+      ],
+      "stopAll": true
+    }
   ]
 }

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/.vscode/tasks.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "WaitForDevServer",
+      "group": "none",
+      "type": "shell",
+      "command": "bash",
+        "args": [
+          "-c",
+          "while ! echo -n > /dev/tcp/localhost/18911; do sleep 1; done;"
+      ],
+      "windows": {
+        "command": "powershell",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy", "Bypass",
+          "while (-not (Test-NetConnection -ComputerName localhost -Port 18911)) { Start-Sleep -Seconds 1 };"
+        ]
+      },
+      "presentation": {
+        "reveal": "silent",
+        "revealProblems": "onProblem",
+        "panel": "shared",
+        "close": true
+      }
+    },
+  ]
+}

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/api/db/schema.prisma
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/api/db/schema.prisma
@@ -1,3 +1,9 @@
+// Don't forget to tell Prisma about your edits to this file using
+// `yarn rw prisma migrate dev` or `yarn rw prisma db push`.
+// `migrate` is like committing while `push` is for prototyping.
+// Read more about both here:
+// https://www.prisma.io/docs/orm/prisma-migrate
+
 datasource db {
   provider = "sqlite"
   url      = env("DATABASE_URL")

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/api/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "7.0.0-canary.981",
-    "@redwoodjs/graphql-server": "7.0.0-canary.981"
+    "@redwoodjs/api": "7.0.0-canary.983",
+    "@redwoodjs/graphql-server": "7.0.0-canary.983"
   }
 }

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/api/src/lib/auth.ts
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/api/src/lib/auth.ts
@@ -23,3 +23,10 @@ export const hasRole = ({ roles }) => {
 export const requireAuth = ({ roles }) => {
   return isAuthenticated()
 }
+
+export const getCurrentUser = async () => {
+  throw new Error(
+    'Auth is not set up yet. See https://redwoodjs.com/docs/authentication ' +
+      'to get started'
+  )
+}

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/api/tsconfig.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/api/tsconfig.json
@@ -7,7 +7,6 @@
     "module": "esnext",
     "moduleResolution": "node",
     "skipLibCheck": false,
-    "baseUrl": "./",
     "rootDirs": [
       "./src",
       "../.redwood/types/mirror/api/src"

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/graphql.config.js
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/graphql.config.js
@@ -1,5 +1,11 @@
-const { getPaths } = require('@redwoodjs/internal')
+// This file is used by the VSCode GraphQL extension
 
-module.exports = {
+const { getPaths } = require('@redwoodjs/project-config')
+
+/** @type {import('graphql-config').IGraphQLConfig} */
+const config = {
   schema: getPaths().generated.schema,
+  documents: './web/src/**/!(*.d).{ts,tsx,js,jsx}',
 }
+
+module.exports = config

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/package.json
@@ -7,7 +7,8 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "7.0.0-canary.981"
+    "@redwoodjs/core": "7.0.0-canary.983",
+    "@redwoodjs/project-config": "7.0.0-canary.983"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/scripts/tsconfig.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/scripts/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
     "paths": {
       "$api/*": [
         "../api/*"

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
@@ -11,9 +11,10 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "7.0.0-canary.981",
-    "@redwoodjs/router": "7.0.0-canary.981",
-    "@redwoodjs/web": "7.0.0-canary.981",
+    "@apollo/experimental-nextjs-app-support": "0.0.0-commit-b8a73fe",
+    "@redwoodjs/forms": "7.0.0-canary.983",
+    "@redwoodjs/router": "7.0.0-canary.983",
+    "@redwoodjs/web": "7.0.0-canary.983",
     "@tobbe.dev/rsc-test": "0.0.3",
     "client-only": "0.0.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
@@ -21,7 +22,7 @@
     "server-only": "0.0.1"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "7.0.0-canary.981",
+    "@redwoodjs/vite": "7.0.0-canary.983",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19"
   }

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/tsconfig.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "baseUrl": "./",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",
@@ -21,30 +20,21 @@
         "../api/src/*",
         "../.redwood/types/mirror/api/src/*"
       ],
-      "$api/*": [
-        "../api/*"
-      ],
-      "types/*": [
-        "./types/*",
-        "../types/*"
-      ],
-      "@redwoodjs/testing": [
-        "../node_modules/@redwoodjs/testing/web"
-      ]
+      "$api/*": ["../api/*"],
+      "types/*": ["./types/*", "../types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]
     },
     "typeRoots": [
       "../node_modules/@types",
-      "./node_modules/@types"
+      "./node_modules/@types",
+      "../node_modules/@testing-library"
     ],
-    "types": [
-      "jest",
-      "@testing-library/jest-dom",
-      "react/experimental"
-    ],
+    "types": ["jest", "jest-dom", "react/experimental"],
     "jsx": "preserve"
   },
   "include": [
     "src",
+    "config",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",
     "../types",

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/vite.config.ts
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/vite.config.ts
@@ -3,11 +3,11 @@ import dns from 'dns'
 import type { UserConfig } from 'vite'
 import { defineConfig } from 'vite'
 
-// See: https://vitejs.dev/config/server-options.html#server-host
-// So that Vite will load on local instead of 127.0.0.1
-dns.setDefaultResultOrder('verbatim')
-
 import redwood from '@redwoodjs/vite'
+
+// So that Vite will load on localhost instead of `127.0.0.1`.
+// See: https://vitejs.dev/config/server-options.html#server-host.
+dns.setDefaultResultOrder('verbatim')
 
 const viteConfig: UserConfig = {
   plugins: [redwood()],


### PR DESCRIPTION
This PR builds on top of what https://github.com/redwoodjs/redwood/pull/9990 started.

The goal is to make the test project fixture match what you'd get if you did this right now, with the latest canary

```
npx -y create-redwood-app@canary -y ~/tmp/rw-test-project
yarn rw experimental setup-streaming-ssr -f
yarn rw experimental setup-rsc
```