### PR TITLE
DEMO RSC vite ssr static flight (do not merge)

### DIFF
--- a/packages/vite/modules.d.ts
+++ b/packages/vite/modules.d.ts
@@ -1,4 +1,6 @@
 declare module 'react-server-dom-webpack/node-loader'
+declare module 'react-server-dom-webpack/client.edge'
+declare module 'react-server-dom-webpack/server.edge'
 
 // Should be able to use just react-dom/server, but right now we can't
 // See https://github.com/facebook/react/issues/26906

--- a/packages/vite/src/clientSsr.ts
+++ b/packages/vite/src/clientSsr.ts
@@ -1,10 +1,22 @@
-export function renderFromDist(rscId: string) {
-  console.log('renderFromDist', rscId)
+import { createFromReadableStream } from 'react-server-dom-webpack/client.edge'
 
-  // TODO: Actually render the component that was requested
+import { moduleMap } from './streaming/ssrModuleMap.js'
+
+export function renderFromDist(_rscId: string) {
   const SsrComponent = () => {
-    return 'Loading...'
+    const flightStream = new Response(flightText).body
+
+    const data = createFromReadableStream(flightStream, {
+      ssrManifest: { moduleMap, moduleLoading: null },
+    })
+
+    return data
   }
 
   return SsrComponent
 }
+
+const flightText = `\
+2:I["/Users/tobbe/tmp/test-project-rsc-external-packages-and-cells/web/dist/client/assets/rsc-AboutCounter.tsx-2-ChTgbQz5.mjs",["/Users/tobbe/tmp/test-project-rsc-external-packages-and-cells/web/dist/client/assets/rsc-AboutCounter.tsx-2-ChTgbQz5.mjs"],"AboutCounter"]
+0:["$","div",null,{"className":"about-page","children":["$","div",null,{"style":{"border":"3px red dashed","margin":"1em","padding":"1em"},"children":[["$","h1",null,{"children":"About Page"}],["$","$L2",null,{}]]}]}]
+1:]`

--- a/packages/vite/src/streaming/ssrModuleMap.ts
+++ b/packages/vite/src/streaming/ssrModuleMap.ts
@@ -1,0 +1,39 @@
+type SSRModuleMap = null | {
+  [clientId: string]: {
+    [clientExportName: string]: ClientReferenceManifestEntry
+  }
+}
+type ClientReferenceManifestEntry = ImportManifestEntry
+type ImportManifestEntry = {
+  id: string
+  // chunks is a double indexed array of chunkId / chunkFilename pairs
+  chunks: Array<string>
+  name: string
+}
+
+// This is passed in as `moduleMap`, but internally they call this
+// `bundlerConfig`. `bundlerConfig` is accessed as an object where the keys are
+// file paths. The values are "moduleExports" objects that have keys that
+// correspond to React Component names, like AboutCounter.
+export const moduleMap: SSRModuleMap = new Proxy(
+  {},
+  {
+    get(_target, filePath: string) {
+      // "moduleExports" proxy
+      return new Proxy<Record<string, ClientReferenceManifestEntry>>(
+        {},
+        {
+          get(_target, name: string) {
+            const manifestEntry: ClientReferenceManifestEntry = {
+              id: filePath,
+              chunks: [filePath],
+              name,
+            }
+
+            return manifestEntry
+          },
+        },
+      )
+    },
+  },
+)

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -18,6 +18,7 @@ import {
   createInjector,
 } from '@redwoodjs/web/dist/components/ServerInject'
 
+import { renderFromDist } from '../clientSsr.js'
 import type { MiddlewareResponse } from '../middleware/MiddlewareResponse.js'
 
 import { createBufferedTransformStream } from './transforms/bufferedTransform.js'
@@ -157,7 +158,8 @@ export async function reactRenderToStreamResponse(
       },
     }
 
-    const root = renderRoot(currentPathName)
+    let root = renderRoot(currentPathName)
+    root = React.createElement(renderFromDist(''))
 
     const reactStream: ReactDOMServerReadableStream =
       await renderToReadableStream(root, renderToStreamOptions)


### PR DESCRIPTION
This does pretty much the same thing as https://github.com/redwoodjs/redwood/pull/10277 but without bypassing all the RW framework code. So if you don't block /assets/ in your browser devtools client side React will take over and recover from broken SSR and everything will appear to work.

Still have to do that same hack as in #10277 where you manually update the React import in /dist