### PR TITLE
fix(deps): remove react types packages from `@redwoodjs/testing` dependencies

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -43,8 +43,6 @@
     "@types/babel-core": "6.25.10",
     "@types/jest": "29.5.8",
     "@types/node": "20.11.10",
-    "@types/react": "^18.2.55",
-    "@types/react-dom": "^18.2.19",
     "@types/webpack": "5.28.5",
     "@types/webpack-env": "1.18.4",
     "babel-jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8704,8 +8704,6 @@ __metadata:
     "@types/babel-core": "npm:6.25.10"
     "@types/jest": "npm:29.5.8"
     "@types/node": "npm:20.11.10"
-    "@types/react": "npm:^18.2.55"
-    "@types/react-dom": "npm:^18.2.19"
     "@types/webpack": "npm:5.28.5"
     "@types/webpack-env": "npm:1.18.4"
     babel-jest: "npm:^29.7.0"


### PR DESCRIPTION
Have been thinking about this one on and off for a while now and I don't think any of our packages should have the react types packages as dependencies if the web workspace in apps is going to have them.

More generally, if a Redwood app is going to explicitly depend on a package that one of our framework packages also depends on, one of them should go or use the `'*'` specifier.

I ran into an issue related to this a day or two ago with the deploy target CI providers. It was easily fixed if you knew what to look for. Unpinning them was a step forward cause yarn can sometimes make it work if you run dedupe or at worst edit or regenerate the lock file. But most people don't know what to look for and we shouldn't expect them to.

The reason we didn't do this before (see the original comment in https://github.com/redwoodjs/redwood/pull/9727) was that the mailer depends on the react types packages but doesn't explicitly list them as dependencies. Well, it can still get the react types packages implicitly from node_modules anyway cause the web workspace puts them there.