### PR TITLE
RSC: Use throw-on-client package

### DIFF
--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@apollo/experimental-nextjs-app-support": "0.0.0-commit-b8a73fe",
+    "@jtoar/throw-on-client": "0.0.1",
     "@redwoodjs/forms": "7.0.0-canary.1011",
     "@redwoodjs/router": "7.0.0-canary.1011",
     "@redwoodjs/web": "7.0.0-canary.1011",
@@ -19,7 +20,6 @@
     "client-only": "0.0.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
     "react-dom": "0.0.0-experimental-e5205658f-20230913",
-    "server-only": "0.0.1"
   },
   "devDependencies": {
     "@redwoodjs/vite": "7.0.0-canary.1011",

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/package.json
@@ -19,7 +19,7 @@
     "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
     "react": "0.0.0-experimental-e5205658f-20230913",
-    "react-dom": "0.0.0-experimental-e5205658f-20230913",
+    "react-dom": "0.0.0-experimental-e5205658f-20230913"
   },
   "devDependencies": {
     "@redwoodjs/vite": "7.0.0-canary.1011",

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/src/pages/HomePage/words.ts
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/src/pages/HomePage/words.ts
@@ -1,4 +1,4 @@
-import 'server-only'
+import '@jtoar/throw-on-client'
 
 const RANDOM_WORDS = [
   'retarders',

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/src/pages/HomePage/words.ts
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/src/pages/HomePage/words.ts
@@ -1,3 +1,4 @@
+// Could also have used `import 'server-only'
 import '@jtoar/throw-on-client'
 
 const RANDOM_WORDS = [


### PR DESCRIPTION
Use "throw-on-client" instead of "server-only" to show that the package name doesn't matter