### PR TITLE
Update jsdoc for ScenarioData type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Update jsdoc for ScenarioData type (#29166)
+
+  Fix formatting of JSDocs in `scenario.ts`
+
 - fix(deps): update opentelemetry-js monorepo (#10065)
 
   Updates our opentelemetry packages. This is a breaking change for users of

--- a/packages/testing/src/api/scenario.ts
+++ b/packages/testing/src/api/scenario.ts
@@ -2,45 +2,51 @@ import type { A } from 'ts-toolbelt'
 
 /**
  * Use this function to define your scenario.
+ *
  * @example
  * export const standard = defineScenario({
- user: {
-   dom: {
-     name: 'Dom Saadi',
-     email: 'dom@redwoodjs.com'
-    }
-  },
-})
-/* @example
-* export const standard = defineScenario<Prisma.CreateUserArgs>({
- user: {
-   dom: {
-     name: 'Dom Saadi',
-     email: 'dom@redwoodjs.com'
-    }
-  },
-})
-*/
+ *   user: {
+ *     dom: {
+ *       name: 'Dom Saadi',
+ *       email: 'dom@redwoodjs.com',
+ *     },
+ *   },
+ * })
+ *
+ * @example
+ * export const standard = defineScenario<Prisma.CreateUserArgs>({
+ *   user: {
+ *     dom: {
+ *       name: 'Dom Saadi',
+ *       email: 'dom@redwoodjs.com',
+ *     },
+ *   },
+ * })
+ */
 export const defineScenario: DefineScenario = (data) => {
   return data
 }
 
 /**
- * @example {
- *  dannyUser: {data :{
- *   id: 1,
- *  name: 'Danny',}
- * }}
+ * @example
+ * {
+ *   dannyUser: {
+ *     data: {
+ *       id: 1,
+ *       name: 'Danny',
+ *     },
+ *   },
+ * }
  *
  * @example
- *  krisUser: (scenario) => {
- *  return {
- *    data: {
- *      id: 2,
- *      name: 'Kris',
- *    }
- *  }
- * }
+ *   krisUser: (scenario) => {
+ *     return {
+ *       data: {
+ *         id: 2,
+ *         name: 'Kris',
+ *       },
+ *     }
+ *   }
  */
 type ScenarioDefinitionMap<
   PrismaCreateType extends { data: any },
@@ -99,7 +105,6 @@ export interface DefineScenario {
  *
  * // You can also define each of the keys in your scenario, so you get stricter type checking
  * export StandardScenario = ScenarioData<Product, 'product', 'shirt'>
- *
  */
 export declare type ScenarioData<
   TModel, // the prisma model, imported from @prisma/client e.g. "Product"

--- a/packages/testing/src/api/scenario.ts
+++ b/packages/testing/src/api/scenario.ts
@@ -85,12 +85,13 @@ export interface DefineScenario {
  * import { Product } from '@prisma/client'
  *
  * // If you scenario looks like this:
- * * export const standard = defineScenario({
- *    product: {
- *    shirt: {
- *      id: 55,
- *      price: 10
- *    }
+ * export const standard = defineScenario({
+ *   product: {
+ *     shirt: {
+ *       id: 55,
+ *       price: 10,
+ *     },
+ *   },
  * })
  *
  * // Export the StandardScenario type as


### PR DESCRIPTION
The indentation of the example scenario in the JSDoc for the `ScenarioData` type is wrong making it hard to read, this PR fixes that.