### PR TITLE
RSC: Fix syntax error in node-loader ('2024' -> 2024)

### DIFF
--- a/packages/vite/src/react-server-dom-webpack/node-loader.ts
+++ b/packages/vite/src/react-server-dom-webpack/node-loader.ts
@@ -332,7 +332,7 @@ async function parseExportNamesIntoNames(
 
           try {
             childBody = acorn.parse(mod.source, {
-              ecmaVersion: '2024',
+              ecmaVersion: 2024,
               sourceType: 'module',
             }).body
           } catch (x: any) {
@@ -489,7 +489,7 @@ async function transformModuleIfNeeded(
 
   try {
     body = acorn.parse(source, {
-      ecmaVersion: '2024',
+      ecmaVersion: 2024,
       sourceType: 'module',
     }).body
   } catch (x: any) {


### PR DESCRIPTION
Apparently acorn wants a number, not a string for the ECMA script version property