### PR TITLE
fix(rsc/ssr): correct route matching behaviour

### DIFF
--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -91,7 +91,7 @@ async function createServer() {
 
     // @TODO we no longer need to use the regex
     const expressPathDef = route.hasParams
-      ? route.matchRegexString
+      ? new RegExp(route.matchRegexString)
       : route.pathDefinition
 
     app.get(expressPathDef, createServerAdapter(routeHandler))

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -130,8 +130,11 @@ export async function runFeServer() {
 
     // @TODO: we don't need regexes here
     // Param matching, etc. all handled within the route handler now
+    // Note: express has it's own particular regex syntax and so we can't simply pass
+    // a string containing standard regex. Instead pass a RegExp object and this results
+    //  in the expected matching behavior.
     const expressPathDef = route.hasParams
-      ? route.matchRegexString
+      ? new RegExp(route.matchRegexString)
       : route.pathDefinition
 
     // TODO(RSC_DC): RSC is rendering blank page, try using this function for initial render


### PR DESCRIPTION
**Problem**
When you use redwoods routing parameters with SSR/RSC you will not get the correct route matching behaviour. For example `/docs/{path...}` will not correctly match any subpath of `/docs/`. This is because of the particular subset of regex that express expects the path string to be in. See: https://expressjs.com/en/guide/routing.html

**Solution**
I have not been able to find any docs what so ever on express that state you can pass regex objects directly as the path to functions such as `get`...

Nevertheless, I tried it and it works. I then went through the express code and you can see it passes the `path` (which I have updated to be a regex when you have route params) to `pathRegexp` from the `path-to-regexp` package. If you then look into that package you'll see that it handles if the `path` is an instance of `RegExp`. Ultimately it looks like it simply returns the same regex it received back. 

**Notes**
This is intended as a fix. It might be possible to argue about any potential performance concerns when using regex but we intend to move away from express and to use fastify. I think we should accept this as an interim solution until we do move to a different server.