### PR TITLE
chore(types): Improve `flattenSearchParams` types and docs

### DIFF
--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -348,23 +348,21 @@ export function replaceParams(
 export type FlattenSearchParams = ReturnType<typeof flattenSearchParams>
 
 /**
- * @param {string} queryString
- * @returns {Array<string | Record<string, any>>} A flat array of search params
+ * Returns a flat array of search params
  *
- * useMatch hook options searchParams requires a flat array
+ * `useMatch` hook options `searchParams` requires a flat array
  *
- * Examples:
+ * Example:
+ * ```
+ *   parseSearch('?key1=val1&key2=val2')
+ *   => { key1: 'val1', key2: 'val2' }
  *
- *  parseSearch('?key1=val1&key2=val2')
- *  => { key1: 'val1', key2: 'val2' }
- *
- * flattenSearchParams(parseSearch('?key1=val1&key2=val2'))
- * => [ { key1: 'val1' }, { key2: 'val2' } ]
+ *   flattenSearchParams(parseSearch('?key1=val1&key2=val2'))
+ *   => [ { key1: 'val1' }, { key2: 'val2' } ]
+ * ```
  */
-export function flattenSearchParams(
-  queryString: string,
-): Array<Record<string, unknown>> {
-  const searchParams = []
+export function flattenSearchParams(queryString: string) {
+  const searchParams: Array<Record<string, unknown>> = []
 
   for (const [key, value] of Object.entries(parseSearch(queryString))) {
     searchParams.push({ [key]: value })

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -363,7 +363,7 @@ export type FlattenSearchParams = ReturnType<typeof flattenSearchParams>
  */
 export function flattenSearchParams(
   queryString: string,
-): Array<string | Record<string, any>> {
+): Array<Record<string, unknown>> {
   const searchParams = []
 
   for (const [key, value] of Object.entries(parseSearch(queryString))) {


### PR DESCRIPTION
This PR fixes/improves the TS types for `flattenSearchParams` in different ways

Here are some of the issues this PR addresses

It's safer to use `unknown` rather than `any` here
![image](https://github.com/redwoodjs/redwood/assets/30793/721c9f72-bc85-4516-8aa5-4cf82349192a)

The array is typed as `any` because there are no values to infer the type from. This makes it so that the loop below is free to insert whatever into the array. It's better to type the array explicitly.
![image](https://github.com/redwoodjs/redwood/assets/30793/79c72be1-2337-49c7-b7eb-203ac96aefdc)

JSDoc types are not needed in TS files
![image](https://github.com/redwoodjs/redwood/assets/30793/fbdd26eb-43c8-44b7-b5c2-db8a26db0808)

This PR also makes the example and the text more nicely formatted in tooltips 
![image](https://github.com/redwoodjs/redwood/assets/30793/fe279b18-b87e-4dd9-938a-61efe8c78c78)

