### PR TITLE
fix(serverauth): Export dbAuthMiddleware as default export to match supabase

### DIFF
--- a/packages/auth-providers/dbAuth/middleware/README.md
+++ b/packages/auth-providers/dbAuth/middleware/README.md
@@ -5,7 +5,7 @@
 import type { TagDescriptor } from '@redwoodjs/web'
 
 import App from './App'
-import { createDbAuthMiddleware } from '@redwoodjs/auth-dbauth-middleware'
+import createDbAuthMiddleware from '@redwoodjs/auth-dbauth-middleware'
 import { Document } from './Document'
 
 // eslint-disable-next-line no-restricted-imports
@@ -22,7 +22,7 @@ export const registerMiddleware = () => {
     cookieName,
     dbAuthHandler,
     getCurrentUser,
-    // dbAuthUrl? optional
+   // dbAuthUrl? optional
   })
   return [dbAuthMiddleware]
 }

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -111,3 +111,5 @@ export const createDbAuthMiddleware = ({
     return res
   }
 }
+
+export default createDbAuthMiddleware


### PR DESCRIPTION
As title

```js
//before
import { createDbAuthMiddleware } from '@redwoodjs/auth-dbauth-middleware'

// after
import createDbAuthMiddleware from '@redwoodjs/auth-dbauth-middleware'
```