### PR TITLE
RSC: setClientEntries: Always 'load', so let's get rid of it

### DIFF
--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -38,10 +38,9 @@ type PipeableStream = { pipe<T extends Writable>(destination: T): T }
 
 const handleSetClientEntries = async ({
   id,
-  value,
 }: MessageReq & { type: 'setClientEntries' }) => {
   try {
-    await setClientEntries(value)
+    await setClientEntries()
 
     if (!parentPort) {
       throw new Error('parentPort is undefined')
@@ -215,14 +214,7 @@ const resolveClientEntry = (
   return clientEntry
 }
 
-async function setClientEntries(
-  value: 'load' | Record<string, string>
-): Promise<void> {
-  if (value !== 'load') {
-    absoluteClientEntries = value
-    return
-  }
-
+async function setClientEntries(): Promise<void> {
   // This is the Vite config
   const config = await configPromise
 

--- a/packages/vite/src/rsc/rscWorkerCommunication.ts
+++ b/packages/vite/src/rsc/rscWorkerCommunication.ts
@@ -30,7 +30,6 @@ export type MessageReq =
   | {
       id: number
       type: 'setClientEntries'
-      value: 'load' | Record<string, string>
     }
   | {
       id: number
@@ -85,9 +84,7 @@ export function shutdown() {
 let nextId = 1
 
 /** Set the client entries in the worker (for the server build) */
-export function setClientEntries(
-  value: 'load' | Record<string, string>
-): Promise<void> {
+export function setClientEntries(): Promise<void> {
   // Just making this function async instead of callback based
   return new Promise((resolve, reject) => {
     const id = nextId++
@@ -102,7 +99,7 @@ export function setClientEntries(
       }
     })
 
-    const message: MessageReq = { id, type: 'setClientEntries', value }
+    const message: MessageReq = { id, type: 'setClientEntries' }
     worker.postMessage(message)
   })
 }

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -53,7 +53,7 @@ export async function runFeServer() {
   if (rscEnabled) {
     try {
       // This will fail if we're not running in RSC mode (i.e. for Streaming SSR)
-      await setClientEntries('load')
+      await setClientEntries()
     } catch (e) {
       console.error('Failed to load client entries')
       console.error(e)


### PR DESCRIPTION
Only time we called `setClientEntries` we always passed `'load'` as the value. So let's just get rid of value and change the code to always just run the "load" behavior