### PR TITLE
chore(rsc): prefix `rsc-analyze-plugin` plugin

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
@@ -8,7 +8,7 @@ export function rscAnalyzePlugin(
   serverEntryCallback: (id: string) => void,
 ): Plugin {
   return {
-    name: 'rsc-analyze-plugin',
+    name: 'redwood-rsc-analyze-plugin',
     transform(code, id) {
       const ext = path.extname(id)
 


### PR DESCRIPTION
All our other plugins are prefixed with `redwood-` and it makes it easier to find in the logs and while debugging. All the Vite plugins are `vite:...`; not sure if that's an internal only convention or not but maybe we want to consider that. But not in this PR.