### PR TITLE
chore(ci): detectChanges: Only analyze newly changed files

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -55,6 +55,9 @@ async function getPrBranchName() {
  *
  * @typedef {Object} Commit
  * @property {string} sha
+ * @property {Object} commit
+ * @property {Object} commit.author
+ * @property {string} commit.author.date
  */
 
 /**
@@ -92,16 +95,12 @@ async function getCommitsNewerThan(timestamp) {
 
   const comparisonDate = new Date(timestamp)
 
-  // Debug
+  // TODO: Remove debug code
   comparisonDate.setHours(comparisonDate.getHours() - 10)
   console.log('comparisonDate', comparisonDate)
 
-  return json?.filter((commit) => {
-    const commitDate = new Date(commit.commit.author.date)
-
-    return commitDate > comparisonDate
-    // Debug
-    // && !commit.commit.message.startsWith('Merge')
+  return json?.filter((/** @type Commit */ commit) => {
+    return new Date(commit.commit.author.date) > comparisonDate
   })
 }
 

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -95,10 +95,6 @@ async function getCommitsNewerThan(timestamp) {
 
   const comparisonDate = new Date(timestamp)
 
-  // TODO: Remove debug code
-  comparisonDate.setHours(comparisonDate.getHours() - 10)
-  console.log('comparisonDate', comparisonDate)
-
   return json?.filter((/** @type Commit */ commit) => {
     return new Date(commit.commit.author.date) > comparisonDate
   })

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -51,7 +51,7 @@ async function getPrBranchName() {
 
 /**
  * @typedef {Object} Workflow
- * @property {string} created_at
+ * @property {string} updated_at
  *
  * @typedef {Object} Commit
  * @property {string} sha
@@ -199,15 +199,15 @@ async function fetchJson(url, retries = 0) {
 // only gives you the full list of commits, there's no way of knowing what
 // "push" they belong to.
 // But every time a "push" happens to a PR branch a new CI run starts. So by
-// looking at when the last CI run started, and comparing that to the
-// timestamps of all commits we can figure out what commits are new, and what
+// looking at when the last completed CI run ended, and comparing that to the
+// timestamps of all commits, we can figure out what commits are new, and what
 // commits we've already run CI for
 //
 // 1. Get the PR branch name
 //    https://api.github.com/repos/redwoodjs/redwood/pulls/10374  .head.ref
 // 2. Get CI workflow runs for that branch
 //    https://api.github.com/repos/redwoodjs/redwood/actions/workflows/24294187/runs?branch=tobbe-redirect-docs
-// 3. Get the `created_at` timestamp for the newest completed run (`status` === 'completed')
+// 3. Get the `updated_at` timestamp for the newest completed run (`status` === 'completed')
 // 4. Get all commits for the PR
 //      https://api.github.com/repos/redwoodjs/redwood/pulls/10374/commits
 // 5. Filter out all commits that are newer than the timestamp from step 3
@@ -228,7 +228,7 @@ async function main() {
 
   const branchName = await getPrBranchName()
   const workflowRun = await getLatestCompletedWorkflowRun(branchName)
-  const prCommits = await getCommitsNewerThan(workflowRun?.created_at)
+  const prCommits = await getCommitsNewerThan(workflowRun?.updated_at)
   let changedFiles = await getFilesInCommits(prCommits)
 
   if (changedFiles.length === 0) {


### PR DESCRIPTION
The goal here is to only run the checks that are relevant to the newly changed files when a push happens to a PR. If a push only has docs changes there's not need to re-run all of the CI workflows even if the PR as a whole changes a bunch of code files