### PR TITLE
chore(middleware): Fix some internal types, spelling etc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
   "peacock.color": "#b85833",
   "cSpell.words": [
     "autoplay",
+    "bazinga",
     "corepack",
     "execa",
     "Fastify",

--- a/packages/vite/src/middleware/CookieJar.ts
+++ b/packages/vite/src/middleware/CookieJar.ts
@@ -5,9 +5,7 @@ export type CookieParams = {
   options?: cookie.CookieSerializeOptions
 }
 
-/**
- * Specialised cookie map, that lets you set cookies with options
- */
+/** Specialized cookie map, that lets you set cookies with options */
 export class CookieJar {
   private map = new Map<string, CookieParams>()
 

--- a/packages/vite/src/middleware/register.test.ts
+++ b/packages/vite/src/middleware/register.test.ts
@@ -85,7 +85,7 @@ describe('groupByRoutePatterns', () => {
       exampleRequest,
       new MiddlewareResponse(),
     )
-    expect(secondOutput?.body).toBe('MW initialized with 2')
+    expect((secondOutput || {})?.body).toBe('MW initialized with 2')
   })
 })
 
@@ -127,7 +127,8 @@ describe('chain', () => {
   it('Routing with find-my-way', async () => {
     const mwRouter = addMiddlewareHandlers(registerList)
     const match = mwRouter.find('GET', '/bazinga')
-    // @ts-expect-error No way of customizing find-my-way route type
+
+    // No way of customizing find-my-way route type
     const output = await match?.handler(
       exampleRequest,
       new MiddlewareResponse(),

--- a/packages/vite/src/middleware/register.test.ts
+++ b/packages/vite/src/middleware/register.test.ts
@@ -2,18 +2,19 @@ import { describe, expect, it, vitest } from 'vitest'
 
 import { MiddlewareRequest } from './MiddlewareRequest'
 import { MiddlewareResponse } from './MiddlewareResponse'
-import type { MiddlewareReg } from './register'
 import { addMiddlewareHandlers, chain, groupByRoutePatterns } from './register'
-import type { Middleware, MiddlewareClass } from './types'
+import type { Middleware, MiddlewareClass, MiddlewareReg } from './types'
 
 const fakeMiddleware: Middleware = vitest.fn()
 
 class FakeClassMw implements MiddlewareClass {
   value: number
+
   constructor(value: number) {
     this.value = value
   }
-  async invoke(req, res) {
+
+  async invoke(_req: MiddlewareRequest, res: MiddlewareResponse) {
     res.body = 'MW initialized with ' + this.value
     res.headers.set('class-mw-value', this.value.toString())
     return res
@@ -57,7 +58,7 @@ describe('groupByRoutePatterns', () => {
   })
 
   it('Throws if not a function, instance or tuple', () => {
-    const badInput: MiddlewareReg = ['/badinput'] as any
+    const badInput: MiddlewareReg = ['/bad-input'] as any
 
     expect(() => groupByRoutePatterns(badInput)).toThrow()
   })
@@ -78,7 +79,7 @@ describe('groupByRoutePatterns', () => {
       exampleRequest,
       new MiddlewareResponse(),
     )
-    expect(firstOutput?.body).toBe('MW initialized with 1')
+    expect((firstOutput || {}).body).toBe('MW initialized with 1')
 
     const secondOutput = await output['/second-path'][0]?.(
       exampleRequest,
@@ -89,12 +90,12 @@ describe('groupByRoutePatterns', () => {
 })
 
 describe('chain', () => {
-  const addHeaderMw: Middleware = (req, res) => {
+  const addHeaderMw: Middleware = (_req, res) => {
     res.headers.append('add-header-mw', 'added')
     return res
   }
 
-  const addCookieMw: Middleware = (req, res) => {
+  const addCookieMw: Middleware = (_req, res) => {
     res.cookies.set('add-cookie-mw', 'added')
     return res
   }
@@ -126,7 +127,7 @@ describe('chain', () => {
   it('Routing with find-my-way', async () => {
     const mwRouter = addMiddlewareHandlers(registerList)
     const match = mwRouter.find('GET', '/bazinga')
-    // @ts-expect-error No way of customising find-my-way route type
+    // @ts-expect-error No way of customizing find-my-way route type
     const output = await match?.handler(
       exampleRequest,
       new MiddlewareResponse(),


### PR DESCRIPTION
Can't use optional chaining here
![image](https://github.com/redwoodjs/redwood/assets/30793/7bf573bd-0019-4642-93ec-46927934ae67)
More info: https://github.com/microsoft/TypeScript/issues/35236

I get this error, so I removed `@ts-expect-error`
![image](https://github.com/redwoodjs/redwood/assets/30793/72ca9ebb-27e5-40bf-b724-473b172c7404)
