### PR TITLE
chore(ci): Don't check the test project fixture for docs-only PRs

### DIFF
--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -11,7 +11,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    if: github.repository == 'redwoodjs/redwood'
+    name: 🔍 Detect changes
+    runs-on: ubuntu-latest
+
+    outputs:
+      onlydocs: ${{ steps.detect-changes.outputs.onlydocs }}
+      rsc: ${{ steps.detect-changes.outputs.rsc }}
+      ssr: ${{ steps.detect-changes.outputs.ssr }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+        with:
+          set-up-yarn-cache: false
+          yarn-install-directory: ./.github/actions/detect-changes
+          build: false
+
+      - name: 🔍 Detect changes
+        id: detect-changes
+        uses: ./.github/actions/detect-changes
+
   check-test-project-fixture:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.onlydocs == 'false'
     name: Check test project fixture
     runs-on: ubuntu-latest
     steps:
@@ -46,3 +71,11 @@ jobs:
             echo
             exit 1;
           fi
+
+  check-test-project-fixture-skip:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.onlydocs == 'true'
+    name: Check test project fixture
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped"


### PR DESCRIPTION
Checking the test-project fixture takes 10 minutes or more. No need to run that check for PRs that only update docs.