### PR TITLE
chore(tw): Add tests to the tailwind setup command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,10 +28,12 @@
     "Fastify",
     "Flightcontrol",
     "graphiql",
+    "memfs",
     "opentelemetry",
     "pino",
     "redwoodjs",
     "RWJS",
+    "tailwindcss",
     "waku"
   ]
 }

--- a/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
+++ b/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
@@ -189,6 +189,7 @@ describe('tasks that should be skipped', () => {
 
   it('should skip adding recommended VS Code extensions to project settings if the user is not using VS Code', async () => {
     setupDefaultProjectStructure()
+    // Delete the .vscode directory to simulate not using VS Code
     memfsFs.rmSync(path.join(APP_PATH, '.vscode'), { recursive: true })
 
     await handler({})

--- a/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
+++ b/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
@@ -4,6 +4,7 @@ let mockSkipValues: Array<string> = []
 let mockPrompt: (() => boolean) | undefined
 
 vi.mock('fs', async () => ({ ...memfsFs, default: { ...memfsFs } }))
+vi.mock('node:fs', async () => ({ ...memfsFs, default: { ...memfsFs } }))
 vi.mock('fs-extra', async () => {
   function outputFileSync(filePath: string, data: string, options?: any) {
     memfsFs.mkdirSync(path.dirname(filePath), { recursive: true })
@@ -19,7 +20,6 @@ vi.mock('fs-extra', async () => {
     },
   }
 })
-vi.mock('node:fs', async () => ({ ...memfsFs, default: { ...memfsFs } }))
 vi.mock('execa', () => ({
   default: (...args: Array<any>) => {
     // Create an empty config file when `tailwindcss init` is called.

--- a/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
+++ b/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
@@ -1,0 +1,225 @@
+let mockExecutedTaskTitles: Array<string> = []
+let mockSkippedTaskTitles: Array<string> = []
+let mockSkipValues: Array<string> = []
+let mockPrompt: (() => boolean) | undefined
+
+vi.mock('fs', async () => ({ ...memfsFs, default: { ...memfsFs } }))
+vi.mock('fs-extra', async () => {
+  function outputFileSync(filePath: string, data: string, options?: any) {
+    memfsFs.mkdirSync(path.dirname(filePath), { recursive: true })
+    memfsFs.writeFileSync(filePath, data, options)
+  }
+
+  return {
+    ...memfsFs,
+    outputFileSync,
+    default: {
+      ...memfsFs,
+      outputFileSync,
+    },
+  }
+})
+vi.mock('node:fs', async () => ({ ...memfsFs, default: { ...memfsFs } }))
+vi.mock('execa', () => ({
+  default: (...args: Array<any>) => {
+    // Create an empty config file when `tailwindcss init` is called.
+    // If we don't do this, later stages of the setup will fail.
+    if (args[0] === 'yarn' && args[1].join(' ').includes('tailwindcss init')) {
+      memfsFs.writeFileSync(args[1][args[1].length - 1], '')
+    }
+  },
+}))
+
+vi.mock('listr2', () => {
+  return {
+    // Return a constructor function, since we're calling `new` on Listr
+    Listr: vi.fn().mockImplementation((tasks: Array<any>) => {
+      return {
+        run: async () => {
+          mockExecutedTaskTitles = []
+          mockSkippedTaskTitles = []
+          mockSkipValues = []
+
+          for (const task of tasks) {
+            const skip =
+              typeof task.skip === 'function' ? task.skip : () => task.skip
+
+            const skipValue = skip()
+
+            if (skipValue) {
+              mockSkippedTaskTitles.push(task.title)
+              mockSkipValues.push(skipValue)
+            } else {
+              mockExecutedTaskTitles.push(task.title)
+
+              task.skip = (reason: string) => {
+                mockSkippedTaskTitles.push(task.title)
+                mockSkipValues.push(reason)
+              }
+
+              if (mockPrompt) {
+                task.prompt = mockPrompt
+              }
+
+              await task.task({}, task)
+            }
+          }
+        },
+      }
+    }),
+  }
+})
+
+import path from 'node:path'
+
+import { vol, fs as memfsFs } from 'memfs'
+import {
+  vi,
+  expect,
+  it,
+  describe,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+} from 'vitest'
+
+// @ts-expect-error - no types
+import { handler } from '../libraries/tailwindcss.js'
+
+// Set up RWJS_CWD
+let original_RWJS_CWD: string | undefined
+const APP_PATH = '/redwood-app'
+
+beforeAll(() => {
+  original_RWJS_CWD = process.env.RWJS_CWD
+  process.env.RWJS_CWD = APP_PATH
+})
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  mockPrompt = undefined
+  vi.mocked(console).log.mockRestore()
+  vol.reset()
+})
+
+afterAll(() => {
+  process.env.RWJS_CWD = original_RWJS_CWD
+  vi.resetAllMocks()
+  vi.resetModules()
+})
+
+describe('tasks that should be skipped', () => {
+  it('should skip installing if called with `install: false`', async () => {
+    setupDefaultProjectStructure()
+
+    await handler({ install: false })
+
+    expect(mockSkippedTaskTitles).toContain(
+      'Installing project-wide packages...',
+    )
+    expect(mockSkippedTaskTitles).toContain('Installing web side packages...')
+    expect(Array.isArray(mockSkipValues)).toBe(true)
+    expect(mockSkipValues.length).toBeGreaterThanOrEqual(2)
+    expect(mockSkipValues[0]).toBe(true)
+    expect(mockSkipValues[1]).toBe(true)
+  })
+
+  it("should skip adding directives to index.css if they're already in there", async () => {
+    setupDefaultProjectStructure({
+      'web/src/index.css': [
+        '@tailwind base;',
+        '@tailwind components;',
+        '@tailwind utilities;',
+      ].join('\n'),
+    })
+
+    await handler({})
+
+    expect(mockSkippedTaskTitles).toContain('Adding directives to index.css...')
+    expect(mockSkipValues).toContain('Directives already exist in index.css')
+  })
+
+  it("should skip updating scaffold.css if it doesn't exist", async () => {
+    // No scaffold.css file is the default
+    setupDefaultProjectStructure()
+
+    mockPrompt = vi.fn()
+
+    await handler({})
+
+    expect(mockSkippedTaskTitles).toContain(
+      "Updating 'scaffold.css' to use tailwind classes...",
+    )
+    expect(mockSkipValues).toContain("No 'scaffold.css' file to update")
+    expect(mockPrompt).not.toHaveBeenCalled()
+  })
+
+  it('should skip updating scaffold.css if the user answers "no" to the prompt', async () => {
+    setupDefaultProjectStructure({
+      'web/src/scaffold.css': [
+        '.rw-scaffold *,',
+        '.rw-scaffold ::after,',
+        '.rw-scaffold ::before {',
+        '  box-sizing: inherit;',
+        '}',
+      ].join('\n'),
+    })
+
+    mockPrompt = vi.fn().mockReturnValue(false)
+
+    await handler({})
+
+    expect(mockSkippedTaskTitles).toContain(
+      "Updating 'scaffold.css' to use tailwind classes...",
+    )
+    expect(mockSkipValues).toContain("Skipping 'scaffold.css' update")
+    expect(mockPrompt).toHaveBeenCalledWith({
+      type: 'Confirm',
+      message:
+        "Do you want to override your 'scaffold.css' to use tailwind classes?",
+    })
+  })
+
+  it('should skip adding recommended VS Code extensions to project settings if the user is not using VS Code', async () => {
+    setupDefaultProjectStructure()
+    memfsFs.rmSync(path.join(APP_PATH, '.vscode'), { recursive: true })
+
+    await handler({})
+
+    expect(mockSkippedTaskTitles).toContain(
+      'Adding recommended VS Code extensions to project settings...',
+    )
+    expect(mockSkipValues).toContain("Looks like you're not using VS Code")
+  })
+})
+
+function setupDefaultProjectStructure(
+  volOverride?: Record<string, string | null>,
+) {
+  vol.fromJSON(
+    {
+      'redwood.toml': '',
+      'prettier.config.js': '',
+      'web/config/': null,
+      'web/src/index.css': '',
+      '.vscode/settings.json': [
+        '{',
+        '  "editor.tabSize": 2,',
+        '  "editor.codeActionsOnSave": {',
+        '    "source.fixAll.eslint": "explicit"',
+        '  }',
+        '}',
+      ].join('\n'),
+      [path.join(__dirname, '../templates/postcss.config.js.template')]: '',
+    },
+    APP_PATH,
+  )
+
+  if (volOverride) {
+    vol.fromJSON(volOverride, APP_PATH)
+  }
+}

--- a/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
+++ b/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
@@ -97,6 +97,9 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
+  // The `recommendExtensionsToInstall` function uses `console.log` to output
+  // the list of recommended extensions. We mock it to keep the output clean
+  // during tests
   vi.spyOn(console, 'log').mockImplementation(() => {})
 })
 

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -210,7 +210,7 @@ export const handler = async ({ force, install }) => {
               fs.unlinkSync(tailwindConfigPath)
             } else {
               throw new Error(
-                'Tailwindcss config already exists.\nUse --force to override existing config.',
+                'Tailwind CSS config already exists.\nUse --force to override existing config.',
               )
             }
           }
@@ -243,10 +243,13 @@ export const handler = async ({ force, install }) => {
         },
       },
       {
-        title: "Updating tailwind 'scaffold.css'...",
+        title: "Updating 'scaffold.css' to use tailwind classes...",
         skip: () => {
-          // Skip this step if the 'scaffold.css' file does not exist
-          return !fs.existsSync(path.join(rwPaths.web.src, 'scaffold.css'))
+          // Skip this step if the 'scaffold.css' file doesn't exist
+          return (
+            !fs.existsSync(path.join(rwPaths.web.src, 'scaffold.css')) &&
+            "No 'scaffold.css' file to update"
+          )
         },
         task: async (_ctx, task) => {
           const overrideScaffoldCss =
@@ -254,63 +257,64 @@ export const handler = async ({ force, install }) => {
             (await task.prompt({
               type: 'Confirm',
               message:
-                "Do you want to override your 'scaffold.css' to use tailwind too?",
+                "Do you want to override your 'scaffold.css' to use tailwind classes?",
             }))
 
-          if (overrideScaffoldCss) {
-            const tailwindScaffoldTemplate = fs.readFileSync(
-              path.join(
-                __dirname,
-                '..',
-                '..',
-                '..',
-                'generate',
-                'scaffold',
-                'templates',
-                'assets',
-                'scaffold.tailwind.css.template',
-              ),
-            )
-            fs.writeFileSync(
-              path.join(rwPaths.web.src, 'scaffold.css'),
-              tailwindScaffoldTemplate,
-            )
-          } else {
-            task.skip('Skipping scaffold.css override')
+          if (!overrideScaffoldCss) {
+            return task.skip("Skipping 'scaffold.css' update")
           }
+
+          const tailwindScaffoldTemplate = fs.readFileSync(
+            path.join(
+              __dirname,
+              '..',
+              '..',
+              '..',
+              'generate',
+              'scaffold',
+              'templates',
+              'assets',
+              'scaffold.tailwind.css.template',
+            ),
+          )
+          fs.writeFileSync(
+            path.join(rwPaths.web.src, 'scaffold.css'),
+            tailwindScaffoldTemplate,
+          )
         },
       },
       {
         title: 'Adding recommended VS Code extensions to project settings...',
-        task: (_ctx, task) => {
+        skip: () => !usingVSCode() && "Looks like you're not using VS Code",
+        task: () => {
           const VS_CODE_EXTENSIONS_PATH = path.join(
             rwPaths.base,
             '.vscode/extensions.json',
           )
 
-          if (!usingVSCode()) {
-            task.skip("Looks like your're not using VS Code")
-          } else {
-            let originalExtensionsJson = { recommendations: [] }
-            if (fs.existsSync(VS_CODE_EXTENSIONS_PATH)) {
-              const originalExtensionsFile = fs.readFileSync(
-                VS_CODE_EXTENSIONS_PATH,
-                'utf-8',
-              )
-              originalExtensionsJson = JSON.parse(originalExtensionsFile)
-            }
-            const newExtensionsJson = {
-              ...originalExtensionsJson,
-              recommendations: [
-                ...originalExtensionsJson.recommendations,
-                ...recommendedVSCodeExtensions,
-              ],
-            }
-            fs.writeFileSync(
+          let originalExtensionsJson = { recommendations: [] }
+
+          if (fs.existsSync(VS_CODE_EXTENSIONS_PATH)) {
+            const originalExtensionsFile = fs.readFileSync(
               VS_CODE_EXTENSIONS_PATH,
-              JSON.stringify(newExtensionsJson, null, 2),
+              'utf-8',
             )
+
+            originalExtensionsJson = JSON.parse(originalExtensionsFile)
           }
+
+          const newExtensionsJson = {
+            ...originalExtensionsJson,
+            recommendations: [
+              ...originalExtensionsJson.recommendations,
+              ...recommendedVSCodeExtensions,
+            ],
+          }
+
+          fs.writeFileSync(
+            VS_CODE_EXTENSIONS_PATH,
+            JSON.stringify(newExtensionsJson, null, 2),
+          )
         },
       },
       {


### PR DESCRIPTION
Adds some tests to the `yarn rw setup ui tailwindcss` command.

Planning to add a new feature to the setup command, but wanted some tests for it first. So just added some basic unit tests that check that different tasks are skipped depending on what files exists in the user's project, and what their contests are.

The tests are simple, but did require quite a lot of setup and mocking to get them running and passing. I think this can serve as a good template for how to test cli handlers.