### PR TITLE
feat(rsc): Different `yarn rw g page` behaviour for RSC projects

### DIFF
--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -163,6 +163,7 @@ export const createYargsForComponentGeneration = ({
   /** function that takes the options object and returns an array of listr tasks */
   includeAdditionalTasks = () => [],
 }) => {
+  const rscEnabled = getConfig().experimental?.rsc?.enabled ?? false
   return {
     command: appendPositionalsToCmd(`${componentName} <name>`, positionalsObj),
     description: `Generate a ${componentName} component`,
@@ -181,10 +182,14 @@ export const createYargsForComponentGeneration = ({
         .option('tests', {
           description: 'Generate test files',
           type: 'boolean',
+          hidden: rscEnabled,
+          default: rscEnabled ? false : undefined,
         })
         .option('stories', {
           description: 'Generate storybook files',
           type: 'boolean',
+          hidden: rscEnabled,
+          default: rscEnabled ? false : undefined,
         })
         .option('verbose', {
           description: 'Print all logs',

--- a/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
+++ b/packages/cli/src/commands/generate/page/__tests__/__snapshots__/page.test.js.snap
@@ -25,6 +25,198 @@ export default CatsPage
 "
 `;
 
+exports[`RSC specific output > Single word files > creates a page component 1`] = `
+"const TestPage = () => {
+  return (
+    <>
+      <h1>TestPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TestPage/TestPage.jsx</code>
+      </p>
+      <p>
+        My default route is named <code>test</code>
+      </p>
+    </>
+  )
+}
+
+export default TestPage
+"
+`;
+
+exports[`RSC specific output > TS Files > TS Params 1`] = `
+"
+type TsParamFilesPageProps = {
+  id: string
+}
+
+const TsParamFilesPage = ({ id }: TsParamFilesPageProps) => {
+  return (
+    <>
+      <h1>TsParamFilesPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TSParamFilesPage/TSParamFilesPage.tsx</code>
+      </p>
+      <p>
+        My default route is named <code>tsParamFiles</code>
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default TsParamFilesPage
+"
+`;
+
+exports[`RSC specific output > TS Files > TS Params with type 1`] = `
+"
+type TsParamTypeFilesPageProps = {
+  id: number
+}
+
+const TsParamTypeFilesPage = ({ id }: TsParamTypeFilesPageProps) => {
+  return (
+    <>
+      <h1>TsParamTypeFilesPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TSParamTypeFilesPage/TSParamTypeFilesPage.tsx</code>
+      </p>
+      <p>
+        My default route is named <code>tsParamTypeFiles</code>
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default TsParamTypeFilesPage
+"
+`;
+
+exports[`RSC specific output > TS Files > generates typescript pages 1`] = `
+"
+const TsFilesPage = () => {
+  return (
+    <>
+      <h1>TsFilesPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TSFilesPage/TSFilesPage.tsx</code>
+      </p>
+      <p>
+        My default route is named <code>tsFiles</code>
+      </p>
+    </>
+  )
+}
+
+export default TsFilesPage
+"
+`;
+
+exports[`RSC specific output > handler > file generation 1`] = `
+{
+  "fileContent": "const HomePage = () => {
+  return (
+    <>
+      <h1>HomePage</h1>
+      <p>
+        Find me in <code>./web/src/pages/HomePage/HomePage.jsx</code>
+      </p>
+      <p>
+        My default route is named <code>home</code>
+      </p>
+    </>
+  )
+}
+
+export default HomePage
+",
+  "filePath": "/path/to/project/web/src/pages/HomePage/HomePage.jsx",
+}
+`;
+
+exports[`RSC specific output > handler > file generation 2`] = `
+{
+  "fileContent": "import { Router, Route } from '@redwoodjs/router'
+
+const Routes = () => {
+  return (
+    <Router>
+      <Route path="/home" page={HomePage} name="home" />
+      <Route path="/about" page={AboutPage} name="about" />
+      <Route notfound page={NotFoundPage} />
+    </Router>
+  )
+}
+
+export default Routes",
+  "filePath": "/path/to/project/web/src/Routes.js",
+}
+`;
+
+exports[`RSC specific output > handler > file generation with route params 1`] = `
+{
+  "fileContent": "const PostPage = ({ id }) => {
+  return (
+    <>
+      <h1>PostPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/PostPage/PostPage.jsx</code>
+      </p>
+      <p>
+        My default route is named <code>post</code>
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default PostPage
+",
+  "filePath": "/path/to/project/web/src/pages/PostPage/PostPage.jsx",
+}
+`;
+
+exports[`RSC specific output > handler > file generation with route params 2`] = `
+{
+  "fileContent": "import { Router, Route } from '@redwoodjs/router'
+
+const Routes = () => {
+  return (
+    <Router>
+      <Route path="/post/{id}" page={PostPage} name="post" />
+      <Route path="/about" page={AboutPage} name="about" />
+      <Route notfound page={NotFoundPage} />
+    </Router>
+  )
+}
+
+export default Routes",
+  "filePath": "/path/to/project/web/src/Routes.js",
+}
+`;
+
+exports[`RSC specific output > paramFiles > creates a page component with params 1`] = `
+"const TestPage = ({ id }) => {
+  return (
+    <>
+      <h1>TestPage</h1>
+      <p>
+        Find me in <code>./web/src/pages/TestPage/TestPage.jsx</code>
+      </p>
+      <p>
+        My default route is named <code>test</code>
+      </p>
+      <p>The parameter passed to me is {id}</p>
+    </>
+  )
+}
+
+export default TestPage
+"
+`;
+
 exports[`Single world files > creates a page component 1`] = `
 "import { Link, routes } from '@redwoodjs/router'
 import { Metadata } from '@redwoodjs/web'

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -133,11 +133,11 @@ export const files = async ({
 
   const files = [pageFile]
 
-  if (tests) {
+  if (tests && !rscEnabled) {
     files.push(testFile)
   }
 
-  if (stories) {
+  if (stories && !rscEnabled) {
     files.push(storiesFile)
   }
 

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -85,7 +85,18 @@ export const paramVariants = (path) => {
   }
 }
 
-export const files = async ({ name, tests, stories, typescript, ...rest }) => {
+export const files = async ({
+  name,
+  tests,
+  stories,
+  typescript,
+  rscEnabled,
+  ...rest
+}) => {
+  const pageTemplate = rscEnabled
+    ? 'page.tsx.rsc.template'
+    : 'page.tsx.template'
+
   const extension = typescript ? '.tsx' : '.jsx'
   const pageFile = await templateForComponentFile({
     name,
@@ -93,7 +104,7 @@ export const files = async ({ name, tests, stories, typescript, ...rest }) => {
     extension,
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'page',
-    templatePath: 'page.tsx.template',
+    templatePath: pageTemplate,
     templateVars: rest,
   })
 
@@ -224,6 +235,8 @@ export const handler = async ({
     }
   }
 
+  const rscEnabled = getConfig().experimental?.rsc?.enabled ?? false
+
   const tasks = new Listr(
     [
       {
@@ -237,6 +250,7 @@ export const handler = async ({
             stories,
             typescript,
             ...paramVariants(path),
+            rscEnabled,
           })
           return writeFilesTask(f, { overwriteExisting: force })
         },
@@ -265,6 +279,7 @@ export const handler = async ({
       },
       {
         title: 'One more thing...',
+        enabled: () => !rscEnabled,
         task: (ctx, task) => {
           task.title =
             `One more thing...\n\n` +

--- a/packages/cli/src/commands/generate/page/templates/page.tsx.rsc.template
+++ b/packages/cli/src/commands/generate/page/templates/page.tsx.rsc.template
@@ -1,0 +1,21 @@
+<% if (paramName !== '') { %>
+type ${pascalName}PageProps = {
+  ${paramName}: ${paramType}
+}
+<% } %>
+const ${pascalName}Page = (<%- paramName === '' ? '' : `${propParam}: ${pascalName}PageProps` %>) => {
+  return (
+    <>
+      <h1>${pascalName}Page</h1>
+      <p>
+        Find me in <code>${outputPath}</code>
+      </p>
+      <p>
+        My default route is named <code>${camelName}</code>
+      </p><% if (paramName !== '') { %>
+      <p>The parameter passed to me is {${ paramName }}</p><% } %>
+    </>
+  )
+}
+
+export default ${pascalName}Page

--- a/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/scaffold.test.js
@@ -1,11 +1,12 @@
 globalThis.__dirname = __dirname
 import path from 'path'
 
-import { vol } from 'memfs'
-import { vi, describe, test, expect, beforeAll } from 'vitest'
+import { vi, describe, test, expect, beforeAll, afterAll } from 'vitest'
 
 // Load mocks
 import '../../../../lib/test'
+
+import { getConfig } from '@redwoodjs/project-config'
 
 import { getDefaultArgs } from '../../../../lib'
 import { yargsDefaults as defaults } from '../../helpers'
@@ -13,10 +14,6 @@ import * as scaffold from '../scaffold'
 
 vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 vi.mock('execa')
-
-beforeAll(() => {
-  vol.fromJSON({ 'redwood.toml': '' }, '/')
-})
 
 describe('in javascript (default) mode', () => {
   let files
@@ -760,16 +757,17 @@ describe("'use client' directive", () => {
   let files
 
   beforeAll(async () => {
-    vol.fromJSON(
-      { 'redwood.toml': '[experimental.rsc]\n  enabled = true' },
-      '/',
-    )
+    getConfig.mockReturnValue({ experimental: { rsc: { enabled: true } } })
 
     files = await scaffold.files({
       ...getDefaultArgs(defaults),
       model: 'Post',
       nestScaffoldByModel: true,
     })
+  })
+
+  afterAll(() => {
+    getConfig.mockReturnValue({})
   })
 
   test("creates a new NewPost component with the 'use client' directive", async () => {

--- a/packages/cli/src/lib/test.js
+++ b/packages/cli/src/lib/test.js
@@ -28,6 +28,7 @@ vi.mock('@redwoodjs/project-config', async (importOriginal) => {
   const originalProjectConfig = await importOriginal()
   return {
     ...originalProjectConfig,
+    getConfig: vi.fn().mockReturnValue({}),
     getPaths: () => {
       const BASE_PATH = '/path/to/project'
       return {


### PR DESCRIPTION
**WIP**
We want the page generation behaviour slightly different for RSC projects. Right now, the template is pretty bare because adding the other standard content makes the page fail. The intention with this PR is to just start the work of deciding on what the template should contain and then make the actual template work. 