### PR TITLE
fix(middeware): Allow registration with async functions

### DIFF
--- a/packages/vite/src/middleware/createMiddlewareRouter.test.ts
+++ b/packages/vite/src/middleware/createMiddlewareRouter.test.ts
@@ -47,7 +47,6 @@ describe('createMiddlewareRouter', () => {
   })
 
   it('Should load import from distEntryServer for prod', async () => {
-    distRegisterMwMock.mockReturnValue([])
     await createMiddlewareRouter()
     expect(distRegisterMwMock).toHaveBeenCalled()
   })

--- a/packages/vite/src/middleware/createMiddlewareRouter.test.ts
+++ b/packages/vite/src/middleware/createMiddlewareRouter.test.ts
@@ -1,0 +1,96 @@
+import type { ViteDevServer } from 'vite'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createMiddlewareRouter } from './register'
+
+vi.mock('@redwoodjs/project-config', async () => {
+  return {
+    getPaths: () => {
+      return {
+        web: {
+          base: '/proj/web',
+          dist: '/proj/web/dist',
+          distEntryServer: '/proj/web/dist/entry-server.mjs',
+          entryServer: '/proj/web/entry-server.tsx',
+        },
+      }
+    },
+  }
+})
+
+const distRegisterMwMock = vi.fn()
+vi.mock('/proj/web/dist/entry-server.mjs', () => {
+  return {
+    registerMiddleware: distRegisterMwMock,
+  }
+})
+
+describe('createMiddlewareRouter', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('Should load using vite dev server, and load from entry-server source', async () => {
+    const mockVite = {
+      ssrLoadModule: vi.fn().mockReturnValue({
+        registerMiddleware: () => {
+          return []
+        },
+      }),
+    } as unknown as ViteDevServer
+
+    await createMiddlewareRouter(mockVite)
+
+    expect(mockVite.ssrLoadModule).toHaveBeenCalledWith(
+      '/proj/web/entry-server.tsx',
+    )
+  })
+
+  it('Should load import from distEntryServer for prod', async () => {
+    distRegisterMwMock.mockReturnValue([])
+    await createMiddlewareRouter()
+    expect(distRegisterMwMock).toHaveBeenCalled()
+  })
+
+  it('(async) should return a router with middleware handlers', async () => {
+    // Testing async case
+    distRegisterMwMock.mockResolvedValue([
+      [vi.fn(), '/bazinga'],
+      [vi.fn(), '/kittens'],
+      vi.fn(),
+    ])
+
+    const result = await createMiddlewareRouter()
+
+    expect(result.prettyPrint()).toMatchInlineSnapshot(`
+      "└── (empty root node)
+          ├── /
+          │   ├── bazinga (GET)
+          │   └── kittens (GET)
+          └── * (GET)
+      "
+    `)
+    expect(distRegisterMwMock).toHaveBeenCalled()
+  })
+
+  it('(sync) should return a router with middleware handlers', async () => {
+    // Testing sync case
+    distRegisterMwMock.mockReturnValue([
+      [vi.fn(), '/bazinga'],
+      [vi.fn(), '/kittens'],
+      vi.fn(),
+    ])
+
+    const result = await createMiddlewareRouter()
+
+    expect(result.prettyPrint()).toMatchInlineSnapshot(`
+      "└── (empty root node)
+          ├── /
+          │   ├── bazinga (GET)
+          │   └── kittens (GET)
+          └── * (GET)
+      "
+    `)
+    expect(distRegisterMwMock).toHaveBeenCalled()
+  })
+})

--- a/packages/vite/src/middleware/register.ts
+++ b/packages/vite/src/middleware/register.ts
@@ -82,7 +82,7 @@ export const chain = (mwList: Middleware[]) => {
   }
 }
 
-export const addMiddlewareHandlers = (mwRegList: MiddlewareReg) => {
+export const addMiddlewareHandlers = (mwRegList: MiddlewareReg = []) => {
   const groupedMw = groupByRoutePatterns(mwRegList)
   const mwRouter = fmw()
 
@@ -128,5 +128,5 @@ export const createMiddlewareRouter = async (
     return fmw()
   }
 
-  return addMiddlewareHandlers(registerMiddleware())
+  return addMiddlewareHandlers(await registerMiddleware())
 }


### PR DESCRIPTION
Today @cannikin and I found a problem with async registrations of middleware. 

This PR fixes this, and adds some extra tests.