### PR TITLE
fix(rsc): only use `web/src/entries.ts` as the `rscBuildAnalyze` entry point

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -61,17 +61,16 @@ export async function rscBuildAnalyze() {
     build: {
       manifest: 'rsc-build-manifest.json',
       write: false,
-      ssr: true,
+      // TODO (RSC): In the future we want to generate the entries file
+      // automatically. Maybe by using `analyzeRoutes()`
+      // For the dev server we might need to generate these entries on the
+      // fly - so we will need something like a plugin or virtual module
+      // to generate these entries, rather than write to actual file.
+      // And so, we might as well use on-the-fly generation for regular
+      // builds too
+      ssr: rwPaths.web.entries,
       rollupOptions: {
         onwarn: onWarn,
-        // TODO (RSC): In the future we want to generate the entries file
-        // automatically. Maybe by using `analyzeRoutes()`
-        // For the dev server we might need to generate these entries on the
-        // fly - so we will need something like a plugin or virtual module
-        // to generate these entries, rather than write to actual file.
-        // And so, we might as well use on-the-fly generation for regular
-        // builds too
-        input: rwPaths.web.entries,
       },
     },
   })

--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -64,16 +64,14 @@ export async function rscBuildAnalyze() {
       ssr: true,
       rollupOptions: {
         onwarn: onWarn,
-        input: {
-          // TODO (RSC): In the future we want to generate the entries file
-          // automatically. Maybe by using `analyzeRoutes()`
-          // For the dev server we might need to generate these entries on the
-          // fly - so we will need something like a plugin or virtual module
-          // to generate these entries, rather than write to actual file.
-          // And so, we might as well use on-the-fly generation for regular
-          // builds too
-          entries: rwPaths.web.entries,
-        },
+        // TODO (RSC): In the future we want to generate the entries file
+        // automatically. Maybe by using `analyzeRoutes()`
+        // For the dev server we might need to generate these entries on the
+        // fly - so we will need something like a plugin or virtual module
+        // to generate these entries, rather than write to actual file.
+        // And so, we might as well use on-the-fly generation for regular
+        // builds too
+        input: rwPaths.web.entries,
       },
     },
   })


### PR DESCRIPTION
Right now `rscBuildAnalyze` scans three entry points and ~1600 files for `'use client'` and `'use server'` directives.

```js
{
  entries: "~/redwood-app/web/src/entries.ts",
  "entry.server": "~/redwood-app/web/src/entry.server.tsx",
  Document: "~/redwood-app/web/src/Document.tsx",
}
```

Checked with @Tobbe and the only entry point we actually need to scan is `web/src/entries.ts`. With this change, we only scan 267 files.
