### PR TITLE
DEMO rsc vite ssr minimal (do not merge)

### DIFF
--- a/packages/vite/modules.d.ts
+++ b/packages/vite/modules.d.ts
@@ -1,4 +1,5 @@
 declare module 'react-server-dom-webpack/node-loader'
+declare module 'react-server-dom-webpack/client.edge'
 
 declare module 'react-server-dom-webpack/client' {
   // https://github.com/facebook/react/blob/dfaed5582550f11b27aae967a8e7084202dd2d90/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js#L31

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -1,175 +1,73 @@
-// TODO (STREAMING) Move this to a new package called @redwoodjs/fe-server (goes
-// well in naming with @redwoodjs/api-server)
-// Only things used during dev can be in @redwoodjs/vite. Everything else has
-// to go in fe-server
-// UPDATE: We decided to name the package @redwoodjs/web-server instead of
-// fe-server. And it's already created, but this hasn't been moved over yet.
-
-import path from 'node:path'
-import url from 'node:url'
+import React from 'react'
 
 import { createServerAdapter } from '@whatwg-node/server'
-// @ts-expect-error We will remove dotenv-defaults from this package anyway
-import { config as loadDotEnv } from 'dotenv-defaults'
 import express from 'express'
-import { createProxyMiddleware } from 'http-proxy-middleware'
-import type { Manifest as ViteBuildManifest } from 'vite'
+// @ts-expect-error - Should be available on 'react-dom/server', but is not.
+// See https://github.com/facebook/react/issues/26906
+import { renderToReadableStream } from 'react-dom/server.edge'
+import { createFromReadableStream } from 'react-server-dom-webpack/client.edge'
 
-import { getConfig, getPaths } from '@redwoodjs/project-config'
-
-import { registerFwGlobalsAndShims } from './lib/registerFwGlobalsAndShims.js'
-import { invoke } from './middleware/invokeMiddleware.js'
-import { createRscRequestHandler } from './rsc/rscRequestHandler.js'
-import { setClientEntries } from './rsc/rscWorkerCommunication.js'
-import { createReactStreamingHandler } from './streaming/createReactStreamingHandler.js'
-import type { RWRouteManifest } from './types.js'
-
-/**
- * TODO (STREAMING)
- * We have this server in the vite package only temporarily.
- * We will need to decide where to put it, so that rwjs/internal and other heavy dependencies
- * can be removed from the final docker image
- */
-
-// --- @MARK This should be removed once we have re-architected the rw serve command ---
-// We need the dotenv, so that prisma knows the DATABASE env var
-// Normally the RW cli loads this for us, but we expect this file to be run directly
-// without using the CLI. Remember to remove dotenv-defaults dependency from this package
-loadDotEnv({
-  path: path.join(getPaths().base, '.env'),
-  defaults: path.join(getPaths().base, '.env.defaults'),
-  multiline: true,
-})
-// ------------------------------------------------
+import { moduleMap } from './streaming/ssrModuleMap.js'
 
 export async function runFeServer() {
   const app = express()
-  const rwPaths = getPaths()
-  const rwConfig = getConfig()
-  const rscEnabled = rwConfig.experimental?.rsc?.enabled
 
-  registerFwGlobalsAndShims()
+  registerFwShims()
 
-  if (rscEnabled) {
-    try {
-      // This will fail if we're not running in RSC mode (i.e. for Streaming SSR)
-      await setClientEntries()
-    } catch (e) {
-      console.error('Failed to load client entries')
-      console.error(e)
-      process.exit(1)
-    }
-  }
+  app.get('/', createServerAdapter(reactRenderToStreamResponse))
 
-  const routeManifestUrl = url.pathToFileURL(rwPaths.web.routeManifest).href
-  const routeManifest: RWRouteManifest = (
-    await import(routeManifestUrl, { with: { type: 'json' } })
-  ).default
-
-  const clientBuildManifestUrl = url.pathToFileURL(
-    path.join(rwPaths.web.distClient, 'client-build-manifest.json'),
-  ).href
-  const clientBuildManifest: ViteBuildManifest = (
-    await import(clientBuildManifestUrl, { with: { type: 'json' } })
-  ).default
-
-  if (rwConfig.experimental?.rsc?.enabled) {
-    console.log('='.repeat(80))
-    console.log('buildManifest', clientBuildManifest)
-    console.log('='.repeat(80))
-  }
-
-  // @MARK: Surely there's a better way than this!
-  const clientEntry = Object.values(clientBuildManifest).find(
-    (manifestItem) => {
-      // For RSC builds, we pass in many Vite entries, so we need to find it differently.
-      return rscEnabled
-        ? manifestItem.file.includes('rwjs-client-entry-')
-        : manifestItem.isEntry
-    },
-  )
-
-  if (!clientEntry) {
-    throw new Error('Could not find client entry in build manifest')
-  }
-
-  // 1. Use static handler for assets
-  // For CF workers, we'd need an equivalent of this
-  app.use(
-    '/assets',
-    express.static(rwPaths.web.distClient + '/assets', { index: false }),
-  )
-
-  // 2. Proxy the api server
-  // TODO (STREAMING) we need to be able to specify whether proxying is required or not
-  // e.g. deploying to Netlify, we don't need to proxy but configure it in Netlify
-  // Also be careful of differences between v2 and v3 of the server
-  app.use(
-    rwConfig.web.apiUrl,
-    // @WARN! Be careful, between v2 and v3 of http-proxy-middleware
-    // the syntax has changed https://github.com/chimurai/http-proxy-middleware
-    createProxyMiddleware({
-      changeOrigin: false,
-      pathRewrite: {
-        [`^${rwConfig.web.apiUrl}`]: '', // remove base path
-      },
-      // Using 127.0.0.1 to force ipv4. With `localhost` you don't really know
-      // if it's going to be ipv4 or ipv6
-      target: `http://127.0.0.1:${rwConfig.api.port}`,
-    }),
-  )
-
-  const getStylesheetLinks = () => clientEntry.css || []
-  const clientEntryPath = '/' + clientEntry.file
-
-  for (const route of Object.values(routeManifest)) {
-    // if it is a 404, register it at the end somehow.
-    if (!route.matchRegexString) {
-      continue
-    }
-
-    // @TODO: we don't need regexes here
-    // Param matching, etc. all handled within the route handler now
-    const expressPathDef = route.hasParams
-      ? route.matchRegexString
-      : route.pathDefinition
-
-    // TODO(RSC_DC): RSC is rendering blank page, try using this function for initial render
-    const routeHandler = await createReactStreamingHandler({
-      route,
-      clientEntryPath,
-      getStylesheetLinks,
-    })
-
-    console.log('Attaching streaming handler for route', route.pathDefinition)
-
-    // Wrap with whatg/server adapter. Express handler -> Fetch API handler
-    app.get(expressPathDef, createServerAdapter(routeHandler))
-  }
-
-  // Mounting middleware at /rw-rsc will strip /rw-rsc from req.url
-  app.use('/rw-rsc', createRscRequestHandler())
-
-  // @MARK: put this after rw-rsc!
-  app.post(
-    '*',
-    createServerAdapter(async (req: Request) => {
-      const entryServerImport = await import(rwPaths.web.distEntryServer)
-
-      const { middleware } = entryServerImport
-
-      const [mwRes] = await invoke(req, middleware)
-
-      return mwRes.toResponse()
-    }),
-  )
-
-  app.use(express.static(rwPaths.web.distClient, { index: false }))
-
-  app.listen(rwConfig.web.port)
-  console.log(
-    `Started production FE server on http://localhost:${rwConfig.web.port}`,
-  )
+  app.listen(8910)
+  console.log('Started production FE server on http://localhost:8910')
 }
 
 runFeServer()
+
+function registerFwShims() {
+  globalThis.__rw_module_cache__ ||= new Map()
+
+  globalThis.__webpack_chunk_load__ ||= async (id: string) => {
+    console.log('rscWebpackShims chunk load id', id)
+    return import(id).then((m) => globalThis.__rw_module_cache__.set(id, m))
+  }
+
+  globalThis.__webpack_require__ ||= (id: string) => {
+    return globalThis.__rw_module_cache__.get(id)
+  }
+}
+
+export async function reactRenderToStreamResponse() {
+  const rootFromDist = await renderFromDist()
+
+  const stream = await renderToReadableStream(
+    React.createElement(rootFromDist),
+    {
+      onError: (err: any) => {
+        console.error(err)
+        throw new Error('🔻🔻 Caught error rendering to stream 🔻🔻')
+      },
+    },
+  )
+
+  return new Response(stream, {
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+async function renderFromDist() {
+  const SsrComponent = () => {
+    const flightStreamFull = new Response(flightText).body
+
+    const data = createFromReadableStream(flightStreamFull, {
+      ssrManifest: { moduleMap, moduleLoading: null },
+    })
+
+    return data
+  }
+
+  return SsrComponent
+}
+
+const flightText = `\
+2:I["/Users/tobbe/tmp/test-project-rsc-external-packages-and-cells/web/dist/client/assets/rsc-AboutCounter.tsx-2-ChTgbQz5.mjs",["/Users/tobbe/tmp/test-project-rsc-external-packages-and-cells/web/dist/client/assets/rsc-AboutCounter.tsx-2-ChTgbQz5.mjs"],"AboutCounter"]
+0:["$","div",null,{"className":"about-page","children":["$","div",null,{"style":{"border":"3px red dashed","margin":"1em","padding":"1em"},"children":[["$","h1",null,{"children":"About Page"}],["$","$L2",null,{}]]}]}]
+1:]`

--- a/packages/vite/src/streaming/ssrModuleMap.ts
+++ b/packages/vite/src/streaming/ssrModuleMap.ts
@@ -1,0 +1,41 @@
+type SSRModuleMap = null | {
+  [clientId: string]: {
+    [clientExportName: string]: ClientReferenceManifestEntry
+  }
+}
+type ClientReferenceManifestEntry = ImportManifestEntry
+type ImportManifestEntry = {
+  id: string
+  // chunks is a double indexed array of chunkId / chunkFilename pairs
+  chunks: Array<string>
+  name: string
+}
+
+// This is passed in as `moduleMap`, but internally they call this
+// `bundlerConfig`. `bundlerConfig` is accessed as an object where the keys are
+// file paths. The values are "moduleExports" objects that have keys that
+// correspond to React Component names, like AboutCounter.
+export const moduleMap: SSRModuleMap = new Proxy(
+  {},
+  {
+    get(_target, filePath: string) {
+      // "moduleExports" proxy
+      return new Proxy<Record<string, ClientReferenceManifestEntry>>(
+        {},
+        {
+          get(_target, name: string) {
+            const manifestEntry: ClientReferenceManifestEntry = {
+              id: filePath,
+              chunks: [filePath],
+              name,
+            }
+
+            console.log('manifestEntry', manifestEntry)
+
+            return manifestEntry
+          },
+        },
+      )
+    },
+  },
+)

--- a/packages/vite/src/streaming/ssrModuleMap.ts
+++ b/packages/vite/src/streaming/ssrModuleMap.ts
@@ -30,8 +30,6 @@ export const moduleMap: SSRModuleMap = new Proxy(
               name,
             }
 
-            console.log('manifestEntry', manifestEntry)
-
             return manifestEntry
           },
         },


### PR DESCRIPTION
~Don't look at the diff. It's pretty meaningless.~ I cleaned it up!

What I've done is try to get a minimal reproduction example going. So I've pretty much put all our SSR+RSC logic in the main `runFeServer` file. If you strip away all the FW stuff we do there actually isn't that much to it 🙂 

To see what's going on here, first get the `test-project-rsc-external-packages-and-cells` project running on `main`. From `web/dist/client/assets` you need the built version of `AboutCounter`, something like `web/dist/client/assets/rsc-AboutCounter.tsx-2-ChTgbQz5.mjs`.

Now check out this PR.
Find `packages/vite/src/runFeServer.ts` and update the path to `AboutCounter` in both two places in the flight data at the bottom of that file to match the path on your computer.
Do a clean rebuild of the framework, then tarsync to your test project. 

Now build and serve the test project and go to http://localhost:8910

...and you should see it fail 😆
![image](https://github.com/redwoodjs/redwood/assets/30793/464782f1-2a9f-4675-85ea-aa5a9dc5eac6)

Now here comes the total hack 😃 

Go to the built version of `AboutCounter` and change the React import at the top to look like this
![image](https://github.com/redwoodjs/redwood/assets/30793/9b8984f8-1f35-4274-9390-b34b6db3f24b)

`serve` your test project again, and this time if you go to localhost:8910 it should work! You should get the SSRed version of the About page.