### PR TITLE
RSC: Fix a prisma client warning during build

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -52,8 +52,8 @@ export async function rscBuildAnalyze() {
       // going to be RSCs
       noExternal: /^(?!node:)/,
       // TODO (RSC): Figure out what the `external` list should be. Right
-      // now it's just copied from waku
-      external: ['react', 'minimatch'],
+      // now it's just copied from waku, plus we added prisma
+      external: ['react', 'minimatch', '@prisma/client'],
       resolve: {
         externalConditions: ['react-server'],
       },


### PR DESCRIPTION
We figured out that we need to externalize prisma client during build. Doing the same during analyze gets rid of a warning that's printed to the console.