### PR TITLE
docs: fix typo on router page

### DIFF
--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -319,7 +319,7 @@ See below for more info on route parameters.
 To match variable data in a path, you can use route parameters, which are specified by a parameter name surrounded by curly braces:
 
 ```jsx title="Routes.js"
-<Route path="/user/{id}>" page={UserPage} name="user" />
+<Route path="/user/{id}" page={UserPage} name="user" />
 ```
 
 This route will match URLs like `/user/7` or `/user/mojombo`. You can have as many route parameters as you like:


### PR DESCRIPTION
Router documentation page - remove extra `>` character from the Route path.

## Before:
<img width="874" alt="Screenshot 2024-03-14 at 08 32 31" src="https://github.com/redwoodjs/redwood/assets/66722479/085c7273-1c56-4981-9e6a-a3b0b2c47210">

## After:
<img width="892" alt="Screenshot 2024-03-17 at 19 15 04" src="https://github.com/redwoodjs/redwood/assets/66722479/53b10a20-2e22-4d04-badd-b344d490f35b">
