### PR TITLE
fix(middleware): Update invoke middleware implementation

### DIFF
--- a/.changesets/10537.md
+++ b/.changesets/10537.md
@@ -1,0 +1,13 @@
+- fix(mw): Make invokeOptions a non-optional type (#10537) by @dac09
+
+The invokeOptions is always supplied when invoking middleware, but may not always be used. 
+
+In order to do this, I had to change how middleware is invoked (use an object instead of parameters)
+
+```js
+// before
+const [mwRes] = await invoke(req, middleware, options)
+
+// after
+const [mwRes] = await invoke({req, middleware, options})
+```

--- a/.changesets/10537.md
+++ b/.changesets/10537.md
@@ -1,8 +1,8 @@
 - fix(mw): Make invokeOptions a non-optional type (#10537) by @dac09
 
-The invokeOptions is always supplied when invoking middleware, but may not always be used. 
+When a middleware is executed (inside invoke), we _always_ pass options, even if the middleware function itself is can be undefined (if the middleware router doesn't match anything). 
 
-In order to do this, I had to change how middleware is invoked (use an object instead of parameters)
+In order to do this, I had to change how middleware is invoked (use an object instead of parameters), because `options` is a required parameter following an optional parameter `middleware`
 
 ```js
 // before

--- a/packages/ogimage-gen/src/OgImageMiddleware.ts
+++ b/packages/ogimage-gen/src/OgImageMiddleware.ts
@@ -11,6 +11,7 @@ import type { RWRouteManifestItem } from '@redwoodjs/internal'
 import { getPaths } from '@redwoodjs/project-config'
 import { LocationProvider, matchPath } from '@redwoodjs/router'
 import type {
+  MiddlewareClass,
   MiddlewareInvokeOptions,
   MiddlewareRequest,
   MiddlewareResponse,
@@ -39,7 +40,7 @@ interface ComponentElementProps {
   debug: boolean
 }
 
-export default class OgImageMiddleware {
+export default class OgImageMiddleware implements MiddlewareClass {
   options: MwOptions
   App: React.FC
   Document: React.FC<{ css: string[]; meta: string[] }>

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -84,9 +84,13 @@ async function createServer() {
         return new Response('No middleware found', { status: 404 })
       }
 
-      const [mwRes] = await invoke(req, middleware, {
-        route,
-        viteDevServer: vite,
+      const [mwRes] = await invoke({
+        req,
+        middleware,
+        options: {
+          route,
+          viteDevServer: vite,
+        },
       })
 
       return mwRes.toResponse()

--- a/packages/vite/src/middleware/invokeMiddleware.test.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.test.ts
@@ -1,6 +1,5 @@
 import type { MockInstance } from 'vitest'
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
-import { M } from 'vitest/dist/reporters-P7C2ytIv.js'
 
 import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth'
 

--- a/packages/vite/src/middleware/invokeMiddleware.test.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.test.ts
@@ -1,5 +1,6 @@
 import type { MockInstance } from 'vitest'
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { M } from 'vitest/dist/reporters-P7C2ytIv.js'
 
 import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth'
 
@@ -9,7 +10,11 @@ import { MiddlewareResponse } from './MiddlewareResponse'
 
 describe('Invoke middleware', () => {
   test('returns a MiddlewareResponse, even if no middleware defined', async () => {
-    const [mwRes, authState] = await invoke(new Request('https://example.com'))
+    const [mwRes, authState] = await invoke({
+      req: new Request('https://example.com'),
+      middleware: undefined,
+      options: {},
+    })
     expect(mwRes).toBeInstanceOf(MiddlewareResponse)
     expect(authState).toEqual(middlewareDefaultAuthProviderState)
   })
@@ -22,10 +27,11 @@ describe('Invoke middleware', () => {
       })
     }
 
-    const [mwRes, authState] = await invoke(
-      new Request('https://example.com'),
-      fakeMiddleware,
-    )
+    const [mwRes, authState] = await invoke({
+      req: new Request('https://example.com'),
+      middleware: fakeMiddleware,
+      options: {},
+    })
 
     expect(mwRes).toBeInstanceOf(MiddlewareResponse)
     expect(authState).toEqual({
@@ -49,10 +55,11 @@ describe('Invoke middleware', () => {
         throw new Error('I want to break free')
       }
 
-      const [mwRes, authState] = await invoke(
-        new Request('https://example.com'),
-        throwingMiddleware,
-      )
+      const [mwRes, authState] = await invoke({
+        req: new Request('https://example.com'),
+        middleware: throwingMiddleware,
+        options: {},
+      })
 
       expect(mwRes).toBeInstanceOf(MiddlewareResponse)
       expect(authState).toEqual(middlewareDefaultAuthProviderState)

--- a/packages/vite/src/middleware/invokeMiddleware.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.ts
@@ -15,11 +15,15 @@ import type { Middleware, MiddlewareInvokeOptions } from './types.js'
  * Returns Tuple<MiddlewareResponse, ServerAuthState>
  *
  */
-export const invoke = async (
-  req: Request,
-  middleware?: Middleware,
-  options?: MiddlewareInvokeOptions,
-): Promise<[MiddlewareResponse, ServerAuthState]> => {
+export const invoke = async ({
+  req,
+  middleware,
+  options,
+}: {
+  req: Request
+  options: MiddlewareInvokeOptions
+  middleware?: Middleware
+}): Promise<[MiddlewareResponse, ServerAuthState]> => {
   if (typeof middleware !== 'function') {
     return [MiddlewareResponse.next(), middlewareDefaultAuthProviderState]
   }

--- a/packages/vite/src/middleware/register.ts
+++ b/packages/vite/src/middleware/register.ts
@@ -63,7 +63,7 @@ export const chain = (mwList: Middleware[]) => {
   return async (
     req: MiddlewareRequest,
     res: MiddlewareResponse = MiddlewareResponse.next(),
-    options?: MiddlewareInvokeOptions,
+    options: MiddlewareInvokeOptions,
   ) => {
     let response = res
     for (const mw of mwList) {

--- a/packages/vite/src/middleware/types.ts
+++ b/packages/vite/src/middleware/types.ts
@@ -8,7 +8,7 @@ import type { MiddlewareResponse } from './MiddlewareResponse.js'
 export type Middleware = (
   req: MiddlewareRequest,
   res: MiddlewareResponse,
-  options?: MiddlewareInvokeOptions,
+  options: MiddlewareInvokeOptions,
 ) => Promise<MiddlewareResponse> | MiddlewareResponse | void
 
 export interface MiddlewareClass {

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -107,7 +107,11 @@ export async function runFeServer() {
         return new Response('No middleware found', { status: 404 })
       }
 
-      const [mwRes] = await invoke(req, middleware, route ? { route } : {})
+      const [mwRes] = await invoke({
+        req,
+        middleware,
+        options: route ? { route } : {},
+      })
 
       return mwRes.toResponse()
     })

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -93,11 +93,15 @@ export const createReactStreamingHandler = async (
     if (middlewareRouter) {
       const matchedMw = middlewareRouter.find(req.method as HTTPMethod, req.url)
       ;[mwResponse, decodedAuthState = middlewareDefaultAuthProviderState] =
-        await invoke(req, matchedMw?.handler as Middleware | undefined, {
-          route: currentRoute,
-          cssPaths: getStylesheetLinks(currentRoute),
-          params: matchedMw?.params,
-          viteDevServer,
+        await invoke({
+          req,
+          middleware: matchedMw?.handler as Middleware | undefined,
+          options: {
+            route: currentRoute,
+            cssPaths: getStylesheetLinks(currentRoute),
+            params: matchedMw?.params,
+            viteDevServer,
+          },
         })
 
       // If mwResponse is a redirect, short-circuit here, and skip React rendering


### PR DESCRIPTION
Found an issue while writing up the blogpost on middleware. 

The invokeOptions is always supplied when invoking middleware, but may not always be used. 

In order to do this, I had to change how middleware is invoked (use an object instead of parameters)

```js
// before
const [mwRes] = await invoke(req, middleware, options)

// after
const [mwRes] = await invoke({req, middleware, options})
```
