### PR TITLE
chore(docs): Add link to SuperTokens auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- chore(docs): Add link to SuperTokens auth (#10067)
+  Add a missing link to the SuperTokens auth page in the docs.
+
 - fix(deps): update opentelemetry-js monorepo (#10065)
 
   Updates our opentelemetry packages. This is a breaking change for users of

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -26,7 +26,7 @@ Redwood has a simple API to integrate any auth provider you can think of. But to
 - [Firebase](./auth/firebase.md)
 - [Netlify](./auth/netlify.md)
 - [Supabase](./auth/supabase.md)
-- SuperTokens
+- [SuperTokens](./auth/supertokens.md)
 
 :::tip how to tell if an integration is official
 


### PR DESCRIPTION
Add a missing link to the SuperTokens auth page