### PR TITLE
RSC: Fix path in setup script readme

### DIFF
--- a/.github/actions/set-up-rsc-external-packages-and-cells-project/README.md
+++ b/.github/actions/set-up-rsc-external-packages-and-cells-project/README.md
@@ -9,10 +9,10 @@ project, runs `yarn install` and `project:copy`. Finally it builds the rw app.
 ## Testing/running locally
 
 Go into the github actions folder
-`cd .github/actions`
+`cd .github/actions/set-up-rsc-external-packages-and-cells-project`
 
 Then run the following command to execute the action
-`node set-up-rsc-external-packages-project/setUpRscExternalPackagesProjectLocally.mjs`
+`node setUpRscExternalPackagesProjectLocally.mjs`
 
 ## Design
 


### PR DESCRIPTION
I changed the name of the folder a while ago, but forgot to update the path in the readme