### PR TITLE
chore: bump TSTyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ora": "7.0.1",
     "prompts": "2.4.2",
     "rimraf": "5.0.5",
-    "tstyche": "1.0.0-beta.9",
+    "tstyche": "1.0.0",
     "tsx": "4.6.2",
     "typescript": "5.3.3",
     "vitest": "1.2.2",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -37,7 +37,7 @@
     "jest": "29.7.0",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913",
-    "tstyche": "1.0.0-beta.9",
+    "tstyche": "1.0.0",
     "typescript": "5.3.3"
   },
   "peerDependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -61,7 +61,7 @@
     "nodemon": "3.0.2",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913",
-    "tstyche": "1.0.0-beta.9",
+    "tstyche": "1.0.0",
     "typescript": "5.3.3"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8613,7 +8613,7 @@ __metadata:
     jest: "npm:29.7.0"
     react: "npm:0.0.0-experimental-e5205658f-20230913"
     react-dom: "npm:0.0.0-experimental-e5205658f-20230913"
-    tstyche: "npm:1.0.0-beta.9"
+    tstyche: "npm:1.0.0"
     typescript: "npm:5.3.3"
   peerDependencies:
     react: 0.0.0-experimental-e5205658f-20230913
@@ -8822,7 +8822,7 @@ __metadata:
     react-hot-toast: "npm:2.4.1"
     stacktracey: "npm:2.1.8"
     ts-toolbelt: "npm:9.6.0"
-    tstyche: "npm:1.0.0-beta.9"
+    tstyche: "npm:1.0.0"
     typescript: "npm:5.3.3"
   peerDependencies:
     react: 0.0.0-experimental-e5205658f-20230913
@@ -29803,7 +29803,7 @@ __metadata:
     ora: "npm:7.0.1"
     prompts: "npm:2.4.2"
     rimraf: "npm:5.0.5"
-    tstyche: "npm:1.0.0-beta.9"
+    tstyche: "npm:1.0.0"
     tsx: "npm:4.6.2"
     typescript: "npm:5.3.3"
     vitest: "npm:1.2.2"
@@ -32238,9 +32238,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:1.0.0-beta.9":
-  version: 1.0.0-beta.9
-  resolution: "tstyche@npm:1.0.0-beta.9"
+"tstyche@npm:1.0.0":
+  version: 1.0.0
+  resolution: "tstyche@npm:1.0.0"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
@@ -32248,7 +32248,7 @@ __metadata:
       optional: true
   bin:
     tstyche: ./build/bin.js
-  checksum: 10c0/2682c3f7e2d83fa0af795ba14e1c83873e3f8c31f761a8af10512c3476cf824b7ef096ba9deec3fc0e12356beaf2a20abfafcb73202db4f14c7c2877db2c5a87
+  checksum: 10c0/79083a3bdc0db3cd1ba4c7205b47b9c3c0bdf5ef56db13cd1d1953dc1d8b0d4d88fa125e20f42d01b4d9e6b205c2477105e9f1908dd5451e33bb27ca327ff479
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TSTyche 1.0.0 was just released.

This PR bumps the version to clean up `package.json` files.
