### PR TITLE
fix(rsc): try fixing dev

### DIFF
--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -2,6 +2,7 @@ import { createServerAdapter } from '@whatwg-node/server'
 import express from 'express'
 import type { ViteDevServer } from 'vite'
 import { createServer as createViteServer } from 'vite'
+import { cjsInterop } from 'vite-plugin-cjs-interop'
 
 import type { RouteSpec } from '@redwoodjs/internal/dist/routes'
 import { getProjectRoutes } from '@redwoodjs/internal/dist/routes'
@@ -50,6 +51,11 @@ async function createServer() {
   // can take control
   const vite = await createViteServer({
     configFile: rwPaths.web.viteConfig,
+    plugins: [
+      cjsInterop({
+        dependencies: ['@redwoodjs/**'],
+      }),
+    ],
     server: { middlewareMode: true },
     logLevel: 'info',
     clearScreen: false,


### PR DESCRIPTION
Based on https://github.com/redwoodjs/redwood/pull/10201, it looks like CI wasn't correctly catching the errors in the [Vite v5 upgrade](https://github.com/redwoodjs/redwood/pull/10197) as far as RSC goes at least. Had some success with configuring this plugin locally.