### PR TITLE
chore(router): route-validators: types and comments

### DIFF
--- a/packages/router/src/route-validators.tsx
+++ b/packages/router/src/route-validators.tsx
@@ -9,75 +9,62 @@ import type {
 } from './Route'
 import { Route } from './Route'
 
-const isNodeTypeRoute = (
+function isNodeTypeRoute(
   node: ReactNode,
-): node is ReactElement<InternalRouteProps> => {
+): node is ReactElement<InternalRouteProps> {
   return isValidElement(node) && node.type === Route
 }
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string'
+}
+
 /**
  * Narrows down the type of the Route element to RouteProps
  *
  * It means that it is not a notfound page or a redirected route
- *
- * @param node
- * @returns boolean
  */
-
 export function isStandardRoute(
   node: ReactElement<InternalRouteProps>,
 ): node is ReactElement<RouteProps> {
   return !node.props.notfound && !node.props.redirect
 }
-/**
- *
- * Checks if a Route element is a Redirect Route
- *
- * @param node
- * @returns
- */
 
+/** Checks if a Route element is a Redirect Route */
 export function isRedirectRoute(
   node: ReactElement<InternalRouteProps>,
 ): node is ReactElement<RedirectRouteProps> {
   return !!node.props.redirect
 }
-/**
- *
- * Checks if a Route element is a Redirect Route
- *
- * @param node
- * @returns
- */
 
+/** Checks if a Route element is a NotFound Route */
 export function isNotFoundRoute(
   node: ReactElement<InternalRouteProps>,
 ): node is ReactElement<NotFoundRouteProps> {
   return !!node.props.notfound
 }
+
 /**
  * Check that the Route element is ok
  * and that it could be one of the following:
  * <Route redirect .../>  (redirect Route)
  * <Route notfound .../>  (notfound Route)
  * <Route .../> (standard Route)
- *
- * @param node
- * @returns boolean
  */
-
 export function isValidRoute(
   node: ReactNode,
 ): node is ReactElement<InternalRouteProps> {
   const isValidRouteElement = isNodeTypeRoute(node)
 
-  // Throw inside here, because we know it's a Route otherwise it could be a Set or Private
   if (isValidRouteElement) {
     const notFoundOrRedirect = node.props.notfound || node.props.redirect
     const requiredKeys = [
       !node.props.notfound && 'path',
-      !node.props.redirect && 'page', // redirects dont need an actual page, but notfound and standard do
-      !notFoundOrRedirect && 'name', // this not so sure about! Redirects should have names too, but maybe we don't need to throw an error for it
-    ].filter(Boolean) as string[]
+      // redirects don't need an actual page, but notfound and standard do
+      !node.props.redirect && 'page',
+      // Redirects can have names, but aren't required to
+      !notFoundOrRedirect && 'name',
+    ].filter(isString)
 
     const missingKeys = requiredKeys.filter((key) => !(key in node.props))
 
@@ -86,10 +73,11 @@ export function isValidRoute(
         node.props.name || node.props.path
           ? `for "${node.props.name || node.props.path}" `
           : ''
+      // Throw inside here, because we know it's a Route otherwise it could be
+      // a Set or Private
       throw new Error(
-        `Route element ${stringToHelpIdentify}is missing required props: ${missingKeys.join(
-          ', ',
-        )}`,
+        `Route element ${stringToHelpIdentify}is missing required props: ` +
+          missingKeys.join(', '),
       )
     }
   }


### PR DESCRIPTION
Was working through some router related files as part of my ServerRouter work for RSCs and cleaned up the route-validators file as I was debugging an issue.

Mainly comment formatting. But also one type improvement (getting rid of a type cast)