### PR TITLE
fix(vercel): specify build env vars as a string

### DIFF
--- a/packages/cli/src/commands/setup/deploy/providers/vercel.js
+++ b/packages/cli/src/commands/setup/deploy/providers/vercel.js
@@ -54,7 +54,7 @@ function writeVercelConfigTask({ overwriteExisting = false } = {}) {
 const vercelConfig = {
   build: {
     env: {
-      ENABLE_EXPERIMENTAL_COREPACK: 1,
+      ENABLE_EXPERIMENTAL_COREPACK: '1',
     },
   },
 }


### PR DESCRIPTION
Quick follow up to https://github.com/redwoodjs/redwood/pull/10355. The value of these env vars have to be strings.