### PR TITLE
chore(rsc): update paths and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,7 +569,10 @@ jobs:
           REDWOOD_TEST_PROJECT_PATH: ${{ steps.set-up-rsc-project.outputs.rsc-project-path }}
           REDWOOD_DISABLE_TELEMETRY: 1
 
+      # TODO(jtoar): This workflow times out on Windows. It looks as if the dev server starts up ok,
+      # but it doesn't seem like the browser is rendering what it should be.
       - name: 🐘 Run RSC dev smoke tests
+        if: matrix.os == 'ubuntu-latest'
         working-directory: tasks/smoke-tests/rsc-dev
         run: npx playwright test
         env:
@@ -683,7 +686,7 @@ jobs:
 
       - name: Build for production
         working-directory: ${{ steps.set-up-test-project.outputs.test-project-path }}
-        run: yarn rw build --no-prerender
+        run: yarn rw build --no-prerender --verbose
         env:
           REDWOOD_DISABLE_TELEMETRY: 1
 

--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -146,7 +146,7 @@ describe('paths', () => {
             'web',
             'dist',
             'server',
-            'entry.server.js',
+            'entry.server.mjs',
           ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
@@ -163,7 +163,7 @@ describe('paths', () => {
             'web',
             'dist',
             'server',
-            'Document.js',
+            'Document.mjs',
           ),
           distRscEntries: path.join(
             FIXTURE_BASEDIR,
@@ -423,14 +423,14 @@ describe('paths', () => {
             'web',
             'dist',
             'server',
-            'entry.server.js',
+            'entry.server.mjs',
           ),
           distDocumentServer: path.join(
             FIXTURE_BASEDIR,
             'web',
             'dist',
             'server',
-            'Document.js',
+            'Document.mjs',
           ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
@@ -749,14 +749,14 @@ describe('paths', () => {
             'web',
             'dist',
             'server',
-            'entry.server.js',
+            'entry.server.mjs',
           ),
           distDocumentServer: path.join(
             FIXTURE_BASEDIR,
             'web',
             'dist',
             'server',
-            'Document.js',
+            'Document.mjs',
           ), // this is constructed regardless of presence of src/Document
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,
@@ -1026,14 +1026,14 @@ describe('paths', () => {
             'web',
             'dist',
             'server',
-            'entry.server.js',
+            'entry.server.mjs',
           ),
           distDocumentServer: path.join(
             FIXTURE_BASEDIR,
             'web',
             'dist',
             'server',
-            'Document.js',
+            'Document.mjs',
           ),
           distRouteHooks: path.join(
             FIXTURE_BASEDIR,

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -130,9 +130,8 @@ const PATH_WEB_DIR_DIST_CLIENT = 'web/dist/client'
 const PATH_WEB_DIR_DIST_RSC = 'web/dist/rsc'
 const PATH_WEB_DIR_DIST_SERVER = 'web/dist/server'
 
-// Don't specify extension, handled by resolve file
-const PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER = 'web/dist/server/entry.server'
-const PATH_WEB_DIR_DIST_DOCUMENT = 'web/dist/server/Document'
+const PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER = 'web/dist/server/entry.server.mjs'
+const PATH_WEB_DIR_DIST_DOCUMENT = 'web/dist/server/Document.mjs'
 
 const PATH_WEB_DIR_DIST_SERVER_ROUTEHOOKS = 'web/dist/server/routeHooks'
 const PATH_WEB_DIR_DIST_RSC_ENTRIES = 'web/dist/rsc/entries.mjs'
@@ -248,12 +247,11 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       distRsc: path.join(BASE_DIR, PATH_WEB_DIR_DIST_RSC),
       distServer: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER),
       // Allow for the possibility of a .mjs file
-      distEntryServer: mjsOrJs(
-        path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER),
+      distEntryServer: path.join(
+        BASE_DIR,
+        PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER,
       ),
-      distDocumentServer: mjsOrJs(
-        path.join(BASE_DIR, PATH_WEB_DIR_DIST_DOCUMENT),
-      ),
+      distDocumentServer: path.join(BASE_DIR, PATH_WEB_DIR_DIST_DOCUMENT),
       distRouteHooks: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER_ROUTEHOOKS),
       distRscEntries: path.join(BASE_DIR, PATH_WEB_DIR_DIST_RSC_ENTRIES),
       routeManifest: path.join(BASE_DIR, PATH_WEB_DIR_ROUTE_MANIFEST),
@@ -432,10 +430,4 @@ export function projectIsEsm() {
   }
 
   return true
-}
-
-/** Default to JS path, but if MJS exists, use it instead */
-const mjsOrJs = (filePath: string) => {
-  const mjsPath = resolveFile(filePath, ['.mjs'])
-  return mjsPath ? mjsPath : filePath + '.js'
 }


### PR DESCRIPTION
This PR extracts out the non Vite v5 related changes from https://github.com/redwoodjs/redwood/pull/10167. That one is proving difficult (the SSR smoke test keeps failing—`entry.server.mjs` isn't in dist, but `entry.client.mjs` is 🤔) and I don't want some of these changes to have to wait since they're unrelated.