### PR TITLE
feat(server-auth): Support auth without graphql

### DIFF
--- a/packages/auth-providers/dbAuth/web/src/getCurrentUserFromMiddleware.ts
+++ b/packages/auth-providers/dbAuth/web/src/getCurrentUserFromMiddleware.ts
@@ -1,0 +1,28 @@
+/*
+ This call allows the middleware to validate the cookie and return the current user.
+ */
+export const getCurrentUserFromMiddleware = async <
+  TCurrentUser = Record<string, unknown>,
+>(
+  authUrl: string,
+): Promise<TCurrentUser> => {
+  const response = await globalThis.fetch(`${authUrl}/currentUser`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      'content-type': 'application/json',
+    },
+  })
+
+  if (response.ok) {
+    const { currentUser } = await response.json()
+    if (!currentUser) {
+      throw new Error('No current user found')
+    }
+    return currentUser
+  } else {
+    throw new Error(
+      `Could not fetch current user: ${response.statusText} (${response.status})`,
+    )
+  }
+}

--- a/packages/auth/src/AuthProvider/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider/AuthProvider.tsx
@@ -19,7 +19,6 @@ import { useToken } from './useToken'
 import { useValidateResetToken } from './useValidateResetToken'
 
 export interface AuthProviderProps {
-  skipFetchCurrentUser?: boolean
   children: ReactNode
 }
 
@@ -77,10 +76,7 @@ export function createAuthProvider<
     ) => (rolesToCheck: string | string[]) => boolean
   },
 ) {
-  const AuthProvider = ({
-    children,
-    skipFetchCurrentUser,
-  }: AuthProviderProps) => {
+  const AuthProvider = ({ children }: AuthProviderProps) => {
     // const [hasRestoredState, setHasRestoredState] = useState(false)
 
     const serverAuthState = useContext(ServerAuthContext)
@@ -104,7 +100,6 @@ export function createAuthProvider<
       authImplementation,
       setAuthProviderState,
       getCurrentUser,
-      skipFetchCurrentUser,
     )
 
     const hasRole = customProviderHooks?.useHasRole
@@ -115,13 +110,11 @@ export function createAuthProvider<
       authImplementation,
       setAuthProviderState,
       getCurrentUser,
-      skipFetchCurrentUser,
     )
     const logIn = useLogIn(
       authImplementation,
       setAuthProviderState,
       getCurrentUser,
-      skipFetchCurrentUser,
     )
     const logOut = useLogOut(authImplementation, setAuthProviderState)
     const forgotPassword = useForgotPassword(authImplementation)
@@ -130,18 +123,22 @@ export function createAuthProvider<
     const type = authImplementation.type
     const client = authImplementation.client
 
-    // Whenever the authImplementation is ready to go, restore auth and
-    // reauthenticate
+    // Whenever the authImplementation is ready to go, restore auth and reauthenticate
     useEffect(() => {
       async function doRestoreState() {
+        // @MARK: this is where we fetch currentUser from graphql again
+        // because without SSR, initial state doesn't exist
+        // what we want to do here is to conditionally call reauthenticate
+        // so that the restoreAuthState comes from the injected state
+
         await authImplementation.restoreAuthState?.()
 
-        // @MARK(SSR-Auth): Conditionally call reauthenticate, because initial
-        // state should come from server (on SSR).
-        // If the initial state didn't come from the server - or was restored
-        // already - reauthenticate will make a call to receive the current
-        // user from the server
-        reauthenticate()
+        // If the inital state didn't come from the server (or was restored before)
+        // reauthenticate will make an API call to the middleware to receive the current user
+        // (instead of called the graphql endpoint with currentUser)
+        if (!serverAuthState) {
+          reauthenticate()
+        }
       }
 
       doRestoreState()

--- a/packages/auth/src/AuthProvider/useLogIn.ts
+++ b/packages/auth/src/AuthProvider/useLogIn.ts
@@ -20,7 +20,7 @@ export const useLogIn = <
   TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
-  TClient,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
@@ -40,14 +40,12 @@ export const useLogIn = <
   setAuthProviderState: React.Dispatch<
     React.SetStateAction<AuthProviderState<TUser>>
   >,
-  getCurrentUser: ReturnType<typeof useCurrentUser>,
-  skipFetchCurrentUser: boolean | undefined,
+  getCurrentUser: ReturnType<typeof useCurrentUser>
 ) => {
   const reauthenticate = useReauthenticate(
     authImplementation,
     setAuthProviderState,
-    getCurrentUser,
-    skipFetchCurrentUser,
+    getCurrentUser
   )
 
   return useCallback(
@@ -58,6 +56,6 @@ export const useLogIn = <
 
       return loginResult
     },
-    [authImplementation, reauthenticate, setAuthProviderState],
+    [authImplementation, reauthenticate, setAuthProviderState]
   )
 }

--- a/packages/auth/src/AuthProvider/useReauthenticate.ts
+++ b/packages/auth/src/AuthProvider/useReauthenticate.ts
@@ -20,7 +20,6 @@ export const useReauthenticate = <TUser>(
     React.SetStateAction<AuthProviderState<TUser>>
   >,
   getCurrentUser: ReturnType<typeof useCurrentUser>,
-  skipFetchCurrentUser: boolean | undefined,
 ) => {
   const getToken = useToken(authImplementation)
 
@@ -53,15 +52,16 @@ export const useReauthenticate = <TUser>(
           client: authImplementation.client,
         })
       } else {
+        // This call here is a local check against the auth provider's client.
+        // e.g. if the auth sdk has logged you out, it'll throw an error
         await getToken()
-
-        const currentUser = skipFetchCurrentUser ? null : await getCurrentUser()
+        const currentUser = await getCurrentUser()
 
         setAuthProviderState((oldState) => ({
           ...oldState,
           userMetadata,
           currentUser,
-          isAuthenticated: true,
+          isAuthenticated: !!currentUser,
           loading: false,
           client: authImplementation.client,
         }))
@@ -73,11 +73,5 @@ export const useReauthenticate = <TUser>(
         error: e as Error,
       })
     }
-  }, [
-    authImplementation,
-    getToken,
-    setAuthProviderState,
-    skipFetchCurrentUser,
-    getCurrentUser,
-  ])
+  }, [authImplementation, setAuthProviderState, getToken, getCurrentUser])
 }

--- a/packages/auth/src/AuthProvider/useSignUp.ts
+++ b/packages/auth/src/AuthProvider/useSignUp.ts
@@ -19,7 +19,7 @@ export const useSignUp = <
   TResetPasswordOptions,
   TResetPassword,
   TValidateResetToken,
-  TClient,
+  TClient
 >(
   authImplementation: AuthImplementation<
     TUser,
@@ -39,14 +39,12 @@ export const useSignUp = <
   setAuthProviderState: React.Dispatch<
     React.SetStateAction<AuthProviderState<TUser>>
   >,
-  getCurrentUser: ReturnType<typeof useCurrentUser>,
-  skipFetchCurrentUser: boolean | undefined,
+  getCurrentUser: ReturnType<typeof useCurrentUser>
 ) => {
   const reauthenticate = useReauthenticate(
     authImplementation,
     setAuthProviderState,
-    getCurrentUser,
-    skipFetchCurrentUser,
+    getCurrentUser
   )
 
   return useCallback(
@@ -55,6 +53,6 @@ export const useSignUp = <
       await reauthenticate()
       return signupOutput
     },
-    [authImplementation, reauthenticate],
+    [authImplementation, reauthenticate]
   )
 }

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -39,9 +39,9 @@ const server = setupServer(
         redwood: {
           currentUser: CURRENT_USER_DATA,
         },
-      }),
+      })
     )
-  }),
+  })
 )
 
 const consoleError = console.error
@@ -165,7 +165,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -189,13 +189,13 @@ describe('Custom auth provider', () => {
     expect(mockAuthClient.getUserMetadata).toBeCalledTimes(1)
     expect(
       screen.getByText(
-        'userMetadata: {"sub":"abcdefg|123456","username":"peterp"}',
-      ),
+        'userMetadata: {"sub":"abcdefg|123456","username":"peterp"}'
+      )
     ).toBeInTheDocument()
     expect(
       screen.getByText(
-        'currentUser: {"name":"Peter Pistorius","email":"nospam@example.net"}',
-      ),
+        'currentUser: {"name":"Peter Pistorius","email":"nospam@example.net"}'
+      )
     ).toBeInTheDocument()
     expect(screen.getByText('authToken: hunter2')).toBeInTheDocument()
 
@@ -204,40 +204,9 @@ describe('Custom auth provider', () => {
     await waitFor(() => screen.getByText('Log In'))
   })
 
-  test('Fetching the current user can be skipped', async () => {
-    const mockAuthClient = customTestAuth
-
-    render(
-      <AuthProvider skipFetchCurrentUser>
-        <AuthConsumer />
-      </AuthProvider>,
-    )
-
-    // We're booting up!
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
-
-    // The user is not authenticated
-    await waitFor(() => screen.getByText('Log In'))
-    expect(mockAuthClient.getUserMetadata).toBeCalledTimes(1)
-
-    // Replace "getUserMetadata" with actual data, and login!
-    mockAuthClient.getUserMetadata = jest.fn(() => {
-      return {
-        sub: 'abcdefg|123456',
-        username: 'peterp',
-      }
-    })
-    fireEvent.click(screen.getByText('Log In'))
-
-    // Check that you're logged in!
-    await waitFor(() => screen.getByText('Log Out'))
-    expect(mockAuthClient.getUserMetadata).toBeCalledTimes(1)
-    expect(screen.getByText(/no current user data/)).toBeInTheDocument()
-
-    // Log out
-    fireEvent.click(screen.getByText('Log Out'))
-    await waitFor(() => screen.getByText('Log In'))
-  })
+  /// @MARK: Breaking change!
+  // skipFetchCurrentUser used to be used for nHost only
+  // and isn't something we want to support anymore
 
   /**
    * This is especially helpful if you want to update the currentUser state.
@@ -248,7 +217,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // The user is not authenticated
@@ -271,8 +240,8 @@ describe('Custom auth provider', () => {
     // The original current user data is fetched.
     expect(
       screen.getByText(
-        'currentUser: {"name":"Peter Pistorius","email":"nospam@example.net"}',
-      ),
+        'currentUser: {"name":"Peter Pistorius","email":"nospam@example.net"}'
+      )
     ).toBeInTheDocument()
 
     CURRENT_USER_DATA = { ...CURRENT_USER_DATA, name: 'Rambo' }
@@ -280,8 +249,8 @@ describe('Custom auth provider', () => {
 
     await waitFor(() =>
       screen.getByText(
-        'currentUser: {"name":"Rambo","email":"nospam@example.net"}',
-      ),
+        'currentUser: {"name":"Rambo","email":"nospam@example.net"}'
+      )
     )
   })
 
@@ -289,7 +258,7 @@ describe('Custom auth provider', () => {
     server.use(
       graphql.query('__REDWOOD__AUTH_GET_CURRENT_USER', (_req, res, ctx) => {
         return res(ctx.status(404))
-      }),
+      })
     )
 
     const mockAuthClient = customTestAuth
@@ -303,14 +272,14 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
     expect(screen.getByText('Loading...')).toBeInTheDocument()
 
     await waitFor(() =>
-      screen.getByText('Could not fetch current user: Not Found (404)'),
+      screen.getByText('Could not fetch current user: Not Found (404)')
     )
   })
 
@@ -329,7 +298,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -376,7 +345,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -423,7 +392,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -470,7 +439,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -516,7 +485,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -559,7 +528,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -606,7 +575,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -652,7 +621,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <AuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     // We're booting up!
@@ -706,7 +675,7 @@ describe('Custom auth provider', () => {
     render(
       <AuthProvider>
         <TestAuthConsumer />
-      </AuthProvider>,
+      </AuthProvider>
     )
 
     await waitFor(() => expect(mockedForgotPassword).toBeCalledWith('username'))


### PR DESCRIPTION
Pairing with @dthyresson

- First step of supporting Auth using middleware. This PR is the smallest slice possible.
- Also removes the unused `skipFetchCurrentUser`, that was only used in `nhost` - a deprecated auth provider. This technically makes this change breaking, so we need to think it through!

To make use of this functionality, we will need:
**1. A specialised middleware auth client**
(naming TBC)  - in your `web/src/auth.ts`, you will need to instantiate the create auth differently. 

```
import {
  createDbAuthClient,
  createMiddlewareAuth, // 👈 not in this PR
} from '@redwoodjs/auth-dbauth-web'

const dbAuthClient = createDbAuthClient({
  middleware: true, // 👈 not in this PR
})

export const { AuthProvider, useAuth } = createMiddlewareAuth(dbAuthClient)
```

2. The middleware to perform auth
3. Updated dbAuth handler for dbAuth

**Checklist**

- [ ] Ensure backwards compatibility with non-SSR auth
- [ ] Should we undo the changes to `skipFetchCurrentUser`
