### PR TITLE
chore(rsc): remove unnecessary cjs option

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -77,9 +77,6 @@ export async function rscBuildAnalyze() {
         },
       },
     },
-    legacy: {
-      buildSsrCjsExternalHeuristics: true,
-    },
   })
 
   const clientEntryFiles = Object.fromEntries(


### PR DESCRIPTION
It doesn't look like this config is necessary since we're only getting the filenames, and I'm trying to isolate why CI is breaking in https://github.com/redwoodjs/redwood/pull/10167 so removing this here to see if it matters.