### PR TITLE
Move .mdx import into separate file

### DIFF
--- a/docs/docs/ReactPlayer.jsx
+++ b/docs/docs/ReactPlayer.jsx
@@ -1,0 +1,5 @@
+'use client'
+
+import ReactPlayer from 'react-player'
+
+export default ReactPlayer

--- a/docs/docs/project-configuration-dev-test-build.mdx
+++ b/docs/docs/project-configuration-dev-test-build.mdx
@@ -3,7 +3,7 @@ title: Project Configuration
 description: Advanced project configuration
 ---
 
-import ReactPlayer from 'react-player'
+import ReactPlayer from './ReactPlayer'
 
 # Project Configuration: Dev, Test, Build
 


### PR DESCRIPTION
This is in preparation of our new docs site: component imports in .mdx files should go into standalone components that can have `'use client'` at the top since they'll generally require user interaction.