### PR TITLE
fix(types): Fix TS type in createServer.test.ts

### DIFF
--- a/packages/api-server/src/__tests__/createServer.test.ts
+++ b/packages/api-server/src/__tests__/createServer.test.ts
@@ -15,6 +15,7 @@ import type { MockInstance } from 'vitest'
 
 import { getConfig } from '@redwoodjs/project-config'
 
+import type { createServer as tCreateServer } from '../createServer.js'
 import {
   resolveOptions,
   DEFAULT_CREATE_SERVER_OPTIONS,
@@ -23,11 +24,7 @@ import {
 // Set up RWJS_CWD.
 let original_RWJS_CWD: string | undefined
 
-// We have to asynchronously import the module because it relies on RWJS_CWD being set.
-// TODO(jtoar): The lint rule below is complaining about the import,
-// but I'm not sure what else to do at the moment. Happy to take suggestions!
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-let createServer: typeof import('../createServer.js').createServer
+let createServer: typeof tCreateServer
 
 beforeAll(async () => {
   original_RWJS_CWD = process.env.RWJS_CWD


### PR DESCRIPTION
Because it's only a type import it's safe to do this. All type imports are removed when building/running. They're just there for TS's sake. 