### PR TITLE
feat(eslint): Disable restricted $api imports for entryserver

### DIFF
--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -196,7 +196,10 @@ module.exports = {
       },
     },
     {
-      files: ['web/src/**/*.routeHooks.{js,ts}'],
+      files: [
+        'web/src/**/*.routeHooks.{js,ts}',
+        'web/src/entry.server.{jsx,tsx}',
+      ],
       rules: { 'no-restricted-imports': 'off' },
     },
   ],


### PR DESCRIPTION
As title. 

With the introduction of middleware, it's pretty common to import things from the $api side. This is a non-issue as entry.server.{jsx,tsx} is not part of the client bundle we generate. 