### PR TITLE
chore(vite): use esbuild instead of babel

### DIFF
--- a/packages/framework-tools/src/buildDefaults.ts
+++ b/packages/framework-tools/src/buildDefaults.ts
@@ -21,7 +21,7 @@ export const defaultBuildOptions: ESBuildOptions = {
   metafile: true,
 }
 
-export const defaultPatterns = ['./src/**/*.{ts,js}']
+export const defaultPatterns = ['./src/**/*.{ts,js,tsx,jsx}']
 export const defaultIgnorePatterns = [
   '**/__tests__',
   '**/*.test.{ts,js}',

--- a/packages/vite/.babelrc.js
+++ b/packages/vite/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/vite/build.mts
+++ b/packages/vite/build.mts
@@ -1,0 +1,3 @@
+import { build } from '@redwoodjs/framework-tools'
+
+await build()

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -57,8 +57,7 @@
     "cjsWrapper.js"
   ],
   "scripts": {
-    "build": "yarn build:js && yarn build:types",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\"",
+    "build": "tsx build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-vite.tgz",
     "build:types": "tsc --build --verbose",
     "test": "vitest run src",
@@ -97,6 +96,7 @@
     "@types/yargs-parser": "21.0.3",
     "glob": "10.3.10",
     "rollup": "3.29.4",
+    "tsx": "4.6.2",
     "typescript": "5.3.3",
     "vitest": "1.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8793,6 +8793,7 @@ __metadata:
     react: "npm:0.0.0-experimental-e5205658f-20230913"
     react-server-dom-webpack: "npm:0.0.0-experimental-e5205658f-20230913"
     rollup: "npm:3.29.4"
+    tsx: "npm:4.6.2"
     typescript: "npm:5.3.3"
     vite: "npm:4.5.2"
     vitest: "npm:1.2.2"


### PR DESCRIPTION
Tried building with esbuild in https://github.com/redwoodjs/redwood/pull/10119 but ran into an error with CI. Keen on trying to fix that here. Looks like it was just a matter of updating the default entry points so far. 