### PR TITLE
chore(deps): acorn-loose 8.4.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -76,7 +76,7 @@
     "@vitejs/plugin-react": "4.2.1",
     "@whatwg-node/fetch": "0.9.16",
     "@whatwg-node/server": "0.9.24",
-    "acorn-loose": "8.3.0",
+    "acorn-loose": "8.4.0",
     "buffer": "6.0.3",
     "busboy": "^1.6.0",
     "cookie": "0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8751,7 +8751,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:4.2.1"
     "@whatwg-node/fetch": "npm:0.9.16"
     "@whatwg-node/server": "npm:0.9.24"
-    acorn-loose: "npm:8.3.0"
+    acorn-loose: "npm:8.4.0"
     buffer: "npm:6.0.3"
     busboy: "npm:^1.6.0"
     cookie: "npm:0.6.0"
@@ -12536,15 +12536,6 @@ __metadata:
   peerDependencies:
     acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
   checksum: 10c0/4c54868fbef3b8d58927d5e33f0a4de35f59012fe7b12cf9dfbb345fb8f46607709e1c4431be869a23fb63c151033d84c4198fa9f79385cec34fcb1dd53974c1
-  languageName: node
-  linkType: hard
-
-"acorn-loose@npm:8.3.0":
-  version: 8.3.0
-  resolution: "acorn-loose@npm:8.3.0"
-  dependencies:
-    acorn: "npm:^8.5.0"
-  checksum: 10c0/970f790a584a2f1703a04711cdc588f424fd7bc2fb37ad8e0b9d6ceaf9c8c6a77f9ce102ce5250259fc96aedbdf346546ed1b496299bc13ed4d1b6fdb2d92f61
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump acorn-loose to 8.4.0

It brings in some improvements to its TS types that I wanted to use in the RSC work I'm doing