### PR TITLE
RSC: smoke-tests: Compare text, not html

### DIFF
--- a/tasks/smoke-tests/rsa/tests/rsa.spec.ts
+++ b/tasks/smoke-tests/rsa/tests/rsa.spec.ts
@@ -3,8 +3,8 @@ import { test, expect } from '@playwright/test'
 test('Submitting the form should return a response', async ({ page }) => {
   await page.goto('/')
 
-  const h3 = await page.locator('h1').innerHTML()
-  expect(h3).toMatch(/Hello Anonymous!!/)
+  const h1 = await page.locator('h1').innerText()
+  expect(h1).toMatch(/Hello Anonymous!!/)
 
   const pageText = await page.locator('#redwood-app > div').innerText()
   expect(pageText).toMatch('The form has been submitted 0 times.')

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -18,7 +18,7 @@ test('Client components should work', async ({ page }) => {
 test('Submitting the form should return a response', async ({ page }) => {
   await page.goto('/')
 
-  const h1 = await page.locator('h1').innerHTML()
+  const h1 = await page.locator('h1').innerText()
   expect(h1).toMatch(/Hello Anonymous!!/)
 
   const pageText = await page.locator('#redwood-app > div').innerText()


### PR DESCRIPTION
Suspense comments shouldn't break the tests. The user only cares about the text they see, not empty html comments in the source code.