### PR TITLE
chore(ci): try `yarn rw upgrade -t canary` instead of npx@canary

### DIFF
--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -83,7 +83,6 @@ async function setUpRscProject(
     '--no-git',
     rscProjectPath,
   ])
-  await execInProject('yarn')
 
   console.log(`Setting up Streaming/SSR in ${rscProjectPath}`)
   const cmdSetupStreamingSSR = `node ${rwBinPath} experimental setup-streaming-ssr -f`

--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -77,7 +77,8 @@ async function setUpRscProject(
   console.log(`Creating project at ${rscProjectPath}`)
   console.log()
   await exec('yarn', [
-    'create redwood-app',
+    'create',
+    'redwood-app',
     '-y',
     '--no-git',
     rscProjectPath,

--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -76,13 +76,14 @@ async function setUpRscProject(
 
   console.log(`Creating project at ${rscProjectPath}`)
   console.log()
-  await exec('npx', [
-    '-y',
-    'create-redwood-app@canary',
+  await exec('yarn', [
+    'create redwood-app',
     '-y',
     '--no-git',
     rscProjectPath,
   ])
+  await execInProject('yarn install')
+  await execInProject('yarn rw upgrade -t canary')
 
   console.log(`Setting up Streaming/SSR in ${rscProjectPath}`)
   const cmdSetupStreamingSSR = `node ${rwBinPath} experimental setup-streaming-ssr -f`


### PR DESCRIPTION
https://github.com/redwoodjs/redwood/pull/10176 didn't work, but I did discover that the SSR test project seems to always be one canary behind and completes successfully: https://github.com/redwoodjs/redwood/pull/10176#issuecomment-1986903142. It uses `yarn rw upgrade`. Let's see if that works for RSC too.