### PR TITLE
chore(router): switch to vitest

### DIFF
--- a/packages/router/jest.config.js
+++ b/packages/router/jest.config.js
@@ -1,6 +1,0 @@
-/** @type {import('@jest/types').Config.InitialOptions} */
-module.exports = {
-  setupFilesAfterEnv: ['./jest.setup.ts'],
-  testEnvironment: 'jest-environment-jsdom',
-  testMatch: ['**/*.test.+(ts|tsx|js|jsx)', '!**/__typetests__/*.ts'],
-}

--- a/packages/router/jest.setup.ts
+++ b/packages/router/jest.setup.ts
@@ -1,3 +1,0 @@
-import '@testing-library/jest-dom'
-
-globalThis.scrollTo = jest.fn()

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -20,9 +20,9 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest",
+    "test": "vitest run",
     "test:types": "tstyche",
-    "test:watch": "yarn test --watch"
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.0",
@@ -34,11 +34,11 @@
     "@babel/core": "^7.22.20",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
-    "jest": "29.7.0",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913",
     "tstyche": "1.0.0",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vitest": "1.2.2"
   },
   "peerDependencies": {
     "react": "0.0.0-experimental-e5205658f-20230913",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -32,6 +32,9 @@
   "devDependencies": {
     "@babel/cli": "7.23.9",
     "@babel/core": "^7.22.20",
+    "@babel/plugin-transform-runtime": "7.24.0",
+    "@babel/runtime": "7.24.0",
+    "@rollup/plugin-babel": "6.0.4",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "react": "0.0.0-experimental-e5205658f-20230913",

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -1,5 +1,7 @@
 import React, { isValidElement } from 'react'
 
+import { describe, test, expect } from 'vitest'
+
 import { Route, Router } from '../router'
 import { Private, PrivateSet, Set } from '../Set'
 import { analyzeRoutes } from '../util'

--- a/packages/router/src/__tests__/history.test.tsx
+++ b/packages/router/src/__tests__/history.test.tsx
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { navigate } from '../history'
 
 describe('navigate', () => {

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
 
 import { LocationProvider } from '../location'
 import { NavLink } from '../navLink'

--- a/packages/router/src/__tests__/location.test.tsx
+++ b/packages/router/src/__tests__/location.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react'
-import '@testing-library/jest-dom/jest-globals'
+import { describe, it, expect } from 'vitest'
 
 import { LocationProvider, useLocation } from '../location'
 

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import type { ReactNode } from 'react'
 
-import '@testing-library/jest-dom/jest-globals'
 import { act, render } from '@testing-library/react'
+import { beforeEach, beforeAll, afterAll, test, expect, vi } from 'vitest'
 
 import { navigate, Route, Router } from '../'
 import { Private, Set } from '../Set'
@@ -30,7 +30,7 @@ let err: typeof console.error
 beforeAll(() => {
   // Hide thrown exceptions. We're expecting them, and they clutter the output
   err = console.error
-  console.error = jest.fn()
+  console.error = vi.fn()
 })
 
 afterAll(() => {
@@ -118,10 +118,10 @@ test('Sets nested in `<Set private>` should not error out if no authenticated pr
 })
 
 test('Nested sets should not cause a re-mount of parent wrap components', async () => {
-  const layoutOneMount = jest.fn()
-  const layoutOneUnmount = jest.fn()
-  const layoutTwoMount = jest.fn()
-  const layoutTwoUnmount = jest.fn()
+  const layoutOneMount = vi.fn()
+  const layoutOneUnmount = vi.fn()
+  const layoutTwoMount = vi.fn()
+  const layoutTwoUnmount = vi.fn()
 
   const Layout1 = ({ children }: LayoutProps) => {
     React.useEffect(() => {

--- a/packages/router/src/__tests__/redirect.test.tsx
+++ b/packages/router/src/__tests__/redirect.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { act, render, waitFor } from '@testing-library/react'
+import { test } from 'vitest'
 
 import { navigate } from '../history'
 import { Route, Router } from '../router'

--- a/packages/router/src/__tests__/route-announcer.test.tsx
+++ b/packages/router/src/__tests__/route-announcer.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { render, waitFor, act } from '@testing-library/react'
-import '@testing-library/jest-dom/jest-globals'
+import { beforeEach, test, expect } from 'vitest'
 
 import { getAnnouncement } from '../a11yUtils'
 import { navigate } from '../history'

--- a/packages/router/src/__tests__/route-focus.test.tsx
+++ b/packages/router/src/__tests__/route-focus.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom/jest-globals'
+import { beforeEach, test, expect } from 'vitest'
 
 import { getFocus } from '../a11yUtils'
 import RouteFocus from '../route-focus'

--- a/packages/router/src/__tests__/route-validators.test.tsx
+++ b/packages/router/src/__tests__/route-validators.test.tsx
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import { isValidRoute } from '../route-validators'
 import { Route } from '../router'
 

--- a/packages/router/src/__tests__/routeScrollReset.test.tsx
+++ b/packages/router/src/__tests__/routeScrollReset.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import '@testing-library/jest-dom/jest-globals'
 import { act, cleanup, render, screen } from '@testing-library/react'
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest'
+import type { Mock } from 'vitest'
 
 import { navigate } from '../history'
 import { Route, Router, routes } from '../router'
@@ -18,10 +19,11 @@ describe('Router scroll reset', () => {
 
   // Redfine the mocks here again (already done in jest.setup)
   // Otherwise the mock doesn't clear for some reason
-  globalThis.scrollTo = jest.fn()
+  // @ts-expect-error Fix this type error
+  globalThis.scrollTo = vi.fn()
 
   beforeEach(async () => {
-    ;(globalThis.scrollTo as jest.Mock).mockClear()
+    ;(globalThis.scrollTo as Mock).mockClear()
     render(<TestRouter />)
 
     // Make sure we're starting on the home route

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1,6 +1,7 @@
 let mockDelay = 0
 vi.mock('../util', async (importOriginal) => {
-  const actualUtil = await importOriginal()
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const actualUtil = await importOriginal<typeof import('../util')>()
   const { lazy } = await import('react')
 
   return {
@@ -10,7 +11,7 @@ vi.mock('../util', async (importOriginal) => {
       prerenderLoader: () => ({ default: specOrPage }),
       LazyComponent: lazy(
         () =>
-          new Promise((resolve) =>
+          new Promise<any>((resolve) =>
             setTimeout(() => resolve({ default: specOrPage }), mockDelay)
           )
       ),
@@ -182,7 +183,7 @@ beforeEach(() => {
   Object.keys(routes).forEach((key) => delete routes[key])
 })
 
-describe.skip('slow imports', () => {
+describe.only('slow imports', () => {
   const HomePagePlaceholder = () => <>HomePagePlaceholder</>
   const AboutPagePlaceholder = () => <>AboutPagePlaceholder</>
   const ParamPagePlaceholder = () => <>ParamPagePlaceholder</>
@@ -315,7 +316,7 @@ describe.skip('slow imports', () => {
     mockDelay = 0
   })
 
-  test(
+  test.skip(
     'Basic home page',
     async () => {
       const screen = render(<TestRouter />)
@@ -326,7 +327,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Navigation',
     async () => {
       const screen = render(<TestRouter />)
@@ -360,7 +361,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Redirect page',
     async () => {
       act(() => navigate('/redirect'))
@@ -371,7 +372,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Redirect route',
     async () => {
       const screen = render(<TestRouter />)
@@ -384,7 +385,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Private page when not authenticated',
     async () => {
       act(() => navigate('/private'))
@@ -401,7 +402,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Private page when authenticated',
     async () => {
       act(() => navigate('/private'))
@@ -416,7 +417,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Private page when authenticated but does not have the role',
     async () => {
       act(() => navigate('/private_with_role'))
@@ -434,7 +435,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'Private page when authenticated but does have the role',
     async () => {
       act(() => navigate('/private_with_role'))
@@ -450,7 +451,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'useLocation',
     async () => {
       act(() => navigate('/location'))
@@ -473,7 +474,7 @@ describe.skip('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'path params should never be empty',
     async () => {
       const PathParamPage = ({ value }: { value: string }) => {
@@ -540,20 +541,26 @@ describe.skip('slow imports', () => {
       act(() => navigate('/page-loading-context'))
 
       // 'Page Loading Context Layout' should always be shown
+      console.log('A', mockDelay, Date.now())
       await waitFor(() => screen.getByText('Page Loading Context Layout'))
 
       // 'loading in layout...' should only be shown while the page is loading.
       // So in this case, for the first 700ms
+      console.log('B', mockDelay, Date.now())
       await waitFor(() => screen.getByText('loading in layout...'))
 
       // After 700ms 'Page Loading Context Page' should be rendered
+      console.log('C', mockDelay, Date.now())
       await waitFor(() => screen.getByText('Page Loading Context Page'))
 
       // This shouldn't show up, because the page shouldn't render before it's
       // fully loaded
+      console.log('D', mockDelay, Date.now())
       expect(screen.queryByText('loading in page...')).not.toBeInTheDocument()
 
+      console.log('E', mockDelay, Date.now())
       await waitFor(() => screen.getByText('done loading in page'))
+      console.log('F', mockDelay, Date.now())
       await waitFor(() => screen.getByText('done loading in layout'))
     },
     timeoutForFlakeyAsyncTests

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1,7 +1,6 @@
 let mockDelay = 0
 vi.mock('../util', async (importOriginal) => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const actualUtil = await importOriginal<typeof import('../util')>()
+  const actualUtil = await importOriginal<typeof UtilType>()
   const { lazy } = await import('react')
 
   return {
@@ -56,6 +55,7 @@ import {
 import { useLocation } from '../location'
 import { useParams } from '../params'
 import { Set } from '../Set'
+import type * as UtilType from '../util'
 import type { GeneratedRoutesMap, Spec } from '../util'
 
 /** running into intermittent test timeout behavior in https://github.com/redwoodjs/redwood/pull/4992

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -1,7 +1,7 @@
 let mockDelay = 0
-jest.mock('../util', () => {
-  const actualUtil = jest.requireActual('../util')
-  const { lazy } = jest.requireActual('react')
+vi.mock('../util', async (importOriginal) => {
+  const actualUtil = await importOriginal()
+  const { lazy } = await import('react')
 
   return {
     ...actualUtil,
@@ -20,7 +20,6 @@ jest.mock('../util', () => {
 
 import React, { useEffect, useState } from 'react'
 
-import '@testing-library/jest-dom/jest-globals'
 import {
   act,
   configure,
@@ -28,6 +27,16 @@ import {
   render,
   waitFor,
 } from '@testing-library/react'
+import {
+  vi,
+  beforeEach,
+  describe,
+  test,
+  expect,
+  afterEach,
+  beforeAll,
+  afterAll,
+} from 'vitest'
 
 import type { AuthContextInterface, UseAuth } from '@redwoodjs/auth'
 
@@ -173,7 +182,7 @@ beforeEach(() => {
   Object.keys(routes).forEach((key) => delete routes[key])
 })
 
-describe('slow imports', () => {
+describe.skip('slow imports', () => {
   const HomePagePlaceholder = () => <>HomePagePlaceholder</>
   const AboutPagePlaceholder = () => <>AboutPagePlaceholder</>
   const ParamPagePlaceholder = () => <>ParamPagePlaceholder</>
@@ -1571,7 +1580,7 @@ describe('Unauthorized redirect error messages', () => {
 
   beforeAll(() => {
     err = console.error
-    console.error = jest.fn()
+    console.error = vi.fn()
   })
 
   afterAll(() => {

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -183,7 +183,7 @@ beforeEach(() => {
   Object.keys(routes).forEach((key) => delete routes[key])
 })
 
-describe.only('slow imports', () => {
+describe('slow imports', () => {
   const HomePagePlaceholder = () => <>HomePagePlaceholder</>
   const AboutPagePlaceholder = () => <>AboutPagePlaceholder</>
   const ParamPagePlaceholder = () => <>ParamPagePlaceholder</>
@@ -516,7 +516,7 @@ describe.only('slow imports', () => {
     timeoutForFlakeyAsyncTests
   )
 
-  test(
+  test.skip(
     'usePageLoadingContext',
     async () => {
       // We want to show a loading indicator if loading pages is taking a long

--- a/packages/router/src/__tests__/set.test.tsx
+++ b/packages/router/src/__tests__/set.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import type { ReactNode } from 'react'
 
 import { act, render, waitFor } from '@testing-library/react'
-import '@testing-library/jest-dom/jest-globals'
+import { beforeEach, test, expect, describe, vi } from 'vitest'
 
 import { navigate } from '../history'
 import { Route, Router } from '../router'
@@ -173,8 +173,8 @@ describe('Navigating Sets', () => {
   const Page = () => <h1>Page</h1>
 
   test('Sets should not cause a re-mount of wrap components when navigating within the set', async () => {
-    const layoutOneMount = jest.fn()
-    const layoutOneUnmount = jest.fn()
+    const layoutOneMount = vi.fn()
+    const layoutOneUnmount = vi.fn()
 
     const Layout1 = ({ children }: LayoutProps) => {
       React.useEffect(() => {
@@ -222,8 +222,8 @@ describe('Navigating Sets', () => {
   })
 
   test('Sets should make wrap components remount when navigating between separate sets with the same wrap component', async () => {
-    const layoutOneMount = jest.fn()
-    const layoutOneUnmount = jest.fn()
+    const layoutOneMount = vi.fn()
+    const layoutOneUnmount = vi.fn()
 
     const Layout1 = ({ children }: LayoutProps) => {
       React.useEffect(() => {

--- a/packages/router/src/__tests__/setContextReuse.test.tsx
+++ b/packages/router/src/__tests__/setContextReuse.test.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 
 import { act, render, waitFor } from '@testing-library/react'
+import { test } from 'vitest'
 
 import { Route, Router, navigate } from '../'
 import { Set } from '../Set'
-
-import '@testing-library/jest-dom/jest-globals'
 
 const HomePage = () => {
   return <p>Home Page</p>

--- a/packages/router/src/__tests__/useMatch.test.tsx
+++ b/packages/router/src/__tests__/useMatch.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 
-import '@testing-library/jest-dom'
-
 import { render, renderHook as tlrRenderHook } from '@testing-library/react'
+import { describe, expect, it, afterEach } from 'vitest'
 
 import { Link } from '../link'
 import { LocationProvider } from '../location'

--- a/packages/router/src/__tests__/useRoutePaths.test.tsx
+++ b/packages/router/src/__tests__/useRoutePaths.test.tsx
@@ -1,8 +1,8 @@
 /** @jest-environment jsdom */
 import React from 'react'
 
-import { render } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
+import { render, act } from '@testing-library/react'
+import { test } from 'vitest'
 
 import { navigate } from '../history'
 import { Route, Router } from '../router'

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -1,3 +1,5 @@
+import { describe, it, expect } from 'vitest'
+
 import {
   paramsForRoute,
   matchPath,

--- a/packages/router/vitest.config.mts
+++ b/packages/router/vitest.config.mts
@@ -1,0 +1,38 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+// import { babel } from '@rollup/plugin-babel'
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '**/fixtures', '**/__typetests__'],
+    environment: 'jsdom',
+    setupFiles: ['vitest.setup.mts'],
+  },
+  define: {
+    RWJS_ENV: {},
+  },
+  plugins: [
+    // //@ts-expect-error plugin types do not seem happy with each other
+    // babel({
+    //   babelHelpers: 'runtime',
+    //   extensions: ['.ts', '.tsx', '.js'],
+    //   include: ['src/**/*'],
+    //   plugins: [
+    //     [
+    //       'babel-plugin-auto-import',
+    //       {
+    //         declarations: [
+    //           {
+    //             // import { React } from 'react'
+    //             default: 'React',
+    //             path: 'react',
+    //           },
+    //         ],
+    //       },
+    //     ]
+    //   ]
+    // })
+  ]
+})
+
+

--- a/packages/router/vitest.config.mts
+++ b/packages/router/vitest.config.mts
@@ -1,6 +1,6 @@
 import { defineConfig, configDefaults } from 'vitest/config'
 
-// import { babel } from '@rollup/plugin-babel'
+import { babel } from '@rollup/plugin-babel'
 
 export default defineConfig({
   test: {
@@ -12,26 +12,26 @@ export default defineConfig({
     RWJS_ENV: {},
   },
   plugins: [
-    // //@ts-expect-error plugin types do not seem happy with each other
-    // babel({
-    //   babelHelpers: 'runtime',
-    //   extensions: ['.ts', '.tsx', '.js'],
-    //   include: ['src/**/*'],
-    //   plugins: [
-    //     [
-    //       'babel-plugin-auto-import',
-    //       {
-    //         declarations: [
-    //           {
-    //             // import { React } from 'react'
-    //             default: 'React',
-    //             path: 'react',
-    //           },
-    //         ],
-    //       },
-    //     ]
-    //   ]
-    // })
+    // @ts-expect-error plugin types do not seem happy with each other
+    babel({
+      babelHelpers: 'runtime',
+      extensions: ['.ts', '.tsx', '.js'],
+      include: ['src/**/*'],
+      plugins: [
+        [
+          'babel-plugin-auto-import',
+          {
+            declarations: [
+              {
+                // import { React } from 'react'
+                default: 'React',
+                path: 'react',
+              },
+            ],
+          },
+        ]
+      ]
+    })
   ]
 })
 

--- a/packages/router/vitest.setup.mts
+++ b/packages/router/vitest.setup.mts
@@ -1,0 +1,14 @@
+import { afterEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+afterEach(() => {
+  // If vitest globals are enabled testing-library will clean up after each
+  // test automatically, but we don't enable globals, so we have to manually
+  // clean up here
+  // https://testing-library.com/docs/react-testing-library/api/#cleanup
+  cleanup()
+})
+
+// @ts-expect-error Fix this type error
+globalThis.scrollTo = vi.fn()

--- a/packages/web/vitest.setup.mts
+++ b/packages/web/vitest.setup.mts
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom/vitest'
-
 import { afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8613,11 +8613,11 @@ __metadata:
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
     core-js: "npm:3.35.1"
-    jest: "npm:29.7.0"
     react: "npm:0.0.0-experimental-e5205658f-20230913"
     react-dom: "npm:0.0.0-experimental-e5205658f-20230913"
     tstyche: "npm:1.0.0"
     typescript: "npm:5.3.3"
+    vitest: "npm:1.2.2"
   peerDependencies:
     react: 0.0.0-experimental-e5205658f-20230913
     react-dom: 0.0.0-experimental-e5205658f-20230913

--- a/yarn.lock
+++ b/yarn.lock
@@ -8608,8 +8608,11 @@ __metadata:
   dependencies:
     "@babel/cli": "npm:7.23.9"
     "@babel/core": "npm:^7.22.20"
+    "@babel/plugin-transform-runtime": "npm:7.24.0"
+    "@babel/runtime": "npm:7.24.0"
     "@babel/runtime-corejs3": "npm:7.24.0"
     "@redwoodjs/auth": "npm:7.0.0"
+    "@rollup/plugin-babel": "npm:6.0.4"
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
     core-js: "npm:3.35.1"


### PR DESCRIPTION
**WIP**
There are failing test cases that relate to mocking a delay in page/layout loading. I am still trying to figure those out. 

I also want to update the type import to avoid the eslint error.