### PR TITLE
RSC: Add build step debug logs

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -15,6 +15,10 @@ import { rscAnalyzePlugin } from './rscVitePlugins'
  * Doesn't output any files, only collects a list of RSCs and RSFs
  */
 export async function rscBuildAnalyze(viteConfigPath: string) {
+  console.log('\n')
+  console.log('1. rscBuildAnalyze')
+  console.log('==================\n')
+
   const rwPaths = getPaths()
   const clientEntryFileSet = new Set<string>()
   const serverEntryFileSet = new Set<string>()

--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -21,6 +21,10 @@ export async function rscBuildClient(
   webDist: string,
   clientEntryFiles: Record<string, string>
 ) {
+  console.log('\n')
+  console.log('2. rscBuildClient')
+  console.log('=================\n')
+
   const rwPaths = getPaths()
 
   const clientBuildOutput = await viteBuild({

--- a/packages/vite/src/rsc/rscBuildClientEntriesFile.ts
+++ b/packages/vite/src/rsc/rscBuildClientEntriesFile.ts
@@ -14,6 +14,10 @@ export function rscBuildClientEntriesMappings(
   clientEntryFiles: Record<string, string>,
   webDistServerEntries: string
 ) {
+  console.log('\n')
+  console.log('5. rscBuildClientEntriesMapping')
+  console.log('===============================\n')
+
   const clientEntries: Record<string, string> = {}
   for (const item of clientBuildOutput) {
     const { name, fileName } = item

--- a/packages/vite/src/rsc/rscBuildCopyCssAssets.ts
+++ b/packages/vite/src/rsc/rscBuildCopyCssAssets.ts
@@ -12,6 +12,10 @@ export function rscBuildCopyCssAssets(
   webDist: string,
   webDistServer: string
 ) {
+  console.log('\n')
+  console.log('4. rscBuildCopyCssAssets')
+  console.log('========================\n')
+
   // TODO (RSC) Some css is now duplicated in two files (i.e. for client
   // components). Probably don't want that.
   // Also not sure if this works on "soft" rerenders (i.e. not a full page

--- a/packages/vite/src/rsc/rscBuildRwEnvVars.ts
+++ b/packages/vite/src/rsc/rscBuildRwEnvVars.ts
@@ -9,6 +9,10 @@ import fs from 'fs/promises'
  * RSC worker we've got set up
  */
 export async function rscBuildRwEnvVars(webDistServerEntries: string) {
+  console.log('\n')
+  console.log('6. rscBuildRwEnvVars')
+  console.log('====================\n')
+
   await fs.appendFile(
     webDistServerEntries,
     `

--- a/packages/vite/src/rsc/rscBuildServer.ts
+++ b/packages/vite/src/rsc/rscBuildServer.ts
@@ -22,6 +22,10 @@ export async function rscBuildServer(
   serverEntryFiles: Record<string, string>,
   customModules: Record<string, string>
 ) {
+  console.log('\n')
+  console.log('3. rscBuildServer')
+  console.log('=================\n')
+
   const input = {
     entries: entriesFile,
     ...clientEntryFiles,


### PR DESCRIPTION
The RSC build process has three main steps and then three additional steps that are needed, but aren't build steps
1. analyze
2. build for client
3. build for server
4. copying CSS assets
5. generate clientEntries mappings
6. making rw env vars available to server components

When debugging build issues it's sometimes difficult to know which one of those steps it is that breaks. Adding some console log headers will make it easier to see what's going on