### PR TITLE
fix(middleware): Handle POST requests in middleware router too

### DIFF
--- a/.changesets/10418.md
+++ b/.changesets/10418.md
@@ -1,0 +1,3 @@
+- fix(middleware): Handle POST requests in middleware router too (#10418) by @dac09
+
+Fixes issue with middleware router not accepted POST requests.

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -75,15 +75,14 @@ async function createServer() {
     return createServerAdapter(async (req: Request) => {
       // Recreate middleware router on each request in dev
       const middlewareRouter = await createMiddlewareRouter(vite)
-
-      if (!middlewareRouter) {
-        return new Response('No middleware found', { status: 404 })
-      }
-
       const middleware = middlewareRouter.find(
         req.method as HTTPMethod,
         req.url,
       )?.handler as Middleware | undefined
+
+      if (!middleware) {
+        return new Response('No middleware found', { status: 404 })
+      }
 
       const [mwRes] = await invoke(req, middleware, route ? { route } : {})
 

--- a/packages/vite/src/middleware/createMiddlewareRouter.test.ts
+++ b/packages/vite/src/middleware/createMiddlewareRouter.test.ts
@@ -64,9 +64,9 @@ describe('createMiddlewareRouter', () => {
     expect(result.prettyPrint()).toMatchInlineSnapshot(`
       "└── (empty root node)
           ├── /
-          │   ├── bazinga (GET)
-          │   └── kittens (GET)
-          └── * (GET)
+          │   ├── bazinga (GET, POST)
+          │   └── kittens (GET, POST)
+          └── * (GET, POST)
       "
     `)
     expect(distRegisterMwMock).toHaveBeenCalled()
@@ -85,9 +85,9 @@ describe('createMiddlewareRouter', () => {
     expect(result.prettyPrint()).toMatchInlineSnapshot(`
       "└── (empty root node)
           ├── /
-          │   ├── bazinga (GET)
-          │   └── kittens (GET)
-          └── * (GET)
+          │   ├── bazinga (GET, POST)
+          │   └── kittens (GET, POST)
+          └── * (GET, POST)
       "
     `)
     expect(distRegisterMwMock).toHaveBeenCalled()

--- a/packages/vite/src/middleware/register.ts
+++ b/packages/vite/src/middleware/register.ts
@@ -88,8 +88,8 @@ export const addMiddlewareHandlers = (mwRegList: MiddlewareReg = []) => {
     const chainedMw = chain(mwList)
 
     // @NOTE: as any, because we don't actually use the fmw router to invoke the mw
-    // we use it just for matching. FMW doesn't seem to have a way of customising the handler signature
-    mwRouter.on('GET', pattern, chainedMw as any)
+    // we use it just for matching. FMW doesn't seem to have a way of customizing the handler type
+    mwRouter.on(['GET', 'POST'], pattern, chainedMw as any)
   }
 
   return mwRouter

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -98,14 +98,14 @@ export async function runFeServer() {
 
   const handleWithMiddleware = (route?: RWRouteManifestItem) => {
     return createServerAdapter(async (req: Request) => {
-      if (!middlewareRouter) {
-        return new Response('No middleware found', { status: 404 })
-      }
-
       const middleware = middlewareRouter.find(
         req.method as HTTPMethod,
         req.url,
       )?.handler as Middleware | undefined
+
+      if (!middleware) {
+        return new Response('No middleware found', { status: 404 })
+      }
 
       const [mwRes] = await invoke(req, middleware, route ? { route } : {})
 


### PR DESCRIPTION
As title. 

I made a mistake in the first implementation of middleware routing, forgot to accept `POST` requests