### PR TITLE
fix(realtime): update logic for including sseLink

### DIFF
--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import fs from 'fs'
 import path from 'path'
 
 import react from '@vitejs/plugin-react'
@@ -29,6 +29,12 @@ export default function redwoodPluginVite(): PluginOption[] {
   }
 
   const relativeEntryPath = path.relative(rwPaths.web.src, clientEntryPath)
+
+  // If realtime is enabled, we want to include the sseLink in the bundle.
+  // Right now the only way we have of telling is if the package is installed on the api side.
+  const realtimeEnabled = fs
+    .readFileSync(path.join(rwPaths.api.base, 'package.json'), 'utf-8')
+    .includes('@redwoodjs/realtime')
 
   return [
     {
@@ -83,7 +89,7 @@ export default function redwoodPluginVite(): PluginOption[] {
           // So we inject the entrypoint with the correct extension .tsx vs .jsx
 
           // And then inject the entry
-          if (existsSync(clientEntryPath)) {
+          if (fs.existsSync(clientEntryPath)) {
             return html.replace(
               '</head>',
               // @NOTE the slash in front, for windows compatibility and for pages in subdirectories
@@ -99,7 +105,7 @@ export default function redwoodPluginVite(): PluginOption[] {
       // but note index.html does not come through as an id during dev
       transform: (code: string, id: string) => {
         if (
-          existsSync(clientEntryPath) &&
+          fs.existsSync(clientEntryPath) &&
           normalizePath(id) === normalizePath(rwPaths.web.html)
         ) {
           return {
@@ -286,7 +292,7 @@ export default function redwoodPluginVite(): PluginOption[] {
         id: /@redwoodjs\/router\/dist\/splash-page/,
       },
     ]),
-    !rwConfig.experimental.realtime.enabled &&
+    !realtimeEnabled &&
       removeFromBundle([
         {
           id: /@redwoodjs\/web\/dist\/apollo\/sseLink/,


### PR DESCRIPTION
Since realtime went out of experimental, the logic for including the SSE Link in the bundle needs to be updated. We can't just use TOML config anymore as a tell since there's none. Right now all I can think of as a real source of truth is if the user has the realtime package on the api side.