### PR TITLE
chore(.vscode): Enable find inside root __fixtures__

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
   "search.exclude": {
     "**/dist": true,
     "**/node_modules": true,
-    "**/__fixtures__": true,
+    "/packages/**/__fixtures__": true,
     ".yarn-packages-cache": true
   },
   "[markdown][html][mjml]": {


### PR DESCRIPTION
When working on RSC a lot of work goes into the test fixtures. When using the VSCode search it's very limiting not being able to search inside those fixtures. So this PR makes it so we only disable search inside package specific __fixtures__ folders.