### PR TITLE
RSC: Add some types for RSDW/client

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
     "opentelemetry",
     "pino",
     "redwoodjs",
-    "RWJS"
+    "RWJS",
+    "waku"
   ]
 }

--- a/packages/vite/modules.d.ts
+++ b/packages/vite/modules.d.ts
@@ -1,6 +1,25 @@
 declare module 'react-server-dom-webpack/node-loader'
 declare module 'react-server-dom-webpack/server'
 declare module 'react-server-dom-webpack/server.node.unbundled'
-declare module 'react-server-dom-webpack/client'
+
+declare module 'react-server-dom-webpack/client' {
+  // https://github.com/facebook/react/blob/dfaed5582550f11b27aae967a8e7084202dd2d90/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js#L31
+  export type Options<A, T> = {
+    callServer?: (id: string, args: A) => Promise<T>
+  }
+
+  export function createFromFetch<A, T>(
+    // `Response` is a Web Response:
+    // https://developer.mozilla.org/en-US/docs/Web/API/Response
+    promiseForResponse: Promise<Response>,
+    options?: Options<A, T>,
+  ): Thenable<T>
+
+  export function encodeReply(
+    // https://github.com/facebook/react/blob/dfaed5582550f11b27aae967a8e7084202dd2d90/packages/react-client/src/ReactFlightReplyClient.js#L65
+    value: ReactServerValue,
+  ): Promise<string | URLSearchParams | FormData>
+}
+
 declare module 'acorn-loose'
 declare module 'vite-plugin-cjs-interop'


### PR DESCRIPTION
Adding types for the methods we use from the `client` export in the `react-server-dom-webpack` package

Types grabbed from https://github.com/facebook/react/blob/main/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js and other relevant files there

While doing this I also noticed that some of our current typings were wrong, so I fixed that (some things that were returned were actually Thenables, but not typed as such)