### PR TITLE
RSC: rscBuildAnalyze: Start at web/src/

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -36,7 +36,7 @@ export async function rscBuildAnalyze() {
   // the build for something.
   await viteBuild({
     configFile: rwPaths.web.viteConfig,
-    root: rwPaths.base,
+    root: rwPaths.web.src,
     // @MARK: We don't care about the build output from this step. It's just
     // for returning the entry names. Plus, the entire RSC build is chatty
     // enough as it is. You can enable this temporarily if you need to for


### PR DESCRIPTION
Start analyzing files at /web/src/ instead of /
Should speed things up, and not find irrelevant files