### PR TITLE
RSC: Rename to buildRscClientAndServer

### DIFF
--- a/packages/vite/src/buildFeServer.ts
+++ b/packages/vite/src/buildFeServer.ts
@@ -3,7 +3,7 @@ import { getConfig, getPaths } from '@redwoodjs/project-config'
 
 import { buildRouteHooks } from './buildRouteHooks'
 import { buildRouteManifest } from './buildRouteManifest'
-import { buildRscFeServer } from './buildRscFeServer'
+import { buildRscClientAndServer } from './buildRscClientAndServer'
 import { buildForStreamingServer } from './streaming/buildForStreamingServer'
 import { ensureProcessDirWeb } from './utils'
 
@@ -42,14 +42,10 @@ export const buildFeServer = async ({ verbose, webDir }: BuildOptions = {}) => {
       throw new Error('RSC entries file not found')
     }
 
-    await buildRscFeServer()
+    await buildRscClientAndServer()
 
     // Write a route manifest
     return await buildRouteManifest()
-
-    //
-    // RSC specific code ends here
-    //
   }
 
   // We generate the RSC client bundle in the rscBuildClient function

--- a/packages/vite/src/buildRscClientAndServer.ts
+++ b/packages/vite/src/buildRscClientAndServer.ts
@@ -5,7 +5,7 @@ import { rscBuildCopyCssAssets } from './rsc/rscBuildCopyCssAssets'
 import { rscBuildForServer } from './rsc/rscBuildForServer'
 import { rscBuildRwEnvVars } from './rsc/rscBuildRwEnvVars'
 
-export const buildRscFeServer = async () => {
+export const buildRscClientAndServer = async () => {
   // Analyze all files and generate a list of RSCs and RSFs
   const { clientEntryFiles, serverEntryFiles } = await rscBuildAnalyze()
 
@@ -20,9 +20,14 @@ export const buildRscFeServer = async () => {
   )
 
   // Copy CSS assets from server to client
+  //
+  // TODO (RSC): We need to better understand how this work and how it can be
+  // improved.
+  // Can we do this more similar to how it's done for streaming?
   await rscBuildCopyCssAssets(serverBuildOutput)
 
   // Mappings from server to client asset file names
+  // Used by the RSC worker
   await rscBuildClientEntriesMappings(
     clientBuildOutput,
     serverBuildOutput,


### PR DESCRIPTION
The file is building for both the client (browser) and server(/worker), so the name is updated to reflect that.