### PR TITLE
chore(deps): Upgrade to React Testing Library 14.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@npmcli/arborist": "7.4.0",
     "@playwright/test": "1.42.1",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.5.2",
     "@types/babel__generator": "7.6.8",
     "@types/fs-extra": "11.0.4",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@redwoodjs/framework-tools": "workspace:*",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "14.3.1",
     "msw": "1.3.3",
     "tsx": "4.7.1",
     "typescript": "5.4.5",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.22.20",
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.5.2",
     "@types/pascalcase": "1.0.3",
     "@types/react": "^18.2.55",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -37,7 +37,7 @@
     "@redwoodjs/router": "workspace:*",
     "@redwoodjs/web": "workspace:*",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.5.2",
     "@types/aws-lambda": "8.10.136",
     "@types/babel-core": "6.25.10",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -57,7 +57,7 @@
     "@babel/runtime": "7.24.1",
     "@rollup/plugin-babel": "6.0.4",
     "@testing-library/jest-dom": "6.4.2",
-    "@testing-library/react": "14.2.2",
+    "@testing-library/react": "14.3.1",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "nodemon": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7987,7 +7987,7 @@ __metadata:
   dependencies:
     "@redwoodjs/framework-tools": "workspace:*"
     "@testing-library/jest-dom": "npm:6.4.2"
-    "@testing-library/react": "npm:14.2.2"
+    "@testing-library/react": "npm:14.3.1"
     core-js: "npm:3.36.1"
     msw: "npm:1.3.3"
     react: "npm:19.0.0-canary-36e62c603-20240418"
@@ -8361,7 +8361,7 @@ __metadata:
     "@babel/runtime-corejs3": "npm:7.24.1"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:6.4.2"
-    "@testing-library/react": "npm:14.2.2"
+    "@testing-library/react": "npm:14.3.1"
     "@testing-library/user-event": "npm:14.5.2"
     "@types/pascalcase": "npm:1.0.3"
     "@types/react": "npm:^18.2.55"
@@ -8787,7 +8787,7 @@ __metadata:
     "@redwoodjs/router": "workspace:*"
     "@redwoodjs/web": "workspace:*"
     "@testing-library/jest-dom": "npm:6.4.2"
-    "@testing-library/react": "npm:14.2.2"
+    "@testing-library/react": "npm:14.3.1"
     "@testing-library/user-event": "npm:14.5.2"
     "@types/aws-lambda": "npm:8.10.136"
     "@types/babel-core": "npm:6.25.10"
@@ -8906,7 +8906,7 @@ __metadata:
     "@redwoodjs/auth": "workspace:*"
     "@rollup/plugin-babel": "npm:6.0.4"
     "@testing-library/jest-dom": "npm:6.4.2"
-    "@testing-library/react": "npm:14.2.2"
+    "@testing-library/react": "npm:14.3.1"
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
     core-js: "npm:3.36.1"
@@ -10567,9 +10567,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:14.2.2":
-  version: 14.2.2
-  resolution: "@testing-library/react@npm:14.2.2"
+"@testing-library/react@npm:14.3.1":
+  version: 14.3.1
+  resolution: "@testing-library/react@npm:14.3.1"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     "@testing-library/dom": "npm:^9.0.0"
@@ -10577,7 +10577,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10c0/ab36707f6701a4a56dd217e16e00d6326e0f760bb2e716245422c7500a0b94efcd351d0aa89c4fab2916e6ebc68c983cec6b3ae0804de813cafc913a612668f6
+  checksum: 10c0/1ccf4eb1510500cc20a805cb0244c9098dca28a8745173a8f71ea1274d63774f0b7898a35c878b43c797b89c13621548909ff37843b835c1a27ee1efbbdd098c
   languageName: node
   linkType: hard
 
@@ -28276,7 +28276,7 @@ __metadata:
     "@npmcli/arborist": "npm:7.4.0"
     "@playwright/test": "npm:1.42.1"
     "@testing-library/jest-dom": "npm:6.4.2"
-    "@testing-library/react": "npm:14.2.2"
+    "@testing-library/react": "npm:14.3.1"
     "@testing-library/user-event": "npm:14.5.2"
     "@types/babel__generator": "npm:7.6.8"
     "@types/fs-extra": "npm:11.0.4"


### PR DESCRIPTION
Was getting
> Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.

![image](https://github.com/redwoodjs/redwood/assets/30793/bc60ee29-aa10-46b8-a707-251f7199c3f8)


I thought I fixed that as part of #10512 but it turns out it wasn't enough to fix our own code. Also needed to upgrade React Testing Library that uses `act` internally. RTL initially fixed this in https://github.com/testing-library/react-testing-library/pull/1294, but then they fixed/patched their fix in https://github.com/testing-library/react-testing-library/pull/1299/files and released that as 14.3.1