### PR TITLE
fix(rw-eslint): Implement more specific checking on Routes

### DIFF
--- a/.changesets/10404.md
+++ b/.changesets/10404.md
@@ -1,0 +1,3 @@
+- fix(rw-eslint): Implement more specific checking on Routes (#10404) by @dac09
+
+Fixes: If you use any other elements outside the Route tree it should not throw a linting error or warning

--- a/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
+++ b/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
@@ -38,10 +38,30 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
           )
         }`.replace(/ +/g, ' '),
     },
+    {
+      code: `
+        const AnotherThing = <Bazinga><p>Hello</p></Bazinga>
+        const Routes = () => {
+          return (
+            <Router>
+              <PrivateSet
+              whileLoadingAuth={AnotherThing}
+              >
+                <Route path="/contacts" page={ContactsPage} name="contacts" />
+              </PrivateSet>
+            </Router>
+          )
+        }`.replace(/ +/g, ' '),
+    },
   ],
   invalid: [
     {
       code: 'const Routes = () => <Router><div><Route path="/" page={HomePage} name="home" /></div></Router>',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // block statement style
+    {
+      code: 'const Routes = () => { return (<Router><div><Route path="/" page={HomePage} name="home" /></div></Router>) }',
       errors: [{ messageId: 'unexpected' }],
     },
     {

--- a/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
+++ b/packages/eslint-plugin/src/__tests__/unsupported-route-components.test.ts
@@ -44,9 +44,7 @@ ruleTester.run('unsupported-route-components', unsupportedRouteComponents, {
         const Routes = () => {
           return (
             <Router>
-              <PrivateSet
-              whileLoadingAuth={AnotherThing}
-              >
+              <PrivateSet whileLoadingAuth={AnotherThing}>
                 <Route path="/contacts" page={ContactsPage} name="contacts" />
               </PrivateSet>
             </Router>

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -53,7 +53,7 @@ export const unsupportedRouteComponents = createRule({
 
           if (routesDeclaration?.type === 'ArrowFunctionExpression') {
             if (routesDeclaration.body.type === 'JSXElement') {
-              // For when outes = () => <Router>...</Router>
+              // Routes = () => <Router>...</Router>
               checkNodes(routesDeclaration.body, context)
             } else if (routesDeclaration.body.type === 'BlockStatement') {
               // For when  Routes = () => { return (<Router>...</Router>) }

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -1,5 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/utils'
 import { ESLintUtils } from '@typescript-eslint/utils'
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs
 
@@ -10,7 +11,7 @@ function isAllowedElement(name: string) {
 
 function checkNodes(
   nodesToCheck: TSESTree.JSXElement | TSESTree.JSXChild,
-  context: any,
+  context: RuleContext<'unexpected', []>,
 ) {
   if (nodesToCheck.type === 'JSXElement') {
     const name =

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -41,7 +41,7 @@ export const unsupportedRouteComponents = createRule({
     },
     messages: {
       unexpected:
-        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, <Set>, <PrivateSet> and <Private> are allowed in the Routes file.',
+        'Unexpected JSX element <{{name}}>. Only <Router>, <Route>, <Set>, <PrivateSet> and <Private> are allowed in the Routes component.',
     },
     schema: [],
   },


### PR DESCRIPTION
Fixes #10383

See issue for more details. 

This change does the following:
1. Searches for the return statement from the `Routes` component
2. If the body contains JSXElements, check each JSXElement and it's children recursively

Point (1) is the real fix. Technically, you could call your `Routes` component something else though, and this linter won't catch it - but it won't break either.