### PR TITLE
chore(paths): Remove outdated comment

### DIFF
--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -246,7 +246,6 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
       distClient: path.join(BASE_DIR, PATH_WEB_DIR_DIST_CLIENT),
       distRsc: path.join(BASE_DIR, PATH_WEB_DIR_DIST_RSC),
       distServer: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SERVER),
-      // Allow for the possibility of a .mjs file
       distEntryServer: path.join(
         BASE_DIR,
         PATH_WEB_DIR_DIST_SERVER_ENTRY_SERVER,


### PR DESCRIPTION
This comment, and the code that went with it, was added in https://github.com/redwoodjs/redwood/pull/10031
The code was later removed in https://github.com/redwoodjs/redwood/pull/10196 but the comment was left behind.