### PR TITLE
chore(changesets): Automatically find PR number

### DIFF
--- a/tasks/changesets/changesets.mts
+++ b/tasks/changesets/changesets.mts
@@ -14,7 +14,7 @@ async function main() {
     return
   }
 
-  const { prNumber } = resolveArgv()
+  const { prNumber } = await resolveArgv()
 
   const changesetFilePath = getChangesetFilePath(prNumber)
   const placeholder = await getPlaceholder(prNumber)

--- a/tasks/changesets/changesetsHelpers.mts
+++ b/tasks/changesets/changesetsHelpers.mts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'node:url'
 
 import { humanId } from 'human-id'
-import { argv, path, fs } from 'zx'
+import { $, argv, path, fs, ProcessPromise } from 'zx'
+
+$.verbose = false
 
 const ROOT_DIR_PATH = fileURLToPath(new URL('../../', import.meta.url))
 const DIRNAME = path.dirname(fileURLToPath(new URL(import.meta.url)))
@@ -14,8 +16,9 @@ Usage: yarn changesets [prNumber]
   prNumber: A PR number. If provided, the changeset will use the PR's title and body as its placeholder.
 
   Examples:
-    yarn changesets                                                  # Create a changeset with the default placeholder
-    yarn changesets 10075                                            # Create a changeset with PR 10075's title and body
+    yarn changesets                                                  # Tries to determine the PR based on the current branch name.
+                                                                     # If no PR is found, it uses the default placeholder.
+    yarn changesets 10075                                            # Create a changeset with PR 10075's title and body.
 `)
 }
 
@@ -42,12 +45,31 @@ export async function getPlaceholder(prNumber?: number) {
   return getDefaultPlaceholder()
 }
 
-export function resolveArgv() {
+export async function resolveArgv() {
   const maybePrNumber = argv._[0]
   if (!maybePrNumber) {
-    return { prNumber: undefined }
+    const currentBranch = await getStdout($`git branch --show-current`)
+
+    const url =
+      'https://api.github.com/repos/redwoodjs/redwood/pulls?state=open&sort=updated&direction=desc&per_page=100'
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${getGitHubToken()}`,
+        ['X-GitHub-Api-Version']: '2022-11-28',
+        Accept: 'application/vnd.github+json',
+      },
+    })
+    const prs = await res.json()
+    const pr = prs.find(
+      (pr: { head: { ref: string } }) => pr.head.ref === currentBranch,
+    )
+
+    return { prNumber: pr?.number ?? undefined }
   }
-  if (typeof maybePrNumber === 'string' && maybePrNumber.startsWith('#')) {
+  if (
+    typeof maybePrNumber === 'string' &&
+    maybePrNumber.startsWith('#')
+  ) {
     return { prNumber: +maybePrNumber.replace('#', '') }
   }
   if (typeof maybePrNumber === 'number') {
@@ -86,20 +108,11 @@ async function fetchFromGitHub({
   query: string
   variables: Record<string, any>
 }) {
-  const token = process.env.GITHUB_TOKEN || process.env.REDWOOD_GITHUB_TOKEN
-
-  if (!token) {
-    throw new Error(
-      '\nNo GitHub token found. Please set GITHUB_TOKEN or ' +
-        'REDWOOD_GITHUB_TOKEN',
-    )
-  }
-
   const res = await fetch('https://api.github.com/graphql', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
+      Authorization: `Bearer ${getGitHubToken()}`,
     },
     body: JSON.stringify({
       query,
@@ -153,4 +166,26 @@ function getPlaceholderForPr(pr: PR) {
     '',
     pr.body,
   ].join('\n')
+}
+
+async function getStdout(cmd: ProcessPromise) {
+  const res = await cmd
+  if (res.exitCode !== 0) {
+    throw new Error(`Command failed (${res.exitCode}): ${res.stderr}`)
+  }
+
+  return res.stdout.trim()
+}
+
+function getGitHubToken() {
+  const token = process.env.GITHUB_TOKEN || process.env.REDWOOD_GITHUB_TOKEN
+
+  if (!token) {
+    throw new Error(
+      '\nNo GitHub token found. Please set GITHUB_TOKEN or ' +
+        'REDWOOD_GITHUB_TOKEN',
+    )
+  }
+
+  return token
 }


### PR DESCRIPTION
Try to automatically find the PR on GitHub that corresponds to the current git branch if no pr number is provided on the command line.

This allows for a workflow where you can do
`git push -u origin tobbe-changesets-find-pr`
and create a PR on GitHub, and then go back to your terminal and just run
`yarn changesets`
to get a changesets file with all the info you just entered on GitHub, without having to memorize the PR number

It's also nice if you're helping a contributor to just being able to check out their branch and run `yarn changesets` to get a changesets file with the correct template