### PR TITLE
chore(vite): remove babel dependencies

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -64,7 +64,6 @@
     "test:watch": "vitest watch src"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "7.24.0",
     "@redwoodjs/babel-config": "workspace:*",
     "@redwoodjs/internal": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",
@@ -88,7 +87,6 @@
     "yargs-parser": "21.1.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.23.9",
     "@types/busboy": "^1",
     "@types/cookie": "^0",
     "@types/express": "4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8766,8 +8766,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/vite@workspace:packages/vite"
   dependencies:
-    "@babel/cli": "npm:7.23.9"
-    "@babel/runtime-corejs3": "npm:7.24.0"
     "@redwoodjs/babel-config": "workspace:*"
     "@redwoodjs/internal": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/10147. Forgot to remove the Babel dependencies now that they're not used.