### PR TITLE
fix(prettier): revert breaking changes in prettier v3 upgrade

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -115,7 +115,7 @@ export const handler = async ({ force, install }) => {
   })
   const rwPaths = getPaths()
 
-  const projectPackages = ['prettier-plugin-tailwindcss']
+  const projectPackages = ['prettier-plugin-tailwindcss@0.4.1']
 
   const webWorkspacePackages = [
     'postcss',

--- a/tasks/test-project/tasks.js
+++ b/tasks/test-project/tasks.js
@@ -296,7 +296,7 @@ async function webTasks(outputPath, { linkWithLatestFwBuild, verbose }) {
         // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
         task: () =>
           execa(
-            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss',
+            'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@0.4.1',
             [],
             getExecaOptions(outputPath)
           ),

--- a/tasks/test-project/tui-tasks.js
+++ b/tasks/test-project/tui-tasks.js
@@ -349,7 +349,7 @@ async function webTasks(outputPath, { linkWithLatestFwBuild }) {
       // @NOTE: use rwfw, because calling the copy function doesn't seem to work here
       task: async () => {
         await exec(
-          'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss',
+          'yarn workspace web add -D postcss postcss-loader tailwindcss autoprefixer prettier-plugin-tailwindcss@0.4.1',
           [],
           getExecaOptions(outputPath)
         )


### PR DESCRIPTION
@Josh-Walker-GM pointed out some breaking changes I included in the prettier v3 upgrade (https://github.com/redwoodjs/redwood/pull/10179) in his PR [here](https://github.com/redwoodjs/redwood/pull/10183). My goal with the prettier v3 upgrade was to first do it in a non-breaking way so that it could be released in the next minor, then come back and include the breaking changes (mainly around the tailwind setup command). This should undo the breaking changes so that we can release prettier v3 in the next minor and redo https://github.com/redwoodjs/redwood/pull/10182.