### PR TITLE
fix: Updates GraphQL Fragments Setup to properly prettify web app after configuring possibleTypes

### DIFF
--- a/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
+++ b/packages/cli/src/commands/setup/graphql/features/fragments/fragmentsHandler.ts
@@ -73,7 +73,7 @@ export async function handler({ force }: Args) {
 
           const prettierOptions = await getPrettierOptions()
 
-          const prettifiedApp = format(source, {
+          const prettifiedApp = await format(source, {
             ...prettierOptions,
             parser: 'babel-ts',
           })


### PR DESCRIPTION
fix: Updates GraphQL Fragments Setup to properly prettify web app after configuring possibleTypes

In 7, the prettier package was updated such that the `format` function is asynchronous and now needs to use await.

```ts
          const prettifiedApp = await format(source, {
            ...prettierOptions,
            parser: 'babel-ts',
          })
```