### PR TITLE
RSC: Refactor: extract common code for env vars

### DIFF
--- a/packages/vite/src/envVarDefinitions.ts
+++ b/packages/vite/src/envVarDefinitions.ts
@@ -1,0 +1,56 @@
+import path from 'node:path'
+
+import { getConfig, getPaths } from '@redwoodjs/project-config'
+
+export function getEnvVarDefinitions() {
+  const rwConfig = getConfig()
+  const rwPaths = getPaths()
+
+  return {
+    RWJS_ENV: {
+      // @NOTE we're avoiding process.env here, unlike webpack
+      RWJS_API_GRAPHQL_URL:
+        rwConfig.web.apiGraphQLUrl ?? rwConfig.web.apiUrl + '/graphql',
+      RWJS_API_URL: rwConfig.web.apiUrl,
+      __REDWOOD__APP_TITLE: rwConfig.web.title || path.basename(rwPaths.base),
+      RWJS_EXP_STREAMING_SSR: rwConfig.experimental.streamingSsr?.enabled,
+      RWJS_EXP_RSC: rwConfig.experimental?.rsc?.enabled,
+    },
+    RWJS_DEBUG_ENV: {
+      RWJS_SRC_ROOT: rwPaths.web.src,
+      REDWOOD_ENV_EDITOR: JSON.stringify(process.env.REDWOOD_ENV_EDITOR),
+    },
+    // Vite can automatically expose environment variables, but we
+    // disable that in `buildFeServer.ts` by setting `envFile: false`
+    // because we want to use our own logic for loading .env,
+    // .env.defaults, etc
+    // The two object spreads below will expose all environment
+    // variables listed in redwood.toml and all environment variables
+    // prefixed with REDWOOD_ENV_
+    ...Object.fromEntries(
+      rwConfig.web.includeEnvironmentVariables.flatMap((envName) => [
+        // TODO: Figure out if/why we need to disable eslint here, when we
+        // didn't have to before, when this code was in index.ts
+        // Re-enable if possible
+        // eslint-disable-next-line
+        [`import.meta.env.${envName}`, JSON.stringify(process.env[envName])],
+        // TODO: Figure out if/why we need to disable eslint here, when we
+        // didn't have to before, when this code was in index.ts
+        // Re-enable if possible
+        // eslint-disable-next-line
+        [`process.env.${envName}`, JSON.stringify(process.env[envName])],
+      ])
+    ),
+    ...Object.entries(process.env).reduce<Record<string, any>>(
+      (acc, [key, value]) => {
+        if (key.startsWith('REDWOOD_ENV_')) {
+          acc[`import.meta.env.${key}`] = JSON.stringify(value)
+          acc[`process.env.${key}`] = JSON.stringify(value)
+        }
+
+        return acc
+      },
+      {}
+    ),
+  }
+}

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -9,6 +9,7 @@ import { normalizePath } from 'vite'
 import { getWebSideDefaultBabelConfig } from '@redwoodjs/babel-config'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 
+import { getEnvVarDefinitions } from './envVarDefinitions'
 import handleJsAsJsx from './plugins/vite-plugin-jsx-loader'
 import removeFromBundle from './plugins/vite-plugin-remove-from-bundle'
 import swapApolloProvider from './plugins/vite-plugin-swap-apollo-provider'
@@ -150,56 +151,7 @@ export default function redwoodPluginVite(): PluginOption[] {
           // },
           envPrefix: 'REDWOOD_ENV_',
           publicDir: path.join(rwPaths.web.base, 'public'),
-          define: {
-            RWJS_ENV: {
-              // @NOTE we're avoiding process.env here, unlike webpack
-              RWJS_API_GRAPHQL_URL:
-                rwConfig.web.apiGraphQLUrl ?? rwConfig.web.apiUrl + '/graphql',
-              RWJS_API_URL: rwConfig.web.apiUrl,
-              __REDWOOD__APP_TITLE:
-                rwConfig.web.title || path.basename(rwPaths.base),
-              RWJS_EXP_STREAMING_SSR:
-                rwConfig.experimental.streamingSsr &&
-                rwConfig.experimental.streamingSsr.enabled,
-              RWJS_EXP_RSC: rwConfig.experimental?.rsc?.enabled,
-            },
-            RWJS_DEBUG_ENV: {
-              RWJS_SRC_ROOT: rwPaths.web.src,
-              REDWOOD_ENV_EDITOR: JSON.stringify(
-                process.env.REDWOOD_ENV_EDITOR
-              ),
-            },
-            // Vite can automatically expose environment variables, but we
-            // disable that in `buildFeServer.ts` by setting `envFile: false`
-            // because we want to use our own logic for loading .env,
-            // .env.defaults, etc
-            // The two object spreads below will expose all environment
-            // variables listed in redwood.toml and all environment variables
-            // prefixed with REDWOOD_ENV_
-            ...Object.fromEntries(
-              rwConfig.web.includeEnvironmentVariables.flatMap((envName) => [
-                [
-                  `import.meta.env.${envName}`,
-                  JSON.stringify(process.env[envName]),
-                ],
-                [
-                  `process.env.${envName}`,
-                  JSON.stringify(process.env[envName]),
-                ],
-              ])
-            ),
-            ...Object.entries(process.env).reduce<Record<string, any>>(
-              (acc, [key, value]) => {
-                if (key.startsWith('REDWOOD_ENV_')) {
-                  acc[`import.meta.env.${key}`] = JSON.stringify(value)
-                  acc[`process.env.${key}`] = JSON.stringify(value)
-                }
-
-                return acc
-              },
-              {}
-            ),
-          },
+          define: getEnvVarDefinitions(),
           css: {
             // @NOTE config path is relative to where vite.config.js is if you use relative path
             // postcss: './config/',

--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -4,8 +4,9 @@ import react from '@vitejs/plugin-react'
 import { build as viteBuild } from 'vite'
 
 import { getWebSideDefaultBabelConfig } from '@redwoodjs/babel-config'
-import { getConfig, getPaths } from '@redwoodjs/project-config'
+import { getPaths } from '@redwoodjs/project-config'
 
+import { getEnvVarDefinitions } from '../envVarDefinitions'
 import { onWarn } from '../lib/onWarn'
 
 import { rscIndexPlugin } from './rscVitePlugins'
@@ -21,10 +22,6 @@ export async function rscBuildClient(
   clientEntryFiles: Record<string, string>
 ) {
   const rwPaths = getPaths()
-  const rwConfig = getConfig()
-
-  const graphQlUrl =
-    rwConfig.web.apiGraphQLUrl ?? rwConfig.web.apiUrl + '/graphql'
 
   const clientBuildOutput = await viteBuild({
     // configFile: viteConfigPath,
@@ -32,49 +29,7 @@ export async function rscBuildClient(
     envPrefix: 'REDWOOD_ENV_',
     publicDir: path.join(rwPaths.web.base, 'public'),
     envFile: false,
-    define: {
-      RWJS_ENV: {
-        __REDWOOD__APP_TITLE: rwConfig.web.title || path.basename(rwPaths.base),
-        RWJS_API_GRAPHQL_URL: graphQlUrl,
-        RWJS_API_URL: rwConfig.web.apiUrl,
-        RWJS_EXP_STREAMING_SSR: rwConfig.experimental?.streamingSsr?.enabled,
-        RWJS_EXP_RSC: rwConfig.experimental?.rsc?.enabled,
-      },
-      RWJS_DEBUG_ENV: {
-        RWJS_SRC_ROOT: rwPaths.web.src,
-        REDWOOD_ENV_EDITOR: JSON.stringify(process.env.REDWOOD_ENV_EDITOR),
-      },
-      // Vite can automatically expose environment variables, but we
-      // disable that in `buildFeServer.ts` by setting `envFile: false`
-      // because we want to use our own logic for loading .env,
-      // .env.defaults, etc
-      // The two object spreads below will expose all environment
-      // variables listed in redwood.toml and all environment variables
-      // prefixed with REDWOOD_ENV_
-      ...Object.fromEntries(
-        rwConfig.web.includeEnvironmentVariables.flatMap((envName) => [
-          // TODO (RSC): Figure out if/why we need to disable eslint here.
-          // Re-enable if possible
-          // eslint-disable-next-line
-          [`import.meta.env.${envName}`, JSON.stringify(process.env[envName])],
-          // TODO (RSC): Figure out if/why we need to disable eslint here
-          // Re-enable if possible
-          // eslint-disable-next-line
-          [`process.env.${envName}`, JSON.stringify(process.env[envName])],
-        ])
-      ),
-      ...Object.entries(process.env).reduce<Record<string, any>>(
-        (acc, [key, value]) => {
-          if (key.startsWith('REDWOOD_ENV_')) {
-            acc[`import.meta.env.${key}`] = JSON.stringify(value)
-            acc[`process.env.${key}`] = JSON.stringify(value)
-          }
-
-          return acc
-        },
-        {}
-      ),
-    },
+    define: getEnvVarDefinitions(),
     plugins: [
       react({
         babel: {

--- a/packages/vite/src/rsc/rscBuildServer.ts
+++ b/packages/vite/src/rsc/rscBuildServer.ts
@@ -6,6 +6,7 @@ import { build as viteBuild } from 'vite'
 import { getWebSideDefaultBabelConfig } from '@redwoodjs/babel-config'
 import { getConfig, getPaths } from '@redwoodjs/project-config'
 
+import { getEnvVarDefinitions } from '../envVarDefinitions'
 import { onWarn } from '../lib/onWarn'
 
 /**
@@ -42,51 +43,7 @@ export async function rscBuildServer(
     envPrefix: 'REDWOOD_ENV_',
     publicDir: path.join(rwPaths.web.base, 'public'),
     envFile: false,
-    define: {
-      RWJS_ENV: {
-        // @NOTE we're avoiding process.env here, unlike webpack
-        RWJS_API_GRAPHQL_URL:
-          rwConfig.web.apiGraphQLUrl ?? rwConfig.web.apiUrl + '/graphql',
-        RWJS_API_URL: rwConfig.web.apiUrl,
-        __REDWOOD__APP_TITLE: rwConfig.web.title || path.basename(rwPaths.base),
-        RWJS_EXP_STREAMING_SSR: rwConfig.experimental?.streamingSsr?.enabled,
-        RWJS_EXP_RSC: rwConfig.experimental?.rsc?.enabled,
-      },
-      RWJS_DEBUG_ENV: {
-        RWJS_SRC_ROOT: rwPaths.web.src,
-        REDWOOD_ENV_EDITOR: JSON.stringify(process.env.REDWOOD_ENV_EDITOR),
-      },
-      // Vite can automatically expose environment variables, but we
-      // disable that in `buildFeServer.ts` by setting `envFile: false`
-      // because we want to use our own logic for loading .env,
-      // .env.defaults, etc
-      // The two object spreads below will expose all environment
-      // variables listed in redwood.toml and all environment variables
-      // prefixed with REDWOOD_ENV_
-      ...Object.fromEntries(
-        rwConfig.web.includeEnvironmentVariables.flatMap((envName) => [
-          // TODO (RSC): Figure out if/why we need to disable eslint here.
-          // Re-enable if possible
-          // eslint-disable-next-line
-          [`import.meta.env.${envName}`, JSON.stringify(process.env[envName])],
-          // TODO (RSC): Figure out if/why we need to disable eslint here
-          // Re-enable if possible
-          // eslint-disable-next-line
-          [`process.env.${envName}`, JSON.stringify(process.env[envName])],
-        ])
-      ),
-      ...Object.entries(process.env).reduce<Record<string, any>>(
-        (acc, [key, value]) => {
-          if (key.startsWith('REDWOOD_ENV_')) {
-            acc[`import.meta.env.${key}`] = JSON.stringify(value)
-            acc[`process.env.${key}`] = JSON.stringify(value)
-          }
-
-          return acc
-        },
-        {}
-      ),
-    },
+    define: getEnvVarDefinitions(),
     ssr: {
       // Externalize everything except packages with files that have
       // 'use client' in them (which are the files in `clientEntryFiles`)


### PR DESCRIPTION
I was repeating the config for ENV vars in three places. Extracted that out into a separate method that I can just call to get the config