### PR TITLE
RSC: babel-plugin-redwood-cell remove redundant reset

### DIFF
--- a/packages/babel-config/src/plugins/babel-plugin-redwood-cell.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-cell.ts
@@ -176,9 +176,6 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
               ])
             )
           )
-
-          hasDefaultExport = false
-          exportNames = []
         },
       },
     },


### PR DESCRIPTION
The resetting of `exportNames` and `hasDefaultExport` is now done in `enter()` instead, to also cover the cases of early returns in `exit()`. So no need to repeat at the end of `exit()`