### PR TITLE
chore(ci): refactor out set up steps

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -1,0 +1,61 @@
+name: Set up job
+description: >
+  Everything you need to run a job in CI.
+  Checkout this repo (redwoodjs/redwood), set up Node.js, yarn install, and build.
+
+inputs:
+  set-up-yarn-cache:
+    description: >
+      For some actions, setting up the yarn cache takes longer than it would to just yarn install.
+    required: false
+    default: true
+
+  yarn-install-directory:
+    description: >
+      The directory to run `yarn install` in.
+    required: false
+
+  build:
+    description: >
+      Whether or not to run `yarn build` to build all the framework packages.
+    required: false
+    default: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: ⬢ Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - name: ⬢ Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    # We have to enable Corepack again for Windows. 🤷
+    # In general, we're waiting on [this issue](https://github.com/actions/setup-node/issues/531)
+    # to be resolved so that `actions/setup-node@v4` has first-class Corepack support.
+    - name: ⬢ Enable Corepack
+      if: runner.os == 'Windows'
+      shell: bash
+      run: corepack enable
+
+    - name: 🐈 Set up yarn cache
+      if: inputs.set-up-yarn-cache == 'true'
+      uses: ./.github/actions/set-up-yarn-cache
+
+    # One of our dependencies is on GitHub instead of NPM and without authentication
+    # we'll get rate limited and this step becomes flaky.
+    - name: 🐈 Yarn install
+      shell: bash
+      working-directory: ${{ inputs.yarn-install-directory }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: yarn install --inline-builds
+
+    - name: 🏗️ Build
+      if: inputs.build == 'true'
+      shell: bash
+      run: yarn build

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -16,16 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
         with:
-          node-version: 20
-
-      - run: yarn install
-        working-directory: ./.github/actions/check_changesets
+          set-up-yarn-cache: false
+          yarn-install-directory: ./.github/actions/check_changesets
+          build: false
 
       - name: Check changesets
         uses: ./.github/actions/check_changesets

--- a/.github/workflows/check-create-redwood-app.yml
+++ b/.github/workflows/check-create-redwood-app.yml
@@ -16,16 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
         with:
-          node-version: 20
-
-      - run: yarn install
-        working-directory: ./.github/actions/check_create_redwood_app
+          set-up-yarn-cache: false
+          yarn-install-directory: ./.github/actions/check_create_redwood_app
+          build: false
 
       - name: Check create redwood app
         uses: ./.github/actions/check_create_redwood_app

--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -17,27 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
+      - name: Set up job
         if: "!contains(github.event.pull_request.labels.*.name, 'fixture-ok')"
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        if: "!contains(github.event.pull_request.labels.*.name, 'fixture-ok')"
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        if: "!contains(github.event.pull_request.labels.*.name, 'fixture-ok')"
-        run: yarn build
+        uses: ./.github/actions/set-up-job
 
       - name: Rebuild test-project fixture
         if: "!contains(github.event.pull_request.labels.*.name, 'fixture-ok')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,20 +28,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
         with:
-          node-version: 20
-
-      - name: 🐈 Yarn install
-        working-directory: ./.github/actions/detect-changes
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          set-up-yarn-cache: false
+          yarn-install-directory: ./.github/actions/detect-changes
+          build: false
 
       - name: 🔍 Detect changes
         id: detect-changes
@@ -56,20 +48,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
         with:
-          node-version: 20
-
-      - name: 🐈 Yarn install
-        working-directory: ./tasks/check
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          set-up-yarn-cache: false
+          yarn-install-directory: ./tasks/check
+          build: false
 
       - name: ✅ Check constraints, dependencies, and package.json's
         uses: ./tasks/check
@@ -100,28 +84,8 @@ jobs:
         run: echo "echo "::remove-matcher owner=tsc::""
 
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🔎 Lint
         run: yarn lint
@@ -163,25 +127,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🌲 Install Cypress
         run: yarn cypress install
@@ -259,28 +206,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🌲 Set up test project
         id: set-up-test-project
@@ -370,28 +297,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🌲 Set up test project
         id: set-up-test-project
@@ -498,28 +405,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 📢 Listen for telemetry (CRWA)
         run: node ./.github/actions/telemetry_check/check.mjs --mode crwa
@@ -560,28 +447,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🌲 Set up RSC project
         id: set-up-rsc-project
@@ -670,25 +537,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🌲 Set up test project
         id: set-up-test-project
@@ -759,28 +609,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🌲 Set up test project
         id: set-up-test-project
@@ -857,25 +687,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: ⬢ Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🏗️ Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: Set up test project
         run: |
@@ -953,25 +766,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: 🔨 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - run: yarn vitest run
         working-directory: ./tasks/server-tests

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -31,24 +31,8 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: ✅ Check constraints, dependencies, and package.json's
-        uses: ./tasks/check
-
-      - name: 🏗 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🔎 Lint
         run: yarn lint

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -65,27 +65,8 @@ jobs:
           #  This is required because lerna uses tags to determine the version.
           fetch-depth: 0
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: ⬢ Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: 🐈 Set up yarn cache
-        uses: ./.github/actions/set-up-yarn-cache
-
-      - name: 🐈 Yarn install
-        run: yarn install --inline-builds
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: ✅ Check constraints, dependencies, and package.json's
-        uses: ./tasks/check
-
-      - name: 🏗 Build
-        run: yarn build
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
 
       - name: 🔎 Lint
         run: yarn lint


### PR DESCRIPTION
Want to keep working on CI every now and then. Starting by cleaning up some things so it's easier to reason about. Most jobs run the following steps:

- enable corepack (this should go away one day when the setup node action supports it)
- set up node
- enable corepack again (for windows)
- set up yarn cache
- yarn install
- build

Refactoring these out into a composite action so that we can save some lines in ci.yml which is starting to get quite long. I can also document some things better this way.