### PR TITLE
chore(ci): detectChanges: Prefer GH_TOKEN

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -152,7 +152,9 @@ async function fetchJson(url, retries = 0) {
   }
 
   const githubToken =
-    process.env.GITHUB_TOKEN || process.env.REDWOOD_GITHUB_TOKEN
+    process.env.GH_TOKEN ||
+    process.env.GITHUB_TOKEN ||
+    process.env.REDWOOD_GITHUB_TOKEN
 
   try {
     const res = await fetch(url, {


### PR DESCRIPTION
> GH_TOKEN, GITHUB_TOKEN (in order of precedence): an authentication token for github.com API requests. Setting this avoids being prompted to authenticate and takes precedence over previously stored credentials.

 – https://cli.github.com/manual/gh_help_environment

I figured we could/should do the same, and allow, and prefer, `GH_TOKEN` for authentication against the GH API