### PR TITLE
feat(baremetal): Add verbose output to ssh exec

### DIFF
--- a/.changesets/10525.md
+++ b/.changesets/10525.md
@@ -1,6 +1,10 @@
 - feat(baremetal): Add verbose output to ssh exec (#10525) by @Tobbe
 
-Passing `--verbose` to the baremetal deploy command is supposed to give you more detailed info about what's happening. This is especially useful if something goes wrong and you get an error. Previously however passing `--verbose` didn't actually provide any extra information about why an SSH command might have failed. With this PR you'll now see what path it's trying to execute the command in, and what the exact error message was if it failed.
+Passing `--verbose` to the baremetal deploy command is supposed to give you
+more detailed info about what's happening. Previously however passing
+`--verbose` didn't actually provide any extra information. This PR adds logging
+to the new SshExecutor class so that you can see exactly what SSH commands are
+being run, and in what path.
 
 Standard output (this stays the same before and after)
 ![image](https://github.com/redwoodjs/redwood/assets/30793/588fcf3d-b059-42d2-a1af-d2fff8b3e4bd)
@@ -10,4 +14,4 @@ Standard output (this stays the same before and after)
 Doesn't really help much compared to the standard output 😅
 
 ## After (verbose output)
-![image](https://github.com/redwoodjs/redwood/assets/30793/02e42560-8e6e-439c-9dd8-1360ba673ffe)
+![image](https://github.com/redwoodjs/redwood/assets/30793/4a87bde4-072f-4bae-a84e-50ac72afe964)

--- a/.changesets/10525.md
+++ b/.changesets/10525.md
@@ -1,0 +1,13 @@
+- feat(baremetal): Add verbose output to ssh exec (#10525) by @Tobbe
+
+Passing `--verbose` to the baremetal deploy command is supposed to give you more detailed info about what's happening. This is especially useful if something goes wrong and you get an error. Previously however passing `--verbose` didn't actually provide any extra information about why an SSH command might have failed. With this PR you'll now see what path it's trying to execute the command in, and what the exact error message was if it failed.
+
+Standard output (this stays the same before and after)
+![image](https://github.com/redwoodjs/redwood/assets/30793/588fcf3d-b059-42d2-a1af-d2fff8b3e4bd)
+
+## Before (verbose output)
+![image](https://github.com/redwoodjs/redwood/assets/30793/65fdfe46-2e82-4c87-897b-99a438e16149)
+Doesn't really help much compared to the standard output 😅
+
+## After (verbose output)
+![image](https://github.com/redwoodjs/redwood/assets/30793/02e42560-8e6e-439c-9dd8-1360ba673ffe)

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -672,7 +672,7 @@ export const handler = async (yargs) => {
     verbose: yargs.verbose,
   })
 
-  const ssh = new SshExecutor()
+  const ssh = new SshExecutor(yargs.verbose)
 
   try {
     const tasks = new Listr(commands(yargs, ssh), {

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -16,19 +16,20 @@ export class SshExecutor {
       sshCommand += ` ${args.join(' ')}`
     }
 
+    if (this.verbose) {
+      console.log(
+        `SshExecutor::exec running command \`${command} ${args.join(' ')}\` in ${path}`,
+      )
+    }
+
     const result = await this.ssh.execCommand(sshCommand, {
       cwd: path,
     })
 
     if (result.code !== 0) {
-      const error = this.verbose
-        ? new Error(
-            `Error while running command \`${command} ${args.join(' ')}\` in ${path}\n` +
-              result.stderr,
-          )
-        : new Error(
-            `Error while running command \`${command} ${args.join(' ')}\``,
-          )
+      const error = new Error(
+        `Error while running command \`${command} ${args.join(' ')}\``,
+      )
       error.exitCode = result.code
       throw error
     }

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -1,7 +1,8 @@
 export class SshExecutor {
-  constructor() {
+  constructor(verbose) {
     const { NodeSSH } = require('node-ssh')
     this.ssh = new NodeSSH()
+    this.verbose = verbose
   }
 
   /**
@@ -20,9 +21,14 @@ export class SshExecutor {
     })
 
     if (result.code !== 0) {
-      const error = new Error(
-        `Error while running command \`${command} ${args.join(' ')}\``,
-      )
+      const error = this.verbose
+        ? new Error(
+            `Error while running command \`${command} ${args.join(' ')}\` in ${path}\n` +
+              result.stderr,
+          )
+        : new Error(
+            `Error while running command \`${command} ${args.join(' ')}\``,
+          )
       error.exitCode = result.code
       throw error
     }


### PR DESCRIPTION
Passing `--verbose` to the baremetal deploy command is supposed to give you more detailed info about what's happening. Previously however passing `--verbose` didn't actually provide any extra information. This PR adds logging to the new SshExecutor class so that you can see exactly what SSH commands are being run, and in what path.

Standard output (this stays the same before and after)
![image](https://github.com/redwoodjs/redwood/assets/30793/588fcf3d-b059-42d2-a1af-d2fff8b3e4bd)

## Before (verbose output)
![image](https://github.com/redwoodjs/redwood/assets/30793/65fdfe46-2e82-4c87-897b-99a438e16149)
Doesn't really help much compared to the standard output 😅

## After (verbose output)
![image](https://github.com/redwoodjs/redwood/assets/30793/4a87bde4-072f-4bae-a84e-50ac72afe964)