### PR TITLE
fix(coherence): update setup command to detect server file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- fix(coherence): update setup command to detect server file
+
+  The `yarn rw setup deploy coherence` command now detects if your project has the server file and configures the api prod command accordingly:
+
+  ```yml
+  # coherence.yml
+
+  api:
+    # ...
+    prod:
+      command: ["yarn", "rw", "build", "api", "&&", "yarn", "node", "api/dist/server.js", "--apiRootPath=/api"]
+  ```
+
 - Update jsdoc for ScenarioData type (#29166)
 
   Fix formatting of JSDocs in `scenario.ts`


### PR DESCRIPTION
Similar to https://github.com/redwoodjs/redwood/pull/10055, updates the setup command for Coherence to detect the server file. This deployed successfully in this commit on deploy target CI here: https://github.com/redwoodjs/deploy-target-ci/commit/4e5883e0276d6563b2f9de7fa88e2ef962007e89.