### PR TITLE
chore(ci): upgrade cache action

### DIFF
--- a/.github/actions/set-up-yarn-cache/action.yml
+++ b/.github/actions/set-up-yarn-cache/action.yml
@@ -17,7 +17,7 @@ runs:
     # If the primary key doesn't match, the cache will probably be stale or incomplete,
     # but still worth restoring for the yarn install step.
     - name: ♻️ Restore yarn cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.get-yarn-cache-directory.outputs.CACHE_DIRECTORY }}
         key: yarn-cache-${{ runner.os }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
@@ -25,13 +25,13 @@ runs:
 
     # We avoid restore-keys for these steps because it's important to just start from scratch for new PRs.
     - name: ♻️ Restore yarn install state
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .yarn/install-state.gz
         key: yarn-install-state-${{ runner.os }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: ♻️ Restore node_modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: '**/node_modules'
         key: yarn-node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}


### PR DESCRIPTION
There's a lot of deprecation warnings for some of our workflows. Working on fixing them here:

<img width="902" alt="image" src="https://github.com/redwoodjs/redwood/assets/32992335/2386398d-7f76-4fd2-9b6d-c91b254e127c">
