### PR TITLE
fix(setup realtime): remove "exp" from suggested setup command

### DIFF
--- a/.changesets/10151.md
+++ b/.changesets/10151.md
@@ -1,0 +1,3 @@
+- fix(setup realtime): remove "exp" from suggested setup command (#10151) by @jtoar
+
+The realtime setup command was still suggesting running the experimental server file setup command if the server file wasn't setup. This fixes it so that it points users to the stable setup command, `yarn rw setup server-file`, instead.

--- a/packages/cli/src/commands/experimental/util.js
+++ b/packages/cli/src/commands/experimental/util.js
@@ -47,7 +47,7 @@ export const printTaskEpilogue = (command, description, topicId) => {
 export const isServerFileSetup = () => {
   if (!serverFileExists()) {
     throw new Error(
-      'RedwoodJS Realtime requires a serverful environment. Please run `yarn rw exp setup-server-file` first.'
+      'RedwoodJS Realtime requires a serverful environment. Please run `yarn rw setup server-file` first.'
     )
   }
 


### PR DESCRIPTION
This should just be `yarn rw setup server-file` instead of `yarn rw exp setup-server-file`.