### PR TITLE
fix(cli): avoid `npx` during upgrade command

### DIFF
--- a/.changesets/10479.md
+++ b/.changesets/10479.md
@@ -1,0 +1,3 @@
+- fix(cli): avoid `npx` during upgrade command (#10479) by @Josh-Walker-GM
+
+This change fixes a problem with the `yarn rw upgrade` command when you don't have `npx` installed. If you don't have `npx` installed you will now have to manually run a command to dedupe dependencies rather than this being done for you automatically during the upgrade command. If this is the case, the `npx` command will be logged to the console when you run `yarn rw upgrade`.

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -401,6 +401,8 @@ const dedupeDeps = async (task, { verbose }) => {
     } else {
       // Redwood projects should not be using yarn 1.x as we specify a version of yarn in the package.json
       // with "packageManager": "yarn@4.1.1" or similar.
+      // Although we could (and previous did) automatically run `npx yarn-deduplicate` here, that would require
+      // the user to have `npx` installed, which is not guaranteed and we do not wish to enforce that.
       task.skip(
         "Yarn 1.x doesn't support dedupe directly. Please use `npx` and run `npx yarn-deduplicate` manually.",
       )

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -404,7 +404,7 @@ const dedupeDeps = async (task, { verbose }) => {
       // Although we could (and previous did) automatically run `npx yarn-deduplicate` here, that would require
       // the user to have `npx` installed, which is not guaranteed and we do not wish to enforce that.
       task.skip(
-        "Yarn 1.x doesn't support dedupe directly. Please use `npx` and run `npx yarn-deduplicate` manually.",
+        "Yarn 1.x doesn't support dedupe directly. Please upgrade yarn or use npx with `npx yarn-deduplicate` manually.",
       )
     }
   } catch (e) {

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -390,11 +390,6 @@ export const getCmdMajorVersion = async (command) => {
 const dedupeDeps = async (task, { verbose }) => {
   try {
     const yarnVersion = await getCmdMajorVersion('yarn')
-    const npxVersion = await getCmdMajorVersion('npx')
-    let npxArgs = []
-    if (npxVersion > 6) {
-      npxArgs = ['--yes']
-    }
 
     const baseExecaArgsForDedupe = {
       shell: true,
@@ -404,10 +399,10 @@ const dedupeDeps = async (task, { verbose }) => {
     if (yarnVersion > 1) {
       await execa('yarn', ['dedupe'], baseExecaArgsForDedupe)
     } else {
-      await execa(
-        'npx',
-        [...npxArgs, 'yarn-deduplicate'],
-        baseExecaArgsForDedupe,
+      // Redwood projects should not be using yarn 1.x as we specify a version of yarn in the package.json
+      // with "packageManager": "yarn@4.1.1" or similar.
+      task.skip(
+        "Yarn 1.x doesn't support dedupe directly. Please use `npx` and run `npx yarn-deduplicate` manually.",
       )
     }
   } catch (e) {


### PR DESCRIPTION
**Problem**
Fixes #10466.

During `yarn rw upgrade` we check the version of `npx` installed. It's entirely possible that `npx` is not available or installed.

We only do this check because we have to handle dedupe differently between yarn v1 and yarn >v1. We specify that redwood projects should be using yarn v4 using `"packageManager": "yarn@4.1.1"` in the `package.json`. Therefore when following the recommended setup users should not be using yarn v1 in their redwood projects.

**Changes**
1. Avoid `npx` version check.
2. Skip dedupe step if for some reason have yarn v1. When this happens we log a warning message to tell the user to run a command manually to dedupe.