### PR TITLE
fix(context): Re-export context from `graphql-server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- fix(context): Re-export context from graphql-server (#10117)
+
+  This change re-exports the `context` and `setContext` properties in
+  `@redwoodjs/graphql-server` from the `@redwoodjs/context` package
+  where they are now (as of v7) located. This is done to retroactively 
+  ease the v7 transition and provide a non-breaking rather than a breaking
+  change.
+
+  See [this forum post](https://community.redwoodjs.com/t/context-imported-from-graphql-server-broken-post-7-0-0/5833)
+  and the links within for more information on this change.
+
 - fix(serve): Allow periods in most paths (#10114)
 
   Partial fix for route paths with periods in them.

--- a/packages/graphql-server/src/index.ts
+++ b/packages/graphql-server/src/index.ts
@@ -31,3 +31,6 @@ export {
 } from './plugins/useRedwoodDirective'
 
 export * as rootSchema from './rootSchema'
+
+// Note: We re-export here for convenience and backwards compatibility
+export { context, setContext } from '@redwoodjs/context'


### PR DESCRIPTION
**Problem**
As part of v7 context refactoring we move context from `@redwoodjs/graphql-server` to `@redwoodjs/context`. We had a period of time where both locations had the code with the `graphql-server` variant being deprecated. However, once it was removed from `graphql-server` this was a breaking change as any user who had specifically imported from `graphql-server` would now have tp update their code. This reverts this and allows them to continue to import from the `graphql-server` package.

**Changes**
1. Re-export the `context` and `setContext` from the package as was done previous to v7. 