### PR TITLE
fix: Handle static assets on the `rw-serve-fe`

### DIFF
--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -175,6 +175,9 @@ export async function runFeServer() {
     })
   )
 
+  // Serve static assets that aren't covered by any of the above routes or middleware
+  app.use(express.static(rwPaths.web.dist, { index: false }))
+
   app.listen(rwConfig.web.port)
   console.log(
     `Started production FE server on http://localhost:${rwConfig.web.port}`

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -176,6 +176,15 @@ export async function runFeServer() {
   )
 
   // Serve static assets that aren't covered by any of the above routes or middleware
+  // Note: That the order here is important and that we are explicitly preventing access
+  // to the server dist folder
+  // TODO: In the future, we should explicitly serve `web/dist/client` and `web/dist/rsc`
+  // and simply not serve the `web/dist/server` folder
+  app.use(`/${path.basename(rwPaths.web.distServer)}/*`, (_req, res, _next) => {
+    return res
+      .status(403)
+      .end('403 Forbidden: Access to server dist is forbidden')
+  })
   app.use(express.static(rwPaths.web.dist, { index: false }))
 
   app.listen(rwConfig.web.port)

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -76,7 +76,7 @@ export async function runFeServer() {
 
   if (rwConfig.experimental?.rsc?.enabled) {
     console.log('='.repeat(80))
-    console.log('buildManifest', buildManifest.default)
+    console.log('buildManifest', buildManifest)
     console.log('='.repeat(80))
   }
 


### PR DESCRIPTION
**Problem**
The current `rw-serve-fe` which is used when you have SSR or RSC enabled does not serve static assets like `robots.txt` or other files such as fonts, images etc which are placed in `web/dist` by the `yarn rw build` process. 

This became apparent when I was upgrading the badge app example to the latest canary. The current behaviour is: 
![image](https://github.com/redwoodjs/redwood/assets/56300765/229a2aa8-307b-4010-97ae-7d20f889e26f)

Whereas the expected behaviour (and the behaviour introduced by the changes here) is:
![image](https://github.com/redwoodjs/redwood/assets/56300765/0db01c47-0983-49ef-9b1b-18f57930f861)

**Changes**
1. This adds a final express static handler for the web dist folder. My understanding is that the order is important such that adding this at the end will mean any match that occurs for the previously defined handlers/middlewares will take precedence.
2. Fixes an unrelated duplicate `.default` for the build manifest console logging.

**Notes**
I'm not certain this is the perfect way of doing this but it appears to match the behaviour we support in the non-rsc/ssr version of serve which registers a handler for static assets covering the full `dist` folder.

I added this as "next-release" just because it felt that way to me but this could be considered a "next-release-patch". Happy for it to be changed. 
