### PR TITLE
Adds 'use client' to Metadata so that it always runs in the client

### DIFF
--- a/packages/web/src/components/Metadata.tsx
+++ b/packages/web/src/components/Metadata.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 
 import { Helmet as HelmetHead } from 'react-helmet-async'


### PR DESCRIPTION
Otherwise throws a TypeError when serving the site, `React.createContext is not a function`