### PR TITLE
chore(web): .js imports to prep for ESM

### DIFF
--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -33,22 +33,22 @@ import './typeOverride'
 import {
   FetchConfigProvider,
   useFetchConfig,
-} from '../components/FetchConfigProvider'
-import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider'
+} from '../components/FetchConfigProvider.js'
+import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider.js'
 
 import {
   fragmentRegistry,
   registerFragment,
   registerFragments,
-} from './fragmentRegistry'
-import { SSELink } from './sseLink'
-import { useCache } from './useCache'
+} from './fragmentRegistry.js'
+import { SSELink } from './sseLink.js'
+import { useCache } from './useCache.js'
 
 export type {
   CacheKey,
   FragmentIdentifier,
   RegisterFragmentResult,
-} from './fragmentRegistry'
+} from './fragmentRegistry.js'
 
 export { useCache }
 

--- a/packages/web/src/apollo/suspense.tsx
+++ b/packages/web/src/apollo/suspense.tsx
@@ -40,7 +40,7 @@ import {
   FetchConfigProvider,
   useFetchConfig,
 } from '../components/FetchConfigProvider'
-import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider'
+import { GraphQLHooksProvider } from '../components/GraphQLHooksProvider.js'
 
 import type {
   RedwoodApolloLink,

--- a/packages/web/src/components/FetchConfigProvider.test.tsx
+++ b/packages/web/src/components/FetchConfigProvider.test.tsx
@@ -7,7 +7,7 @@ import type { AuthContextInterface } from '@redwoodjs/auth'
 
 globalThis.RWJS_API_GRAPHQL_URL = 'https://api.example.com/graphql'
 
-import { FetchConfigProvider, useFetchConfig } from './FetchConfigProvider'
+import { FetchConfigProvider, useFetchConfig } from './FetchConfigProvider.js'
 
 const FetchConfigToString: React.FunctionComponent = () => {
   const c = useFetchConfig()

--- a/packages/web/src/components/MetaTags.tsx
+++ b/packages/web/src/components/MetaTags.tsx
@@ -1,8 +1,8 @@
-import { Head as HelmetHead } from '../index'
+import { Helmet as HelmetHead } from 'react-helmet-async'
 
 // Ideally we wouldn't include this for non experiment builds
 // But.... not worth the effort to remove it from bundle atm
-import PortalHead from './PortalHead'
+import PortalHead from './PortalHead.js'
 
 type RobotsParams =
   | 'noindex'

--- a/packages/web/src/components/Metadata.test.tsx
+++ b/packages/web/src/components/Metadata.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { describe, beforeAll, it, expect } from 'vitest'
 
-import { Metadata } from './Metadata'
+import { Metadata } from './Metadata.js'
 
 // DOCS: can return a structured object from the database and just give it to `og` and it works
 

--- a/packages/web/src/components/Metadata.tsx
+++ b/packages/web/src/components/Metadata.tsx
@@ -4,7 +4,7 @@ import { Helmet as HelmetHead } from 'react-helmet-async'
 
 // Ideally we wouldn't include this for non experiment builds
 // But.... not worth the effort to remove it from bundle atm
-import PortalHead from './PortalHead'
+import PortalHead from './PortalHead.js'
 
 type ValueOrCollection<T> = T | ValueOrCollection<T>[] | Record<string, T>
 type ParentValue = ValueOrCollection<string>

--- a/packages/web/src/components/PortalHead.tsx
+++ b/packages/web/src/components/PortalHead.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { createPortal } from 'react-dom'
 
-import { useServerInsertedHTML } from './ServerInject'
+import { useServerInsertedHTML } from './ServerInject.js'
 
 function addDataAttributeMarker(
   children: React.ReactNode,

--- a/packages/web/src/components/cell/CellErrorBoundary.tsx
+++ b/packages/web/src/components/cell/CellErrorBoundary.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import type { CellFailureProps } from './cellTypes'
+import type { CellFailureProps } from './cellTypes.js'
 
 export type FallbackProps = {
   error: QueryOperationResult['error']

--- a/packages/web/src/components/cell/createCell.test.tsx
+++ b/packages/web/src/components/cell/createCell.test.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { vi, describe, beforeAll, test, expect } from 'vitest'
 
-import { GraphQLHooksProvider } from '../GraphQLHooksProvider'
+import { GraphQLHooksProvider } from '../GraphQLHooksProvider.js'
 
-import { createCell } from './createCell'
+import { createCell } from './createCell.js'
 
 describe('createCell', () => {
   beforeAll(() => {

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -1,14 +1,14 @@
-import { fragmentRegistry } from '../../apollo'
-import { getOperationName } from '../../graphql'
+import { fragmentRegistry } from '../../apollo/fragmentRegistry.js'
+import { getOperationName } from '../../graphql.js'
 /**
  * This is part of how we let users swap out their GraphQL client while staying compatible with Cells.
  */
-import { useQuery } from '../GraphQLHooksProvider'
+import { useQuery } from '../GraphQLHooksProvider.js'
 
-import { useCellCacheContext } from './CellCacheContext'
-import type { CreateCellProps } from './cellTypes'
-import { createSuspendingCell } from './createSuspendingCell'
-import { isDataEmpty } from './isCellEmpty'
+import { useCellCacheContext } from './CellCacheContext.js'
+import type { CreateCellProps } from './cellTypes.js'
+import { createSuspendingCell } from './createSuspendingCell.js'
+import { isDataEmpty } from './isCellEmpty.js'
 
 // 👇 Note how we switch which cell factory to use!
 export const createCell = RWJS_ENV.RWJS_EXP_STREAMING_SSR

--- a/packages/web/src/components/cell/createServerCell.tsx
+++ b/packages/web/src/components/cell/createServerCell.tsx
@@ -5,9 +5,9 @@ import { Suspense } from 'react'
 // Class components are not supported on the server
 // https://nextjs.org/docs/app/building-your-application/rendering/composition-patterns#when-to-use-server-and-client-components
 // Consider https://github.com/bvaughn/react-error-boundary
-// import { CellErrorBoundary } from './CellErrorBoundary'
-import type { CreateCellProps } from './cellTypes'
-import { isDataEmpty } from './isCellEmpty'
+// import { CellErrorBoundary } from './CellErrorBoundary.js'
+import type { CreateCellProps } from './cellTypes.js'
+import { isDataEmpty } from './isCellEmpty.js'
 
 // TODO(RSC): Clean this type up and consider moving to cellTypes
 type CreateServerCellProps<CellProps, CellVariables> = Omit<

--- a/packages/web/src/components/cell/createSuspendingCell.test.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.test.tsx
@@ -5,9 +5,9 @@ import { loadErrorMessages, loadDevMessages } from '@apollo/client/dev'
 import { render, screen } from '@testing-library/react'
 import { vi, describe, beforeAll, test } from 'vitest'
 
-import { GraphQLHooksProvider } from '../GraphQLHooksProvider'
+import { GraphQLHooksProvider } from '../GraphQLHooksProvider.js'
 
-import { createSuspendingCell } from './createSuspendingCell'
+import { createSuspendingCell } from './createSuspendingCell.js'
 
 type ReadQueryHook = typeof useReadQuery
 type BgQueryHook = typeof useBackgroundQuery

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -3,20 +3,20 @@ import { Suspense } from 'react'
 import type { OperationVariables, QueryReference } from '@apollo/client'
 import { useApolloClient } from '@apollo/client'
 
-import { useBackgroundQuery, useReadQuery } from '../GraphQLHooksProvider'
+import { useBackgroundQuery, useReadQuery } from '../GraphQLHooksProvider.js'
 
 /**
  * This is part of how we let users swap out their GraphQL client while staying compatible with Cells.
  */
-import type { FallbackProps } from './CellErrorBoundary'
-import { CellErrorBoundary } from './CellErrorBoundary'
+import type { FallbackProps } from './CellErrorBoundary.js'
+import { CellErrorBoundary } from './CellErrorBoundary.js'
 import type {
   CreateCellProps,
   DataObject,
   SuspendingSuccessProps,
   SuspenseCellQueryResult,
 } from './cellTypes'
-import { isDataEmpty } from './isCellEmpty'
+import { isDataEmpty } from './isCellEmpty.js'
 
 type AnyObj = Record<string, unknown>
 /**

--- a/packages/web/src/components/cell/isCellEmpty.tsx
+++ b/packages/web/src/components/cell/isCellEmpty.tsx
@@ -1,4 +1,4 @@
-import type { DataObject } from './cellTypes'
+import type { DataObject } from './cellTypes.js'
 
 /**
  * The default `isEmpty` implementation. Checks if any of the field is `null` or an empty array.

--- a/packages/web/src/components/portalHead.test.tsx
+++ b/packages/web/src/components/portalHead.test.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
 
-import PortalHead from './PortalHead'
-import * as ServerInject from './ServerInject'
+import PortalHead from './PortalHead.js'
+import * as ServerInject from './ServerInject.js'
 
 const serverInsertionHookSpy = vi
   .spyOn(ServerInject, 'useServerInsertedHTML')

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,22 +1,22 @@
-import './global.web-auto-imports'
-import './config'
-import './assetImports'
+import './global.web-auto-imports.js'
+import './config.js'
+import './assetImports.js'
 
-export { default as FatalErrorBoundary } from './components/FatalErrorBoundary'
+export { default as FatalErrorBoundary } from './components/FatalErrorBoundary.js'
 export {
   FetchConfigProvider,
   useFetchConfig,
-} from './components/FetchConfigProvider'
+} from './components/FetchConfigProvider.js'
 export {
   GraphQLHooksProvider,
   useQuery,
   useMutation,
   useSubscription,
-} from './components/GraphQLHooksProvider'
+} from './components/GraphQLHooksProvider.js'
 
-export * from './components/cell/CellCacheContext'
+export * from './components/cell/CellCacheContext.js'
 
-export { createCell } from './components/cell/createCell'
+export { createCell } from './components/cell/createCell.js'
 
 export {
   CellProps,
@@ -24,19 +24,19 @@ export {
   CellLoadingProps,
   CellSuccessProps,
   CellSuccessData,
-} from './components/cell/cellTypes'
+} from './components/cell/cellTypes.js'
 
-export * from './graphql'
+export * from './graphql.js'
 
-export * from './components/RedwoodProvider'
+export * from './components/RedwoodProvider.js'
 
-export * from './components/MetaTags'
-export * from './components/Metadata'
+export * from './components/MetaTags.js'
+export * from './components/Metadata.js'
 export { Helmet as Head, Helmet } from 'react-helmet-async'
 
-export * from './components/htmlTags'
-export * from './routeHooks.types'
+export * from './components/htmlTags.js'
+export * from './routeHooks.types.js'
 
-export * from './components/ServerInject'
+export * from './components/ServerInject.js'
 
-export type { TypedDocumentNode } from './components/GraphQLHooksProvider'
+export type { TypedDocumentNode } from './components/GraphQLHooksProvider.js'

--- a/packages/web/src/routeHooks.types.ts
+++ b/packages/web/src/routeHooks.types.ts
@@ -1,4 +1,4 @@
-import type { TagDescriptor } from './components/htmlTags'
+import type { TagDescriptor } from './components/htmlTags.js'
 
 export type RouteHookOutput = {
   meta: TagDescriptor[]


### PR DESCRIPTION
`.js` imports are needed for ESM. So this PR just updates all imports to use the .js file extension.

I also did this as I was hoping it'd surface directory imports (vs file imports) that might be causing our 
`error TS5055: Cannot write file '/Users/tobbe/dev/redwood/redwood/packages/web/dist/components/cell/CellCacheContext.d.ts' because it would overwrite input file.` etc errors, but no such luck. (Directory imports being troublesome were something I picked up from https://stackoverflow.com/a/37098165/88106, but I knew it was a long-shot as we're not outputting our definition files to our src folder(s))