### PR TITLE
RSC: Be consistent about inlining rollup input

### DIFF
--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -80,7 +80,6 @@ export async function rscBuildForServer(
           ...serverEntryFiles,
           ...customModules,
         },
-
         output: {
           banner: (chunk) => {
             // HACK to bring directives to the front


### PR DESCRIPTION
We inline the `input`s for vite's rollup config in other places, so let's do that here as well to be more consistent