### PR TITLE
RSC: Upgrade test-project-rsa to v8 canary

### DIFF
--- a/__fixtures__/test-project-rsa/api/package.json
+++ b/__fixtures__/test-project-rsa/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "7.0.0-canary.717",
-    "@redwoodjs/graphql-server": "7.0.0-canary.717"
+    "@redwoodjs/api": "8.0.0-canary.144",
+    "@redwoodjs/graphql-server": "8.0.0-canary.144"
   }
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "7.0.0-canary.717"
+    "@redwoodjs/core": "8.0.0-canary.144"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/test-project-rsa/web/package.json
+++ b/__fixtures__/test-project-rsa/web/package.json
@@ -11,13 +11,15 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "7.0.0-canary.717",
-    "@redwoodjs/router": "7.0.0-canary.717",
-    "@redwoodjs/web": "7.0.0-canary.717",
+    "@redwoodjs/forms": "8.0.0-canary.144",
+    "@redwoodjs/router": "8.0.0-canary.144",
+    "@redwoodjs/web": "8.0.0-canary.144",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
-    "@redwoodjs/vite": "7.0.0-canary.717"
+    "@redwoodjs/vite": "8.0.0-canary.144",
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.19"
   }
 }

--- a/__fixtures__/test-project-rsa/web/package.json
+++ b/__fixtures__/test-project-rsa/web/package.json
@@ -11,6 +11,7 @@
     ]
   },
   "dependencies": {
+    "@apollo/experimental-nextjs-app-support": "0.0.0-commit-b8a73fe",
     "@redwoodjs/forms": "8.0.0-canary.144",
     "@redwoodjs/router": "8.0.0-canary.144",
     "@redwoodjs/web": "8.0.0-canary.144",


### PR DESCRIPTION
Upgrading the rsa test-project to latest canary (which is now on 8.0.0 instead of 7.0.0) to make it possible to run `rwfw project:copy` without getting error about missing bins

(maybe we should switch to `project:tarsync`)