### PR TITLE
RSC: Refactor forRsc camelcase and add rscEnabled

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -22,7 +22,7 @@ export interface Flags {
   forJest?: boolean // will change the alias for module-resolver plugin
   forPrerender?: boolean // changes what babel-plugin-redwood-routes-auto-loader does
   forVite?: boolean
-  forRSC?: boolean
+  forRsc?: boolean
 }
 
 export const getWebSideBabelPlugins = (
@@ -109,10 +109,10 @@ export const getWebSideBabelPlugins = (
 }
 
 export const getWebSideOverrides = (
-  { forPrerender, forVite, forRSC }: Flags = {
+  { forPrerender, forVite, forRsc }: Flags = {
     forPrerender: false,
     forVite: false,
-    forRSC: false,
+    forRsc: false,
   },
 ): Array<TransformOptions> => {
   // Have to use a readonly array here because of a limitation in TS
@@ -126,7 +126,7 @@ export const getWebSideOverrides = (
     // the `./web/src/Routes.[ts|jsx]` file.
     // We do not do this for RSC because there are differences between server and client
     // so each specific build stage handles the auto-importing of routes
-    !forRSC && {
+    !forRsc && {
       test: /Routes.(js|tsx|jsx)$/,
       plugins: [
         [

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -38,6 +38,7 @@ export default function redwoodPluginVite(): PluginOption[] {
     fs.readFileSync(apiPackageJsonPath, 'utf-8').includes('@redwoodjs/realtime')
 
   const streamingEnabled = rwConfig.experimental.streamingSsr.enabled
+  const rscEnabled = rwConfig.experimental?.rsc?.enabled
 
   return [
     {
@@ -151,7 +152,7 @@ export default function redwoodPluginVite(): PluginOption[] {
       babel: {
         ...getWebSideDefaultBabelConfig({
           forVite: true,
-          forRSC: rwConfig.experimental?.rsc?.enabled,
+          forRsc: rscEnabled,
         }),
       },
     }),


### PR DESCRIPTION
Minor refactor of some RSC related code.
  * I prefer camel cased variable names
  * Introduce `rscEnabled` var at the top of the function, which is a pattern we've been using