### PR TITLE
chore(ci): use tarsync for rsc test projects

### DIFF
--- a/.github/actions/actionsLib.mjs
+++ b/.github/actions/actionsLib.mjs
@@ -144,15 +144,8 @@ export async function setUpRscTestProject(
   console.log()
   fs.cpSync(fixturePath, testProjectPath, { recursive: true })
 
-  console.log(`Adding framework dependencies to ${testProjectPath}`)
-  await projectDeps(testProjectPath)
-  console.log()
-
-  console.log(`Installing node_modules in ${testProjectPath}`)
-  await execInProject('yarn install')
-
-  console.log(`Copying over framework files to ${testProjectPath}`)
-  await execInProject(`node ${rwfwBinPath} project:copy`, {
+  console.log('Syncing framework')
+  await execInProject(`node ${rwfwBinPath} project:tarsync --verbose`, {
     env: { RWFW_PATH: REDWOOD_FRAMEWORK_PATH },
   })
   console.log()

--- a/.github/actions/set-up-rsc-project/setUpRscProject.mjs
+++ b/.github/actions/set-up-rsc-project/setUpRscProject.mjs
@@ -69,10 +69,6 @@ async function setUpRscProject(
     REDWOOD_FRAMEWORK_PATH,
     'packages/cli/dist/index.js'
   )
-  const rwfwBinPath = path.join(
-    REDWOOD_FRAMEWORK_PATH,
-    'packages/cli/dist/rwfw.js'
-  )
 
   console.log(`Creating project at ${rscProjectPath}`)
   console.log()
@@ -95,14 +91,10 @@ async function setUpRscProject(
   await execInProject(`node ${rwBinPath} experimental setup-rsc`)
   console.log()
 
-  console.log(`Copying over framework files to ${rscProjectPath}`)
-  await execInProject(`node ${rwfwBinPath} project:copy`, {
+  console.log('Syncing framework')
+  await execInProject('yarn rwfw project:tarsync --verbose', {
     env: { RWFW_PATH: REDWOOD_FRAMEWORK_PATH },
   })
-  console.log()
-
-  console.log('Installing dependencies')
-  await execInProject('yarn install')
   console.log()
 
   console.log(`Building project in ${rscProjectPath}`)

--- a/.github/actions/set-up-test-project/setUpTestProject.mjs
+++ b/.github/actions/set-up-test-project/setUpTestProject.mjs
@@ -58,10 +58,6 @@ async function setUpTestProject({ canary }) {
 
   await execInFramework('yarn project:tarsync --verbose', { env: { RWJS_CWD: TEST_PROJECT_PATH } })
 
-  console.log(`Installing node_modules in ${TEST_PROJECT_PATH}`)
-  await execInProject('yarn install')
-  console.log()
-
   if (canary) {
     console.log(`Upgrading project to canary`)
     await execInProject('yarn rw upgrade -t canary')


### PR DESCRIPTION
Does the same https://github.com/redwoodjs/redwood/pull/10205 did but for the RSC test projects.