### PR TITLE
fix(rsc): Disable RSC CSS loading plugin

### DIFF
--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -3,7 +3,7 @@ import { build as viteBuild } from 'vite'
 import { getPaths } from '@redwoodjs/project-config'
 
 import { onWarn } from '../lib/onWarn.js'
-import { rscCssPreinitPlugin } from '../plugins/vite-plugin-rsc-css-preinit.js'
+// import { rscCssPreinitPlugin } from '../plugins/vite-plugin-rsc-css-preinit.js'
 import { rscRoutesAutoLoader } from '../plugins/vite-plugin-rsc-routes-auto-loader.js'
 import { rscTransformUseClientPlugin } from '../plugins/vite-plugin-rsc-transform-client.js'
 import { rscTransformUseServerPlugin } from '../plugins/vite-plugin-rsc-transform-server.js'
@@ -17,7 +17,7 @@ export async function rscBuildForServer(
   clientEntryFiles: Record<string, string>,
   serverEntryFiles: Record<string, string>,
   customModules: Record<string, string>,
-  componentImportMap: Map<string, string[]>,
+  _componentImportMap: Map<string, string[]>
 ) {
   console.log('\n')
   console.log('3. rscBuildForServer')
@@ -65,7 +65,8 @@ export async function rscBuildForServer(
       // (It does other things as well, but that's why it needs clientEntryFiles)
       rscTransformUseClientPlugin(clientEntryFiles),
       rscTransformUseServerPlugin(),
-      rscCssPreinitPlugin(clientEntryFiles, componentImportMap),
+      // Note: Temporary disabled while we fix the underlying css issue
+      // rscCssPreinitPlugin(clientEntryFiles, componentImportMap),
       rscRoutesAutoLoader(),
     ],
     build: {

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -17,7 +17,7 @@ export async function rscBuildForServer(
   clientEntryFiles: Record<string, string>,
   serverEntryFiles: Record<string, string>,
   customModules: Record<string, string>,
-  _componentImportMap: Map<string, string[]>
+  _componentImportMap: Map<string, string[]>,
 ) {
   console.log('\n')
   console.log('3. rscBuildForServer')

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -17,33 +17,33 @@ test('Setting up RSC should give you a test project with a client side counter c
   page.close()
 })
 
-test('CSS has been loaded', async ({ page }) => {
+// Note: Disabled temporarily while we fix the underlying css issue
+test.skip('CSS has been loaded', async ({ page }) => {
   await page.goto('/')
 
-  // Note: Disabled temporarily while we fix the underlying css issue
-  // // Check color of server component h3
-  // const serverH3 = page.getByText('This is a server component.')
-  // await expect(serverH3).toBeVisible()
-  // const serverH3Color = await serverH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('color')
-  // })
-  // // rgb(255, 165, 0) is orange
-  // expect(serverH3Color).toBe('rgb(255, 165, 0)')
+  // Check color of server component h3
+  const serverH3 = page.getByText('This is a server component.')
+  await expect(serverH3).toBeVisible()
+  const serverH3Color = await serverH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
+  // rgb(255, 165, 0) is orange
+  expect(serverH3Color).toBe('rgb(255, 165, 0)')
 
-  // // Check color of client component h3
-  // const clientH3 = page.getByText('This is a client component.')
-  // await expect(clientH3).toBeVisible()
-  // const clientH3Color = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('color')
-  // })
-  // // rgb(255, 165, 0) is orange
-  // expect(clientH3Color).toBe('rgb(255, 165, 0)')
+  // Check color of client component h3
+  const clientH3 = page.getByText('This is a client component.')
+  await expect(clientH3).toBeVisible()
+  const clientH3Color = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
+  // rgb(255, 165, 0) is orange
+  expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // // Check font style of client component h3
-  // const clientH3Font = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('font-style')
-  // })
-  // expect(clientH3Font).toBe('italic')
+  // Check font style of client component h3
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -20,16 +20,16 @@ test('Setting up RSC should give you a test project with a client side counter c
 test('CSS has been loaded', async ({ page }) => {
   await page.goto('/')
 
-  // Check color of server component h3
-  const serverH3 = page.getByText('This is a server component.')
-  await expect(serverH3).toBeVisible()
-  const serverH3Color = await serverH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('color')
-  })
-  // rgb(255, 165, 0) is orange
-  expect(serverH3Color).toBe('rgb(255, 165, 0)')
-
   // Note: Disabled temporarily while we fix the underlying css issue
+  // // Check color of server component h3
+  // const serverH3 = page.getByText('This is a server component.')
+  // await expect(serverH3).toBeVisible()
+  // const serverH3Color = await serverH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('color')
+  // })
+  // // rgb(255, 165, 0) is orange
+  // expect(serverH3Color).toBe('rgb(255, 165, 0)')
+
   // // Check color of client component h3
   // const clientH3 = page.getByText('This is a client component.')
   // await expect(clientH3).toBeVisible()

--- a/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc-dev/tests/rsc.spec.ts
@@ -29,20 +29,21 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(serverH3Color).toBe('rgb(255, 165, 0)')
 
-  // Check color of client component h3
-  const clientH3 = page.getByText('This is a client component.')
-  await expect(clientH3).toBeVisible()
-  const clientH3Color = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('color')
-  })
-  // rgb(255, 165, 0) is orange
-  expect(clientH3Color).toBe('rgb(255, 165, 0)')
+  // Note: Disabled temporarily while we fix the underlying css issue
+  // // Check color of client component h3
+  // const clientH3 = page.getByText('This is a client component.')
+  // await expect(clientH3).toBeVisible()
+  // const clientH3Color = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('color')
+  // })
+  // // rgb(255, 165, 0) is orange
+  // expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // Check font style of client component h3
-  const clientH3Font = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('font-style')
-  })
-  expect(clientH3Font).toBe('italic')
+  // // Check font style of client component h3
+  // const clientH3Font = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('font-style')
+  // })
+  // expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
+++ b/tasks/smoke-tests/rsc-external-packages-and-cells/tests/rsc-external-packages-and-cells.spec.ts
@@ -15,7 +15,8 @@ test('Client components should work', async ({ page }) => {
   page.close()
 })
 
-test('CSS has been loaded', async ({ page }) => {
+// Note: Disabled temporarily while we fix the underlying css issue
+test.skip('CSS has been loaded', async ({ page }) => {
   await page.goto('/')
 
   // Check color of client component h3

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -17,33 +17,33 @@ test('Setting up RSC should give you a test project with a client side counter c
   page.close()
 })
 
-test('CSS has been loaded', async ({ page }) => {
+// Note: Disabled temporarily while we fix the underlying css issue
+test.skip('CSS has been loaded', async ({ page }) => {
   await page.goto('/')
 
-  // Note: Disabled temporarily while we fix the underlying css issue
-  // // Check color of server component h3
-  // const serverH3 = page.getByText('This is a server component.')
-  // await expect(serverH3).toBeVisible()
-  // const serverH3Color = await serverH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('color')
-  // })
-  // // rgb(255, 165, 0) is orange
-  // expect(serverH3Color).toBe('rgb(255, 165, 0)')
+  // Check color of server component h3
+  const serverH3 = page.getByText('This is a server component.')
+  await expect(serverH3).toBeVisible()
+  const serverH3Color = await serverH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
+  // rgb(255, 165, 0) is orange
+  expect(serverH3Color).toBe('rgb(255, 165, 0)')
 
-  // // Check color of client component h3
-  // const clientH3 = page.getByText('This is a client component.')
-  // await expect(clientH3).toBeVisible()
-  // const clientH3Color = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('color')
-  // })
-  // // rgb(255, 165, 0) is orange
-  // expect(clientH3Color).toBe('rgb(255, 165, 0)')
+  // Check color of client component h3
+  const clientH3 = page.getByText('This is a client component.')
+  await expect(clientH3).toBeVisible()
+  const clientH3Color = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('color')
+  })
+  // rgb(255, 165, 0) is orange
+  expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // // Check font style of client component h3
-  // const clientH3Font = await clientH3.evaluate((el) => {
-  //   return window.getComputedStyle(el).getPropertyValue('font-style')
-  // })
-  // expect(clientH3Font).toBe('italic')
+  // Check font style of client component h3
+  const clientH3Font = await clientH3.evaluate((el) => {
+    return window.getComputedStyle(el).getPropertyValue('font-style')
+  })
+  expect(clientH3Font).toBe('italic')
 
   page.close()
 })

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -20,16 +20,16 @@ test('Setting up RSC should give you a test project with a client side counter c
 test('CSS has been loaded', async ({ page }) => {
   await page.goto('/')
 
-  // Check color of server component h3
-  const serverH3 = page.getByText('This is a server component.')
-  await expect(serverH3).toBeVisible()
-  const serverH3Color = await serverH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('color')
-  })
-  // rgb(255, 165, 0) is orange
-  expect(serverH3Color).toBe('rgb(255, 165, 0)')
-
   // Note: Disabled temporarily while we fix the underlying css issue
+  // // Check color of server component h3
+  // const serverH3 = page.getByText('This is a server component.')
+  // await expect(serverH3).toBeVisible()
+  // const serverH3Color = await serverH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('color')
+  // })
+  // // rgb(255, 165, 0) is orange
+  // expect(serverH3Color).toBe('rgb(255, 165, 0)')
+
   // // Check color of client component h3
   // const clientH3 = page.getByText('This is a client component.')
   // await expect(clientH3).toBeVisible()

--- a/tasks/smoke-tests/rsc/tests/rsc.spec.ts
+++ b/tasks/smoke-tests/rsc/tests/rsc.spec.ts
@@ -29,20 +29,21 @@ test('CSS has been loaded', async ({ page }) => {
   // rgb(255, 165, 0) is orange
   expect(serverH3Color).toBe('rgb(255, 165, 0)')
 
-  // Check color of client component h3
-  const clientH3 = page.getByText('This is a client component.')
-  await expect(clientH3).toBeVisible()
-  const clientH3Color = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('color')
-  })
-  // rgb(255, 165, 0) is orange
-  expect(clientH3Color).toBe('rgb(255, 165, 0)')
+  // Note: Disabled temporarily while we fix the underlying css issue
+  // // Check color of client component h3
+  // const clientH3 = page.getByText('This is a client component.')
+  // await expect(clientH3).toBeVisible()
+  // const clientH3Color = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('color')
+  // })
+  // // rgb(255, 165, 0) is orange
+  // expect(clientH3Color).toBe('rgb(255, 165, 0)')
 
-  // Check font style of client component h3
-  const clientH3Font = await clientH3.evaluate((el) => {
-    return window.getComputedStyle(el).getPropertyValue('font-style')
-  })
-  expect(clientH3Font).toBe('italic')
+  // // Check font style of client component h3
+  // const clientH3Font = await clientH3.evaluate((el) => {
+  //   return window.getComputedStyle(el).getPropertyValue('font-style')
+  // })
+  // expect(clientH3Font).toBe('italic')
 
   page.close()
 })


### PR DESCRIPTION
**Problem**
Our current plugin that loads CSS via preinit is not working. This is holding up other PRs.

**Changes**
1. We disable this plugin for now and the associated smoke tests until we fix the CSS loading. 