### PR TITLE
7.0 RC: Remove hardcoded check for `session.id`

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
@@ -2944,6 +2944,48 @@ describe('dbAuth', () => {
 
       expect(user.id).toEqual(dbUser.id)
     })
+
+    it('returns the user when id field is other than `id`', async () => {
+      const randomId = Math.floor(Math.random() * 1000000)
+      const dbUser = await createDbUser({ userId: randomId })
+      const options = {
+        authFields: {
+          id: 'userId',
+        },
+        authModelAccessor: 'user',
+        db: db,
+        forgotPassword: {
+          handler: () => {},
+        },
+        login: {
+          handler: () => {},
+          expires: 1,
+        },
+        resetPassword: {
+          handler: () => {},
+        },
+        signup: {
+          handler: () => {},
+        },
+      }
+      const headers = {
+        cookie: encryptToCookie(
+          JSON.stringify({ userId: dbUser.userId }) + ';' + 'token'
+        ),
+      }
+
+      const req = new Request('http://localhost:8910/_rw_mw', {
+        method: 'POST',
+        headers,
+      })
+
+      const dbAuth = new DbAuthHandler(req, context, options)
+      await dbAuth.init()
+
+      const user = await dbAuth._getCurrentUser()
+
+      expect(user.userId).toEqual(dbUser.userId)
+    })
   })
 
   describe('_createUser()', () => {

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -2651,6 +2651,46 @@ describe('dbAuth', () => {
 
       expect(user.id).toEqual(dbUser.id)
     })
+
+    it('returns the user when id field is other than `id`', async () => {
+      const randomId = Math.floor(Math.random() * 1000000)
+      const dbUser = await createDbUser({ userId: randomId })
+
+      const event = {
+        headers: {
+          cookie: encryptToCookie(
+            JSON.stringify({ userId: dbUser.userId }) + ';' + 'token'
+          ),
+        },
+      }
+      const context = { foo: 'bar' }
+      const options = {
+        authFields: {
+          id: 'userId',
+        },
+        authModelAccessor: 'user',
+        db: db,
+        forgotPassword: {
+          handler: () => {},
+        },
+        login: {
+          handler: () => {},
+          expires: 1,
+        },
+        resetPassword: {
+          handler: () => {},
+        },
+        signup: {
+          handler: () => {},
+        },
+      }
+      const dbAuth = new DbAuthHandler(event, context, options)
+      await dbAuth.init()
+
+      const user = await dbAuth._getCurrentUser()
+
+      expect(user.userId).toEqual(dbUser.userId)
+    })
   })
 
   describe('_createUser()', () => {


### PR DESCRIPTION
Fixes bug when User table had a primary key other than `id`. Shout out to @will-ks for finding this!

### Impact 

For apps which had a primary key other than `id`, all users will be logged out on their next request after this is deployed.

Not sure if we consider that breaking? But it is 7.0 so anything goes!

Closes #10005