### PR TITLE
fix(dbauth-mw): Unset cookie instead of clearing

### DIFF
--- a/.changesets/10502.md
+++ b/.changesets/10502.md
@@ -1,0 +1,2 @@
+- fix(dbauth-mw): Unset cookie instead of clearing (#10502) by @dac09
+Updates dbAuth middleware implementation to _unset_ the cookies, instead of clearing them.

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
@@ -522,6 +522,7 @@ describe('createDbAuthMiddleware()', () => {
 
       const serverAuthContext = req.serverAuthContext.get()
       expect(serverAuthContext).toBeNull()
+      expect(res.cookies.entries()).toBe('bazinga')
     })
     it('handles a GET request with no cookies', async () => {
       const request = new Request('http://localhost:8911/functions/no-cookie', {

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
@@ -523,10 +523,8 @@ describe('createDbAuthMiddleware()', () => {
       const serverAuthContext = req.serverAuthContext.get()
       expect(serverAuthContext).toBeNull()
 
-      // mwResponse gets converted to a response eventually.
-      const finalResponse = res.toResponse()
-      expect(finalResponse.headers.getSetCookie()).toEqual([
-        // Expired cookies here!
+      expect(res.toResponse().headers.getSetCookie()).toEqual([
+        // Expired cookies, will be removed by browser
         'session_8911=; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
         'auth-provider=; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
       ])

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
@@ -522,7 +522,14 @@ describe('createDbAuthMiddleware()', () => {
 
       const serverAuthContext = req.serverAuthContext.get()
       expect(serverAuthContext).toBeNull()
-      expect(res.cookies.entries()).toBe('bazinga')
+
+      // mwResponse gets converted to a response eventually.
+      const finalResponse = res.toResponse()
+      expect(finalResponse.headers.getSetCookie()).toEqual([
+        // Expired cookies here!
+        'session_8911=; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+        'auth-provider=; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+      ])
     })
     it('handles a GET request with no cookies', async () => {
       const request = new Request('http://localhost:8911/functions/no-cookie', {

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -101,9 +101,10 @@ export const createDbAuthMiddleware = ({
       console.error(e, 'Error decrypting dbAuth cookie')
       req.serverAuthContext.set(null)
 
-      // Clear the cookies, because decryption was invalid
-      res.cookies.clear(cookieNameCreator(cookieName))
-      res.cookies.clear('auth-provider')
+      // Note we have to use ".unset" and not ".clear"
+      // because we want to remove these cookies from the browser
+      res.cookies.unset(cookieNameCreator(cookieName))
+      res.cookies.unset('auth-provider')
     }
 
     return res


### PR DESCRIPTION
Updates dbAuth middleware implementation to _unset_ the cookies, instead of clearing them.

This fixes the case where the cookie should be removed when decryption fails.