### PR TITLE
chore(ci): detectChanges: Retry fetch on NOK

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -168,6 +168,8 @@ async function fetchJson(url, retries = 0) {
       console.log()
       console.error('Response not ok')
       console.log('res', res)
+
+      throw new Error('status: ' + res.status)
     }
 
     const json = await res.json()


### PR DESCRIPTION
The `detectChanges` script was failing because the fetches were getting HTTP 403 replies back.
![image](https://github.com/redwoodjs/redwood/assets/30793/35042afd-5abb-4ccf-a244-162b221016bc)

Let's see if we can fix that by just retrying.