### PR TITLE
Add redwood.toml to `yarn rw info`

### DIFF
--- a/.changesets/10518.md
+++ b/.changesets/10518.md
@@ -1,0 +1,48 @@
+- Add redwood.toml to `yarn rw info` (#10518) by @Tobbe
+
+The project `redwood.toml` file is now included in the `yarn rw info` output to
+make it easier and faster to help with issue reports
+
+
+## Before
+```
+  System:
+    OS: macOS 14.1.1
+    Shell: 5.9 - /bin/zsh
+  Binaries:
+    Node: 20.11.0 - /usr/local/bin/node
+    Yarn: 4.1.1 - /usr/local/bin/yarn
+  Databases:
+    SQLite: 3.39.5 - /usr/bin/sqlite3
+  Browsers:
+    Safari: 17.1
+```
+
+## After
+```
+  System:
+    OS: macOS 14.1.1
+    Shell: 5.9 - /bin/zsh
+  Binaries:
+    Node: 20.11.0 - /usr/local/bin/node
+    Yarn: 4.1.1 - /usr/local/bin/yarn
+  Databases:
+    SQLite: 3.39.5 - /usr/bin/sqlite3
+  Browsers:
+    Safari: 17.1
+  redwood.toml:
+    [web]
+      title = "Redwood App"
+      port = 8910
+      apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+      includeEnvironmentVariables = [
+        # Add any ENV vars that should be available to the web side to this array
+        # See https://redwoodjs.com/docs/environment-variables#web
+      ]
+    [api]
+      port = 8911
+    [browser]
+      open = true
+    [notifications]
+      versionUpdates = ["latest"]
+```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "autoplay",
     "bazinga",
     "corepack",
+    "envinfo",
     "execa",
     "Fastify",
     "Flightcontrol",

--- a/packages/cli/src/commands/__tests__/info.test.js
+++ b/packages/cli/src/commands/__tests__/info.test.js
@@ -1,0 +1,116 @@
+// import '../../lib/test'
+import '../../lib/mockTelemetry'
+
+import { vi, afterEach, beforeEach, describe, it, expect } from 'vitest'
+
+import { handler } from '../info'
+
+vi.mock('envinfo', () => ({ default: { run: () => '' } }))
+vi.mock('@redwoodjs/project-config', () => ({ getPaths: () => ({}) }))
+
+const mockRedwoodToml = {
+  fileContents: '',
+}
+
+// Before rw tests run, api/ and web/ `jest.config.js` is confirmed via existsSync()
+vi.mock('node:fs', async () => ({
+  default: {
+    readFileSync: () => {
+      return mockRedwoodToml.fileContents
+    },
+  },
+}))
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.mocked(console).log.mockRestore()
+})
+
+describe('yarn rw info', () => {
+  describe('redwood.toml', () => {
+    it('is included in the output', async () => {
+      mockRedwoodToml.fileContents = 'title = "Hello World"'
+
+      await handler()
+
+      expect(vi.mocked(console).log).toHaveBeenCalledWith(
+        [
+          // There should be nothing before 'redwood.toml:' in the output
+          // because we mock envinfo
+          '  redwood.toml:',
+          '    title = "Hello World"',
+        ].join('\n'),
+      )
+    })
+
+    it('has blank lines removed', async () => {
+      mockRedwoodToml.fileContents = `
+[web]
+
+  title = "Hello World"
+`
+
+      await handler()
+
+      expect(vi.mocked(console).log).toHaveBeenCalledWith(
+        [
+          // The important part is that there is no blank line after [web]
+          '  redwood.toml:',
+          '    [web]',
+          '      title = "Hello World"',
+        ].join('\n'),
+      )
+    })
+
+    it('has start-of-line-comment lines removed', async () => {
+      mockRedwoodToml.fileContents = `
+# This is a start-of-line-comment that we want to remove.
+# And so is this
+[web]
+  # Used for the <title> tag (this comment should be kept)
+  title = "Hello World"
+
+# Another comment that should be removed
+`
+
+      await handler()
+
+      expect(vi.mocked(console).log).toHaveBeenCalledWith(
+        [
+          '  redwood.toml:',
+          '    [web]',
+          '      # Used for the <title> tag (this comment should be kept)',
+          '      title = "Hello World"',
+        ].join('\n'),
+      )
+    })
+
+    // TODO: Actually want to strip this comment, but it's too much work to do
+    // without a proper parser and pretty-printer. (We've tried finding one,
+    // but couldn't find anything. So we'll have to write our own at some
+    // point)
+    it('keeps end-of-line comments', async () => {
+      mockRedwoodToml.fileContents = `
+[web]
+  title = "Hello World" # Used for the <title> tag
+  apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
+`
+
+      await handler()
+
+      expect(vi.mocked(console).log).toHaveBeenCalledWith(
+        [
+          '  redwood.toml:',
+          '    [web]',
+          '      title = "Hello World" # Used for the <title> tag',
+          // This next line is a bit more tricky because it has a # to make it
+          // a comment, but then also a # in the URL.
+          '      apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths',
+        ].join('\n'),
+      )
+    })
+  })
+})

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -32,14 +32,18 @@ export const handler = async () => {
 
   const redwoodToml = fs.readFileSync(getPaths().base + '/redwood.toml', 'utf8')
 
-  console.log(
-    output +
-      '  redwood.toml:\n' +
-      redwoodToml
-        .split('\n')
-        .filter((line) => line.trim().length > 0)
-        .filter((line) => !/^#/.test(line))
-        .map((line) => `    ${line}`)
-        .join('\n'),
-  )
+  console.log(output)
+
+  if (Math.random() > 5) {
+    console.log(
+      output +
+        '  redwood.toml:\n' +
+        redwoodToml
+          .split('\n')
+          .filter((line) => line.trim().length > 0)
+          .filter((line) => !/^#/.test(line))
+          .map((line) => `    ${line}`)
+          .join('\n'),
+    )
+  }
 }

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -32,18 +32,14 @@ export const handler = async () => {
 
   const redwoodToml = fs.readFileSync(getPaths().base + '/redwood.toml', 'utf8')
 
-  console.log(output)
-
-  if (Math.random() > 5) {
-    console.log(
-      output +
-        '  redwood.toml:\n' +
-        redwoodToml
-          .split('\n')
-          .filter((line) => line.trim().length > 0)
-          .filter((line) => !/^#/.test(line))
-          .map((line) => `    ${line}`)
-          .join('\n'),
-    )
-  }
+  console.log(
+    output +
+      '  redwood.toml:\n' +
+      redwoodToml
+        .split('\n')
+        .filter((line) => line.trim().length > 0)
+        .filter((line) => !/^#/.test(line))
+        .map((line) => `    ${line}`)
+        .join('\n'),
+  )
 }

--- a/packages/cli/src/commands/info.js
+++ b/packages/cli/src/commands/info.js
@@ -1,9 +1,12 @@
 // inspired by gatsby/packages/gatsby-cli/src/create-cli.js and
-// and gridsome/packages/cli/lib/commands/info.js
+// gridsome/packages/cli/lib/commands/info.js
+import fs from 'node:fs'
+
 import envinfo from 'envinfo'
 import terminalLink from 'terminal-link'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
+import { getPaths } from '@redwoodjs/project-config'
 
 export const command = 'info'
 export const description = 'Print your system environment information'
@@ -16,9 +19,8 @@ export const builder = (yargs) => {
   )
 }
 export const handler = async () => {
-  recordTelemetryAttributes({
-    command: 'info',
-  })
+  recordTelemetryAttributes({ command: 'info' })
+
   const output = await envinfo.run({
     System: ['OS', 'Shell'],
     Binaries: ['Node', 'Yarn'],
@@ -27,5 +29,17 @@ export const handler = async () => {
     npmPackages: '@redwoodjs/*',
     Databases: ['SQLite'],
   })
-  console.log(output)
+
+  const redwoodToml = fs.readFileSync(getPaths().base + '/redwood.toml', 'utf8')
+
+  console.log(
+    output +
+      '  redwood.toml:\n' +
+      redwoodToml
+        .split('\n')
+        .filter((line) => line.trim().length > 0)
+        .filter((line) => !/^#/.test(line))
+        .map((line) => `    ${line}`)
+        .join('\n'),
+  )
 }


### PR DESCRIPTION
As people start trying more experimental features, like streaming-ssr and RSCs it'll be good to know exactly what redwood.toml settings they have.

This PR includes (a somewhat slimmed down version of) their redwood.toml in the `yarn rw info` output that we ask everyone to include in their issue reports.
(It would have helped with my misunderstanding of the issue in https://github.com/redwoodjs/redwood/issues/10511 and saved @dthyresson from asking about the `apiGraphQLUrl` in https://github.com/redwoodjs/redwood/issues/10470, etc)


## Before
```
  System:
    OS: macOS 14.1.1
    Shell: 5.9 - /bin/zsh
  Binaries:
    Node: 20.11.0 - /usr/local/bin/node
    Yarn: 4.1.1 - /usr/local/bin/yarn
  Databases:
    SQLite: 3.39.5 - /usr/bin/sqlite3
  Browsers:
    Safari: 17.1
```

## After
```
  System:
    OS: macOS 14.1.1
    Shell: 5.9 - /bin/zsh
  Binaries:
    Node: 20.11.0 - /usr/local/bin/node
    Yarn: 4.1.1 - /usr/local/bin/yarn
  Databases:
    SQLite: 3.39.5 - /usr/bin/sqlite3
  Browsers:
    Safari: 17.1
  redwood.toml:
    [web]
      title = "Redwood App"
      port = 8910
      apiUrl = "/.redwood/functions" # You can customize graphql and dbauth urls individually too: see https://redwoodjs.com/docs/app-configuration-redwood-toml#api-paths
      includeEnvironmentVariables = [
        # Add any ENV vars that should be available to the web side to this array
        # See https://redwoodjs.com/docs/environment-variables#web
      ]
    [api]
      port = 8911
    [browser]
      open = true
    [notifications]
      versionUpdates = ["latest"]
```
