### PR TITLE
chore(test-project): Upgrade postcss-loader version

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
-    "postcss-loader": "^8.1.0",
+    "postcss-loader": "^8.1.1",
     "prettier-plugin-tailwindcss": "0.4.1",
     "tailwindcss": "^3.4.1"
   }


### PR DESCRIPTION
PRs were failing because the test-project needed updating. But it was not relevant to those PRs. It's just a new patch release version of postcss-loader :) 