### PR TITLE
chore(whatwg-fetch): Switch to importing instead of requiring

### DIFF
--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -1,4 +1,4 @@
-require('whatwg-fetch')
+// require('whatwg-fetch')
 
 import React, { useEffect, useState } from 'react'
 
@@ -13,6 +13,7 @@ import { renderHook, act } from '@testing-library/react'
 import '@testing-library/jest-dom/jest-globals'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
+import 'whatwg-fetch'
 
 import type { CustomTestAuthClient } from './fixtures/customTestAuth'
 import { createCustomTestAuth } from './fixtures/customTestAuth'

--- a/packages/testing/src/web/__tests__/MockHandlers.test.tsx
+++ b/packages/testing/src/web/__tests__/MockHandlers.test.tsx
@@ -1,8 +1,8 @@
-import 'whatwg-fetch'
 import React, { useCallback, useState } from 'react'
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
+import 'whatwg-fetch'
 
 import { mockGraphQLQuery } from '../mockRequests'
 


### PR DESCRIPTION
I was having issues converting a package from jest to vitest. First I thought it might have to do with moving from `require` to `import`, but importing works just fine currently too. So this PR just moves away from `require` as we want to move towards ESM syntax, while also demonstrating that `require` vs `import` is not the issue with moving to vitest for #10423 