### PR TITLE
chore(jsdocs): Fix jsdoc formatting for hover help

### DIFF
--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -578,9 +578,7 @@ export const runCommandTask = async (commands, { verbose }) => {
   }
 }
 
-/*
- * Extract default CLI args from an exported builder
- */
+/** Extract default CLI args from an exported builder */
 export const getDefaultArgs = (builder) => {
   return Object.entries(builder).reduce(
     (options, [optionName, optionConfig]) => {


### PR DESCRIPTION
Before:
![image](https://github.com/redwoodjs/redwood/assets/30793/836ffc28-fe33-4b02-a1a3-398b4e7fbb08)

After:
![image](https://github.com/redwoodjs/redwood/assets/30793/872718a5-8db8-4678-b4e4-08a5432ceae3)

With properly formatted jsdocs we get better hover help texts.

---

This is just a chore, because this is only code that's used internally