### PR TITLE
Fix storybook preview config path reference

### DIFF
--- a/.changesets/10160.md
+++ b/.changesets/10160.md
@@ -1,0 +1,3 @@
+- Fix storybook preview config path reference (#10160) by @pvenable
+
+This change fixes a small regression related to storybook preview config which resulted it in your config not being loaded. Details of this issue can be found in [#10113](https://github.com/redwoodjs/redwood/issues/10113). 

--- a/packages/testing/config/storybook/main.js
+++ b/packages/testing/config/storybook/main.js
@@ -76,8 +76,8 @@ const baseConfig = {
 
     let userPreviewPath = './preview.example.js'
 
-    if (redwoodProjectPaths.storybookPreviewConfig) {
-      userPreviewPath = redwoodProjectPaths.storybookPreviewConfig
+    if (redwoodProjectPaths.web.storybookPreviewConfig) {
+      userPreviewPath = redwoodProjectPaths.web.storybookPreviewConfig
     }
 
     sbConfig.resolve.alias['~__REDWOOD__USER_STORYBOOK_PREVIEW_CONFIG'] =


### PR DESCRIPTION
Fixes #10113.  I didn't see a pull request for this, but the fix seems to have already been identified in the linked issue and worked in my local testing.