### PR TITLE
RSC: Move vite plugins into their own files

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
@@ -1,0 +1,38 @@
+import path from 'node:path'
+
+import * as swc from '@swc/core'
+import type { Plugin } from 'vite'
+
+export function rscAnalyzePlugin(
+  clientEntryCallback: (id: string) => void,
+  serverEntryCallback: (id: string) => void
+): Plugin {
+  return {
+    name: 'rsc-analyze-plugin',
+    transform(code, id) {
+      const ext = path.extname(id)
+
+      if (['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
+        const mod = swc.parseSync(code, {
+          syntax: ext === '.ts' || ext === '.tsx' ? 'typescript' : 'ecmascript',
+          tsx: ext === '.tsx',
+        })
+
+        for (const item of mod.body) {
+          if (
+            item.type === 'ExpressionStatement' &&
+            item.expression.type === 'StringLiteral'
+          ) {
+            if (item.expression.value === 'use client') {
+              clientEntryCallback(id)
+            } else if (item.expression.value === 'use server') {
+              serverEntryCallback(id)
+            }
+          }
+        }
+      }
+
+      return code
+    },
+  }
+}

--- a/packages/vite/src/plugins/vite-plugin-rsc-reload.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-reload.ts
@@ -1,0 +1,54 @@
+import path from 'node:path'
+
+import * as swc from '@swc/core'
+import type { Plugin } from 'vite'
+
+export function rscReloadPlugin(fn: (type: 'full-reload') => void): Plugin {
+  let enabled = false
+  const isClientEntry = (id: string, code: string) => {
+    const ext = path.extname(id)
+    if (['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
+      // @MARK: We're using swc here, because that's what the code that I
+      // copy/pasted used. It works, but it's another dependency, and a
+      // slightly different syntax to get used to compared to babel or other
+      // AST parsing libraries we use. So maybe, in the future, we change this
+      // to something else that we use in other places in this package.
+      const mod = swc.parseSync(code, {
+        syntax: ext === '.ts' || ext === '.tsx' ? 'typescript' : 'ecmascript',
+        tsx: ext === '.tsx',
+      })
+
+      for (const item of mod.body) {
+        if (
+          item.type === 'ExpressionStatement' &&
+          item.expression.type === 'StringLiteral' &&
+          item.expression.value === 'use client'
+        ) {
+          return true
+        }
+      }
+    }
+
+    return false
+  }
+
+  return {
+    name: 'reload-plugin',
+    configResolved(config) {
+      if (config.mode === 'development') {
+        enabled = true
+      }
+    },
+    async handleHotUpdate(ctx) {
+      if (!enabled) {
+        return []
+      }
+
+      if (ctx.modules.length && !isClientEntry(ctx.file, await ctx.read())) {
+        return fn('full-reload')
+      } else {
+        return []
+      }
+    },
+  }
+}

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform.ts
@@ -1,6 +1,3 @@
-import path from 'node:path'
-
-import * as swc from '@swc/core'
 import type { Plugin } from 'vite'
 
 import * as RSDWNodeLoader from '../react-server-dom-webpack/node-loader.js'
@@ -18,6 +15,7 @@ export function rscTransformPlugin(
         id,
         options
       )
+
       if (!id.endsWith('.js')) {
         return id
       }
@@ -93,87 +91,6 @@ export function rscTransformPlugin(
       const mod = await RSDWNodeLoader.load(id, null, load, clientEntryFiles)
 
       return mod.source
-    },
-  }
-}
-
-export function rscReloadPlugin(fn: (type: 'full-reload') => void): Plugin {
-  let enabled = false
-  const isClientEntry = (id: string, code: string) => {
-    const ext = path.extname(id)
-    if (['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
-      // @MARK: We're using swc here, because that's what the code that I
-      // copy/pasted used. It works, but it's another dependency, and a
-      // slightly different syntax to get used to compared to babel or other
-      // AST parsing libraries we use. So maybe, in the future, we change this
-      // to something else that we use in other places in this package.
-      const mod = swc.parseSync(code, {
-        syntax: ext === '.ts' || ext === '.tsx' ? 'typescript' : 'ecmascript',
-        tsx: ext === '.tsx',
-      })
-
-      for (const item of mod.body) {
-        if (
-          item.type === 'ExpressionStatement' &&
-          item.expression.type === 'StringLiteral' &&
-          item.expression.value === 'use client'
-        ) {
-          return true
-        }
-      }
-    }
-
-    return false
-  }
-
-  return {
-    name: 'reload-plugin',
-    configResolved(config) {
-      if (config.mode === 'development') {
-        enabled = true
-      }
-    },
-    async handleHotUpdate(ctx) {
-      if (!enabled) {
-        return []
-      }
-
-      if (ctx.modules.length && !isClientEntry(ctx.file, await ctx.read())) {
-        return fn('full-reload')
-      } else {
-        return []
-      }
-    },
-  }
-}
-
-export function rscAnalyzePlugin(
-  clientEntryCallback: (id: string) => void,
-  serverEntryCallback: (id: string) => void
-): Plugin {
-  return {
-    name: 'rsc-analyze-plugin',
-    transform(code, id) {
-      const ext = path.extname(id)
-      if (['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
-        const mod = swc.parseSync(code, {
-          syntax: ext === '.ts' || ext === '.tsx' ? 'typescript' : 'ecmascript',
-          tsx: ext === '.tsx',
-        })
-        for (const item of mod.body) {
-          if (
-            item.type === 'ExpressionStatement' &&
-            item.expression.type === 'StringLiteral'
-          ) {
-            if (item.expression.value === 'use client') {
-              clientEntryCallback(id)
-            } else if (item.expression.value === 'use server') {
-              serverEntryCallback(id)
-            }
-          }
-        }
-      }
-      return code
     },
   }
 }

--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -3,7 +3,6 @@ import { build as viteBuild } from 'vite'
 import { getPaths } from '@redwoodjs/project-config'
 
 import { onWarn } from '../lib/onWarn.js'
-
 import { rscAnalyzePlugin } from '../plugins/vite-plugin-rsc-analyze.js'
 
 /**

--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -4,7 +4,7 @@ import { getPaths } from '@redwoodjs/project-config'
 
 import { onWarn } from '../lib/onWarn.js'
 
-import { rscAnalyzePlugin } from './rscVitePlugins.js'
+import { rscAnalyzePlugin } from '../plugins/vite-plugin-rsc-analyze.js'
 
 /**
  * RSC build. Step 1.

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -5,8 +5,7 @@ import { build as viteBuild } from 'vite'
 import { getPaths } from '@redwoodjs/project-config'
 
 import { onWarn } from '../lib/onWarn.js'
-
-import { rscTransformPlugin } from './rscVitePlugins.js'
+import { rscTransformPlugin } from '../plugins/vite-plugin-rsc-transform.js'
 
 /**
  * RSC build. Step 3.

--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -20,8 +20,8 @@ import { getPaths } from '@redwoodjs/project-config'
 import type { defineEntries } from '../entries.js'
 import { registerFwGlobals } from '../lib/registerGlobals.js'
 import { StatusError } from '../lib/StatusError.js'
+import { rscReloadPlugin } from '../plugins/vite-plugin-rsc-reload.js'
 
-import { rscReloadPlugin } from './rscVitePlugins.js'
 import type {
   RenderInput,
   MessageRes,


### PR DESCRIPTION
There's some upcoming work to be done with our RSC related Vite plugins, so I wanted them in their own separate files before doing that work