### PR TITLE
Fix invisible tags in MetaTag & Metadata JSDoc

### DIFF
--- a/.changesets/10504.md
+++ b/.changesets/10504.md
@@ -1,0 +1,3 @@
+- Fix invisible tags in MetaTag & Metadata JSDoc (#10504) by @Philzen
+
+This change fixes the common pitfall that tags of all kind are not visible in JSDoc view because it will try to interpret them as HTML. Now these tags should be visible when the JSDoc is rendered. See #10504 for more information

--- a/packages/web/src/components/MetaTags.tsx
+++ b/packages/web/src/components/MetaTags.tsx
@@ -61,11 +61,11 @@ interface MetaTagsProps {
 }
 
 /**
- * Add commonly used <meta> tags for unfurling/seo purposes
+ * Add commonly used `<meta>` tags for unfurling/seo purposes
  * using the open graph protocol https://ogp.me/
  * @example
  * <MetaTags title="About Page" ogContentUrl="/static/about-og.png"/>
- * @deprecated Please use <Metadata> instead
+ * @deprecated Please use `<Metadata>` instead
  */
 export const MetaTags = (props: MetaTagsProps) => {
   const {

--- a/packages/web/src/components/Metadata.tsx
+++ b/packages/web/src/components/Metadata.tsx
@@ -39,7 +39,7 @@ const propToMetaTag = (
 }
 
 /**
- * Add commonly used <meta> tags for unfurling/seo purposes
+ * Add commonly used `<meta>` tags for unfurling/seo purposes
  * using the open graph protocol https://ogp.me/
  * @example
  * <Metadata title="About Page" og={{ image: "/static/about-og.png" }} />


### PR DESCRIPTION
Fixes the common pitfall that tags of all kind are not visible in JSDoc view b/c it will try to interpret them as HTML.

Before:
![grafik](https://github.com/redwoodjs/redwood/assets/1634615/2d89e44c-fe34-4e41-901b-34ffe3f3628a)

After:
![grafik](https://github.com/redwoodjs/redwood/assets/1634615/4d0f1814-133f-4d14-9c0f-d77799012ab5)
