### PR TITLE
chore(ci): Rename onlydocs -> docs_only

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -98,7 +98,7 @@ async function main() {
 
   // If there's no branch, we're not in a pull request.
   if (!branch) {
-    core.setOutput('docs-only', false)
+    core.setOutput('docs_only', false)
     core.setOutput('rsc', false)
     core.setOutput('ssr', false)
     return
@@ -112,7 +112,7 @@ async function main() {
       'No changed files found. Something must have gone wrong. Falling back ' +
         'to running all tests.'
     )
-    core.setOutput('docs-only', false)
+    core.setOutput('docs_only', false)
     core.setOutput('rsc', true)
     core.setOutput('ssr', true)
     return
@@ -120,13 +120,13 @@ async function main() {
 
   if (!hasCodeChanges(changedFiles)) {
     console.log('No code changes detected, only docs')
-    core.setOutput('docs-only', true)
+    core.setOutput('docs_only', true)
     core.setOutput('rsc', false)
     core.setOutput('ssr', false)
     return
   }
 
-  core.setOutput('docs-only', false)
+  core.setOutput('docs_only', false)
   core.setOutput('rsc', rscChanged(changedFiles))
   core.setOutput('ssr', ssrChanged(changedFiles))
 }

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -98,7 +98,7 @@ async function main() {
 
   // If there's no branch, we're not in a pull request.
   if (!branch) {
-    core.setOutput('onlydocs', false)
+    core.setOutput('docs-only', false)
     core.setOutput('rsc', false)
     core.setOutput('ssr', false)
     return
@@ -112,7 +112,7 @@ async function main() {
       'No changed files found. Something must have gone wrong. Falling back ' +
         'to running all tests.'
     )
-    core.setOutput('onlydocs', false)
+    core.setOutput('docs-only', false)
     core.setOutput('rsc', true)
     core.setOutput('ssr', true)
     return
@@ -120,13 +120,13 @@ async function main() {
 
   if (!hasCodeChanges(changedFiles)) {
     console.log('No code changes detected, only docs')
-    core.setOutput('onlydocs', true)
+    core.setOutput('docs-only', true)
     core.setOutput('rsc', false)
     core.setOutput('ssr', false)
     return
   }
 
-  core.setOutput('onlydocs', false)
+  core.setOutput('docs-only', false)
   core.setOutput('rsc', rscChanged(changedFiles))
   core.setOutput('ssr', ssrChanged(changedFiles))
 }

--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      onlydocs: ${{ steps.detect-changes.outputs.onlydocs }}
+      docs_only: ${{ steps.detect-changes.outputs.docs_only }}
       rsc: ${{ steps.detect-changes.outputs.rsc }}
       ssr: ${{ steps.detect-changes.outputs.ssr }}
 
@@ -36,7 +36,7 @@ jobs:
 
   check-test-project-fixture:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'false'
+    if: needs.detect-changes.outputs.docs_only == 'false'
     name: Check test project fixture
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   check-test-project-fixture-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
     name: Check test project fixture
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      onlydocs: ${{ steps.detect-changes.outputs.onlydocs }}
+      docs_only: ${{ steps.detect-changes.outputs.docs_only }}
       rsc: ${{ steps.detect-changes.outputs.rsc }}
       ssr: ${{ steps.detect-changes.outputs.ssr }}
 
@@ -41,7 +41,7 @@ jobs:
 
   check:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'false'
+    if: needs.detect-changes.outputs.docs_only == 'false'
 
     name: ✅ Check constraints, dependencies, and package.json's
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
 
   check-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     name: ✅ Check constraints, dependencies, and package.json's
     runs-on: ubuntu-latest
@@ -103,7 +103,7 @@ jobs:
 
   build-lint-test-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     strategy:
       matrix:
@@ -177,7 +177,7 @@ jobs:
 
   tutorial-e2e-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     strategy:
       matrix:
@@ -268,7 +268,7 @@ jobs:
 
   smoke-tests-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     strategy:
       matrix:
@@ -378,7 +378,7 @@ jobs:
 
   cli-smoke-tests-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     strategy:
       matrix:
@@ -418,7 +418,7 @@ jobs:
 
   telemetry-check-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     strategy:
       matrix:
@@ -750,7 +750,7 @@ jobs:
 
   crwa-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     name: 🌲 Create Redwood App
     runs-on: ubuntu-latest
@@ -774,7 +774,7 @@ jobs:
 
   server-tests-skip:
     needs: detect-changes
-    if: needs.detect-changes.outputs.onlydocs == 'true'
+    if: needs.detect-changes.outputs.docs_only == 'true'
 
     name: Server tests
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -5,7 +5,7 @@ on:
     branches: [main, next]
     # We don't want this to run when we publish a release.
     tags-ignore: ['v**']
-    # No need to run on docs-only changes
+    # No need to run on docs_only changes
     paths-ignore: ['docs/**']
 
 # Cancel in-progress runs of this workflow.

--- a/.github/workflows/publish-release-candidate.yml
+++ b/.github/workflows/publish-release-candidate.yml
@@ -5,7 +5,7 @@ on:
     branches: ['release/**']
     # We don't want this to run on release
     tags-ignore: ['v**']
-    # No need to run on docs-only changes
+    # No need to run on docs_only changes
     paths-ignore: ['docs/**']
 
 # Cancel in-progress runs of this workflow.


### PR DESCRIPTION
1. My spell checker doesn't like onlydocs
    ![image](https://github.com/redwoodjs/redwood/assets/30793/c6e65b9c-b6a5-4ab7-afe7-cb6fea46a6b5)
2. My immature brain doesn't like onlydocs, because it keeps reading it as OnlyFans 🙈 

Because of this, I decided to rename the variable to `docs_only`
