### PR TITLE
RSC: fix css and add smoke tests for it

### DIFF
--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-css-preinit.test.mts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-css-preinit.test.mts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { vol } from 'memfs'
+import { normalizePath } from 'vite'
 
 import { generateCssMapping, rscCssPreinitPlugin, generateServerComponentClientComponentMapping, splitClientAndServerComponents } from '../vite-plugin-rsc-css-preinit'
 import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest'
@@ -27,8 +28,7 @@ beforeAll(() => {
   const manifestPath = path.join(
     getPaths().web.distClient,
     'client-build-manifest.json',
-  )
-  console.error('JGMW: mocking: manifestPath:', manifestPath)
+  ).substring(process.env.RWJS_CWD.length)
   vol.fromJSON({
     'redwood.toml': '',
     [manifestPath]: JSON.stringify(clientBuildManifest),
@@ -52,6 +52,7 @@ describe('rscCssPreinitPlugin', () => {
 
     // Calling `bind` to please TS
     // See https://stackoverflow.com/a/70463512/88106
+    const id = path.join(process.env.RWJS_CWD!, 'web', 'src', 'pages', 'HomePage', 'HomePage.tsx')
     const output = await plugin.transform.bind({})(
       `import { jsx, jsxs } from "react/jsx-runtime";
       import { RscForm } from "@tobbe.dev/rsc-test";
@@ -83,7 +84,7 @@ describe('rscCssPreinitPlugin', () => {
         ] });
       };
       export default HomePage;`,
-      path.join(process.env.RWJS_CWD!, 'web', 'src', 'pages', 'HomePage', 'HomePage.tsx')
+      normalizePath(id)
     )
 
     // You will see that this snapshot contains:

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-css-preinit.test.mts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-css-preinit.test.mts
@@ -28,6 +28,7 @@ beforeAll(() => {
     getPaths().web.distClient,
     'client-build-manifest.json',
   )
+  console.error('JGMW: mocking: manifestPath:', manifestPath)
   vol.fromJSON({
     'redwood.toml': '',
     [manifestPath]: JSON.stringify(clientBuildManifest),

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-css-preinit.test.mts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-css-preinit.test.mts
@@ -9,6 +9,7 @@ import {
   clientEntryFiles,
   componentImportMap,
 } from './vite-plugin-rsc-css-preinit-fixture-values'
+import { getPaths } from '@redwoodjs/project-config'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 
@@ -16,11 +17,22 @@ const RWJS_CWD = process.env.RWJS_CWD
 
 let consoleLogSpy
 beforeAll(() => {
+  // Add the toml so that getPaths will work
   process.env.RWJS_CWD = '/Users/mojombo/rw-app/'
   vol.fromJSON({
     'redwood.toml': '',
-    [path.join('web', 'dist', 'client', 'client-build-manifest.json')]: JSON.stringify(clientBuildManifest),
   }, process.env.RWJS_CWD)
+
+  // Add the client build manifest
+  const manifestPath = path.join(
+    getPaths().web.distClient,
+    'client-build-manifest.json',
+  )
+  vol.fromJSON({
+    'redwood.toml': '',
+    [manifestPath]: JSON.stringify(clientBuildManifest),
+  }, process.env.RWJS_CWD)
+
   consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 })
 
@@ -29,7 +41,7 @@ afterAll(() => {
   consoleLogSpy.mockRestore()
 })
 
-describe.skip('rscCssPreinitPlugin', () => {
+describe('rscCssPreinitPlugin', () => {
   it('should insert preinits for all nested client components', async () => {
     const plugin = rscCssPreinitPlugin(clientEntryFiles, componentImportMap)
 

--- a/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import * as swc from '@swc/core'
 import type { Plugin } from 'vite'
+import { normalizePath } from 'vite'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -43,7 +44,7 @@ export function rscAnalyzePlugin(
     },
     moduleParsed(moduleInfo) {
       // TODO: Maybe this is not needed?
-      if (moduleInfo.id.startsWith(webSrcPath)) {
+      if (moduleInfo.id.startsWith(normalizePath(webSrcPath))) {
         componentImportsCallback(moduleInfo.id, moduleInfo.importedIds)
       }
     },

--- a/packages/vite/src/plugins/vite-plugin-rsc-css-preinit.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-css-preinit.ts
@@ -94,12 +94,11 @@ export function rscCssPreinitPlugin(
 
   // This plugin is build only and we expect the client build manifest to be
   // available at this point. We use it to find the correct css assets names
-  const clientBuildManifest = JSON.parse(
-    fs.readFileSync(
-      path.join(getPaths().web.distClient, 'client-build-manifest.json'),
-      'utf-8',
-    ),
+  const manifestPath = path.join(
+    getPaths().web.distClient,
+    'client-build-manifest.json',
   )
+  const clientBuildManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
 
   // We generate a mapping of all the css assets that a client build manifest
   // entry contains (looking deep into the tree of entries)

--- a/packages/vite/src/plugins/vite-plugin-rsc-css-preinit.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-css-preinit.ts
@@ -7,6 +7,7 @@ import type { NodePath } from '@babel/traverse'
 import traverse from '@babel/traverse'
 import * as t from '@babel/types'
 import type { Plugin } from 'vite'
+import { normalizePath } from 'vite'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -98,7 +99,6 @@ export function rscCssPreinitPlugin(
     getPaths().web.distClient,
     'client-build-manifest.json',
   )
-  console.error('JGMW: plugin: manifestPath:', manifestPath)
   const clientBuildManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
 
   // We generate a mapping of all the css assets that a client build manifest
@@ -123,7 +123,7 @@ export function rscCssPreinitPlugin(
     apply: 'build',
     transform: async function (code, id) {
       // We only care about code in the project itself
-      if (!id.startsWith(webSrc)) {
+      if (!id.startsWith(normalizePath(webSrc))) {
         return null
       }
 

--- a/packages/vite/src/plugins/vite-plugin-rsc-css-preinit.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-css-preinit.ts
@@ -98,6 +98,7 @@ export function rscCssPreinitPlugin(
     getPaths().web.distClient,
     'client-build-manifest.json',
   )
+  console.error('JGMW: plugin: manifestPath:', manifestPath)
   const clientBuildManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
 
   // We generate a mapping of all the css assets that a client build manifest

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -49,7 +49,8 @@ export async function rscBuildForServer(
       // it's likely way less efficient because we have to do so many files.
       // Files included in `noExternal` are files we want Vite to analyze
       noExternal: /^(?!node:)/,
-      // Can't inline prisma client (db calls fail at runtime) or react-dom (css preinit failure)
+      // Can't inline prisma client (db calls fail at runtime) or react-dom
+      // (css preinit failure)
       external: ['@prisma/client', 'react-dom'],
       resolve: {
         // These conditions are used in the plugin pipeline, and only affect non-externalized

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -49,8 +49,8 @@ export async function rscBuildForServer(
       // it's likely way less efficient because we have to do so many files.
       // Files included in `noExternal` are files we want Vite to analyze
       noExternal: /^(?!node:)/,
-      // Can't inline prisma client
-      external: ['@prisma/client'],
+      // Can't inline prisma client (db calls fail at runtime) or react-dom (css preinit failure)
+      external: ['@prisma/client', 'react-dom'],
       resolve: {
         // These conditions are used in the plugin pipeline, and only affect non-externalized
         // dependencies during the SSR build. Which because of `noExternal: /^(?!node:)/` means

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -22,10 +22,12 @@ test('CSS has been loaded', async ({ page }) => {
 
   // Check color of server component h3
   const serverH3 = page.getByText('This is a server component.')
+  await expect(serverH3).toBeVisible()
   expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
 
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
+  await expect(clientH3).toBeVisible()
   expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
 
   // Check font style of client component h3

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -32,11 +32,12 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
+  // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3
-  const clientH3Font = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('font-style')
-  })
-  expect(clientH3Font).toBe('italic')
+  // const clientH3Font = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('font-style')
+  // })
+  // expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -23,14 +23,20 @@ test('CSS has been loaded', async ({ page }) => {
   // Check color of server component h3
   const serverH3 = page.getByText('This is a server component.')
   await expect(serverH3).toBeVisible()
+  const serverH3Color = await serverH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
   // rgb(255, 165, 0) is orange
-  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)')
+  expect(serverH3Color).toBe('rgb(255, 165, 0)')
 
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
   await expect(clientH3).toBeVisible()
+  const clientH3Color = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
   // rgb(255, 165, 0) is orange
-  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
+  expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
   // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -17,6 +17,26 @@ test('Setting up RSC should give you a test project with a client side counter c
   page.close()
 })
 
+test('CSS has been loaded', async ({ page }) => {
+  await page.goto('/')
+
+  // Check color of server component h3
+  const serverH3 = page.getByText('This is a server component.')
+  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+
+  // Check color of client component h3
+  const clientH3 = page.getByText('This is a client component.')
+  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+
+  // Check font style of client component h3
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
+
+  page.close()
+})
+
 test('RWJS_* env vars', async ({ page }) => {
   await page.goto('/about')
 

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -23,12 +23,14 @@ test('CSS has been loaded', async ({ page }) => {
   // Check color of server component h3
   const serverH3 = page.getByText('This is a server component.')
   await expect(serverH3).toBeVisible()
-  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+  // rgb(255, 165, 0) is orange
+  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
   await expect(clientH3).toBeVisible()
-  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+  // rgb(255, 165, 0) is orange
+  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
   // Check font style of client component h3
   const clientH3Font = await clientH3.evaluate((el) => {

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -38,12 +38,11 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3
-  // const clientH3Font = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('font-style')
-  // })
-  // expect(clientH3Font).toBe('italic')
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -15,6 +15,23 @@ test('Client components should work', async ({ page }) => {
   page.close()
 })
 
+test('CSS has been loaded', async ({ page }) => {
+  await page.goto('/')
+
+  // Check color of client component h3
+  const clientH3 = page.getByText('This is a client component.')
+  await expect(clientH3).toBeVisible()
+  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+
+  // Check font style of client component h3
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
+
+  page.close()
+})
+
 test('Submitting the form should return a response', async ({ page }) => {
   await page.goto('/')
 

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -21,8 +21,11 @@ test('CSS has been loaded', async ({ page }) => {
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
   await expect(clientH3).toBeVisible()
+  const clientH3Color = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
   // rgb(255, 165, 0) is orange
-  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
+  expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
   // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -24,11 +24,12 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
+  // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3
-  const clientH3Font = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('font-style')
-  })
-  expect(clientH3Font).toBe('italic')
+  // const clientH3Font = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('font-style')
+  // })
+  // expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -27,12 +27,11 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3
-  // const clientH3Font = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('font-style')
-  // })
-  // expect(clientH3Font).toBe('italic')
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -21,7 +21,8 @@ test('CSS has been loaded', async ({ page }) => {
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
   await expect(clientH3).toBeVisible()
-  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+  // rgb(255, 165, 0) is orange
+  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
   // Check font style of client component h3
   const clientH3Font = await clientH3.evaluate((el) => {

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -22,10 +22,12 @@ test('CSS has been loaded', async ({ page }) => {
 
   // Check color of server component h3
   const serverH3 = page.getByText('This is a server component.')
+  await expect(serverH3).toBeVisible()
   expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
 
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
+  await expect(clientH3).toBeVisible()
   expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
 
   // Check font style of client component h3

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -32,7 +32,7 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
-  // TODO: Reenable this test once we can easily debug windows behaviour
+  // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3
   // const clientH3Font = await clientH3.evaluate((el) => {
   //   return window.getComputedStyle(el).getPropertyValue('font-style')

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -23,14 +23,20 @@ test('CSS has been loaded', async ({ page }) => {
   // Check color of server component h3
   const serverH3 = page.getByText('This is a server component.')
   await expect(serverH3).toBeVisible()
+  const serverH3Color = await serverH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
   // rgb(255, 165, 0) is orange
-  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)')
+  expect(serverH3Color).toBe('rgb(255, 165, 0)')
 
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
   await expect(clientH3).toBeVisible()
+  const clientH3Color = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
   // rgb(255, 165, 0) is orange
-  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
+  expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
   // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -32,11 +32,12 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
+  // TODO: Reenable this test once we can easily debug windows behaviour
   // Check font style of client component h3
-  const clientH3Font = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('font-style')
-  })
-  expect(clientH3Font).toBe('italic')
+  // const clientH3Font = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('font-style')
+  // })
+  // expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -17,6 +17,26 @@ test('Setting up RSC should give you a test project with a client side counter c
   page.close()
 })
 
+test('CSS has been loaded', async ({ page }) => {
+  await page.goto('/')
+
+  // Check color of server component h3
+  const serverH3 = page.getByText('This is a server component.')
+  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+
+  // Check color of client component h3
+  const clientH3 = page.getByText('This is a client component.')
+  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+
+  // Check font style of client component h3
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
+
+  page.close()
+})
+
 test('RWJS_* env vars', async ({ page }) => {
   await page.goto('/about')
 

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -23,12 +23,14 @@ test('CSS has been loaded', async ({ page }) => {
   // Check color of server component h3
   const serverH3 = page.getByText('This is a server component.')
   await expect(serverH3).toBeVisible()
-  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+  // rgb(255, 165, 0) is orange
+  expect(serverH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
   // Check color of client component h3
   const clientH3 = page.getByText('This is a client component.')
   await expect(clientH3).toBeVisible()
-  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)') // rgb(255, 165, 0) is orange
+  // rgb(255, 165, 0) is orange
+  expect(clientH3).toHaveCSS('color', 'rgb(255, 165, 0)')
 
   // Check font style of client component h3
   const clientH3Font = await clientH3.evaluate((el) => {

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -38,12 +38,11 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // TODO: Reenable this test once we can easily debug windows behavior
   // Check font style of client component h3
-  // const clientH3Font = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('font-style')
-  // })
-  // expect(clientH3Font).toBe('italic')
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
 
   page.close()
 })


### PR DESCRIPTION
**Changes**
1. Add smoke tests that expect certain CSS to have loaded as we would expect. This should hopefully identify CSS regressions.
2. Had to externalize the `react-dom` package to get the CSS preinit plugin to work again. We can circle back to this. 