### PR TITLE
chore(ci): get ci running on next

### DIFF
--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -226,7 +226,7 @@ async function main() {
 
   // If there's no branch, we're not in a pull request.
   if (!branch) {
-    core.setOutput('code', false)
+    core.setOutput('code', true)
     core.setOutput('rsc', false)
     core.setOutput('ssr', false)
     return


### PR DESCRIPTION
Follow up to https://github.com/redwoodjs/redwood/pull/10393. After that PR, CI no longer runs on the next branch when commits are pushed up. This is important to double check if triage or a merge conflict was resolved properly