### PR TITLE
chore(dataMigrate): Fix package.json directory value

### DIFF
--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/redwoodjs/redwood.git",
-    "directory": "packages/cli-packages/storybook"
+    "directory": "packages/cli-packages/dataMigrate"
   },
   "license": "MIT",
   "exports": "./dist/index.js",


### PR DESCRIPTION
Pretty sure this was a copy/paste error. Now updated the `directory` value in `package.json` to have the correct directory