### PR TITLE
SSR: Better ServerEntry types

### DIFF
--- a/.changesets/10412.md
+++ b/.changesets/10412.md
@@ -1,0 +1,7 @@
+- SSR: Better ServerEntry types (#10412) by @Tobbe
+
+When enabling SSR the setup command will generate an `entry.server.tsx` file in
+the user's app. This file exports a `ServerEntry` component that takes `css`
+and ` meta` as props. The `meta` props used to be typed as `any`, making it
+difficult to use with confidence. This PR makes the type be `TagDescriptor[]`
+which is more correct.

--- a/__fixtures__/test-project-rsa/web/src/entry.server.tsx
+++ b/__fixtures__/test-project-rsa/web/src/entry.server.tsx
@@ -1,9 +1,11 @@
+import type { TagDescriptor } from '@redwoodjs/web'
+
 import App from './App'
 import { Document } from './Document'
 
 interface Props {
   css: string[]
-  meta?: any[]
+  meta?: TagDescriptor[]
 }
 
 export const ServerEntry: React.FC<Props> = ({ css, meta }) => {

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/web/src/entry.server.tsx
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/web/src/entry.server.tsx
@@ -1,9 +1,11 @@
+import type { TagDescriptor } from '@redwoodjs/web'
+
 import App from './App'
 import { Document } from './Document'
 
 interface Props {
   css: string[]
-  meta?: any[]
+  meta?: TagDescriptor[]
 }
 
 export const ServerEntry: React.FC<Props> = ({ css, meta }) => {

--- a/packages/cli/src/commands/experimental/templates/streamingSsr/entry.server.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/entry.server.tsx.template
@@ -1,9 +1,11 @@
+import type { TagDescriptor } from '@redwoodjs/web'
+
 import App from './App'
 import { Document } from './Document'
 
 interface Props {
   css: string[]
-  meta?: any[]
+  meta?: TagDescriptor[]
 }
 
 export const ServerEntry: React.FC<Props> = ({ css, meta }) => {

--- a/packages/vite/src/middleware/types.ts
+++ b/packages/vite/src/middleware/types.ts
@@ -18,3 +18,8 @@ export type MiddlewareInvokeOptions = {
   cssPaths?: Array<string>
   params?: Record<string, unknown>
 }
+
+// Tuple of [mw, '*.{extension}']
+export type MiddlewareReg = Array<
+  [Middleware | MiddlewareClass, string] | Middleware | MiddlewareClass
+>

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -15,23 +15,11 @@ import type { TagDescriptor } from '@redwoodjs/web'
 import { invoke } from '../middleware/invokeMiddleware.js'
 import { MiddlewareResponse } from '../middleware/MiddlewareResponse.js'
 import type { Middleware } from '../middleware/types.js'
+import type { EntryServer } from '../types.js'
 import { makeFilePath } from '../utils.js'
 
-import type { ServerEntryType } from './streamHelpers.js'
 import { reactRenderToStreamResponse } from './streamHelpers.js'
 import { loadAndRunRouteHooks } from './triggerRouteHooks.js'
-
-export type EntryServer =
-  | {
-      middleware?: Middleware
-      ServerEntry: ServerEntryType
-      default: never
-    }
-  | {
-      middleware?: Middleware
-      ServerEntry: never
-      default: ServerEntryType
-    }
 
 interface CreateReactStreamingHandlerOptions {
   routes: RWRouteManifestItem[]

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -16,7 +16,7 @@ import { invoke } from '../middleware/invokeMiddleware.js'
 import { MiddlewareResponse } from '../middleware/MiddlewareResponse.js'
 import type { Middleware } from '../middleware/types.js'
 import type { EntryServer } from '../types.js'
-import { makeFilePath } from '../utils.js'
+import { makeFilePath, ssrLoadEntryServer } from '../utils.js'
 
 import { reactRenderToStreamResponse } from './streamHelpers.js'
 import { loadAndRunRouteHooks } from './triggerRouteHooks.js'
@@ -119,15 +119,7 @@ export const createReactStreamingHandler = async (
     // Do this inside the handler for **dev-only**.
     // This makes sure that changes to entry-server are picked up on refresh
     if (!isProd) {
-      if (!rwPaths.web.entryServer) {
-        throw new Error('entryServer not defined')
-      }
-
-      entryServerImport = (await viteDevServer.ssrLoadModule(
-        rwPaths.web.entryServer,
-        // Have to type cast here because ssrLoadModule just returns a generic
-        // Record<string, any> type
-      )) as EntryServer
+      entryServerImport = await ssrLoadEntryServer(viteDevServer)
       fallbackDocumentImport = await viteDevServer.ssrLoadModule(
         rwPaths.web.document,
       )

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -56,7 +56,6 @@ export const createReactStreamingHandler = async (
 
   const isProd = !viteDevServer
   const middlewareRouter: Router.Instance<any> = await getMiddlewareRouter()
-
   let entryServerImport: EntryServer
   let fallbackDocumentImport: Record<string, any>
 

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -19,15 +19,11 @@ import {
 } from '@redwoodjs/web/dist/components/ServerInject'
 
 import type { MiddlewareResponse } from '../middleware/MiddlewareResponse.js'
+import type { ServerEntryType } from '../types.js'
 
 import { createBufferedTransformStream } from './transforms/bufferedTransform.js'
 import { createTimeoutTransform } from './transforms/cancelTimeoutTransform.js'
 import { createServerInjectionTransform } from './transforms/serverInjectionTransform.js'
-
-export type ServerEntryType = React.FunctionComponent<{
-  css: string[]
-  meta: TagDescriptor[]
-}>
 
 interface RenderToStreamArgs {
   ServerEntry: ServerEntryType

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -24,9 +24,15 @@ import { createBufferedTransformStream } from './transforms/bufferedTransform.js
 import { createTimeoutTransform } from './transforms/cancelTimeoutTransform.js'
 import { createServerInjectionTransform } from './transforms/serverInjectionTransform.js'
 
+export type ServerEntryType = React.FunctionComponent<{
+  url?: string
+  css: string[]
+  meta: TagDescriptor[]
+}>
+
 interface RenderToStreamArgs {
-  ServerEntry: any
-  FallbackDocument: any
+  ServerEntry: ServerEntryType
+  FallbackDocument: React.FunctionComponent
   currentPathName: string
   metaTags: TagDescriptor[]
   cssLinks: string[]

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -25,7 +25,6 @@ import { createTimeoutTransform } from './transforms/cancelTimeoutTransform.js'
 import { createServerInjectionTransform } from './transforms/serverInjectionTransform.js'
 
 export type ServerEntryType = React.FunctionComponent<{
-  url?: string
   css: string[]
   meta: TagDescriptor[]
 }>
@@ -126,8 +125,7 @@ export async function reactRenderToStreamResponse(
           {
             value: injectToPage,
           },
-          ServerEntry({
-            url: path,
+          React.createElement(ServerEntry, {
             css: cssLinks,
             meta: metaTags,
           }),

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -10,7 +10,27 @@
  * **All** of these properties are used by the prod FE server
  */
 import type { RWRouteManifestItem } from '@redwoodjs/internal'
+import type { TagDescriptor } from '@redwoodjs/web'
+
+import type { MiddlewareReg } from './middleware/types'
 
 export type RWRouteManifest = Record<PathDefinition, RWRouteManifestItem>
 
 type PathDefinition = string
+
+export type ServerEntryType = React.FunctionComponent<{
+  css: string[]
+  meta: TagDescriptor[]
+}>
+
+export type EntryServer =
+  | {
+      registerMiddleware?: () => MiddlewareReg
+      ServerEntry: ServerEntryType
+      default: never
+    }
+  | {
+      registerMiddleware?: () => MiddlewareReg
+      ServerEntry: never
+      default: ServerEntryType
+    }

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,4 +1,8 @@
+import type { ViteDevServer } from 'vite'
+
 import { getPaths } from '@redwoodjs/project-config'
+
+import type { EntryServer } from './types'
 
 export function stripQueryStringAndHashFromPath(url: string) {
   return url.split('?')[0].split('#')[0]
@@ -19,7 +23,22 @@ export function ensureProcessDirWeb(webDir: string = getPaths().web.base) {
     process.chdir(webDir)
   }
 }
+
 export function makeFilePath(path: string): string {
   // Without this, absolute paths can't be imported on Windows
   return 'file:///' + path
+}
+
+export async function ssrLoadEntryServer(viteDevServer: ViteDevServer) {
+  const rwPaths = getPaths()
+
+  if (!rwPaths.web.entryServer) {
+    throw new Error('entryServer not defined')
+  }
+
+  return viteDevServer.ssrLoadModule(
+    rwPaths.web.entryServer,
+    // Have to type cast here because ssrLoadModule just returns a generic
+    // Record<string, any> type
+  ) as Promise<EntryServer>
 }

--- a/packages/web/ambient.d.ts
+++ b/packages/web/ambient.d.ts
@@ -2,6 +2,8 @@
 import type { NormalizedCacheObject } from '@apollo/client'
 import type { HelmetServerState } from 'react-helmet-async'
 
+import type { TagDescriptor } from '@redwoodjs/web'
+
 declare global {
   var __REDWOOD__PRERENDERING: boolean
   var __REDWOOD__HELMET_CONTEXT: { helmet?: HelmetServerState }


### PR DESCRIPTION
* Add types to `entryServerImport` that include `ServerEntry`
* Use specific type for `meta` in `ServerEntry` everywhere

This spills over into user apps when they have SSR enabled, making user apps more type safe.
It also makes it easier and safer to work with the code internally in the framework

Had SSR not been an experimental feature we should have included a codemod with this change to update the type in users' projects. But since it is experimental I'm skipping that.