### PR TITLE
RSC: chore - upgrade @tobbe.dev/rsc-test to v0.0.5

### DIFF
--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
@@ -15,7 +15,7 @@
     "@redwoodjs/forms": "7.0.0-canary.1011",
     "@redwoodjs/router": "7.0.0-canary.1011",
     "@redwoodjs/web": "7.0.0-canary.1011",
-    "@tobbe.dev/rsc-test": "0.0.3",
+    "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913",


### PR DESCRIPTION
I've updated my rsc test package to fix some esm/cjs packaging issues. Now using the latest version in our RSC test fixture