### PR TITLE
chore(tests): Fix `act` import warning

### DIFF
--- a/packages/router/src/__tests__/useRoutePaths.test.tsx
+++ b/packages/router/src/__tests__/useRoutePaths.test.tsx
@@ -1,8 +1,7 @@
 /** @jest-environment jsdom */
 import React from 'react'
 
-import { render } from '@testing-library/react'
-import { act } from 'react-dom/test-utils'
+import { render, act } from '@testing-library/react'
 
 import { navigate } from '../history'
 import { Route } from '../Route'


### PR DESCRIPTION
Fixes this warning:

![image](https://github.com/redwoodjs/redwood/assets/30793/fb798fb1-f4c8-4322-9e81-b3239cec7734)
```
Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`.
  Import `act` from `react` instead of `react-dom/test-utils`.
  See https://react.dev/warnings/react-dom-test-utils for more info.
```

If you go to that link they have there in the warning message it says to use `@testing-library/react` instead, so that's what I did 🙂 