### PR TITLE
chore(types): Type react-dom/server.edge

### DIFF
--- a/packages/vite/modules.d.ts
+++ b/packages/vite/modules.d.ts
@@ -1,5 +1,11 @@
 declare module 'react-server-dom-webpack/node-loader'
 
+// Should be able to use just react-dom/server, but right now we can't
+// See https://github.com/facebook/react/issues/26906
+declare module 'react-dom/server.edge' {
+  export * from 'react-dom/server'
+}
+
 declare module 'react-server-dom-webpack/client' {
   // https://github.com/facebook/react/blob/dfaed5582550f11b27aae967a8e7084202dd2d90/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js#L31
   export type Options<A, T> = {

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -6,6 +6,7 @@ import type {
   RenderToReadableStreamOptions,
   ReactDOMServerReadableStream,
 } from 'react-dom/server'
+import { renderToReadableStream } from 'react-dom/server.edge'
 
 import type { ServerAuthState } from '@redwoodjs/auth'
 import { ServerAuthProvider } from '@redwoodjs/auth'
@@ -100,10 +101,6 @@ export async function reactRenderToStreamResponse(
   }, 10000)
 
   const timeoutTransform = createTimeoutTransform(timeoutHandle)
-
-  // Possible that we need to upgrade the @types/* packages
-  // @ts-expect-error Something in React's packages mean types don't come through
-  const { renderToReadableStream } = await import('react-dom/server.edge')
 
   const renderRoot = (path: string) => {
     return React.createElement(


### PR DESCRIPTION
Looking at the types, we should be able to just use `react-dom/server`, but when you try you get a runtime error about `renderToReadableStream` isn't a function. So we have to import from `react-dom/server.edge` instead. But that package export doesn't have any types. This PR "aliases" the types from `react-dom/server` to also be used for `react-dom/server.edge`

Also see https://github.com/facebook/react/issues/26906