### PR TITLE
chore(crwa): update version in e2e test

### DIFF
--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -47,7 +47,7 @@ describe('create-redwood-app', () => {
 
     expect(p.exitCode).toEqual(0)
     expect(p.stdout).toMatchInlineSnapshot(`
-      "6.0.7
+      "7.0.0
       [?25l[?25h"
     `)
     expect(p.stderr).toMatchInlineSnapshot(`"[?25l[?25h"`)


### PR DESCRIPTION
Updates the CRWA version snapshot for the e2e test post v7 release.