### PR TITLE
chore(tests): Fix packages/web tests

### DIFF
--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -22,6 +22,7 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "@apollo/client/rehackt": "0.0.0-pr.10.0"
+    "@apollo/client/rehackt": "0.0.0-pr.10.0",
+    "react-is": "19.0.0-canary-cb151849e1-20240424"
   }
 }

--- a/__fixtures__/test-project-rsc-external-packages-and-cells/package.json
+++ b/__fixtures__/test-project-rsc-external-packages-and-cells/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "@apollo/client/rehackt": "0.0.0-pr.10.0"
+    "@apollo/client/rehackt": "0.0.0-pr.10.0",
+    "react-is": "19.0.0-canary-cb151849e1-20240424"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "@apollo/client/rehackt": "0.0.0-pr.10.0"
+    "@apollo/client/rehackt": "0.0.0-pr.10.0",
+    "react-is": "19.0.0-canary-cb151849e1-20240424"
   }
 }

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "@apollo/client/rehackt": "0.0.0-pr.10.0"
+    "@apollo/client/rehackt": "0.0.0-pr.10.0",
+    "react-is": "19.0.0-canary-cb151849e1-20240424"
   }
 }

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "@apollo/client/rehackt": "0.0.0-pr.10.0"
+    "@apollo/client/rehackt": "0.0.0-pr.10.0",
+    "react-is": "19.0.0-canary-cb151849e1-20240424"
   }
 }


### PR DESCRIPTION
React 19 changed the Symbol name it uses for standard html elements. The Jest pretty printer uses `react-it` to figure out how to convert JSX to a string for comparisons in tests. So we have to put a resolution in place for `react-it` to get a version that's updated to also work with the new React 19 symbol name