### PR TITLE
fix(deps): add missing dependency `@redwoodjs/babel-config` to `@redwoodis/vite`

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.0",
+    "@redwoodjs/babel-config": "7.0.0",
     "@redwoodjs/internal": "7.0.0",
     "@redwoodjs/project-config": "7.0.0",
     "@redwoodjs/web": "7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8742,6 +8742,7 @@ __metadata:
   dependencies:
     "@babel/cli": "npm:7.23.9"
     "@babel/runtime-corejs3": "npm:7.24.0"
+    "@redwoodjs/babel-config": "npm:7.0.0"
     "@redwoodjs/internal": "npm:7.0.0"
     "@redwoodjs/project-config": "npm:7.0.0"
     "@redwoodjs/web": "npm:7.0.0"


### PR DESCRIPTION
Noticed this was missing while testing packages with yarn PnP. Imported in a few places:

https://github.com/redwoodjs/redwood/blob/e9ecbb07da216210c59a1e499816f31c025fe81d/packages/vite/src/buildRouteHooks.ts#L4-L7

https://github.com/redwoodjs/redwood/blob/e9ecbb07da216210c59a1e499816f31c025fe81d/packages/vite/src/index.ts#L8

This is also the case in the next branch, so I milestoned it `next-release-patch`.