### PR TITLE
chore(k6 tests): update entry point

### DIFF
--- a/tasks/k6-test/run-k6-tests.mts
+++ b/tasks/k6-test/run-k6-tests.mts
@@ -49,7 +49,7 @@ const API_SERVER_COMMANDS = [
     host: 'http://localhost:8911',
   },
   {
-    cmd: `node ${path.resolve(REDWOOD_PROJECT_DIRECTORY, 'node_modules/@redwoodjs/api-server/dist/index.js')} api`,
+    cmd: `node ${path.resolve(REDWOOD_PROJECT_DIRECTORY, 'node_modules/@redwoodjs/api-server/dist/bin.js')} api`,
     host: 'http://localhost:8911'
   },
 ]


### PR DESCRIPTION
Ran the k6 tests with @Josh-Walker-GM and we noticed that I forgot to update one of the entry points in my api server PRs (see https://github.com/redwoodjs/redwood/pull/9948).