### PR TITLE
fix(env files): rename to `--load-env-files`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Some apps rely on reading the host header(eg multi-tenant apps served over multi
 
 - Add support for loading more env var files (#9961, #10093, and #10094)
 
-  Fixes #9877. This PR adds CLI functionality to load more `.env` files via `NODE_ENV` and an `--add-env-files` flag.
+  Fixes #9877. This PR adds CLI functionality to load more `.env` files via `NODE_ENV` and an `--load-env-files` flag.
   Env vars loaded via either of these methods override the values in `.env`:
 
   ```
@@ -49,9 +49,9 @@ Some apps rely on reading the host header(eg multi-tenant apps served over multi
   NODE_ENV=production yarn rw exec myScript
 
   # Load '.env.stripe' and '.env.nakama', which overrides values
-  yarn rw exec myScript --add-env-files stripe --add-env-files nakama
-  # Or you can specify the flag once:
-  yarn rw exec myScript --add-env-files stripe nakama
+  yarn rw exec myScript --load-env-files stripe nakama
+  # Or you can specify them individually:
+  yarn rw exec myScript --load-env-files stripe --load-env-files nakama
   ```
 
   Note that this feature is mainly for local scripting. Most deploy providers don't let you upload `.env` files (unless you're using baremetal) and usually have their own way of determining environments.

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -192,7 +192,7 @@ async function runYargs() {
     })
     .example(
       'yarn rw g page home /',
-      "\"Create a page component named 'Home' at path '/'\""
+      "Create a page component named 'Home' at path '/'"
     )
     .demandCommand()
     .strict()

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -166,7 +166,7 @@ async function runYargs() {
         (argv) => {
           delete argv.cwd
           delete argv.addEnvFiles
-          delete argv['add-env-files']
+          delete argv['load-env-files']
           delete argv.telemetry
         },
         telemetry && telemetryMiddleware,
@@ -176,13 +176,13 @@ async function runYargs() {
     .option('cwd', {
       describe: 'Working directory to use (where `redwood.toml` is located)',
     })
-    .option('add-env-files', {
+    .option('load-env-files', {
       describe:
         'Load additional .env files. Values defined in files specified later override earlier ones.',
       array: true,
     })
     .example(
-      'yarn rw exec migrateUsers --add-env-files stripe nakama',
+      'yarn rw exec migrateUsers --load-env-files stripe nakama',
       "Run a script, also loading env vars from '.env.stripe' and '.env.nakama'"
     )
     .option('telemetry', {

--- a/packages/cli/src/lib/loadEnvFiles.js
+++ b/packages/cli/src/lib/loadEnvFiles.js
@@ -19,14 +19,14 @@ export function loadEnvFiles() {
   loadDefaultEnvFiles(base)
   loadNodeEnvDerivedEnvFile(base)
 
-  const { addEnvFiles } = Parser(hideBin(process.argv), {
+  const { loadEnvFiles } = Parser(hideBin(process.argv), {
     array: ['load-env-files'],
     default: {
-      addEnvFiles: [],
+      loadEnvFiles: [],
     },
   })
-  if (addEnvFiles.length > 0) {
-    loadUserSpecifiedEnvFiles(base, addEnvFiles)
+  if (loadEnvFiles.length > 0) {
+    loadUserSpecifiedEnvFiles(base, loadEnvFiles)
   }
 
   process.env.REDWOOD_ENV_FILES_LOADED = 'true'
@@ -65,8 +65,8 @@ export function loadNodeEnvDerivedEnvFile(cwd) {
 /**
  * @param {string} cwd
  */
-export function loadUserSpecifiedEnvFiles(cwd, addEnvFiles) {
-  for (const suffix of addEnvFiles) {
+export function loadUserSpecifiedEnvFiles(cwd, loadEnvFiles) {
+  for (const suffix of loadEnvFiles) {
     const envPath = path.join(cwd, `.env.${suffix}`)
     if (!fs.pathExistsSync(envPath)) {
       throw new Error(

--- a/packages/cli/src/lib/loadEnvFiles.js
+++ b/packages/cli/src/lib/loadEnvFiles.js
@@ -20,7 +20,7 @@ export function loadEnvFiles() {
   loadNodeEnvDerivedEnvFile(base)
 
   const { addEnvFiles } = Parser(hideBin(process.argv), {
-    array: ['add-env-files'],
+    array: ['load-env-files'],
     default: {
       addEnvFiles: [],
     },
@@ -70,7 +70,7 @@ export function loadUserSpecifiedEnvFiles(cwd, addEnvFiles) {
     const envPath = path.join(cwd, `.env.${suffix}`)
     if (!fs.pathExistsSync(envPath)) {
       throw new Error(
-        `Couldn't find an .env file at '${envPath}' as specified by '--add-env-files'`
+        `Couldn't find an .env file at '${envPath}' as specified by '--load-env-files'`
       )
     }
 

--- a/tasks/server-tests/bothServer.test.mts
+++ b/tasks/server-tests/bothServer.test.mts
@@ -20,7 +20,7 @@ describe('rw serve', () => {
             --version                             Show version number        [boolean]
             --cwd                                 Working directory to use (where
                                                   \`redwood.toml\` is located)
-            --add-env-files                       Load additional .env files. Values
+            --load-env-files                      Load additional .env files. Values
                                                   defined in files specified later
                                                   override earlier ones.       [array]
             --telemetry                           Whether to send anonymous usage
@@ -68,7 +68,7 @@ describe('rw serve', () => {
               --version                             Show version number        [boolean]
               --cwd                                 Working directory to use (where
                                                     \`redwood.toml\` is located)
-              --add-env-files                       Load additional .env files. Values
+              --load-env-files                      Load additional .env files. Values
                                                     defined in files specified later
                                                     override earlier ones.       [array]
               --telemetry                           Whether to send anonymous usage


### PR DESCRIPTION
Last change before releasing the minor. This wraps up the env files feature started in https://github.com/redwoodjs/redwood/pull/9961. To recap on the naming decision a bit, we can't use just "--env-file" because Node.js seems to parse it no matter what, and since Redwood's flag operates on suffixes, Node throws a "not found" error. It also seems to parse "--env-files", with an "s", which seems like a bug. I opted for "--add-env-files" back when this flag only added additional env vars, which didn't override existing ones. This is no longer the case (they override), so I don't want to imply that they don't. "--load-env-files" seems like the best alternative, and there's a precedence in the work done in Node.js here which exposes a new `loadEnvFile` function: https://github.com/nodejs/node/pull/51476.