### PR TITLE
RSC: Babel react plugin not needed for analyze phase

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -1,4 +1,3 @@
-import react from '@vitejs/plugin-react'
 import { build as viteBuild } from 'vite'
 
 import { getPaths } from '@redwoodjs/project-config'
@@ -44,7 +43,6 @@ export async function rscBuildAnalyze() {
     // debugging, but we're keeping it silent by default.
     logLevel: 'silent',
     plugins: [
-      react(),
       rscAnalyzePlugin(
         (id) => clientEntryFileSet.add(id),
         (id) => serverEntryFileSet.add(id)


### PR DESCRIPTION
The react babel plugin is not needed for the analyze phase of the RSC build process.