### PR TITLE
chore(filepath): Use node:url to convert to file path

### DIFF
--- a/packages/vite/src/middleware/createMiddlewareRouter.test.ts
+++ b/packages/vite/src/middleware/createMiddlewareRouter.test.ts
@@ -1,32 +1,29 @@
-let mockPlatform = 'unix'
-const mockWin32Paths = {
-  web: {
-    base: 'C:\\proj\\web',
-    dist: 'C:\\proj\\web\\dist',
-    distEntryServer: 'C:\\proj\\web\\dist\\entry-server.mjs',
-    entryServer: 'C:\\proj\\web\\entry-server.tsx',
-  },
-}
-const mockUnixPaths = {
-  web: {
-    base: '/proj/web',
-    dist: '/proj/web/dist',
-    distEntryServer: '/proj/web/dist/entry-server.mjs',
-    entryServer: '/proj/web/entry-server.tsx',
-  },
-}
-
-import * as process from 'node:process'
-
 import type { ViteDevServer } from 'vite'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createMiddlewareRouter } from './register'
 
 vi.mock('@redwoodjs/project-config', async () => {
+  const mockWin32Paths = {
+    web: {
+      base: 'C:\\proj\\web',
+      dist: 'C:\\proj\\web\\dist',
+      distEntryServer: 'C:\\proj\\web\\dist\\entry-server.mjs',
+      entryServer: 'C:\\proj\\web\\entry-server.tsx',
+    },
+  }
+  const mockUnixPaths = {
+    web: {
+      base: '/proj/web',
+      dist: '/proj/web/dist',
+      distEntryServer: '/proj/web/dist/entry-server.mjs',
+      entryServer: '/proj/web/entry-server.tsx',
+    },
+  }
+
   return {
     getPaths: () => {
-      return mockPlatform === 'win32' ? mockWin32Paths : mockUnixPaths
+      return process.platform === 'win32' ? mockWin32Paths : mockUnixPaths
     },
   }
 })
@@ -45,7 +42,6 @@ vi.mock('/C:/proj/web/dist/entry-server.mjs', () => {
 
 describe('createMiddlewareRouter', () => {
   beforeEach(() => {
-    mockPlatform = 'unix'
     vi.resetAllMocks()
   })
 
@@ -61,23 +57,13 @@ describe('createMiddlewareRouter', () => {
     await createMiddlewareRouter(mockVite)
 
     expect(mockVite.ssrLoadModule).toHaveBeenCalledWith(
-      '/proj/web/entry-server.tsx',
+      // '/proj/web/entry-server.tsx'
+      // 'C:\proj\web\entry-server.tsx'
+      expect.stringMatching(/^.?.?[/\\]proj[/\\]web[/\\]entry-server.tsx$/),
     )
   })
 
-  it('Should load import from distEntryServer for prod on Unix', async () => {
-    mockPlatform = 'unix'
-    await createMiddlewareRouter()
-    expect(distRegisterMwMock).toHaveBeenCalled()
-  })
-
-  /** This test only works on Windows */
-  it('Should load import from distEntryServer for prod on Windows', async (context) => {
-    if (process.platform !== 'win32') {
-      context.skip()
-    }
-
-    mockPlatform = 'win32'
+  it('Should load import from distEntryServer for prod', async () => {
     await createMiddlewareRouter()
     expect(distRegisterMwMock).toHaveBeenCalled()
   })

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'node:url'
+
 import type { ViteDevServer } from 'vite'
 
 import { getPaths } from '@redwoodjs/project-config'
@@ -26,7 +28,8 @@ export function ensureProcessDirWeb(webDir: string = getPaths().web.base) {
 
 export function makeFilePath(path: string): string {
   // Without this, absolute paths can't be imported on Windows
-  return 'file:///' + path
+  // https://nodejs.org/api/url.html#urlpathtofileurlpath
+  return pathToFileURL(path).href
 }
 
 export async function ssrLoadEntryServer(viteDevServer: ViteDevServer) {

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -26,9 +26,11 @@ export function ensureProcessDirWeb(webDir: string = getPaths().web.base) {
   }
 }
 
-export function makeFilePath(path: string): string {
-  // Without this, absolute paths can't be imported on Windows
-  // https://nodejs.org/api/url.html#urlpathtofileurlpath
+/**
+ * Converts a file path to a URL path (file://...)
+ * Without this, absolute paths can't be imported on Windows
+ */
+export function makeFilePath(path: string) {
   return pathToFileURL(path).href
 }
 


### PR DESCRIPTION
Use `pathToFileURL` from `node:url` to import from absolute paths, as recommended here: https://github.com/nodejs/node/issues/31710#issuecomment-584696415