### PR TITLE
fix(telemetry): Fix 'destroy' spelling

### DIFF
--- a/packages/cli/src/commands/destroy/helpers.js
+++ b/packages/cli/src/commands/destroy/helpers.js
@@ -34,7 +34,7 @@ export const createYargsForComponentDestroy = ({
     },
     handler: async (options) => {
       recordTelemetryAttributes({
-        command: `destory ${componentName}`,
+        command: `destroy ${componentName}`,
       })
       options = await preTasksFn({ ...options, isDestroyer: true })
       await tasks({ componentName, filesFn, name: options.name }).run()

--- a/packages/cli/src/commands/destroy/page/page.js
+++ b/packages/cli/src/commands/destroy/page/page.js
@@ -51,7 +51,7 @@ export const tasks = ({ name, path }) =>
 
 export const handler = async ({ name, path }) => {
   recordTelemetryAttributes({
-    command: 'destory page',
+    command: 'destroy page',
   })
   const t = tasks({ name, path })
   try {

--- a/packages/cli/src/commands/destroy/sdl/sdl.js
+++ b/packages/cli/src/commands/destroy/sdl/sdl.js
@@ -34,7 +34,7 @@ export const tasks = ({ model }) =>
 
 export const handler = async ({ model }) => {
   recordTelemetryAttributes({
-    command: 'destory sdl',
+    command: 'destroy sdl',
   })
   try {
     const { name } = await verifyModelName({ name: model, isDestroyer: true })


### PR DESCRIPTION
Fix "destroy" spelling when reporting command usage using telemetry