### PR TITLE
fix(dbauth-mw): Use response passed in to middleware

### DIFF
--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
@@ -23,26 +23,7 @@ afterAll(() => {
 })
 
 describe('createDbAuthMiddleware()', () => {
-  // beforeAll(() => {
-  //   vi.mock('@redwoodjs/auth-dbauth-api', async (importOriginal) => {
-  //     const actual = await importOriginal<object>()
-  //     return {
-  //       ...actual,
-  //       dbAuthSession: vi.fn().mockResolvedValue({
-  //         user: {
-  //           id: 'fake-user',
-  //           email: 'fakeuser@bazinga.com',
-  //         },
-  //       }),
-  //     }
-  //   })
-  // })
-
-  // afterAll(() => {
-  //   vi.resetAllMocks()
-  // })
-
-  it('When no cookie headers, pass through', async () => {
+  it('When no cookie headers, pass through the response', async () => {
     const options: DbAuthMiddlewareOptions = {
       cookieName: '8911',
       getCurrentUser: async () => {
@@ -63,7 +44,7 @@ describe('createDbAuthMiddleware()', () => {
       url: 'http://localhost:8911',
     } as MiddlewareRequest
 
-    // Intentionally overriding the res value to be something else
+    // Typecase for the test
     const res = await middleware(req, { passthrough: true } as any)
 
     expect(res).toEqual({ passthrough: true })
@@ -109,7 +90,7 @@ describe('createDbAuthMiddleware()', () => {
       },
     })
 
-    // Allow react render
+    // Allow react render, because body is not defined, and status code not redirect
     expect(res).toHaveProperty('body', undefined)
     expect(res).toHaveProperty('status', 200)
   })

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -27,9 +27,10 @@ export const createDbAuthMiddleware = ({
   getCurrentUser,
   dbAuthUrl = '/middleware/dbauth',
 }: DbAuthMiddlewareOptions) => {
-  return async (req: MiddlewareRequest) => {
-    const res = MiddlewareResponse.next()
-
+  return async (
+    req: MiddlewareRequest,
+    res: MiddlewareResponse = MiddlewareResponse.next(),
+  ) => {
     // Handoff POST requests to the dbAuthHandler. The url is configurable on the dbAuth client side.
     // This is where we handle login, logout, and signup, etc., but we don't want to intercept
     if (req.method === 'POST') {


### PR DESCRIPTION
Middleware can be chained - which means if auth middleware is not the first one on the list of middleware being registered, we need to use the `MiddlewareResponse` that gets passed to the middleware, instead of creating a new one.

Also adds test for the positive case where a valid cookie gets decrypted, and sets server auth context.