### PR TITLE
RSC: Vite route auto loader plugin: Fix error message grammar

### DIFF
--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.mts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.mts
@@ -331,7 +331,7 @@ describe('rscRoutesAutoLoader', () => {
     }
 
     expect(getOutput).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the follow page directories: 'AboutPage']`
+      "[Error: Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the following page directories: 'AboutPage']"
     )
   })
 

--- a/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
@@ -51,12 +51,13 @@ export function rscRoutesAutoLoader(): Plugin {
     }
   }
   if (duplicatePageImportNames.size > 0) {
+    const pageNames = Array.from(duplicatePageImportNames)
+      .map((name) => `'${name}'`)
+      .join(', ')
+
     throw new Error(
-      `Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in the follow page directories: ${Array.from(
-        duplicatePageImportNames,
-      )
-        .map((name) => `'${name}'`)
-        .join(', ')}`,
+      "Unable to find only a single file ending in 'Page.{js,jsx,ts,tsx}' in " +
+        `the following page directories: ${pageNames}`,
     )
   }
 


### PR DESCRIPTION
Same thing I did for https://github.com/redwoodjs/redwood/pull/10280 but now for our new vite plugin