### PR TITLE
RSC: Simplify node-loader and clientEntryFiles

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform.ts
@@ -308,7 +308,7 @@ async function transformClientModule(
   code: string,
   body: any,
   url: string,
-  clientEntryFiles?: Record<string, string>
+  clientEntryFiles: Record<string, string>
 ): Promise<string> {
   const names: Array<string> = []
 
@@ -316,16 +316,19 @@ async function transformClientModule(
   await parseExportNamesIntoNames(code, body, names)
   console.log('transformClientModule names', names)
 
-  const entryRecord = Object.entries(clientEntryFiles || {}).find(
-    ([_key, value]) => value === url
+  const entryRecord = Object.values(clientEntryFiles).find(
+    (value) => value === url
   )
 
-  // TODO (RSC): Check if we always find a record. If we do, we should
-  // throw an error if it's undefined
+  if (!entryRecord || !entryRecord[0]) {
+    throw new Error('Entry not found for ' + url)
+  }
 
-  const loadId = entryRecord
-    ? path.join(getPaths().web.distRsc, 'assets', entryRecord[0] + '.js')
-    : url
+  const loadId = path.join(
+    getPaths().web.distRsc,
+    'assets',
+    entryRecord[0] + '.js'
+  )
 
   let newSrc =
     "const CLIENT_REFERENCE = Symbol.for('react.client.reference');\n"

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform.ts
@@ -316,8 +316,8 @@ async function transformClientModule(
   await parseExportNamesIntoNames(code, body, names)
   console.log('transformClientModule names', names)
 
-  const entryRecord = Object.values(clientEntryFiles).find(
-    (value) => value === url
+  const entryRecord = Object.entries(clientEntryFiles).find(
+    ([_key, value]) => value === url
   )
 
   if (!entryRecord || !entryRecord[0]) {
@@ -327,7 +327,7 @@ async function transformClientModule(
   const loadId = path.join(
     getPaths().web.distRsc,
     'assets',
-    entryRecord[0] + '.js'
+    `${entryRecord[0]}.js`
   )
 
   let newSrc =

--- a/packages/vite/src/react-server-dom-webpack/node-loader.ts
+++ b/packages/vite/src/react-server-dom-webpack/node-loader.ts
@@ -354,8 +354,8 @@ async function transformClientModule(
   // This will insert the names into the `names` array
   await parseExportNamesIntoNames(body, names, url, loader)
 
-  const entryRecord = Object.values(clientEntryFiles).find(
-    (value) => value === url
+  const entryRecord = Object.entries(clientEntryFiles).find(
+    ([_key, value]) => value === url
   )
 
   if (!entryRecord || !entryRecord[0]) {
@@ -365,7 +365,7 @@ async function transformClientModule(
   const loadId = path.join(
     getPaths().web.distRsc,
     'assets',
-    entryRecord[0] + '.js'
+    `${entryRecord[0]}.js`
   )
 
   let newSrc =


### PR DESCRIPTION
There was a bunch of code in the node-loader that I don't think is being used. So let's try to get rid of it. And in doing so I could also simplify some things around `clientEntryFiles`. Also did the same change in the vite transform plugin