### PR TITLE
chore(location): Accept URL-like object

### DIFF
--- a/packages/router/src/location.tsx
+++ b/packages/router/src/location.tsx
@@ -4,11 +4,15 @@ import { createNamedContext } from './createNamedContext'
 import { gHistory } from './history'
 import type { TrailingSlashesTypes } from './util'
 
-export interface LocationContextType extends URL {}
+export interface LocationContextType {
+  pathname: string
+  search?: string
+  hash?: string
+}
 
 const LocationContext = createNamedContext<LocationContextType>('Location')
 
-interface Location extends URL {}
+type Location = LocationContextType
 
 interface LocationProviderProps {
   location?: Location

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -64,14 +64,11 @@ export const createReactStreamingHandler = async (
     let currentRoute: RWRouteManifestItem | undefined
     let parsedParams: any = {}
 
-    const currentUrl = new URL(req.url)
+    const urlPath = new URL(req.url).pathname
 
     // @TODO validate this is correct
     for (const route of routes) {
-      const { match, ...rest } = matchPath(
-        route.pathDefinition,
-        currentUrl.pathname,
-      )
+      const { match, ...rest } = matchPath(route.pathDefinition, urlPath)
       if (match) {
         currentRoute = route
         parsedParams = rest
@@ -174,7 +171,7 @@ export const createReactStreamingHandler = async (
       {
         ServerEntry,
         FallbackDocument,
-        currentUrl,
+        urlPath,
         metaTags,
         cssLinks,
         isProd,

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -28,7 +28,7 @@ import { createServerInjectionTransform } from './transforms/serverInjectionTran
 interface RenderToStreamArgs {
   ServerEntry: ServerEntryType
   FallbackDocument: React.FunctionComponent
-  currentUrl: URL
+  urlPath: string
   metaTags: TagDescriptor[]
   cssLinks: string[]
   isProd: boolean
@@ -64,7 +64,7 @@ export async function reactRenderToStreamResponse(
   const {
     ServerEntry,
     FallbackDocument,
-    currentUrl,
+    urlPath,
     metaTags,
     cssLinks,
     isProd,
@@ -103,7 +103,7 @@ export async function reactRenderToStreamResponse(
 
   const timeoutTransform = createTimeoutTransform(timeoutHandle)
 
-  const renderRoot = (url: URL) => {
+  const renderRoot = (urlPath: string) => {
     return React.createElement(
       ServerAuthProvider,
       {
@@ -112,7 +112,7 @@ export async function reactRenderToStreamResponse(
       React.createElement(
         LocationProvider,
         {
-          location: url,
+          location: { pathname: urlPath },
         },
         React.createElement(
           ServerHtmlProvider,
@@ -155,7 +155,7 @@ export async function reactRenderToStreamResponse(
       },
     }
 
-    const root = renderRoot(currentUrl)
+    const root = renderRoot(urlPath)
 
     const reactStream: ReactDOMServerReadableStream =
       await renderToReadableStream(root, renderToStreamOptions)


### PR DESCRIPTION
`urlPath` is more descriptive of what we actually have. And there's no need to require a full URL object – we're not using all properties on it anyway. All we need is `pathname`, and optionally `hash` and `search`