### PR TITLE
fix(rsc): avoid overriding `NODE_ENV`

### DIFF
--- a/packages/vite/bins/rw-vite-build.mjs
+++ b/packages/vite/bins/rw-vite-build.mjs
@@ -42,7 +42,9 @@ const buildWebSide = async (webDir) => {
     throw new Error('Could not locate your web/vite.config.{js,ts} file')
   }
 
-  process.env.NODE_ENV = 'production'
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'production'
+  }
 
   if (getConfig().experimental?.streamingSsr?.enabled) {
     // Webdir checks handled in the rwjs/vite package in new build system


### PR DESCRIPTION
Similar to https://github.com/redwoodjs/redwood/pull/10227, I can't pull in the development build of react or any of react's packages for debugging because we're hardcoding `NODE_ENV` in rw-vite-build.