### PR TITLE
chore(realtime): switch to vitest

### DIFF
--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -18,8 +18,8 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
-    "test:watch": "run test --watch"
+    "test": "vitest run",
+    "test:watch": "vitest watch"
   },
   "dependencies": {
     "@envelop/live-query": "7.0.0",
@@ -39,10 +39,10 @@
     "@envelop/testing": "7.0.0",
     "@envelop/types": "5.0.0",
     "@redwoodjs/framework-tools": "workspace:*",
-    "jest": "29.7.0",
     "nodemon": "3.0.2",
     "tsx": "4.6.2",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "vitest": "1.2.2"
   },
   "peerDependencies": {
     "ioredis": "^5.3.2"

--- a/packages/realtime/src/graphql/plugins/__tests__/__snapshots__/useRedwoodRealtime.test.ts.snap
+++ b/packages/realtime/src/graphql/plugins/__tests__/__snapshots__/useRedwoodRealtime.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`useRedwoodRealtime should update schema with live directive 1`] = `"@live"`;
+exports[`useRedwoodRealtime > should update schema with live directive 1`] = `"@live"`;

--- a/packages/realtime/src/graphql/plugins/__tests__/useRedwoodRealtime.test.ts
+++ b/packages/realtime/src/graphql/plugins/__tests__/useRedwoodRealtime.test.ts
@@ -3,6 +3,7 @@ import {
   createSpiedPlugin,
   assertStreamExecutionValue,
 } from '@envelop/testing'
+import { describe, it, expect } from 'vitest'
 
 import { testQuery, testLiveQuery, testSchema } from '../__fixtures__/common'
 import {

--- a/packages/realtime/vitest.config.mts
+++ b/packages/realtime/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig, configDefaults } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '**/__fixtures__'],
+    setupFiles: ['vitest.setup.mts'],
+  },
+})

--- a/packages/realtime/vitest.setup.mts
+++ b/packages/realtime/vitest.setup.mts
@@ -1,0 +1,7 @@
+import { vi } from 'vitest'
+
+// Note: @envelop/testing appears to require jest to be defined, even though they take no
+// dependency or peer-dependency on it. This is a hacky workaround to make it work with vitest.
+// We should ask the Guild about this...
+// @ts-expect-error Figure this type error out when we totally remove jest
+globalThis.jest = vi

--- a/yarn.lock
+++ b/yarn.lock
@@ -8599,10 +8599,10 @@ __metadata:
     "@redwoodjs/framework-tools": "workspace:*"
     graphql: "npm:16.8.1"
     ioredis: "npm:^5.3.2"
-    jest: "npm:29.7.0"
     nodemon: "npm:3.0.2"
     tsx: "npm:4.6.2"
     typescript: "npm:5.3.3"
+    vitest: "npm:1.2.2"
   peerDependencies:
     ioredis: ^5.3.2
   peerDependenciesMeta:


### PR DESCRIPTION
This PR switches out the `@redwoodjs/realtime` to use vitest.

There is a hack here to get it to work with the `@envelop/testing` package we use as a testing utility provider. That package uses `jest.fn()` and other jest functions although it does not depend on jest (peer or otherwise). You can see in the `vitest.setup.mts` that I have simply added `globalThis.jest = vi`. I am not thrilled with this, it also has a type error I have marked as expected. I think we should clarify with the Guild on this?