### PR TITLE
chore(router): Prevent circular dependency for namedRoutes

### DIFF
--- a/packages/router/src/AuthenticatedRoute.tsx
+++ b/packages/router/src/AuthenticatedRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react'
 
+import { namedRoutes } from './namedRoutes'
 import { Redirect } from './redirect'
-import { routes } from './router'
 import { useRouterState } from './router-context'
 import type { GeneratedRoutesMap } from './util'
 
@@ -38,15 +38,18 @@ export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = ({
         globalThis.location.pathname +
         encodeURIComponent(globalThis.location.search)
 
-      // We reassign the type like this, because AvailableRoutes is generated in the user's project
-      if (!(routes as GeneratedRoutesMap)[unauthenticated]) {
+      // We type cast like this, because AvailableRoutes is generated in the
+      // user's project
+      const generatedRoutesMap = namedRoutes as GeneratedRoutesMap
+
+      if (!generatedRoutesMap[unauthenticated]) {
         throw new Error(`We could not find a route named ${unauthenticated}`)
       }
 
       let unauthenticatedPath
 
       try {
-        unauthenticatedPath = (routes as GeneratedRoutesMap)[unauthenticated]()
+        unauthenticatedPath = generatedRoutesMap[unauthenticated]()
       } catch (e) {
         if (
           e instanceof Error &&

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -12,7 +12,8 @@ export {
   PageLoadingContextProvider,
 } from './PageLoadingContext'
 export { useParams, ParamsProvider, ParamsContext } from './params'
-export { Router, Route, routes } from './router'
+export { Router, Route } from './router'
+export { namedRoutes as routes } from './namedRoutes'
 
 export * from './Set'
 

--- a/packages/router/src/namedRoutes.ts
+++ b/packages/router/src/namedRoutes.ts
@@ -1,0 +1,7 @@
+import type { AvailableRoutes } from './index'
+
+// namedRoutes is populated at run-time by iterating over the `<Route />`
+// components, and appending them to this object.
+// Has to be `const`, or there'll be a race condition with imports in users'
+// projects
+export const namedRoutes: AvailableRoutes = {}

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, memo } from 'react'
 import { ActiveRouteLoader } from './active-route-loader'
 import { AuthenticatedRoute } from './AuthenticatedRoute'
 import { LocationProvider, useLocation } from './location'
+import { namedRoutes } from './namedRoutes'
 import { normalizePage } from './page'
 import type { PageType } from './page'
 import { PageLoadingContextProvider } from './PageLoadingContext'
@@ -23,14 +24,6 @@ import {
   validatePath,
 } from './util'
 import type { Wrappers, TrailingSlashesTypes } from './util'
-
-import type { AvailableRoutes } from './index'
-
-// namedRoutes is populated at run-time by iterating over the `<Route />`
-// components, and appending them to this object.
-// Has to be `const`, or there'll be a race condition with imports in users'
-// projects
-const namedRoutes: AvailableRoutes = {}
 
 export interface RouterProps
   extends Omit<RouterContextProviderProps, 'routes' | 'activeRouteName'> {
@@ -271,9 +264,14 @@ const WrappedPage = memo(({ routeLoaderElement, sets }: WrappedPageProps) => {
 
 export {
   Router,
+  // TODO: Remove this export in the next major version
   Route,
+  // TODO: Remove this export in the next major version
   namedRoutes as routes,
+  // TODO: Remove this export in the next major version
   isValidRoute as isRoute,
+  // TODO: Remove this export in the next major version
   PageType,
+  // TODO: Remove this export in the next major version
   RouteProps,
 }


### PR DESCRIPTION
`AuthenticatedRoute.tsx` was importing `router.tsx` because it needed `routes` from there. `router.tsx` was importing `AuthenticatedRoute.tsx` for `<AuthenticatedRoute>`. So we had a circular dependency between `router.tsx` and `AuthenticatedRoute.tsx`. By putting `namedRoutes` in its separate file we can get around this, because now `AuthenticatedRoute.tsx` no longer needs to import `router.tsx`