### PR TITLE
chore(cli): Wrap NodeSSH to make sshExec an instance method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
   "peacock.color": "#b85833",
   "cSpell.words": [
     "autoplay",
+    "baremetal",
     "bazinga",
     "corepack",
     "envinfo",

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -13,6 +13,8 @@ import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
 import { getPaths } from '../../lib'
 import c from '../../lib/colors'
 
+import { SshExecutor } from './baremetal/SshExecutor'
+
 const CONFIG_FILENAME = 'deploy.toml'
 const SYMLINK_FLAGS = '-nsf'
 const CURRENT_RELEASE_SYMLINK_NAME = 'current'
@@ -653,47 +655,6 @@ export const commands = (yargs, ssh) => {
   }
 
   return servers
-}
-
-class SshExecutor {
-  constructor() {
-    const { NodeSSH } = require('node-ssh')
-    this.ssh = new NodeSSH()
-  }
-
-  /**
-   * Executes a single command via SSH connection. Throws an error and sets
-   * the exit code with the same code returned from the SSH command.
-   */
-  async exec(path, command, args) {
-    let sshCommand = command
-
-    if (args) {
-      sshCommand += ` ${args.join(' ')}`
-    }
-
-    const result = await this.ssh.execCommand(sshCommand, {
-      cwd: path,
-    })
-
-    if (result.code !== 0) {
-      const error = new Error(
-        `Error while running command \`${command} ${args.join(' ')}\``,
-      )
-      error.exitCode = result.code
-      throw error
-    }
-
-    return result
-  }
-
-  connect(options) {
-    return this.ssh.connect(options)
-  }
-
-  dispose() {
-    return this.ssh.dispose()
-  }
 }
 
 export const handler = async (yargs) => {

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -131,30 +131,6 @@ export const builder = (yargs) => {
   )
 }
 
-// Executes a single command via SSH connection. Throws an error and sets
-// the exit code with the same code returned from the SSH command.
-const sshExec = async (ssh, path, command, args) => {
-  let sshCommand = command
-
-  if (args) {
-    sshCommand += ` ${args.join(' ')}`
-  }
-
-  const result = await ssh.execCommand(sshCommand, {
-    cwd: path,
-  })
-
-  if (result.code !== 0) {
-    const error = new Error(
-      `Error while running command \`${command} ${args.join(' ')}\``,
-    )
-    error.exitCode = result.code
-    throw error
-  }
-
-  return result
-}
-
 export const throwMissingConfig = (name) => {
   throw new Error(
     `"${name}" config option not set. See https://redwoodjs.com/docs/deployment/baremetal#deploytoml`,
@@ -192,7 +168,7 @@ export const verifyServerConfig = (config) => {
 }
 
 const symlinkCurrentCommand = async (dir, ssh, path) => {
-  return await sshExec(ssh, path, 'ln', [
+  return await ssh.exec(path, 'ln', [
     SYMLINK_FLAGS,
     dir,
     CURRENT_RELEASE_SYMLINK_NAME,
@@ -200,7 +176,7 @@ const symlinkCurrentCommand = async (dir, ssh, path) => {
 }
 
 const restartProcessCommand = async (processName, ssh, serverConfig, path) => {
-  return await sshExec(ssh, path, serverConfig.monitorCommand, [
+  return await ssh.exec(path, serverConfig.monitorCommand, [
     'restart',
     processName,
   ])
@@ -222,11 +198,11 @@ export const maintenanceTasks = (status, ssh, serverConfig) => {
     tasks.push({
       title: `Enabling maintenance page...`,
       task: async () => {
-        await sshExec(ssh, deployPath, 'cp', [
+        await ssh.exec(deployPath, 'cp', [
           pathJoin('web', 'dist', '200.html'),
           pathJoin('web', 'dist', '200.html.orig'),
         ])
-        await sshExec(ssh, deployPath, 'ln', [
+        await ssh.exec(deployPath, 'ln', [
           SYMLINK_FLAGS,
           pathJoin('..', 'src', 'maintenance.html'),
           pathJoin('web', 'dist', '200.html'),
@@ -238,7 +214,7 @@ export const maintenanceTasks = (status, ssh, serverConfig) => {
       tasks.push({
         title: `Stopping ${serverConfig.processNames.join(', ')} processes...`,
         task: async () => {
-          await sshExec(ssh, serverConfig.path, serverConfig.monitorCommand, [
+          await ssh.exec(serverConfig.path, serverConfig.monitorCommand, [
             'stop',
             serverConfig.processNames.join(' '),
           ])
@@ -249,7 +225,7 @@ export const maintenanceTasks = (status, ssh, serverConfig) => {
     tasks.push({
       title: `Starting ${serverConfig.processNames.join(', ')} processes...`,
       task: async () => {
-        await sshExec(ssh, serverConfig.path, serverConfig.monitorCommand, [
+        await ssh.exec(serverConfig.path, serverConfig.monitorCommand, [
           'start',
           serverConfig.processNames.join(' '),
         ])
@@ -260,10 +236,10 @@ export const maintenanceTasks = (status, ssh, serverConfig) => {
       tasks.push({
         title: `Disabling maintenance page...`,
         task: async () => {
-          await sshExec(ssh, deployPath, 'rm', [
+          await ssh.exec(deployPath, 'rm', [
             pathJoin('web', 'dist', '200.html'),
           ])
-          await sshExec(ssh, deployPath, 'cp', [
+          await ssh.exec(deployPath, 'cp', [
             pathJoin('web', 'dist', '200.html.orig'),
             pathJoin('web', 'dist', '200.html'),
           ])
@@ -287,13 +263,11 @@ export const rollbackTasks = (count, ssh, serverConfig) => {
       title: `Rolling back ${rollbackCount} release(s)...`,
       task: async () => {
         const currentLink = (
-          await sshExec(ssh, serverConfig.path, 'readlink', ['-f', 'current'])
+          await ssh.exec(serverConfig.path, 'readlink', ['-f', 'current'])
         ).stdout
           .split('/')
           .pop()
-        const dirs = (
-          await sshExec(ssh, serverConfig.path, 'ls', ['-t'])
-        ).stdout
+        const dirs = (await ssh.exec(serverConfig.path, 'ls', ['-t'])).stdout
           .split('\n')
           .filter((dirs) => !dirs.match(/current/))
 
@@ -350,7 +324,7 @@ export const lifecycleTask = (
       tasks.push({
         title: `${titleCase(lifecycle)} ${task}: \`${command}\``,
         task: async () => {
-          await sshExec(ssh, cmdPath, command)
+          await ssh.exec(cmdPath, command)
         },
         skip: () => skip,
       })
@@ -371,6 +345,13 @@ export const commandWithLifecycleEvents = ({ name, config, skip, command }) => {
   return tasks.flat().filter((t) => t)
 }
 
+/**
+ * @param {Yargs} yargs
+ * @param {SshExecutor} ssh
+ * @param {*} serverConfig
+ * @param {*} serverLifecycle
+ * @returns Yargs tasks
+ */
 export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
   const cmdPath = pathJoin(serverConfig.path, yargs.releaseDir)
   const config = { yargs, ssh, serverConfig, serverLifecycle, cmdPath }
@@ -384,7 +365,7 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
       command: {
         title: `Cloning \`${serverConfig.branch}\` branch...`,
         task: async () => {
-          await sshExec(ssh, serverConfig.path, 'git', [
+          await ssh.exec(serverConfig.path, 'git', [
             'clone',
             `--branch=${serverConfig.branch}`,
             `--depth=1`,
@@ -404,7 +385,7 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
       command: {
         title: `Symlink .env...`,
         task: async () => {
-          await sshExec(ssh, cmdPath, 'ln', [SYMLINK_FLAGS, '../.env', '.env'])
+          await ssh.exec(cmdPath, 'ln', [SYMLINK_FLAGS, '../.env', '.env'])
         },
       },
     }),
@@ -418,7 +399,7 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
       command: {
         title: `Installing dependencies...`,
         task: async () => {
-          await sshExec(ssh, cmdPath, serverConfig.packageManagerCommand, [
+          await ssh.exec(cmdPath, serverConfig.packageManagerCommand, [
             'install',
           ])
         },
@@ -434,18 +415,18 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
       command: {
         title: `DB Migrations...`,
         task: async () => {
-          await sshExec(ssh, cmdPath, serverConfig.packageManagerCommand, [
+          await ssh.exec(cmdPath, serverConfig.packageManagerCommand, [
             'rw',
             'prisma',
             'migrate',
             'deploy',
           ])
-          await sshExec(ssh, cmdPath, serverConfig.packageManagerCommand, [
+          await ssh.exec(cmdPath, serverConfig.packageManagerCommand, [
             'rw',
             'prisma',
             'generate',
           ])
-          await sshExec(ssh, cmdPath, serverConfig.packageManagerCommand, [
+          await ssh.exec(cmdPath, serverConfig.packageManagerCommand, [
             'rw',
             'dataMigrate',
             'up',
@@ -464,7 +445,7 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
         command: {
           title: `Building ${side}...`,
           task: async () => {
-            await sshExec(ssh, cmdPath, serverConfig.packageManagerCommand, [
+            await ssh.exec(cmdPath, serverConfig.packageManagerCommand, [
               'rw',
               'build',
               side,
@@ -501,20 +482,12 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
             command: {
               title: `Starting ${processName} process for the first time...`,
               task: async () => {
-                await sshExec(
-                  ssh,
-                  serverConfig.path,
-                  serverConfig.monitorCommand,
-                  [
-                    'start',
-                    pathJoin(
-                      CURRENT_RELEASE_SYMLINK_NAME,
-                      'ecosystem.config.js',
-                    ),
-                    '--only',
-                    processName,
-                  ],
-                )
+                await ssh.exec(serverConfig.path, serverConfig.monitorCommand, [
+                  'start',
+                  pathJoin(CURRENT_RELEASE_SYMLINK_NAME, 'ecosystem.config.js'),
+                  '--only',
+                  processName,
+                ])
               },
             },
           }),
@@ -522,7 +495,7 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
         tasks.push({
           title: `Saving ${processName} state for future startup...`,
           task: async () => {
-            await sshExec(ssh, serverConfig.path, serverConfig.monitorCommand, [
+            await ssh.exec(serverConfig.path, serverConfig.monitorCommand, [
               'save',
             ])
           },
@@ -562,8 +535,7 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
           // add 2 to skip `current` and start on the keepReleases + 1th release
           const fileStartIndex = serverConfig.keepReleases + 2
 
-          await sshExec(
-            ssh,
+          await ssh.exec(
             serverConfig.path,
             `ls -t | tail -n +${fileStartIndex} | xargs rm -rf`,
           )
@@ -613,6 +585,11 @@ export const parseConfig = (yargs, rawConfigToml) => {
   return { envConfig, envLifecycle }
 }
 
+/**
+ * @param {Yargs} yargs
+ * @param {SshExecutor} ssh
+ * @returns Yargs tasks
+ */
 export const commands = (yargs, ssh) => {
   const deployConfig = fs
     .readFileSync(pathJoin(getPaths().base, CONFIG_FILENAME))
@@ -678,6 +655,47 @@ export const commands = (yargs, ssh) => {
   return servers
 }
 
+class SshExecutor {
+  constructor() {
+    const { NodeSSH } = require('node-ssh')
+    this.ssh = new NodeSSH()
+  }
+
+  /**
+   * Executes a single command via SSH connection. Throws an error and sets
+   * the exit code with the same code returned from the SSH command.
+   */
+  async exec(path, command, args) {
+    let sshCommand = command
+
+    if (args) {
+      sshCommand += ` ${args.join(' ')}`
+    }
+
+    const result = await this.ssh.execCommand(sshCommand, {
+      cwd: path,
+    })
+
+    if (result.code !== 0) {
+      const error = new Error(
+        `Error while running command \`${command} ${args.join(' ')}\``,
+      )
+      error.exitCode = result.code
+      throw error
+    }
+
+    return result
+  }
+
+  connect(options) {
+    return this.ssh.connect(options)
+  }
+
+  dispose() {
+    return this.ssh.dispose()
+  }
+}
+
 export const handler = async (yargs) => {
   recordTelemetryAttributes({
     command: 'deploy baremetal',
@@ -693,8 +711,7 @@ export const handler = async (yargs) => {
     verbose: yargs.verbose,
   })
 
-  const { NodeSSH } = require('node-ssh')
-  const ssh = new NodeSSH()
+  const ssh = new SshExecutor()
 
   try {
     const tasks = new Listr(commands(yargs, ssh), {

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -1,0 +1,40 @@
+export class SshExecutor {
+  constructor() {
+    const { NodeSSH } = require('node-ssh')
+    this.ssh = new NodeSSH()
+  }
+
+  /**
+   * Executes a single command via SSH connection. Throws an error and sets
+   * the exit code with the same code returned from the SSH command.
+   */
+  async exec(path, command, args) {
+    let sshCommand = command
+
+    if (args) {
+      sshCommand += ` ${args.join(' ')}`
+    }
+
+    const result = await this.ssh.execCommand(sshCommand, {
+      cwd: path,
+    })
+
+    if (result.code !== 0) {
+      const error = new Error(
+        `Error while running command \`${command} ${args.join(' ')}\``,
+      )
+      error.exitCode = result.code
+      throw error
+    }
+
+    return result
+  }
+
+  connect(options) {
+    return this.ssh.connect(options)
+  }
+
+  dispose() {
+    return this.ssh.dispose()
+  }
+}


### PR DESCRIPTION
Refactoring NodeSSH usage in baremetal deploy command to make `sshExec` an instance method instead.
So that you can do `ssh.exec(...)` instead of `sshExec(ssh, ...)`. Also put the new class I introduced into its own file, because `baremetal.js` is too long! It's difficult to navigate.

The refactor is in preparation of some upcoming changes where I want to be able to customize `sshExec` without passing more options to every invocation of it.