### PR TITLE
Update MetaTags to be MetaData in Docs

### DIFF
--- a/docs/docs/tutorial/chapter1/layouts.md
+++ b/docs/docs/tutorial/chapter1/layouts.md
@@ -94,12 +94,12 @@ export default BlogLayout
 
 ```jsx title="web/src/pages/AboutPage/AboutPage.jsx"
 import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const AboutPage = () => {
   return (
     <>
-      <MetaTags title="About" description="About page" />
+      <MetaData title="About" description="About page" />
 
       <p>
         This site was created to demonstrate my mastery of Redwood: Look on my
@@ -118,12 +118,12 @@ export default AboutPage
 
 ```jsx title="web/src/pages/AboutPage/AboutPage.tsx"
 import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const AboutPage = () => {
   return (
     <>
-      <MetaTags title="About" description="About page" />
+      <MetaData title="About" description="About page" />
 
       <p>
         This site was created to demonstrate my mastery of Redwood: Look on my
@@ -144,12 +144,12 @@ export default AboutPage
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/HomePage/HomePage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const HomePage = () => {
   return (
     <>
-      <MetaTags title="Home" description="Home page" />
+      <MetaData title="Home" description="Home page" />
       Home
     </>
   )
@@ -162,12 +162,12 @@ export default HomePage
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/pages/HomePage/HomePage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const HomePage = () => {
   return (
     <>
-      <MetaTags title="Home" description="Home page" />
+      <MetaData title="Home" description="Home page" />
       Home
     </>
   )
@@ -347,12 +347,12 @@ And then we can remove the extra "Return to Home" link (and Link/routes import) 
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/AboutPage/AboutPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const AboutPage = () => {
   return (
     <>
-      <MetaTags title="About" description="About page" />
+      <MetaData title="About" description="About page" />
 
       <p>
         This site was created to demonstrate my mastery of Redwood: Look on my
@@ -369,12 +369,12 @@ export default AboutPage
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/pages/AboutPage/AboutPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const AboutPage = () => {
   return (
     <>
-      <MetaTags title="About" description="About page" />
+      <MetaData title="About" description="About page" />
 
       <p>
         This site was created to demonstrate my mastery of Redwood: Look on my

--- a/docs/docs/tutorial/chapter1/second-page.md
+++ b/docs/docs/tutorial/chapter1/second-page.md
@@ -25,12 +25,12 @@ But no one's going to find it by manually changing the URL so let's add a link f
 
 ```jsx title="web/src/pages/HomePage/HomePage.jsx"
 import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const HomePage = () => {
   return (
     <>
-      <MetaTags title="Home" description="Home page" />
+      <MetaData title="Home" description="Home page" />
 
       // highlight-start
       <header>
@@ -57,12 +57,12 @@ export default HomePage
 
 ```jsx title="web/src/pages/HomePage/HomePage.tsx"
 import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const HomePage = () => {
   return (
     <>
-      <MetaTags title="Home" description="Home page" />
+      <MetaData title="Home" description="Home page" />
 
       // highlight-start
       <header>
@@ -105,12 +105,12 @@ Once we get to the About page we don't have any way to get back so let's add a l
 
 ```jsx title="web/src/pages/AboutPage/AboutPage.jsx"
 import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const AboutPage = () => {
   return (
     <>
-      <MetaTags title="About" description="About page" />
+      <MetaData title="About" description="About page" />
 
       // highlight-start
       <header>
@@ -143,12 +143,12 @@ export default AboutPage
 
 ```jsx title="web/src/pages/AboutPage/AboutPage.tsx"
 import { Link, routes } from '@redwoodjs/router'
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 const AboutPage = () => {
   return (
     <>
-      <MetaTags title="About" description="About page" />
+      <MetaData title="About" description="About page" />
 
       // highlight-start
       <header>

--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -342,7 +342,7 @@ Let's plug this cell into our `HomePage` and see what happens:
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/HomePage/HomePage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 // highlight-next-line
 import ArticlesCell from 'src/components/ArticlesCell'
@@ -350,7 +350,7 @@ import ArticlesCell from 'src/components/ArticlesCell'
 const HomePage = () => {
   return (
     <>
-      <MetaTags title="Home" description="Home page" />
+      <MetaData title="Home" description="Home page" />
       // highlight-next-line
       <ArticlesCell />
     </>
@@ -364,7 +364,7 @@ export default HomePage
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/pages/HomePage/HomePage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 
 // highlight-next-line
 import ArticlesCell from 'src/components/ArticlesCell'
@@ -372,7 +372,7 @@ import ArticlesCell from 'src/components/ArticlesCell'
 const HomePage = () => {
   return (
     <>
-      <MetaTags title="Home" description="Home page" />
+      <MetaData title="Home" description="Home page" />
       // highlight-next-line
       <ArticlesCell />
     </>

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -203,12 +203,12 @@ You may have noticed that when trying to view the new single-article page that y
 
 ```diff title="web/src/pages/ArticlePage.js"
 - import { Link, routes } from '@redwoodjs/router'
-  import { MetaTags } from '@redwoodjs/web'
+  import { MetaData } from '@redwoodjs/web'
 
   const ArticlePage = () => {
     return (
       <>
-        <MetaTags title="Article" description="Article page" />
+        <MetaData title="Article" description="Article page" />
 
         <h1>ArticlePage</h1>
         <p>
@@ -230,12 +230,12 @@ You may have noticed that when trying to view the new single-article page that y
 
 ```diff title="web/src/pages/ArticlePage.tsx"
 - import { Link, routes } from '@redwoodjs/router'
-  import { MetaTags } from '@redwoodjs/web'
+  import { MetaData } from '@redwoodjs/web'
 
   const ArticlePage = () => {
     return (
       <>
-        <MetaTags title="Article" description="Article page" />
+        <MetaData title="Article" description="Article page" />
 
         <h1>ArticlePage</h1>
         <p>
@@ -269,14 +269,14 @@ And then we'll use that cell in `ArticlePage`:
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ArticlePage/ArticlePage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import ArticleCell from 'src/components/ArticleCell'
 
 const ArticlePage = () => {
   return (
     <>
-      <MetaTags title="Article" description="Article page" />
+      <MetaData title="Article" description="Article page" />
 
       // highlight-next-line
       <ArticleCell />
@@ -291,14 +291,14 @@ export default ArticlePage
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/pages/ArticlePage/ArticlePage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import ArticleCell from 'src/components/ArticleCell'
 
 const ArticlePage = () => {
   return (
     <>
-      <MetaTags title="Article" description="Article page" />
+      <MetaData title="Article" description="Article page" />
 
       // highlight-next-line
       <ArticleCell />
@@ -388,14 +388,14 @@ Okay, we're getting closer. Still, where will that `$id` come from? Redwood has 
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ArticlePage/ArticlePage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import ArticleCell from 'src/components/ArticleCell'
 
 // highlight-next-line
 const ArticlePage = ({ id }) => {
   return (
     <>
-      <MetaTags title="Article" description="Article page" />
+      <MetaData title="Article" description="Article page" />
 
       // highlight-next-line
       <ArticleCell id={id} />
@@ -410,7 +410,7 @@ export default ArticlePage
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="web/src/pages/ArticlePage/ArticlePage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import ArticleCell from 'src/components/ArticleCell'
 
 // highlight-start
@@ -423,7 +423,7 @@ interface Props {
 const ArticlePage = ({ id }: Props) => {
   return (
     <>
-      <MetaTags title="Article" description="Article page" />
+      <MetaData title="Article" description="Article page" />
 
       // highlight-next-line
       <ArticleCell id={id} />

--- a/docs/docs/tutorial/chapter3/forms.md
+++ b/docs/docs/tutorial/chapter3/forms.md
@@ -186,14 +186,14 @@ We won't be pulling any data from the database on our Contact page so we won't c
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form } from '@redwoodjs/forms'
 
 const ContactPage = () => {
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       // highlight-next-line
       <Form></Form>
@@ -208,14 +208,14 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form } from '@redwoodjs/forms'
 
 const ContactPage = () => {
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       // highlight-next-line
       <Form></Form>
@@ -235,14 +235,14 @@ Well that was anticlimactic. You can't even see it in the browser. Let's add a f
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form, TextField } from '@redwoodjs/forms'
 
 const ContactPage = () => {
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form>
         // highlight-next-line
@@ -259,14 +259,14 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form, TextField } from '@redwoodjs/forms'
 
 const ContactPage = () => {
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form>
         // highlight-next-line
@@ -290,14 +290,14 @@ Something is showing! Still, pretty boring. How about adding a submit button?
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form, TextField, Submit } from '@redwoodjs/forms'
 
 const ContactPage = () => {
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form>
         <TextField name="input" />
@@ -315,14 +315,14 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form, TextField, Submit } from '@redwoodjs/forms'
 
 const ContactPage = () => {
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form>
         <TextField name="input" />
@@ -351,7 +351,7 @@ Similar to a plain HTML form we'll give `<Form>` an `onSubmit` handler. That han
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import { Form, TextField, Submit } from '@redwoodjs/forms'
 
 const ContactPage = () => {
@@ -363,7 +363,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       // highlight-next-line
       <Form onSubmit={onSubmit}>
@@ -381,7 +381,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form, TextField, Submit, SubmitHandler } from '@redwoodjs/forms'
 
@@ -400,7 +400,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       // highlight-next-line
       <Form onSubmit={onSubmit}>
@@ -427,7 +427,7 @@ Great! Let's turn this into a more useful form by adding a couple fields. We'll 
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-next-line
 import { Form, TextField, TextAreaField, Submit } from '@redwoodjs/forms'
 
@@ -438,7 +438,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         // highlight-start
@@ -459,7 +459,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 // highlight-start
 import {
   Form,
@@ -485,7 +485,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         // highlight-start
@@ -515,7 +515,7 @@ Let's add some labels:
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import { Form, TextField, TextAreaField, Submit } from '@redwoodjs/forms'
 
 const ContactPage = () => {
@@ -525,7 +525,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         // highlight-next-line
@@ -553,7 +553,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   Form,
   TextField,
@@ -575,7 +575,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         // highlight-next-line
@@ -726,7 +726,7 @@ Introducing `<FieldError>` (don't forget to include it in the `import` statement
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   // highlight-next-line
   FieldError,
@@ -743,7 +743,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         <label htmlFor="name">Name</label>
@@ -774,7 +774,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   // highlight-next-line
   FieldError,
@@ -798,7 +798,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         <label htmlFor="name">Name</label>
@@ -838,7 +838,7 @@ But this is just the beginning. Let's make sure folks realize this is an error m
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -854,7 +854,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         <label htmlFor="name">Name</label>
@@ -885,7 +885,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -908,7 +908,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         <label htmlFor="name">Name</label>
@@ -946,7 +946,7 @@ You know what would be nice? If the input itself somehow displayed the fact that
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -962,7 +962,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         <label htmlFor="name">Name</label>
@@ -1005,7 +1005,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -1028,7 +1028,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         <label htmlFor="name">Name</label>
@@ -1078,7 +1078,7 @@ Oooo, what if the _label_ could change as well? It can, but we'll need Redwood's
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -1096,7 +1096,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         // highlight-start
@@ -1148,7 +1148,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -1173,7 +1173,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit}>
         // highlight-start

--- a/docs/docs/tutorial/chapter3/saving-data.md
+++ b/docs/docs/tutorial/chapter3/saving-data.md
@@ -361,7 +361,7 @@ Our GraphQL mutation is ready to go on the backend so all that's left is to invo
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -388,7 +388,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit} config={{ mode: 'onBlur' }}>
         <Label name="name" errorClassName="error">
@@ -440,7 +440,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags } from '@redwoodjs/web'
+import { MetaData } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -474,7 +474,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit} config={{ mode: 'onBlur' }}>
         <Label name="name" errorClassName="error">
@@ -534,7 +534,7 @@ Next we'll call the `useMutation` hook provided by Redwood which will allow us t
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
 // highlight-next-line
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -562,7 +562,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit} config={{ mode: 'onBlur' }}>
         <Label name="name" errorClassName="error">
@@ -615,7 +615,7 @@ export default ContactPage
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
 // highlight-next-line
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -661,7 +661,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit} config={{ mode: 'onBlur' }}>
         <Label name="name" errorClassName="error">
@@ -748,7 +748,7 @@ That means we can update the `onSubmit` function to invoke the mutation with the
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -776,7 +776,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit} config={{ mode: 'onBlur' }}>
         <Label name="name" errorClassName="error">
@@ -828,7 +828,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import {
   FieldError,
   Form,
@@ -871,7 +871,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Form onSubmit={onSubmit} config={{ mode: 'onBlur' }}>
         <Label name="name" errorClassName="error">
@@ -1039,7 +1039,7 @@ Add the `onCompleted` callback to `useMutation` and include the **&lt;Toaster&gt
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import {
@@ -1074,7 +1074,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       // highlight-next-line
       <Toaster />
@@ -1128,7 +1128,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import {
@@ -1178,7 +1178,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       // highlight-next-line
       <Toaster />
@@ -1347,7 +1347,7 @@ Add a `<FormError>` component, passing the `error` constant we got from `useMuta
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import {
   FieldError,
@@ -1381,7 +1381,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Toaster />
       // highlight-start
@@ -1434,7 +1434,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import {
   FieldError,
@@ -1483,7 +1483,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Toaster />
       // highlight-start
@@ -1807,7 +1807,7 @@ Here's the entire page:
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/pages/ContactPage/ContactPage.jsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import {
   FieldError,
@@ -1844,7 +1844,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Toaster />
       <Form
@@ -1904,7 +1904,7 @@ export default ContactPage
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/pages/ContactPage/ContactPage.tsx"
-import { MetaTags, useMutation } from '@redwoodjs/web'
+import { MetaData, useMutation } from '@redwoodjs/web'
 import { toast, Toaster } from '@redwoodjs/web/toast'
 import {
   FieldError,
@@ -1956,7 +1956,7 @@ const ContactPage = () => {
 
   return (
     <>
-      <MetaTags title="Contact" description="Contact page" />
+      <MetaData title="Contact" description="Contact page" />
 
       <Toaster />
       <Form


### PR DESCRIPTION
While working through the tutorial I found that `MetaTags` is replaced by `MetaData` in the code generators, however the tutorial still shows `Metatags`. 

This PR updates all instances of `MetaTags` with `MetaData`. 