### PR TITLE
docs: Add information about how to turn off Prisma/db operations during a Vercel deploy to reduce Postgres Storage use

### DIFF
--- a/docs/docs/deploy/vercel.md
+++ b/docs/docs/deploy/vercel.md
@@ -40,9 +40,13 @@ This updates your `redwood.toml` file, setting `apiUrl = "/api"`:
 Follow the steps in the [Prisma and Database](./introduction#3-prisma-and-database) section above. _(Skip this step if your project does not require a database.)_
 
 :::info
- If you're using Vercel Postgres as part of its Storage features, you may want to limit certain Prisma operations when you deploy. For example, if you're on the Hobby plan, there are some storage and write limits that you can mitigate by turning the Prisma and data migration steps off during deploy and only enabling them on a case-by-case basis when needed:
 
- `yarn rw deploy vercel --prisma=false --data-migrate=false`
+If you're using Vercel Postgres as part of its Storage features, you may want to limit certain Prisma operations when you deploy. For example, if you're on the Hobby plan, there are some storage and write limits that you can mitigate by turning the Prisma and data migration steps off during deploy and only enabling them on a case-by-case basis when needed:
+
+```
+yarn rw deploy vercel --prisma=false --data-migrate=false
+```
+
 :::
 
 ### Vercel Initial Setup and Configuration

--- a/docs/docs/deploy/vercel.md
+++ b/docs/docs/deploy/vercel.md
@@ -39,6 +39,12 @@ This updates your `redwood.toml` file, setting `apiUrl = "/api"`:
 
 Follow the steps in the [Prisma and Database](./introduction#3-prisma-and-database) section above. _(Skip this step if your project does not require a database.)_
 
+:::info
+ If you are using Vercel Postgres as part of the Storage features, you may want to limit certain Prisma operations when you deploy. For example, if you are on the Hobby plan, there are some storage and write limits that you can mitigate by turning Prisma abd data migration steps off during a deploy -- and only doing those steps on a case-by-case basis when needed:
+
+ `yarn rw deploy vercel --prisma=false --data-migrate=false`
+:::
+
 ### Vercel Initial Setup and Configuration
 Either [login](https://vercel.com/login) to your Vercel account and select "Import Project" or use the Vercel [quick start](https://vercel.com/#get-started).
 

--- a/docs/docs/deploy/vercel.md
+++ b/docs/docs/deploy/vercel.md
@@ -41,7 +41,7 @@ Follow the steps in the [Prisma and Database](./introduction#3-prisma-and-databa
 
 :::info
 
-If you're using Vercel Postgres as part of its Storage features, you may want to limit certain Prisma operations when you deploy. For example, if you're on the Hobby plan, there are some storage and write limits that you can mitigate by turning the Prisma and data migration steps off during deploy and only enabling them on a case-by-case basis when needed:
+If you're using Vercel Postgres, you may want to limit certain Prisma operations when you deploy. For example, if you're on the Hobby plan, there are some storage and write limits that you can mitigate by turning the Prisma and data migration steps off during deploy and only enabling them on a case-by-case basis when needed:
 
 ```
 yarn rw deploy vercel --prisma=false --data-migrate=false

--- a/docs/docs/deploy/vercel.md
+++ b/docs/docs/deploy/vercel.md
@@ -40,7 +40,7 @@ This updates your `redwood.toml` file, setting `apiUrl = "/api"`:
 Follow the steps in the [Prisma and Database](./introduction#3-prisma-and-database) section above. _(Skip this step if your project does not require a database.)_
 
 :::info
- If you are using Vercel Postgres as part of the Storage features, you may want to limit certain Prisma operations when you deploy. For example, if you are on the Hobby plan, there are some storage and write limits that you can mitigate by turning Prisma abd data migration steps off during a deploy -- and only doing those steps on a case-by-case basis when needed:
+ If you're using Vercel Postgres as part of its Storage features, you may want to limit certain Prisma operations when you deploy. For example, if you're on the Hobby plan, there are some storage and write limits that you can mitigate by turning the Prisma and data migration steps off during deploy and only enabling them on a case-by-case basis when needed:
 
  `yarn rw deploy vercel --prisma=false --data-migrate=false`
 :::


### PR DESCRIPTION
See: https://discord.com/channels/679514959968993311/1221799675586154577

For Redwood developers using Vercel and their Postgres storage option, the lower Hobby plans have some storage and write limits per month.

By default when redwood deploys, Prisma migrations and data migrations can be called -- which adds some overhead that can eat into those usage limits.

This PR adds a note to show how these options can be turned off during deploys and then folks can run migrations only when needed.

This resolved the user's issue noted above in the Discord chat.