### PR TITLE
chore(babel-config): Fix error message grammar

### DIFF
--- a/.changesets/10280.md
+++ b/.changesets/10280.md
@@ -1,0 +1,5 @@
+- chore(babel-config): Fix error message grammar (#10280) by @Tobbe
+
+Fixed the grammar of the error message you see if you have more than one Page file in a single Page directory
+
+"...in the follow page directories..." -> "...in the following page directories..."

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
@@ -39,7 +39,7 @@ describe('mulitiple files ending in Page.{js,jsx,ts,tsx}', () => {
       transform(getPaths().web.routes)
     }).toThrowError(
       "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' " +
-        "in the follow page directories: 'HomePage'",
+        "in the following page directories: 'HomePage'",
     )
   })
 })

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
@@ -39,7 +39,7 @@ describe('mulitiple files ending in Page.{js,jsx,ts,tsx}', () => {
       transform(getPaths().web.routes)
     }).toThrowError(
       "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' " +
-        "in the follow page directories: 'HomePage",
+        "in the follow page directories: 'HomePage'",
     )
   })
 })

--- a/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
+++ b/packages/babel-config/src/plugins/__tests__/babel-plugin-redwood-routes-auto-loader.test.ts
@@ -38,7 +38,8 @@ describe('mulitiple files ending in Page.{js,jsx,ts,tsx}', () => {
     expect(() => {
       transform(getPaths().web.routes)
     }).toThrowError(
-      "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the follow page directories: 'HomePage",
+      "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' " +
+        "in the follow page directories: 'HomePage",
     )
   })
 })

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -55,7 +55,7 @@ export default function (
   }
   if (duplicatePageImportNames.size > 0) {
     throw new Error(
-      `Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the follow page directories: ${Array.from(
+      `Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the following page directories: ${Array.from(
         duplicatePageImportNames,
       )
         .map((name) => `'${name}'`)


### PR DESCRIPTION
Fixed the grammar of the error message you see if you have more than one Page file in a single Page directory

"...in the follow page directories..." -> "...in the following page directories..."