### PR TITLE
docs: Adds important admonition for generate dbAuth to clarify that must setup dbAuth not just generate the pages

### DIFF
--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -621,6 +621,11 @@ If you'd rather create your own, you might want to start from the generated
 pages anyway as they'll contain the other code you need to actually submit the
 log in credentials or sign up fields to the server for processing.
 
+:::important
+This `generate dbAuth` command simply adds the pages. You must add the necessary dbAuth functions and
+app setup by running `yarn rw setup auth dbAuth` to fully use dbAuth.
+:::
+
 ### generate directive
 
 Generate a directive.


### PR DESCRIPTION
Fixes: https://github.com/redwoodjs/redwood/issues/10290

This PR clarifies that one must not just generate the dbAuth pages, but also setup dbAuth.

![image](https://github.com/redwoodjs/redwood/assets/1051633/6ec1dd65-a09e-4489-bbff-499b430a1a68)
