### PR TITLE
chore(deps): add missing dependencies `@babel/core` and `fs-extra`

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -29,6 +29,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@babel/core": "^7.22.20",
     "@babel/parser": "^7.22.16",
     "@babel/plugin-transform-react-jsx": "^7.22.15",
     "@babel/plugin-transform-typescript": "^7.22.15",
@@ -70,7 +71,6 @@
   },
   "devDependencies": {
     "@babel/cli": "7.23.9",
-    "@babel/core": "^7.22.20",
     "@types/fs-extra": "11.0.4",
     "graphql-tag": "2.12.6",
     "jest": "29.7.0",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -36,6 +36,7 @@
     "dotenv-defaults": "5.0.2",
     "enquirer": "2.4.1",
     "fast-glob": "3.3.2",
+    "fs-extra": "11.2.0",
     "graphql": "16.8.1",
     "lazy-get-decorator": "2.2.1",
     "line-column": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8671,6 +8671,7 @@ __metadata:
     dotenv-defaults: "npm:5.0.2"
     enquirer: "npm:2.4.1"
     fast-glob: "npm:3.3.2"
+    fs-extra: "npm:11.2.0"
     graphql: "npm:16.8.1"
     lazy-get-decorator: "npm:2.2.1"
     line-column: "npm:1.0.2"


### PR DESCRIPTION
Was trying to isolate the Vite package to test its exports, but some of its dependencies have missing dependencies that are getting in the way. These ones are the easiest to fix.

```
~/esm-test/.pnp.cjs:19182
      Error.captureStackTrace(firstError);
            ^

Error: @redwoodjs/structure tried to access fs-extra, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: fs-extra
Required by: @redwoodjs/structure@file:./tarballs/redwoodjs-structure.tgz#./tarballs/redwoodjs-structure.tgz::hash=9b5cd1&locator=esm-test%40workspace%3A.
```