### PR TITLE
RSC: Fix babel-plugin-redwood-cell to work wiht more than one cell

### DIFF
--- a/packages/babel-config/src/plugins/babel-plugin-redwood-cell.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-cell.ts
@@ -114,6 +114,12 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         }
       },
       Program: {
+        enter() {
+          // Reset variables as they're still in scope from the previous file
+          // babel transformed in the same process
+          exportNames = []
+          hasDefaultExport = false
+        },
         exit(path) {
           const hasQueryOrDataExport =
             exportNames.includes('QUERY') || exportNames.includes('DATA')


### PR DESCRIPTION
When building for RSC we actually build it three times
1. Analyze the source code to find 'use client' and 'use server'
2. Build for the client
3. Build for the server

In the last step, where we build for the server, babel (for some unknown reason) parses over the files multiple times and keeps plugins in memory. And because it keeps plugins in memory plugin-scoped variables keep their values between different files. This caused a problem for us when transforming cells, so now I clear those variables as soon as we enter a new file.