### PR TITLE
chore(telemetry): build with esbuild

### DIFF
--- a/packages/telemetry/.babelrc.js
+++ b/packages/telemetry/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/telemetry/build.mts
+++ b/packages/telemetry/build.mts
@@ -1,0 +1,3 @@
+import { build } from '@redwoodjs/framework-tools'
+
+await build()

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -13,32 +13,29 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn build:js",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\"",
+    "build": "tsx build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-telemetry.tgz",
-    "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
+    "build:types": "tsc --build --verbose",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "7.24.1",
     "@redwoodjs/project-config": "workspace:*",
     "@redwoodjs/structure": "workspace:*",
     "@whatwg-node/fetch": "0.9.17",
     "ci-info": "4.0.0",
-    "core-js": "3.36.1",
     "envinfo": "7.11.1",
     "systeminformation": "5.22.6",
     "uuid": "9.0.1",
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "@babel/cli": "7.24.1",
-    "@babel/core": "^7.22.20",
     "@types/envinfo": "7.8.3",
     "@types/uuid": "9.0.8",
     "@types/yargs": "17.0.32",
+    "tsx": "4.7.1",
+    "typescript": "5.4.3",
     "vitest": "1.4.0"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8797,9 +8797,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/telemetry@workspace:packages/telemetry"
   dependencies:
-    "@babel/cli": "npm:7.24.1"
-    "@babel/core": "npm:^7.22.20"
-    "@babel/runtime-corejs3": "npm:7.24.1"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/structure": "workspace:*"
     "@types/envinfo": "npm:7.8.3"
@@ -8807,9 +8804,10 @@ __metadata:
     "@types/yargs": "npm:17.0.32"
     "@whatwg-node/fetch": "npm:0.9.17"
     ci-info: "npm:4.0.0"
-    core-js: "npm:3.36.1"
     envinfo: "npm:7.11.1"
     systeminformation: "npm:5.22.6"
+    tsx: "npm:4.7.1"
+    typescript: "npm:5.4.3"
     uuid: "npm:9.0.1"
     vitest: "npm:1.4.0"
     yargs: "npm:17.7.2"


### PR DESCRIPTION
As @jtoar pointed out in #10323 we load and depend on additional packages as a result of building with our babel build config. This PR switches out the `@redwoodjs/telemetry` package to use esbuild over babel for building itself.

The changes here are:
1. Remove babel config and dependencies
2. Build with esbuild instead, adding `tsx` and `typescript` dev dependencies
3. Build types too. We didn't previously do that, impact on package size vs usefulness?

The resulting file changes in the dist output are that the existing files change and that each file now also has a `.d.ts` and `d.ts.map` companion. 

Although this does reduce the number of files/packages loaded when you run `yarn rw dev --help` it doesn't come with a noticeable performance improvement. Still nice not to load stuff that we don't actually need.