### PR TITLE
fix(upgrade): Download yarn patches

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -375,30 +375,36 @@ async function downloadYarnPatches(ctx, { dryRun, verbose }) {
     ),
   )
 
-  fs.mkdirSync(path.join(getPaths().web.base, '.yarn', 'patches'), {
-    recursive: true,
-  })
+  const patchDir = path.join(getPaths().base, '.yarn', 'patches')
+
+  if (verbose) {
+    console.log('Creating patch directory', patchDir)
+  }
+
+  if (!dryRun) {
+    fs.mkdirSync(patchDir, { recursive: true })
+  }
 
   return new Listr(
-    patches.map(async (patch) => {
+    patches.map((patch) => {
       return {
         title: `Downloading ${patch.path}`,
         task: async () => {
           const res = await fetch(patch.url)
-          const patchText = await res.text()
+          const patchMeta = await res.json()
           const patchPath = path.join(
-            getPaths().web.base,
+            getPaths().base,
             '.yarn',
             'patches',
             path.basename(patch.path),
           )
 
           if (verbose) {
-            console.log('writing patch', patchPath)
+            console.log('Writing patch', patchPath)
           }
 
           if (!dryRun) {
-            await fs.writeFile(patchPath, patchText)
+            await fs.writeFile(patchPath, patchMeta.content, 'base64')
           }
         },
       }


### PR DESCRIPTION
When upgrading from stable to canary you (currently) won't have the patch files required. Because they're not part of the stable CRWA template.

This PR adds a step to `yarn rw upgrade` that downloads the patches if you're upgrading to canary

The patches were introduced in https://github.com/redwoodjs/redwood/pull/10482 and like I said in that PR - we should get rid of all of this ASAP. Just need to wait for those packages to gain proper React 19 support