### PR TITLE
chore(web): Fix .d.ts overwrite build issue

### DIFF
--- a/packages/web/ambient.d.ts
+++ b/packages/web/ambient.d.ts
@@ -2,18 +2,11 @@
 import type { NormalizedCacheObject } from '@apollo/client'
 import type { HelmetServerState } from 'react-helmet-async'
 
-import type { TagDescriptor } from '@redwoodjs/web'
-
 declare global {
   var __REDWOOD__PRERENDERING: boolean
   var __REDWOOD__HELMET_CONTEXT: { helmet?: HelmetServerState }
   var __REDWOOD__APP_TITLE: string
   var __REDWOOD__APOLLO_STATE: NormalizedCacheObject
-
-  var __REDWOOD__ASSET_MAP: {
-    css?: string[]
-    meta?: TagDescriptor[]
-  }
 
   // Provided by Vite.config, or Webpack in the user's project
   var RWJS_ENV: {

--- a/packages/web/src/components/htmlTags.tsx
+++ b/packages/web/src/components/htmlTags.tsx
@@ -1,11 +1,26 @@
 import { Fragment } from 'react'
 
-const extractFromAssetMap = (key: 'css' | 'meta') => {
+declare const window: {
+  __REDWOOD__ASSET_MAP: {
+    css?: string[]
+    meta?: TagDescriptor[]
+  }
+} & Window
+
+const extractCssFromAssetMap = () => {
   if (typeof window !== 'undefined') {
-    return window?.__REDWOOD__ASSET_MAP?.[key]
+    return window.__REDWOOD__ASSET_MAP?.css
   }
 
-  return null
+  return undefined
+}
+
+const extractMetaFromAssetMap = () => {
+  if (typeof window !== 'undefined') {
+    return window.__REDWOOD__ASSET_MAP?.meta
+  }
+
+  return undefined
 }
 
 function addSlashIfNeeded(path: string): string {
@@ -18,9 +33,7 @@ function addSlashIfNeeded(path: string): string {
 
 /** CSS is a specialised metatag */
 export const Css = ({ css }: { css: string[] }) => {
-  const cssLinks = (css || extractFromAssetMap('css') || []).map(
-    addSlashIfNeeded,
-  )
+  const cssLinks = (css || extractCssFromAssetMap() || []).map(addSlashIfNeeded)
 
   return (
     <>
@@ -99,7 +112,7 @@ interface MetaProps {
 }
 
 export const Meta = ({ tags }: MetaProps) => {
-  const metaTags = tags || extractFromAssetMap('meta') || []
+  const metaTags = tags || extractMetaFromAssetMap() || []
 
   return (
     <>


### PR DESCRIPTION
A clean build would work, but trying to build again after changing something in `@redwoodjs/web` you'd get errors like these

![image](https://github.com/redwoodjs/redwood/assets/30793/bb92163b-f0b3-4186-a50b-b433d8b5e2b0)

After a long session with `git bisect` I narrowed it down to the commit that introduced this regression. It was https://github.com/redwoodjs/redwood/pull/10412

Specifically it's this line https://github.com/redwoodjs/redwood/pull/10412/files#diff-3a6b1602e214ff07d5aea85aead0ff0e5c99e225f658b476050cc3f730b8a8e7R5 `import type { TagDescriptor } from '@redwoodjs/web'`. That pulls in all the type def files for `@redwoodjs/web` and makes them input files.

I tried with a relative import instead (`./src/components/htmlTags`), but got the same error.
Tried a script instead of a module. Same error.
Tried putting it inside `./src/`. Same error.

And when it finally did pick up on the types correctly, it revealed another type issue we had with the return value from `extractFromAssetMap` where TS couldn't figure out if it was returning the css (`string[]`) or the meta tags (`TagDescriptor[]`), so it gave us both (`string[] | TagDescriptor[]`) which you're not really allowed to pass to `isTitleTag` for example. So I had to fix that issue too. 

`__REDWOOD__ASSET_MAP` is only used in a way where types matter in this one file, so I decided to make the `window` type augmentation local to the module instead of global. The other place we use `__REDWOOD__ASSET_MAP` is in a string that we inject in user's apps during streaming. There's no type checking/safety going on there, so a global type definition is not needed.