### PR TITLE
chore(release): fix updating `peerDependencies` in release script

### DIFF
--- a/tasks/release/release.mjs
+++ b/tasks/release/release.mjs
@@ -762,8 +762,8 @@ function updateRWJSPkgsVersion(pkgPath, version) {
   }
 
   for (const dep of Object.keys(pkg.peerDependencies ?? {}).filter(isRWJSPkg)) {
-    console.log(` - ${dep}: ${pkg.devDependencies[dep]} => ${version}`)
-    pkg.devDependencies[dep] = `${version}`
+    console.log(` - ${dep}: ${pkg.peerDependencies[dep]} => ${version}`)
+    pkg.peerDependencies[dep] = `${version}`
   }
 
   fs.writeJSONSync(path.join(pkgPath, 'package.json'), pkg, { spaces: 2 })


### PR DESCRIPTION
`@redwoodjs/api-server`'s peerDependency on `@redwoodjs/graphql-server` didn't get bumped to v7; a user caught it here: https://community.redwoodjs.com/t/redwood-v7-0-0-upgrade-guide/5713/22. Turns out there's a small bug in our release script. Fixing here then I'll release a patch.