### PR TITLE
chore(renovate): Remove config for unused package

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,15 +62,6 @@
         "sort-package-json",
         "zx"
       ]
-    },
-
-    {
-      "groupName": "experimental",
-      "enabled": false,
-
-      "matchPackageNames": [
-        "@apollo/experimental-nextjs-app-support"
-      ]
     }
   ]
 }


### PR DESCRIPTION
As of https://github.com/redwoodjs/redwood/pull/10484 we don't use the `@apollo/experimental-nextjs-app-support` package anymore, so we can remove this renovate config