### PR TITLE
RSC: serve.js: Extract "enabled" var rsc and streaming

### DIFF
--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -19,6 +19,9 @@ export const description =
   'Start a server for serving both the api and web sides'
 
 export const builder = async (yargs) => {
+  const rscEnabled = getConfig().experimental?.rsc?.enabled
+  const streamingEnabled = getConfig().experimental?.streamingSsr?.enabled
+
   yargs
     .command({
       command: '$0',
@@ -38,10 +41,7 @@ export const builder = async (yargs) => {
             './serveBothHandler.js'
           )
           await bothServerFileHandler(argv)
-        } else if (
-          getConfig().experimental?.rsc?.enabled ||
-          getConfig().experimental?.streamingSsr?.enabled
-        ) {
+        } else if (rscEnabled || streamingEnabled) {
           const { bothSsrRscServerHandler } = await import(
             './serveBothHandler.js'
           )
@@ -86,7 +86,7 @@ export const builder = async (yargs) => {
           apiHost: argv.apiHost,
         })
 
-        if (getConfig().experimental?.streamingSsr?.enabled) {
+        if (streamingEnabled) {
           await webSsrServerHandler()
         } else {
           await webServerCLIConfig.handler(argv)
@@ -136,7 +136,7 @@ export const builder = async (yargs) => {
 
       // serve both
       if (positionalArgs.length === 1) {
-        if (!apiSideExists && !getConfig().experimental?.rsc?.enabled) {
+        if (!apiSideExists && !rscEnabled) {
           console.error(
             c.error(
               '\n Unable to serve the both sides as no `api` folder exists. Please use `yarn rw serve web` instead. \n',


### PR DESCRIPTION
We've started extracting the "enabled" check logic into variables up top in other places, so just doing the same thing here.