### PR TITLE
RSC: Insert 'use client' in scaffolded components

### DIFF
--- a/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/destroy/scaffold/__tests__/scaffoldNoNest.test.js
@@ -16,6 +16,7 @@ import {
 import { files } from '../../../generate/scaffold/scaffold'
 import { tasks } from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('fs-extra')
 vi.mock('execa')
 
@@ -64,30 +65,38 @@ templateDirectories.forEach(async (directory) => {
 describe('rw destroy scaffold', () => {
   describe('destroy scaffold post', () => {
     beforeEach(async () => {
-      vol.fromJSON(scaffoldTemplates)
-      vol.fromJSON({
-        ...scaffoldTemplates,
-        ...(await files({
-          ...getDefaultArgs(defaults),
-          model: 'Post',
-          tests: false,
-          nestScaffoldByModel: false,
-        })),
-        [getPaths().web.routes]: [
-          '<Routes>',
-          '  <Route path="/posts/new" page={NewPostPage} name="newPost" />',
-          '  <Route path="/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />',
-          '  <Route path="/posts/{id:Int}" page={PostPage} name="post" />',
-          '  <Route path="/posts" page={PostsPage} name="posts" />',
-          '  <Route path="/" page={HomePage} name="home" />',
-          '  <Route notfound page={NotFoundPage} />',
-          '</Routes>',
-        ].join('\n'),
+      // This fs is needed for the `files` function imported from `generate`
+      vol.fromJSON({ 'redwood.toml': '', ...scaffoldTemplates }, '/')
+
+      const postFiles = await files({
+        ...getDefaultArgs(defaults),
+        model: 'Post',
+        tests: false,
+        nestScaffoldByModel: false,
       })
+
+      // This fs is needed for all the tests here
+      vol.fromJSON(
+        {
+          ...scaffoldTemplates,
+          ...postFiles,
+          [getPaths().web.routes]: [
+            '<Routes>',
+            '  <Route path="/posts/new" page={NewPostPage} name="newPost" />',
+            '  <Route path="/posts/{id:Int}/edit" page={EditPostPage} name="editPost" />',
+            '  <Route path="/posts/{id:Int}" page={PostPage} name="post" />',
+            '  <Route path="/posts" page={PostsPage} name="posts" />',
+            '  <Route path="/" page={HomePage} name="home" />',
+            '  <Route notfound page={NotFoundPage} />',
+            '</Routes>',
+          ].join('\n'),
+        },
+        '/'
+      )
     })
 
     afterEach(() => {
-      vol.fromJSON(scaffoldTemplates)
+      vol.fromJSON({ 'redwood.toml': '', ...scaffoldTemplates }, '/')
       vi.spyOn(fs, 'unlinkSync').mockClear()
     })
 
@@ -109,15 +118,15 @@ describe('rw destroy scaffold', () => {
             nestScaffoldByModel: false,
           })
         )
-        expect(generatedFiles.length).toEqual(unlinkSpy.mock.calls.length)
         generatedFiles.forEach((f) => expect(unlinkSpy).toHaveBeenCalledWith(f))
+        expect(generatedFiles.length).toEqual(unlinkSpy.mock.calls.length)
       })
     })
 
     describe('for typescript files', () => {
       beforeEach(async () => {
         vol.reset()
-        vol.fromJSON(scaffoldTemplates)
+        vol.fromJSON({ 'redwood.toml': '', ...scaffoldTemplates }, '/')
         vol.fromJSON({
           ...scaffoldTemplates,
           ...(await files({
@@ -191,6 +200,7 @@ describe('rw destroy scaffold', () => {
 
   describe('destroy namespaced scaffold post', () => {
     beforeEach(async () => {
+      vol.fromJSON({ 'redwood.toml': '' }, '/')
       vol.fromJSON({
         ...scaffoldTemplates,
         ...(await files({
@@ -244,6 +254,7 @@ describe('rw destroy scaffold', () => {
 
     describe('for typescript files', () => {
       beforeEach(async () => {
+        vol.fromJSON({ 'redwood.toml': '' }, '/')
         vol.fromJSON({
           ...scaffoldTemplates,
           ...(await files({

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -1,5 +1,230 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`'use client' directive > creates a new EditPostCell cell with the 'use client' directive 1`] = `
+"'use client'
+
+import { navigate, routes } from '@redwoodjs/router'
+
+import { useMutation } from '@redwoodjs/web'
+import { toast } from '@redwoodjs/web/toast'
+
+import PostForm from 'src/components/Post/PostForm'
+
+export const QUERY = gql\`
+  query EditPostById($id: Int!) {
+    post: post(id: $id) {
+      id
+      title
+      slug
+      author
+      body
+      image
+      postedAt
+      isPinned
+      readTime
+      rating
+      upvotes
+      metadata
+      hugeNumber
+    }
+  }
+\`
+
+const UPDATE_POST_MUTATION = gql\`
+  mutation UpdatePostMutation($id: Int!, $input: UpdatePostInput!) {
+    updatePost(id: $id, input: $input) {
+      id
+      title
+      slug
+      author
+      body
+      image
+      postedAt
+      isPinned
+      readTime
+      rating
+      upvotes
+      metadata
+      hugeNumber
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Failure = ({ error }) => (
+  <div className="rw-cell-error">{error?.message}</div>
+)
+
+export const Success = ({ post }) => {
+  const [updatePost, { loading, error }] = useMutation(UPDATE_POST_MUTATION, {
+    onCompleted: () => {
+      toast.success('Post updated')
+      navigate(routes.posts())
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const onSave = (input, id) => {
+    updatePost({ variables: { id, input } })
+  }
+
+  return (
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">
+          Edit Post {post?.id}
+        </h2>
+      </header>
+      <div className="rw-segment-main">
+        <PostForm post={post} onSave={onSave} error={error} loading={loading} />
+      </div>
+    </div>
+  )
+}
+"
+`;
+
+exports[`'use client' directive > creates a new NewPost component with the 'use client' directive 1`] = `
+"'use client'
+
+import { navigate, routes } from '@redwoodjs/router'
+import { useMutation } from '@redwoodjs/web'
+
+import { toast } from '@redwoodjs/web/toast'
+
+import PostForm from 'src/components/Post/PostForm'
+
+const CREATE_POST_MUTATION = gql\`
+  mutation CreatePostMutation($input: CreatePostInput!) {
+    createPost(input: $input) {
+      id
+    }
+  }
+\`
+
+const NewPost = () => {
+  const [createPost, { loading, error }] = useMutation(CREATE_POST_MUTATION, {
+    onCompleted: () => {
+      toast.success('Post created')
+      navigate(routes.posts())
+    },
+    onError: (error) => {
+      toast.error(error.message)
+    },
+  })
+
+  const onSave = (input) => {
+    createPost({ variables: { input } })
+  }
+
+  return (
+    <div className="rw-segment">
+      <header className="rw-segment-header">
+        <h2 className="rw-heading rw-heading-secondary">New Post</h2>
+      </header>
+      <div className="rw-segment-main">
+        <PostForm onSave={onSave} loading={loading} error={error} />
+      </div>
+    </div>
+  )
+}
+
+export default NewPost
+"
+`;
+
+exports[`'use client' directive > creates a new PostCell cell with the 'use client' directive 1`] = `
+"'use client'
+
+import Post from 'src/components/Post/Post'
+
+export const QUERY = gql\`
+  query FindPostById($id: Int!) {
+    post: post(id: $id) {
+      id
+      title
+      slug
+      author
+      body
+      image
+      postedAt
+      isPinned
+      readTime
+      rating
+      upvotes
+      metadata
+      hugeNumber
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Post not found</div>
+
+export const Failure = ({ error }) => (
+  <div className="rw-cell-error">{error?.message}</div>
+)
+
+export const Success = ({ post }) => {
+  return <Post post={post} />
+}
+"
+`;
+
+exports[`'use client' directive > creates a new PostsCell cell with the 'use client' directive 1`] = `
+"'use client'
+
+import { Link, routes } from '@redwoodjs/router'
+
+import Posts from 'src/components/Post/Posts'
+
+export const QUERY = gql\`
+  query FindPosts {
+    posts {
+      id
+      title
+      slug
+      author
+      body
+      image
+      postedAt
+      isPinned
+      readTime
+      rating
+      upvotes
+      metadata
+      hugeNumber
+    }
+  }
+\`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => {
+  return (
+    <div className="rw-text-center">
+      {'No posts yet. '}
+      <Link to={routes.newPost()} className="rw-link">
+        {'Create one?'}
+      </Link>
+    </div>
+  )
+}
+
+export const Failure = ({ error }) => (
+  <div className="rw-cell-error">{error?.message}</div>
+)
+
+export const Success = ({ posts }) => {
+  return <Posts posts={posts} />
+}
+"
+`;
+
 exports[`in javascript (default) mode > creates a edit page 1`] = `
 "import EditPostCell from 'src/components/Post/EditPostCell'
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/editableColumns.test.js
@@ -4,12 +4,14 @@ import path from 'path'
 // Load mocks
 import '../../../../lib/test'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import { getDefaultArgs } from '../../../../lib'
 import { yargsDefaults as defaults } from '../../helpers'
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
 
 describe('editable columns', () => {
@@ -17,6 +19,8 @@ describe('editable columns', () => {
   let form
 
   beforeAll(async () => {
+    vol.fromJSON({ 'redwood.toml': '' }, '/')
+
     files = await scaffold.files({
       ...getDefaultArgs(defaults),
       model: 'ExcludeDefault',

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -1,6 +1,7 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, test, expect, beforeAll } from 'vitest'
 
 // Load mocks
@@ -10,7 +11,12 @@ import { getDefaultArgs } from '../../../../lib'
 import { yargsDefaults as defaults } from '../../helpers'
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('in javascript (default) mode', () => {
   let files
@@ -740,6 +746,63 @@ describe('tailwind flag', () => {
 
     expect(
       files[path.normalize('/path/to/project/web/src/scaffold.css')]
+    ).toMatchSnapshot()
+  })
+})
+
+describe("'use client' directive", () => {
+  let files
+
+  beforeAll(async () => {
+    vol.fromJSON(
+      { 'redwood.toml': '[experimental.rsc]\n  enabled = true' },
+      '/'
+    )
+
+    files = await scaffold.files({
+      ...getDefaultArgs(defaults),
+      model: 'Post',
+      nestScaffoldByModel: true,
+    })
+  })
+
+  test("creates a new NewPost component with the 'use client' directive", async () => {
+    expect(
+      files[
+        path.normalize(
+          '/path/to/project/web/src/components/Post/NewPost/NewPost.jsx'
+        )
+      ]
+    ).toMatchSnapshot()
+  })
+
+  test("creates a new PostCell cell with the 'use client' directive", async () => {
+    expect(
+      files[
+        path.normalize(
+          '/path/to/project/web/src/components/Post/PostCell/PostCell.jsx'
+        )
+      ]
+    ).toMatchSnapshot()
+  })
+
+  test("creates a new PostsCell cell with the 'use client' directive", async () => {
+    expect(
+      files[
+        path.normalize(
+          '/path/to/project/web/src/components/Post/PostsCell/PostsCell.jsx'
+        )
+      ]
+    ).toMatchSnapshot()
+  })
+
+  test("creates a new EditPostCell cell with the 'use client' directive", async () => {
+    expect(
+      files[
+        path.normalize(
+          '/path/to/project/web/src/components/Post/EditPostCell/EditPostCell.jsx'
+        )
+      ]
     ).toMatchSnapshot()
   })
 })

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldCustomIdName.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldCustomIdName.test.js
@@ -1,6 +1,7 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 // Load mocks
@@ -10,12 +11,15 @@ import { getDefaultArgs } from '../../../../lib'
 import { yargsDefaults as defaults } from '../../helpers'
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
 
 describe('support custom @id name', () => {
   let files
 
   beforeAll(async () => {
+    vol.fromJSON({ 'redwood.toml': '' }, '/')
+
     files = await scaffold.files({
       ...getDefaultArgs(defaults),
       typescript: true,

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldNoNest.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldNoNest.test.js
@@ -1,6 +1,7 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 // Load mocks
@@ -10,12 +11,14 @@ import { getDefaultArgs } from '../../../../lib'
 import { yargsDefaults as defaults } from '../../helpers'
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
 
 describe('in javascript (default) mode', () => {
   let files
 
   beforeAll(async () => {
+    vol.fromJSON({ 'redwood.toml': '' }, '/')
     files = await scaffold.files({
       ...getDefaultArgs(defaults),
       model: 'Post',

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPath.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPath.test.js
@@ -1,13 +1,19 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, it, expect } from 'vitest'
 
 import '../../../../lib/test'
 
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('admin/post', () => {
   let filesLower

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMulti.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMulti.test.js
@@ -1,13 +1,19 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import '../../../../lib/test'
 
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('admin/pages/post', () => {
   let filesNestedLower

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiNoNest.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiNoNest.test.js
@@ -1,13 +1,19 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import '../../../../lib/test'
 
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('admin/pages/post', () => {
   let filesNestedLower

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiword.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiword.test.js
@@ -1,13 +1,19 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import '../../../../lib/test'
 
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('AdminPages/Post', () => {
   let filesMultiwordUpper

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiwordNoNest.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathMultiwordNoNest.test.js
@@ -1,13 +1,19 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import '../../../../lib/test'
 
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('AdminPages/Post', () => {
   let filesMultiwordUpper

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathNoNest.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffoldPathNoNest.test.js
@@ -1,13 +1,19 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 import '../../../../lib/test'
 
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
+
+beforeAll(() => {
+  vol.fromJSON({ 'redwood.toml': '' }, '/')
+})
 
 describe('admin/Post', () => {
   let filesLower

--- a/packages/cli/src/commands/generate/scaffold/__tests__/shouldUseEmptyAsUndefined.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/shouldUseEmptyAsUndefined.test.js
@@ -1,6 +1,7 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
+import { vol } from 'memfs'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
 // Load mocks
@@ -10,12 +11,14 @@ import { getDefaultArgs } from '../../../../lib'
 import { yargsDefaults as defaults } from '../../helpers'
 import * as scaffold from '../scaffold'
 
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
 
 describe('relational form field', () => {
   let form
 
   beforeAll(async () => {
+    vol.fromJSON({ 'redwood.toml': '' }, '/')
     const files = await scaffold.files({
       ...getDefaultArgs(defaults),
       model: 'Tag',

--- a/packages/cli/src/commands/generate/scaffold/scaffold.js
+++ b/packages/cli/src/commands/generate/scaffold/scaffold.js
@@ -593,6 +593,10 @@ const componentFiles = async (
       outputComponentName
     )
 
+    const useClientDirective = getConfig().experimental?.rsc?.enabled
+      ? "'use client'\n\n"
+      : ''
+
     const template = generateTemplate(
       customOrDefaultTemplatePath({
         side: 'web',
@@ -606,6 +610,7 @@ const componentFiles = async (
         pascalIdName,
         intForeignKeys,
         pascalScaffoldPath,
+        useClientDirective,
         ...templateStrings,
         ...modelRelatedVariables(model),
       }

--- a/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/EditNameCell.tsx.template
@@ -1,4 +1,4 @@
-import type {
+${useClientDirective}import type {
   Edit${singularPascalName}By${pascalIdName},
   Update${singularPascalName}Input,
   Update${singularPascalName}MutationVariables

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NameCell.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NameCell.tsx.template
@@ -1,4 +1,4 @@
-import type { Find${singularPascalName}By${pascalIdName}, Find${singularPascalName}By${pascalIdName}Variables } from 'types/graphql'
+${useClientDirective}import type { Find${singularPascalName}By${pascalIdName}, Find${singularPascalName}By${pascalIdName}Variables } from 'types/graphql'
 
 import type {
   CellSuccessProps,

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.tsx.template
@@ -1,4 +1,4 @@
-import type { Find${pluralPascalName}, Find${pluralPascalName}Variables } from 'types/graphql'
+${useClientDirective}import type { Find${pluralPascalName}, Find${pluralPascalName}Variables } from 'types/graphql'
 
 import { Link, routes } from '@redwoodjs/router'
 import type {

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NewName.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NewName.tsx.template
@@ -1,4 +1,4 @@
-import type {
+${useClientDirective}import type {
   Create${singularPascalName}Mutation,
   Create${singularPascalName}Input,
   Create${singularPascalName}MutationVariables


### PR DESCRIPTION
When the RSC experimental feature is enabled the scaffold generator will now insert `'use client'` at the top of the client only components that it generates