### PR TITLE
feat(upgrade): Use GitHub token if available when downloading patches

### DIFF
--- a/.changesets/10515.md
+++ b/.changesets/10515.md
@@ -1,5 +1,8 @@
 - feat(upgrade): Use GitHub token if available when downloading patches (#10515) by @Tobbe
 
-If a GitHub token is available in the environment we use that when fetching the git tree from GitHub. That way we're less likely to be rate limited
+If a GitHub token is available in the environment we use that when fetching the
+git tree from GitHub. That way we're less likely to be rate limited. For most
+users the token shouldn't be needed. The free allowance/usage of the GitHub API
+should be enough.
 
 We support `GH_TOKEN`, `GITHUB_TOKEN` and `REDWOOD_GITHUB_TOKEN` as the env var names

--- a/.changesets/10515.md
+++ b/.changesets/10515.md
@@ -1,0 +1,5 @@
+- feat(upgrade): Use GitHub token if available when downloading patches (#10515) by @Tobbe
+
+If a GitHub token is available in the environment we use that when fetching the git tree from GitHub. That way we're less likely to be rate limited
+
+We support `GH_TOKEN`, `GITHUB_TOKEN` and `REDWOOD_GITHUB_TOKEN` as the env var names


### PR DESCRIPTION
If a GitHub token is available in the environment we use that when fetching the git tree from GitHub. That way we're less likely to be rate limited

Depends on #10497 