### PR TITLE
fix(RSC/SSR): pass CLI options through to apiServerHandler

### DIFF
--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -80,11 +80,10 @@ export const bothServerFileHandler = async (argv) => {
 }
 
 export const bothSsrRscServerHandler = async (argv) => {
-  // TODO Allow specifying port, socket and apiRootPath
   const apiPromise = apiServerHandler({
-    ...argv,
-    port: 8911,
-    apiRootPath: '/',
+    apiRootPath: argv.apiRootPath,
+    host: argv.apiHost,
+    port: argv.apiPort,
   })
 
   // TODO More gracefully handle Ctrl-C


### PR DESCRIPTION
@dac09 pointed me to this bug; looks like we were still hardcoding the port passed to the api server for RSC/SSR serve.

Not sure if this should be milestoned RSC or SSR since it applies to both.