### PR TITLE
bug: Update setupHandler.ts firebase version

### DIFF
--- a/packages/auth-providers/firebase/setup/src/setupHandler.ts
+++ b/packages/auth-providers/firebase/setup/src/setupHandler.ts
@@ -19,7 +19,7 @@ export async function handler({ force: forceArg }: Args) {
     webPackages: ['firebase@^10', `@redwoodjs/auth-firebase-web@${version}`],
     apiPackages: [
       // Note that the version of this package should be exactly the same as the version in `@redwoodjs/auth-firebase-api` .
-      'firebase-admin@11.10.1',
+      'firebase-admin@11.11.1',
       `@redwoodjs/auth-firebase-api@${version}`,
     ],
     notes: [


### PR DESCRIPTION
To match the same version on redwood's api, otherwise it will fail to work after auth setup.