### PR TITLE
chore: make crwa e2e test work across branches

### DIFF
--- a/packages/create-redwood-app/tests/e2e.test.ts
+++ b/packages/create-redwood-app/tests/e2e.test.ts
@@ -46,10 +46,7 @@ describe('create-redwood-app', () => {
     const p = await $`yarn create-redwood-app --version`
 
     expect(p.exitCode).toEqual(0)
-    expect(p.stdout).toMatchInlineSnapshot(`
-      "7.0.0
-      [?25l[?25h"
-    `)
+    expect(p.stdout).toMatch(/\d+\.\d+\.\d+/)
     expect(p.stderr).toMatchInlineSnapshot(`"[?25l[?25h"`)
   })
 


### PR DESCRIPTION
On main we run CI on every pull request. On next, we run it on every push to the next branch. This gives whoever's doing release confidence that cherry picking was done correctly.

There's one CRWA test that doesn't translate across branches because it's a snapshot of the package's version. See https://github.com/redwoodjs/redwood/actions/runs/8607313332. This PR updates that test so that it checks that the version string matches a RegExp instead of a snapshot.
