### PR TITLE
fix(server): fix env var loading in `createServer`

### DIFF
--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -15,7 +15,6 @@ import type { MockInstance } from 'vitest'
 
 import { getConfig } from '@redwoodjs/project-config'
 
-import { createServer } from '../createServer'
 import {
   resolveOptions,
   DEFAULT_CREATE_SERVER_OPTIONS,
@@ -24,9 +23,16 @@ import {
 // Set up RWJS_CWD.
 let original_RWJS_CWD: string | undefined
 
-beforeAll(() => {
+// We have to asynchronously import the module because it relies on RWJS_CWD being set.
+// TODO(jtoar): The lint rule below is complaining about the import,
+// but I'm not sure what else to do at the moment. Happy to take suggestions!
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+let createServer: typeof import('../createServer.js').createServer
+
+beforeAll(async () => {
   original_RWJS_CWD = process.env.RWJS_CWD
   process.env.RWJS_CWD = path.join(__dirname, './fixtures/redwood-app')
+  createServer = (await import('../createServer.js')).createServer
 })
 
 afterAll(() => {

--- a/packages/api-server/src/createServer.ts
+++ b/packages/api-server/src/createServer.ts
@@ -29,7 +29,7 @@ interface Server extends FastifyInstance {
 // ```
 //
 // We do it here and not in the function below so that users can access env vars before calling `createServer`
-if (process.env.RWJS_CWD && !process.env.REDWOOD_ENV_FILES_LOADED) {
+if (!process.env.REDWOOD_ENV_FILES_LOADED) {
   config({
     path: path.join(getPaths().base, '.env'),
     defaults: path.join(getPaths().base, '.env.defaults'),


### PR DESCRIPTION
Running the server file via node means `RWJS_CWD` will never be set so we can't rely on it to load env files. I seemed to have gotten this right for the web server in https://github.com/redwoodjs/redwood/pull/9948 but missed it here in the api server.