### PR TITLE
RSC: Remove one level of nesting for server-router

### DIFF
--- a/packages/router/src/server-router.tsx
+++ b/packages/router/src/server-router.tsx
@@ -21,26 +21,6 @@ export interface RouterProps
 }
 
 export const Router: React.FC<RouterProps> = ({
-  useAuth,
-  paramTypes,
-  pageLoadingDelay,
-  children,
-  location,
-}) => {
-  return (
-    // Level 1/3 (outer-most)
-    <LocationAwareRouter
-      useAuth={useAuth}
-      paramTypes={paramTypes}
-      pageLoadingDelay={pageLoadingDelay}
-      location={location}
-    >
-      {children}
-    </LocationAwareRouter>
-  )
-}
-
-const LocationAwareRouter: React.FC<RouterProps> = ({
   paramTypes,
   children,
   location,
@@ -135,7 +115,6 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
     }
   }
 
-  // Level 2/3 (LocationAwareRouter)
   return (
     <>
       {!redirectPath && page && (


### PR DESCRIPTION
For the server router we don't need `<LocationAwareRouter>` because we're not using contexts to store the location – we're passing it in as a prop instead. So this change just simplifies the code a bit to make it easier to read and understand.