### PR TITLE
Revert "chore(location): Accept URL-like object"

### DIFF
--- a/packages/router/src/location.tsx
+++ b/packages/router/src/location.tsx
@@ -4,15 +4,11 @@ import { createNamedContext } from './createNamedContext'
 import { gHistory } from './history'
 import type { TrailingSlashesTypes } from './util'
 
-export interface LocationContextType {
-  pathname: string
-  search?: string
-  hash?: string
-}
+export interface LocationContextType extends URL {}
 
 const LocationContext = createNamedContext<LocationContextType>('Location')
 
-type Location = LocationContextType
+interface Location extends URL {}
 
 interface LocationProviderProps {
   location?: Location

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -64,11 +64,14 @@ export const createReactStreamingHandler = async (
     let currentRoute: RWRouteManifestItem | undefined
     let parsedParams: any = {}
 
-    const urlPath = new URL(req.url).pathname
+    const currentUrl = new URL(req.url)
 
     // @TODO validate this is correct
     for (const route of routes) {
-      const { match, ...rest } = matchPath(route.pathDefinition, urlPath)
+      const { match, ...rest } = matchPath(
+        route.pathDefinition,
+        currentUrl.pathname,
+      )
       if (match) {
         currentRoute = route
         parsedParams = rest
@@ -171,7 +174,7 @@ export const createReactStreamingHandler = async (
       {
         ServerEntry,
         FallbackDocument,
-        urlPath,
+        currentUrl,
         metaTags,
         cssLinks,
         isProd,

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -28,7 +28,7 @@ import { createServerInjectionTransform } from './transforms/serverInjectionTran
 interface RenderToStreamArgs {
   ServerEntry: ServerEntryType
   FallbackDocument: React.FunctionComponent
-  urlPath: string
+  currentUrl: URL
   metaTags: TagDescriptor[]
   cssLinks: string[]
   isProd: boolean
@@ -64,7 +64,7 @@ export async function reactRenderToStreamResponse(
   const {
     ServerEntry,
     FallbackDocument,
-    urlPath,
+    currentUrl,
     metaTags,
     cssLinks,
     isProd,
@@ -103,7 +103,7 @@ export async function reactRenderToStreamResponse(
 
   const timeoutTransform = createTimeoutTransform(timeoutHandle)
 
-  const renderRoot = (urlPath: string) => {
+  const renderRoot = (url: URL) => {
     return React.createElement(
       ServerAuthProvider,
       {
@@ -112,7 +112,7 @@ export async function reactRenderToStreamResponse(
       React.createElement(
         LocationProvider,
         {
-          location: { pathname: urlPath },
+          location: url,
         },
         React.createElement(
           ServerHtmlProvider,
@@ -155,7 +155,7 @@ export async function reactRenderToStreamResponse(
       },
     }
 
-    const root = renderRoot(urlPath)
+    const root = renderRoot(currentUrl)
 
     const reactStream: ReactDOMServerReadableStream =
       await renderToReadableStream(root, renderToStreamOptions)


### PR DESCRIPTION
Reverts redwoodjs/redwood#10467

We need the URL-like object because with server rendering, and SSR - we should let people have access to more properties like origin. 

Motivation here described in the original PR here: https://github.com/redwoodjs/redwood/pull/10441

We need `origin` for example, for generating the ogImage url in hooks 