### PR TITLE
chore(server-auth): Automagic middleware auth on supported providers (dbAuth so far)

### DIFF
--- a/.changesets/10529.md
+++ b/.changesets/10529.md
@@ -1,0 +1,5 @@
+- chore(server-auth): Automagic middleware auth on supported providers (dbAuth so far) (#10529) by @dac09
+
+This change means that we will automatically configure the dbAuth client in middleware mode, based on the redwood.toml flag.
+
+Also renames `useMiddlewareAuth` -> `middlewareAuthEnabled`

--- a/packages/auth-providers/dbAuth/web/ambient.d.ts
+++ b/packages/auth-providers/dbAuth/web/ambient.d.ts
@@ -13,13 +13,12 @@ declare global {
    **/
   var RWJS_API_URL: string
 
-  // Provided by Vite.config in the user's project
+  // Provided by redwood-plugin-vite
   var RWJS_ENV: {
     RWJS_API_GRAPHQL_URL: string
-    /** URL or absolute path to serverless functions */
     RWJS_API_URL: string
-
     __REDWOOD__APP_TITLE: string
+    RWJS_EXP_STREAMING_SSR: boolean
   }
 
   namespace NodeJS {

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.middleware.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.middleware.test.ts
@@ -14,8 +14,7 @@ const defaultArgs = {
 export function getMwDbAuth(
   args: DbAuthClientArgs & CustomProviderHooks = defaultArgs,
 ) {
-  // We have to create a special createDbAuthClient with middleware = true
-  const dbAuthClient = createDbAuthClient({ ...args, middleware: true })
+  const dbAuthClient = createDbAuthClient({ ...args })
   const { useAuth, AuthProvider } = createAuth(dbAuthClient, {
     useCurrentUser: args.useCurrentUser,
     useHasRole: args.useHasRole,
@@ -31,6 +30,20 @@ export function getMwDbAuth(
 // They test the middleware specific things about the dbAuth client
 
 describe('dbAuth web ~ cookie/middleware auth', () => {
+  let originalEnv
+
+  // This tells the dbAuth client to setup in middleware mode
+  beforeAll(() => {
+    originalEnv = globalThis.RWJS_ENV
+    globalThis.RWJS_ENV = {
+      RWJS_EXP_STREAMING_SSR: true,
+    }
+  })
+
+  afterAll(() => {
+    globalThis.RWJS_ENV = originalEnv
+  })
+
   it('will create a middleware version of the auth client', async () => {
     const { current: dbAuthInstance } = getMwDbAuth()
 

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -91,6 +91,7 @@ fetchMock.mockImplementation(async (url, options) => {
 
 beforeAll(() => {
   globalThis.fetch = fetchMock
+  globalThis.RWJS_ENV = {}
 })
 
 beforeEach(() => {

--- a/packages/auth-providers/dbAuth/web/src/dbAuth.ts
+++ b/packages/auth-providers/dbAuth/web/src/dbAuth.ts
@@ -69,7 +69,7 @@ export function createDbAuthClient({
   webAuthn,
   dbAuthUrl,
   fetchConfig,
-  middleware = false,
+  middleware = RWJS_ENV.RWJS_EXP_STREAMING_SSR,
 }: DbAuthClientArgs = {}) {
   const credentials = fetchConfig?.credentials || 'same-origin'
   webAuthn?.setAuthApiUrl(dbAuthUrl)

--- a/packages/auth-providers/dbAuth/web/src/dbAuth.ts
+++ b/packages/auth-providers/dbAuth/web/src/dbAuth.ts
@@ -49,7 +49,7 @@ export function createAuth(
     ) => (rolesToCheck: string | string[]) => boolean
   },
 ) {
-  if (dbAuthClient.useMiddlewareAuth) {
+  if (dbAuthClient.middlewareAuthEnabled) {
     return createMiddlewareAuth(dbAuthClient, customProviderHooks)
   }
 
@@ -229,6 +229,6 @@ export function createDbAuthClient({
     // so we can get the dbAuthUrl in getCurrentUserFromMiddleware
     getAuthUrl: getDbAuthUrl,
     // This is so that we can skip fetching getCurrentUser in reauthenticate
-    useMiddlewareAuth: middleware,
+    middlewareAuthEnabled: middleware,
   }
 }

--- a/packages/auth/src/AuthImplementation.ts
+++ b/packages/auth/src/AuthImplementation.ts
@@ -53,8 +53,8 @@ export interface AuthImplementation<
    */
   loadWhileReauthenticating?: boolean
 
-  // 👇 @TODO: Naming! Middleware-auth only
-  useMiddlewareAuth?: boolean
+  // This property is either manually set by the user, or inferred from the experimental.streamingSsr setting in TOML
+  middlewareAuthEnabled?: boolean
   // This is the endpoint on the middleware we are going to hit for POST requests
   getAuthUrl?: () => string
 }

--- a/packages/auth/src/AuthProvider/useReauthenticate.ts
+++ b/packages/auth/src/AuthProvider/useReauthenticate.ts
@@ -54,7 +54,7 @@ export const useReauthenticate = <TUser>(
       } else {
         // Prevent a double fetch of the current user if the auth provider is using middleware
         let currentUser
-        if (authImplementation.useMiddlewareAuth) {
+        if (authImplementation.middlewareAuthEnabled) {
           // userMetadata === currentUser in middleware-auth
           currentUser = userMetadata
         } else {


### PR DESCRIPTION
Closes https://github.com/orgs/redwoodjs/projects/18/views/3?pane=issue&itemId=61343580

This change means that we will automatically configure the dbAuth client in middleware mode, based on the redwood.toml flag.

Originally I was hesitating to do this, because we were expecting to have to customise the supabase/firebase ones, but looks like we have a way around it! 

Also renames `useMiddlewareAuth` -> `middlewareAuthEnabled`

### What this means?
You create your dbAuth client exactly the same as before (no template changes necessary!)

```js
const dbAuthClient = createDbAuthClient({
  webAuthn: new WebAuthnClient(),
})

export const { AuthProvider, useAuth } = createAuth(dbAuthClient)
```