### PR TITLE
RSC: ensureProcessDirWeb()

### DIFF
--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -8,6 +8,7 @@ import { getPaths } from '@redwoodjs/project-config'
 
 import { getEnvVarDefinitions } from '../envVarDefinitions'
 import { onWarn } from '../lib/onWarn'
+import { ensureProcessDirWeb } from '../utils'
 
 import { rscIndexPlugin } from './rscVitePlugins'
 
@@ -22,6 +23,13 @@ export async function rscBuildClient(clientEntryFiles: Record<string, string>) {
   console.log('=================\n')
 
   const rwPaths = getPaths()
+
+  // Safe-guard for the future, if someone tries to include this function in
+  // code that gets executed by running `vite build` or some other bin from the
+  // cli
+  // Running the web build in the wrong working directory can lead to
+  // unintended consequences on CSS processing
+  ensureProcessDirWeb()
 
   const clientBuildOutput = await viteBuild({
     // configFile: viteConfigPath,


### PR DESCRIPTION
Safe-guard for the future, if someone tries to include this function in code that gets executed by running `vite build` or some other bin from the cli
Running the web build in the wrong working directory can lead to unintended consequences on CSS processing