### PR TITLE
fix(rsc): remove `noExternals` in `rscBuildAnalyze`

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -48,12 +48,6 @@ export async function rscBuildAnalyze() {
       ),
     ],
     ssr: {
-      // We can ignore everything that starts with `node:` because it's not
-      // going to be RSCs
-      noExternal: /^(?!node:)/,
-      // TODO (RSC): Figure out what the `external` list should be. Right
-      // now it's just copied from waku
-      external: ['react', 'minimatch'],
       resolve: {
         externalConditions: ['react-server'],
       },

--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -48,6 +48,7 @@ export async function rscBuildAnalyze() {
       ),
     ],
     ssr: {
+      external: ['react'],
       resolve: {
         externalConditions: ['react-server'],
       },


### PR DESCRIPTION
This seems like unwise config to keep around if we don't need it because it tells Vite to consider any import that isn't `node:` (e.g. `import fs from 'node:fs'`, so anything other than that, which is basically every dependency) to be source code that needs transformed effectively, and in this step we're just scanning for client entry and server entry files. See https://vitejs.dev/guide/ssr.html#ssr-externals.


Here's an example of the `clientEntryFileSet` and `serverEntryFileSet` produced by `rscBuildAnalyze` before/after change using the minimal test project:

Before:

```
clientEntryFileSet [
  '~/redwood-app/web/src/components/Counter/Counter.tsx',
  '~/redwood-app/web/src/components/Counter/AboutCounter.tsx',
  '~/redwood-app/node_modules/@redwoodjs/web/dist/components/cell/CellErrorBoundary.js',
  '~/redwood-app/node_modules/@apollo/experimental-nextjs-app-support/dist/ssr/ApolloNextAppProvider.js',
  '~/redwood-app/node_modules/@apollo/experimental-nextjs-app-support/dist/ssr/hooks.js',
  '~/redwood-app/node_modules/@redwoodjs/router/dist/navLink.js',
  '~/redwood-app/node_modules/@redwoodjs/router/dist/link.js',
  '~/redwood-app/node_modules/@apollo/experimental-nextjs-app-support/dist/ssr/useTransportValue.js'
]
serverEntryFileSet []
```

After:

```
clientEntryFileSet [
  '~/redwood-app/web/src/components/Counter/Counter.tsx'
  '~/redwood-app/web/src/components/Counter/AboutCounter.tsx',
]
serverEntryFileSet []
```

