### PR TITLE
feat(baremetal): Add more details to error messages

### DIFF
--- a/.changesets/10527.md
+++ b/.changesets/10527.md
@@ -1,0 +1,10 @@
+- feat(baremetal): Add more details to error messages (#10527) by @Tobbe
+
+Now when an ssh command execution fails the error message will additionally
+include the directory it was executed in and the full stderr message
+
+## Before
+![image](https://github.com/redwoodjs/redwood/assets/30793/bda480ee-7c26-40c8-9128-42a830574a53)
+
+## After
+![image](https://github.com/redwoodjs/redwood/assets/30793/85080fa8-be2f-4638-9af1-0ba4c79057e3)

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -28,7 +28,8 @@ export class SshExecutor {
 
     if (result.code !== 0) {
       const error = new Error(
-        `Error while running command \`${command} ${args.join(' ')}\``,
+        `Error while running command \`${command} ${args.join(' ')}\` in ${path}\n` +
+          result.stderr,
       )
       error.exitCode = result.code
       throw error


### PR DESCRIPTION
Now when an ssh command execution fails the error message will additionally include the directory it was executed in and the full stderr message

## Before
![image](https://github.com/redwoodjs/redwood/assets/30793/bda480ee-7c26-40c8-9128-42a830574a53)

## After
![image](https://github.com/redwoodjs/redwood/assets/30793/85080fa8-be2f-4638-9af1-0ba4c79057e3)
