### PR TITLE
chore(crwa): Fix `ts-to-js` script

### DIFF
--- a/packages/create-redwood-app/scripts/tsToJS.js
+++ b/packages/create-redwood-app/scripts/tsToJS.js
@@ -67,7 +67,7 @@ for (const filePath of filePaths) {
     throw new Error(`Error: Couldn't transform ${filePath}`)
   }
 
-  const formattedCode = format(result.code, {
+  const formattedCode = await format(result.code, {
     ...prettierConfig,
     parser: 'babel',
   })


### PR DESCRIPTION
**Problem**
The `ts-to-js` script within the create-redwood-app package is failing when executed.

It appears when I upgraded to prettier v3 I failed to consider this particular code. Specifically, prettier v3 changed their API to be async rather than sync so we must now await the function call to obtain the value and not a promise. See: [here](https://prettier.io/blog/2023/07/05/3.0.0.html#change-public-apis-to-asynchronous-12574httpsgithubcomprettierprettierpull12574-12788httpsgithubcomprettierprettierpull12788-12790httpsgithubcomprettierprettierpull12790-13265httpsgithubcomprettierprettierpull13265-by-fiskerhttpsgithubcomfisker) for prettier's breaking change notice.

**Changes**
1. Await the prettier `format` call.