### PR TITLE
chore(framework-tools): Warn about missing metafile

### DIFF
--- a/packages/framework-tools/src/buildDefaults.ts
+++ b/packages/framework-tools/src/buildDefaults.ts
@@ -71,7 +71,16 @@ export async function build({
     ...buildOptions,
   })
 
-  await fs.writeJSON(path.join(cwd, metafileName), result.metafile, {
-    spaces: 2,
-  })
+  if (!result.metafile) {
+    console.warn(
+      'No metafile found in esbuild result\n\n' +
+        'This is unexpected and probably means something is wrong with the ' +
+        'build\n\n' +
+        '---\n\n',
+    )
+  } else {
+    await fs.writeJSON(path.join(cwd, metafileName), result.metafile, {
+      spaces: 2,
+    })
+  }
 }

--- a/packages/framework-tools/src/buildDefaults.ts
+++ b/packages/framework-tools/src/buildDefaults.ts
@@ -76,11 +76,10 @@ export async function build({
       spaces: 2,
     })
   } else {
+    console.warn("No metafile found in esbuild's result.")
     console.warn(
-      'No metafile found in esbuild result.\n\n' +
-        'This is unexpected and probably means something is wrong with the ' +
-        'build.\n\n' +
-        '---\n\n',
+      'This is unexpected and probably means something is wrong with the ' +
+        'build.',
     )
   }
 }

--- a/packages/framework-tools/src/buildDefaults.ts
+++ b/packages/framework-tools/src/buildDefaults.ts
@@ -71,16 +71,16 @@ export async function build({
     ...buildOptions,
   })
 
-  if (!result.metafile) {
-    console.warn(
-      'No metafile found in esbuild result\n\n' +
-        'This is unexpected and probably means something is wrong with the ' +
-        'build\n\n' +
-        '---\n\n',
-    )
-  } else {
+  if (result.metafile) {
     await fs.writeJSON(path.join(cwd, metafileName), result.metafile, {
       spaces: 2,
     })
+  } else {
+    console.warn(
+      'No metafile found in esbuild result.\n\n' +
+        'This is unexpected and probably means something is wrong with the ' +
+        'build.\n\n' +
+        '---\n\n',
+    )
   }
 }


### PR DESCRIPTION
If there were no metafile the build would crash (invalid json). Now we warn instead and just skip writing the json to disk.

This is the error you get without this PR
![image](https://github.com/redwoodjs/redwood/assets/30793/d852bf01-fc29-4d7a-9633-9211ee30d22f)

With this PR
![image](https://github.com/redwoodjs/redwood/assets/30793/6be1ce2b-d103-46b4-bd04-68d629d0dd72)

