### PR TITLE
chore(ci): use tarsync instead of project sync for test project tests

### DIFF
--- a/.github/actions/set-up-test-project/setUpTestProject.mjs
+++ b/.github/actions/set-up-test-project/setUpTestProject.mjs
@@ -3,16 +3,13 @@
 
 import path from 'node:path'
 
-import cache from '@actions/cache'
 import core from '@actions/core'
 
 import fs from 'fs-extra'
 
 import {
-  createCacheKeys,
   createExecWithEnvInCwd,
-  projectCopy,
-  projectDeps,
+  execInFramework,
   REDWOOD_FRAMEWORK_PATH,
 } from '../actionsLib.mjs'
 
@@ -35,36 +32,13 @@ console.log({
 
 console.log()
 
-const {
-  dependenciesKey,
-  distKey
-} = await createCacheKeys({ baseKeyPrefix: 'test-project', distKeyPrefix: bundler, canary })
-
 /**
  * @returns {Promise<void>}
  */
 async function main() {
-  const distCacheKey = await cache.restoreCache([TEST_PROJECT_PATH], distKey)
-
-  if (distCacheKey) {
-    console.log(`Cache restored from key: ${distKey}`)
-    return
-  }
-
-  const dependenciesCacheKey = await cache.restoreCache([TEST_PROJECT_PATH], dependenciesKey)
-
-  if (dependenciesCacheKey) {
-    console.log(`Cache restored from key: ${dependenciesKey}`)
-    await sharedTasks()
-  } else {
-    console.log(`Cache not found for input keys: ${distKey}, ${dependenciesKey}`)
-    await setUpTestProject({
-      canary: true
-    })
-  }
-
-  await cache.saveCache([TEST_PROJECT_PATH], distKey)
-  console.log(`Cache saved with key: ${distKey}`)
+  await setUpTestProject({
+    canary: true
+  })
 }
 
 /**
@@ -82,9 +56,7 @@ async function setUpTestProject({ canary }) {
   console.log()
   await fs.copy(TEST_PROJECT_FIXTURE_PATH, TEST_PROJECT_PATH)
 
-  console.log(`Adding framework dependencies to ${TEST_PROJECT_PATH}`)
-  await projectDeps(TEST_PROJECT_PATH)
-  console.log()
+  await execInFramework('yarn project:tarsync --verbose', { env: { RWJS_CWD: TEST_PROJECT_PATH } })
 
   console.log(`Installing node_modules in ${TEST_PROJECT_PATH}`)
   await execInProject('yarn install')
@@ -96,9 +68,6 @@ async function setUpTestProject({ canary }) {
     console.log()
   }
 
-  await cache.saveCache([TEST_PROJECT_PATH], dependenciesKey)
-  console.log(`Cache saved with key: ${dependenciesKey}`)
-
   await sharedTasks()
 }
 
@@ -108,10 +77,6 @@ const execInProject = createExecWithEnvInCwd(TEST_PROJECT_PATH)
  * @returns {Promise<void>}
  */
 async function sharedTasks() {
-  console.log('Copying framework packages to project')
-  await projectCopy(TEST_PROJECT_PATH)
-  console.log()
-
   console.log({ bundler })
   console.log()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  YARN_ENABLE_HARDENED_MODE: 0
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Want to clean up the code in the action more, but this may be enough changes to do things incrementally. The regular sync strategy we use in CI (`yarn rwfw project:sync`) has never handled dependencies or `yarn install`, and since I just recently had some churn with the Vite 5 upgrade and now the React canary one, I want to see if things could "just work" a little more (while also being more correct).

Disabling Yarn's hardened mode should speed up yarn install times. Yarn recommends opting out of it for most cases:

> Installs operating under Hardened Mode constraints are significantly slower than usual as they need to perform many network requests that would be skipped otherwise. We don't recommend enabling it by default - if you need it in a specific CI job, toggle it on via an environment variable:

See https://yarnpkg.com/blog/release/4.0.