### PR TITLE
chore(ci): try yarn installing after npx crwa

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -83,7 +83,7 @@ async function setUpRscProject(
     '--no-git',
     rscProjectPath,
   ])
-  await exec('yarn', null, { cwd: rscProjectPath })
+  await execInProject('yarn')
 
   console.log(`Setting up Streaming/SSR in ${rscProjectPath}`)
   const cmdSetupStreamingSSR = `node ${rwBinPath} experimental setup-streaming-ssr -f`

--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -83,6 +83,7 @@ async function setUpRscProject(
     '--no-git',
     rscProjectPath,
   ])
+  await exec('yarn', null, { cwd: rscProjectPath })
 
   console.log(`Setting up Streaming/SSR in ${rscProjectPath}`)
   const cmdSetupStreamingSSR = `node ${rwBinPath} experimental setup-streaming-ssr -f`


### PR DESCRIPTION
Not sure if this will be effective yet, but trying to fix the CI errors we're seeing with canary versions not being found (e.g. https://github.com/redwoodjs/redwood/actions/runs/8213589113/job/22465174520#step:9:49). This just runs yarn install after running create redwood app. Before, the error would surface when we first added a package in `yarn rw exp setup-streaming-ssr`. There's no lock file before yarn add is being run. Will be hard to tell if it works since it's only intermittently failing, but just have to try some things.