### PR TITLE
chore(route-manifest): Add relativeFilePath to route manifest

### DIFF
--- a/packages/internal/src/routes.ts
+++ b/packages/internal/src/routes.ts
@@ -71,8 +71,8 @@ export interface RWRouteManifestItem {
   routeHooks: string | null
   bundle: string | null
   hasParams: boolean
+  relativeFilePath: string | undefined
   redirect: { to: string; permanent: boolean } | null
-  renderMode: 'html' | 'stream'
   // Probably want isNotFound here, so we can attach a separate 404 handler
 }
 

--- a/packages/vite/src/buildRouteManifest.ts
+++ b/packages/vite/src/buildRouteManifest.ts
@@ -46,7 +46,7 @@ export async function buildRouteManifest() {
             permanent: false,
           }
         : null,
-      renderMode: route.renderMode,
+      relativeFilePath: route.relativeFilePath,
     }
 
     return acc


### PR DESCRIPTION
**Rationale**
For OG Middleware, we need to know the original src path of the route. This is so we can find the relevant component to render as an image. 

We want to keep the same name as the routes returned from `getProjectRoutes`, so we don't litter if statements.

**How will this work eventually?**

1. Add original file path (Relative path from project routes) to route manifest.
2. In vite plugin, map filepath to ogImg/AboutPage/AboutPage.mjs: this is the og image component in the dist folder. The ogImg components will maintain the same nesting/directory structure as the pages
3. In the middleware, we find the matching route
4. Now that we know the original file path, so we can lookup the og image component (and if it doesn't exist, 404)

**Extra**
This PR also removes `renderMode` as it's not used 