### PR TITLE
chore(prerender): switch to vitest

### DIFF
--- a/packages/prerender/jest.config.js
+++ b/packages/prerender/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('@jest/types').Config.InitialOptions} */
-module.exports = {
-  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/*.test.[jt]s?(x)'],
-  testPathIgnorePatterns: ['fixtures', '__fixtures__'],
-}

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -21,8 +21,8 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "yarn build",
-    "test": "jest src",
-    "test:watch": "yarn test --watch"
+    "test": "vitest run src",
+    "test:watch": "vitest watch src"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.0",
@@ -44,8 +44,8 @@
     "@babel/core": "^7.22.20",
     "@types/mime-types": "2.1.4",
     "babel-plugin-tester": "11.0.4",
-    "jest": "29.7.0",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vitest": "1.2.2"
   },
   "peerDependencies": {
     "react": "0.0.0-experimental-e5205658f-20230913",

--- a/packages/prerender/src/__tests__/detectRoutes.test.ts
+++ b/packages/prerender/src/__tests__/detectRoutes.test.ts
@@ -1,27 +1,29 @@
+import { vi, describe, it, expect } from 'vitest'
+
 import type { RWRoute } from '@redwoodjs/structure/dist/model/RWRoute'
 
 import { detectPrerenderRoutes } from '../detection'
 
-jest.mock('@redwoodjs/project-config', () => {
+vi.mock('@redwoodjs/project-config', () => {
   return {
-    getPaths: jest.fn(() => {
+    getPaths: vi.fn(() => {
       return {
         base: '/mock/path',
         web: `/mock/path/web`,
       }
     }),
-    processPagesDir: jest.fn(() => []),
+    processPagesDir: vi.fn(() => []),
   }
 })
 
 // Mock route detection, tested in @redwoodjs/structure separately
 
 let mockedRoutes: Partial<RWRoute>[] = []
-jest.mock('@redwoodjs/structure', () => {
+vi.mock('@redwoodjs/structure', () => {
   return {
-    getProject: jest.fn(() => {
+    getProject: vi.fn(() => {
       return {
-        getRouter: jest.fn(() => {
+        getRouter: vi.fn(() => {
           return {
             routes: mockedRoutes,
           }

--- a/packages/prerender/src/babelPlugins/__tests__/babel-plugin-redwood-prerender-media-imports.test.ts
+++ b/packages/prerender/src/babelPlugins/__tests__/babel-plugin-redwood-prerender-media-imports.test.ts
@@ -4,6 +4,7 @@ import pluginTester from 'babel-plugin-tester'
 import { vi, describe, beforeEach, afterAll } from 'vitest'
 
 import { BundlerEnum } from '@redwoodjs/project-config'
+import type projectConfig from '@redwoodjs/project-config'
 
 import plugin from '../babel-plugin-redwood-prerender-media-imports'
 
@@ -11,10 +12,7 @@ let mockDistDir
 let mockSrcDir
 
 vi.mock('@redwoodjs/project-config', async (importOriginal) => {
-  const originalProjectConfig = await importOriginal<
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    typeof import('@redwoodjs/project-config')
-  >()
+  const originalProjectConfig = await importOriginal<typeof projectConfig>()
   return {
     ...originalProjectConfig,
     getPaths: () => {

--- a/packages/prerender/src/babelPlugins/__tests__/babel-plugin-redwood-prerender-media-imports.test.ts
+++ b/packages/prerender/src/babelPlugins/__tests__/babel-plugin-redwood-prerender-media-imports.test.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 
 import pluginTester from 'babel-plugin-tester'
+import { vi, describe, beforeEach, afterAll } from 'vitest'
 
 import { BundlerEnum } from '@redwoodjs/project-config'
 
@@ -9,9 +10,13 @@ import plugin from '../babel-plugin-redwood-prerender-media-imports'
 let mockDistDir
 let mockSrcDir
 
-jest.mock('@redwoodjs/project-config', () => {
+vi.mock('@redwoodjs/project-config', async (importOriginal) => {
+  const originalProjectConfig = await importOriginal<
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    typeof import('@redwoodjs/project-config')
+  >()
   return {
-    ...jest.requireActual('@redwoodjs/project-config'),
+    ...originalProjectConfig,
     getPaths: () => {
       return {
         web: {
@@ -23,7 +28,7 @@ jest.mock('@redwoodjs/project-config', () => {
   }
 })
 
-jest.mock('../utils', () => {
+vi.mock('../utils', () => {
   return {
     convertToDataUrl: (assetPath) => {
       return `data:image/jpg;base64,xxx-mock-b64-${assetPath}`
@@ -81,7 +86,7 @@ describe('Webpack bundler', () => {
     })
 
     afterAll(() => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
     })
   })
 
@@ -106,7 +111,7 @@ describe('Webpack bundler', () => {
     })
 
     afterAll(() => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
     })
   })
 })
@@ -165,7 +170,7 @@ describe('Vite bundler', () => {
     })
 
     afterAll(() => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
     })
   })
 
@@ -194,7 +199,7 @@ describe('Vite bundler', () => {
     })
 
     afterAll(() => {
-      jest.clearAllMocks()
+      vi.clearAllMocks()
     })
   })
 })

--- a/packages/prerender/vitest.config.mts
+++ b/packages/prerender/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '**/fixtures', '**/__fixtures__'],
+  },
+})

--- a/packages/prerender/vitest.config.mts
+++ b/packages/prerender/vitest.config.mts
@@ -3,5 +3,6 @@ import { defineConfig, configDefaults } from 'vitest/config'
 export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, '**/fixtures', '**/__fixtures__'],
+    globals: true
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8530,9 +8530,9 @@ __metadata:
     cheerio: "npm:1.0.0-rc.12"
     core-js: "npm:3.35.1"
     graphql: "npm:16.8.1"
-    jest: "npm:29.7.0"
     mime-types: "npm:2.1.35"
     typescript: "npm:5.3.3"
+    vitest: "npm:1.2.2"
   peerDependencies:
     react: 0.0.0-experimental-e5205658f-20230913
     react-dom: 0.0.0-experimental-e5205658f-20230913


### PR DESCRIPTION
Switches the `@redwoodjs/prerender` package to use vitest over jest.