### PR TITLE
chore(tests): Refactor analyzeRoutes test

### DIFF
--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -14,9 +14,11 @@ interface LayoutProps {
 const FakeLayout1 = ({ children }: LayoutProps) => (
   <div className="layout1">{children}</div>
 )
+
 const FakeLayout2 = ({ children }: LayoutProps) => (
   <div className="layout2">{children}</div>
 )
+
 const FakeLayout3 = ({ children }: LayoutProps) => (
   <div className="layout2">{children}</div>
 )
@@ -95,70 +97,52 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     expect(activeRoutePath).toBeDefined()
     expect(activeRoutePath).toBe('/recipe/{id}')
   })
+})
 
-  test('No home Route', () => {
-    const CheckRoutes = (
-      <Router>
-        <Route path="/iGots" name="iGots" page={FakePage} />
-        <Route path="/noHome" name="noHome" page={FakePage} />
-      </Router>
-    )
+describe('setWrapper', () => {
+  interface WrapperXProps {
+    children: React.ReactNode
+    id: string
+    passThruProp: string
+  }
 
-    const { pathRouteMap, namedRoutesMap, hasHomeRoute } = analyzeRoutes(
-      CheckRoutes.props.children,
-      {
-        currentPathName: '/',
-      },
-    )
+  const WrapperX = ({ children }: WrapperXProps) => (
+    <>
+      <h1>WrapperX</h1>
+      {children}
+    </>
+  )
 
-    expect(Object.keys(namedRoutesMap).length).toEqual(2)
-    expect(Object.keys(pathRouteMap).length).toEqual(2)
-    expect(hasHomeRoute).toBe(false)
-  })
+  interface WrapperYProps {
+    children: React.ReactNode
+    id: string
+    theme: string
+  }
 
-  test('Creates setWrapper map', () => {
-    interface WrapperXProps {
-      children: React.ReactNode
-      id: string
-      passThruProp: string
-    }
+  const WrapperY = ({ children }: WrapperYProps) => (
+    <>
+      <h1>WrapperY</h1>
+      {children}
+    </>
+  )
 
-    const WrapperX = ({ children }: WrapperXProps) => (
-      <>
-        <h1>WrapperA</h1>
-        {children}
-      </>
-    )
-
-    interface WrapperYProps {
-      children: React.ReactNode
-      id: string
-      theme: string
-    }
-
-    const WrapperY = ({ children }: WrapperYProps) => (
-      <>
-        <h1>WrapperY</h1>
-        {children}
-      </>
-    )
-
-    const Simple = (
-      <Router>
-        <Set wrap={[WrapperX]} id="set-one" passThruProp="bazinga">
-          <Route path="/a" name="routeA" page={FakePage} />
-          <Set wrap={[WrapperY]} id="set-two" theme="blue">
-            <Route name="routeB" path="/b" page={FakePage} />
-            <Route name="routeC" path="/c" page={FakePage} />
-          </Set>
+  const Simple = (
+    <Router>
+      <Set wrap={[WrapperX]} id="set-one" passThruProp="bazinga">
+        <Route path="/a" name="routeA" page={FakePage} />
+        <Set wrap={[WrapperY]} id="set-two" theme="blue">
+          <Route name="routeB" path="/b" page={FakePage} />
+          <Route name="routeC" path="/c" page={FakePage} />
         </Set>
-      </Router>
-    )
+      </Set>
+    </Router>
+  )
 
     const { pathRouteMap } = analyzeRoutes(Simple.props.children, {
       currentPathName: '/',
     })
 
+  test('Creates setWrapper map', () => {
     expect(pathRouteMap['/a']).toEqual(
       expect.objectContaining({
         redirect: null,
@@ -239,48 +223,6 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
   })
 
   test('Connects Set wrapper props with correct Set', () => {
-    interface WrapperXProps {
-      children: React.ReactNode
-      id: string
-      passThruProp: string
-    }
-
-    const WrapperX = ({ children }: WrapperXProps) => (
-      <>
-        <h1>WrapperA</h1>
-        {children}
-      </>
-    )
-
-    interface WrapperYProps {
-      children: React.ReactNode
-      id: string
-      theme: string
-    }
-
-    const WrapperY = ({ children }: WrapperYProps) => (
-      <>
-        <h1>WrapperY</h1>
-        {children}
-      </>
-    )
-
-    const Simple = (
-      <Router>
-        <Set wrap={[WrapperX]} id="set-one" passThruProp="bazinga">
-          <Route path="/a" name="routeA" page={FakePage} />
-          <Set wrap={[WrapperY]} id="set-two" theme="blue">
-            <Route name="routeB" path="/b" page={FakePage} />
-            <Route name="routeC" path="/c" page={FakePage} />
-          </Set>
-        </Set>
-      </Router>
-    )
-
-    const { pathRouteMap } = analyzeRoutes(Simple.props.children, {
-      currentPathName: '/',
-    })
-
     expect(pathRouteMap['/a']).toEqual(
       expect.objectContaining({
         redirect: null,
@@ -431,245 +373,257 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
 
     // @TODO finish writing the expectations
   })
+})
 
-  test('Handles Private', () => {
-    const Routes = (
-      <Router>
-        <Route path="/" name="home" page={FakePage} />
-        <Private unauthenticated="home">
-          <Route path="/private" name="privateRoute" page={FakePage} />
-        </Private>
-      </Router>
-    )
+test('No home Route', () => {
+  const CheckRoutes = (
+    <Router>
+      <Route path="/iGots" name="iGots" page={FakePage} />
+      <Route path="/noHome" name="noHome" page={FakePage} />
+    </Router>
+  )
 
-    const { pathRouteMap } = analyzeRoutes(Routes.props.children, {
+  const { pathRouteMap, namedRoutesMap, hasHomeRoute } = analyzeRoutes(
+    CheckRoutes.props.children,
+    {
       currentPathName: '/',
-    })
+    },
+  )
 
-    expect(pathRouteMap['/private']).toStrictEqual({
-      redirect: null,
-      name: 'privateRoute',
-      path: '/private',
-      whileLoadingPage: undefined,
-      page: FakePage,
-      sets: [
-        {
-          id: '1',
-          wrappers: [],
-          isPrivate: true,
-          props: { unauthenticated: 'home' },
-        },
-      ],
-    })
+  expect(Object.keys(namedRoutesMap).length).toEqual(2)
+  expect(Object.keys(pathRouteMap).length).toEqual(2)
+  expect(hasHomeRoute).toBe(false)
+})
+
+test('Handles Private', () => {
+  const Routes = (
+    <Router>
+      <Route path="/" name="home" page={FakePage} />
+      <Private unauthenticated="home">
+        <Route path="/private" name="privateRoute" page={FakePage} />
+      </Private>
+    </Router>
+  )
+
+  const { pathRouteMap } = analyzeRoutes(Routes.props.children, {
+    currentPathName: '/',
   })
 
-  test('Handles PrivateSet', () => {
-    const Routes = (
-      <Router>
-        <Route path="/" name="home" page={FakePage} />
-        <PrivateSet unauthenticated="home">
-          <Route path="/private" name="privateRoute" page={FakePage} />
-        </PrivateSet>
-      </Router>
-    )
+  expect(pathRouteMap['/private']).toStrictEqual({
+    redirect: null,
+    name: 'privateRoute',
+    path: '/private',
+    whileLoadingPage: undefined,
+    page: FakePage,
+    sets: [
+      {
+        id: '1',
+        wrappers: [],
+        isPrivate: true,
+        props: { unauthenticated: 'home' },
+      },
+    ],
+  })
+})
 
-    const { pathRouteMap } = analyzeRoutes(Routes.props.children, {
-      currentPathName: '/',
-    })
+test('Handles PrivateSet', () => {
+  const Routes = (
+    <Router>
+      <Route path="/" name="home" page={FakePage} />
+      <PrivateSet unauthenticated="home">
+        <Route path="/private" name="privateRoute" page={FakePage} />
+      </PrivateSet>
+    </Router>
+  )
 
-    expect(pathRouteMap['/private']).toStrictEqual({
-      redirect: null,
-      name: 'privateRoute',
-      path: '/private',
-      whileLoadingPage: undefined,
-      page: FakePage,
-      sets: [
-        {
-          id: '1',
-          wrappers: [],
-          isPrivate: true,
-          props: { unauthenticated: 'home' },
-        },
-      ],
-    })
+  const { pathRouteMap } = analyzeRoutes(Routes.props.children, {
+    currentPathName: '/',
   })
 
-  test('Redirect routes analysis', () => {
-    const RedirectedRoutes = (
-      <Router>
-        <Route path="/simple" redirect="/rdSimple" name="simple" />
+  expect(pathRouteMap['/private']).toStrictEqual({
+    redirect: null,
+    name: 'privateRoute',
+    path: '/private',
+    whileLoadingPage: undefined,
+    page: FakePage,
+    sets: [
+      {
+        id: '1',
+        wrappers: [],
+        isPrivate: true,
+        props: { unauthenticated: 'home' },
+      },
+    ],
+  })
+})
+
+test('Redirect routes analysis', () => {
+  const RedirectedRoutes = (
+    <Router>
+      <Route path="/simple" redirect="/rdSimple" name="simple" />
+      <Route
+        path="/rdSimple"
+        name="rdSimple"
+        page={() => <h1>Redirected page</h1>}
+      />
+    </Router>
+  )
+
+  const { pathRouteMap, namedRoutesMap } = analyzeRoutes(
+    RedirectedRoutes.props.children,
+    {
+      currentPathName: '/simple',
+    },
+  )
+
+  expect(pathRouteMap['/simple'].redirect).toBe('/rdSimple')
+  expect(pathRouteMap['/rdSimple'].redirect).toBeFalsy()
+
+  expect(Object.keys(namedRoutesMap).length).toBe(2)
+  expect(namedRoutesMap.simple()).toBe('/simple')
+  expect(namedRoutesMap.rdSimple()).toBe('/rdSimple')
+})
+
+test('Nested sets, and authentication logic', () => {
+  const PrivateAdminPage = () => <h1>Private Admin Page</h1>
+  const PrivateEmployeePage = () => <h1>Private Employee Page</h1>
+  const PrivateNoRolesAssigned = () => <h1>Private Employee Page</h1>
+
+  const RedirectedRoutes = (
+    <Router>
+      <Route path="/" page={FakePage} name="home" />
+      <PrivateSet unauthenticated="home">
         <Route
-          path="/rdSimple"
-          name="rdSimple"
-          page={() => <h1>Redirected page</h1>}
+          path="/no-roles-assigned"
+          page={PrivateNoRolesAssigned}
+          name="noRolesAssigned"
         />
-      </Router>
-    )
+        <Set
+          private
+          unauthenticated="noRolesAssigned"
+          roles={['ADMIN', 'EMPLOYEE']}
+          someProp="propFromNoRolesSet"
+        >
+          <PrivateSet unauthenticated="admin" roles={'EMPLOYEE'}>
+            <Route
+              path="/employee"
+              page={PrivateEmployeePage}
+              name="privateEmployee"
+            />
+          </PrivateSet>
 
-    const { pathRouteMap, namedRoutesMap } = analyzeRoutes(
-      RedirectedRoutes.props.children,
-      {
-        currentPathName: '/simple',
-      },
-    )
+          <PrivateSet unauthenticated="employee" roles={'ADMIN'}>
+            <Route path="/admin" page={PrivateAdminPage} name="privateAdmin" />
+          </PrivateSet>
+        </Set>
+      </PrivateSet>
+    </Router>
+  )
 
-    expect(pathRouteMap['/simple'].redirect).toBe('/rdSimple')
-    expect(pathRouteMap['/rdSimple'].redirect).toBeFalsy()
+  const { pathRouteMap, namedRoutesMap } = analyzeRoutes(
+    RedirectedRoutes.props.children,
+    {
+      currentPathName: '/does-not-exist',
+    },
+  )
 
-    // @TODO true for now, but we may not allow names on a redirect route
-    expect(Object.keys(namedRoutesMap).length).toBe(2)
-    expect(namedRoutesMap.simple()).toBe('/simple')
-    expect(namedRoutesMap.rdSimple()).toBe('/rdSimple')
+  // Level 1: wrapped with private
+  expect(pathRouteMap).toMatchObject({
+    '/no-roles-assigned': {
+      redirect: null,
+      sets: [
+        {
+          id: '1',
+          isPrivate: true,
+          props: { unauthenticated: 'home' },
+        },
+      ],
+    },
   })
 
-  test('Nested sets, and authentication logic', () => {
-    const HomePage = () => <h1>Home Page</h1>
-    const PrivateAdminPage = () => <h1>Private Admin Page</h1>
-    const PrivateEmployeePage = () => <h1>Private Employee Page</h1>
-    const PrivateNoRolesAssigned = () => <h1>Private Employee Page</h1>
+  expect(Object.keys(namedRoutesMap).length).toBe(4)
 
-    const RedirectedRoutes = (
-      <Router>
-        <Route path="/" page={HomePage} name="home" />
-        <PrivateSet unauthenticated="home">
-          <Route
-            path="/no-roles-assigned"
-            page={PrivateNoRolesAssigned}
-            name="noRolesAssigned"
-          />
-          <Set
-            private
-            unauthenticated="noRolesAssigned"
-            roles={['ADMIN', 'EMPLOYEE']}
-            someProp="propFromNoRolesSet"
-          >
-            <PrivateSet unauthenticated="admin" roles={'EMPLOYEE'}>
-              <Route
-                path="/employee"
-                page={PrivateEmployeePage}
-                name="privateEmployee"
-              />
-            </PrivateSet>
+  // Level 2: wrapped in 2 private sets
+  expect(pathRouteMap).toMatchObject({
+    '/employee': {
+      redirect: null,
+      sets: [
+        {
+          id: '1',
+          wrappers: [],
+          isPrivate: true,
+          props: { unauthenticated: 'home' },
+        },
+        {
+          id: '1.1',
+          wrappers: [],
+          isPrivate: true,
+          props: expect.objectContaining({
+            unauthenticated: 'noRolesAssigned',
+            roles: ['ADMIN', 'EMPLOYEE'],
+          }),
+        },
+        {
+          id: '1.1.1',
+          wrappers: [],
+          isPrivate: true,
+          props: {
+            unauthenticated: 'admin',
+            roles: 'EMPLOYEE',
+          },
+        },
+      ],
+    },
+  })
 
-            <PrivateSet unauthenticated="employee" roles={'ADMIN'}>
-              <Route
-                path="/admin"
-                page={PrivateAdminPage}
-                name="privateAdmin"
-              />
-            </PrivateSet>
-          </Set>
-        </PrivateSet>
-      </Router>
-    )
-
-    const { pathRouteMap, namedRoutesMap } = analyzeRoutes(
-      RedirectedRoutes.props.children,
-      {
-        currentPathName: '/does-not-exist',
-      },
-    )
-
-    // Level 1: wrapped with private
-    expect(pathRouteMap).toMatchObject({
-      '/no-roles-assigned': {
-        redirect: null,
-        sets: [
-          {
-            id: '1',
-            isPrivate: true,
-            props: { unauthenticated: 'home' },
+  // Level 3: wrapped in 3 private sets
+  expect(pathRouteMap).toMatchObject({
+    '/admin': {
+      redirect: null,
+      sets: [
+        // Should have the first one, but also..
+        {
+          id: '1',
+          wrappers: [],
+          isPrivate: true,
+          props: { unauthenticated: 'home' },
+        },
+        // ...the second private set's props
+        {
+          id: '1.1',
+          wrappers: [],
+          isPrivate: true,
+          props: {
+            unauthenticated: 'noRolesAssigned',
+            roles: ['ADMIN', 'EMPLOYEE'],
           },
-        ],
-      },
-    })
-
-    expect(Object.keys(namedRoutesMap).length).toBe(4)
-
-    // Level 2: wrapped in 2 private sets
-    expect(pathRouteMap).toMatchObject({
-      '/employee': {
-        redirect: null,
-        sets: [
-          {
-            id: '1',
-            wrappers: [],
-            isPrivate: true,
-            props: { unauthenticated: 'home' },
+        },
+        // ...and the third private set's props
+        {
+          id: '1.1.2',
+          wrappers: [],
+          isPrivate: true,
+          props: {
+            unauthenticated: 'employee',
+            roles: 'ADMIN',
           },
-          {
-            id: '1.1',
-            wrappers: [],
-            isPrivate: true,
-            props: expect.objectContaining({
-              unauthenticated: 'noRolesAssigned',
-              roles: ['ADMIN', 'EMPLOYEE'],
-            }),
-          },
-          {
-            id: '1.1.1',
-            wrappers: [],
-            isPrivate: true,
-            props: {
-              unauthenticated: 'admin',
-              roles: 'EMPLOYEE',
-            },
-          },
-        ],
-      },
-    })
-
-    // Level 3: wrapped in 3 private sets
-    expect(pathRouteMap).toMatchObject({
-      '/admin': {
-        redirect: null,
-        sets: [
-          // Should have the first one, but also..
-          {
-            id: '1',
-            wrappers: [],
-            isPrivate: true,
-            props: { unauthenticated: 'home' },
-          },
-          // ...the second private set's props
-          {
-            id: '1.1',
-            wrappers: [],
-            isPrivate: true,
-            props: {
-              unauthenticated: 'noRolesAssigned',
-              roles: ['ADMIN', 'EMPLOYEE'],
-            },
-          },
-          // ...and the third private set's props
-          {
-            id: '1.1.2',
-            wrappers: [],
-            isPrivate: true,
-            props: {
-              unauthenticated: 'employee',
-              roles: 'ADMIN',
-            },
-          },
-        ],
-      },
-    })
+        },
+      ],
+    },
   })
 })
 
 test('Give correct ids to root sets', () => {
-  const HomePage = () => <h1>Home Page</h1>
-  const Page = () => <h1>Page</h1>
   const Layout = ({ children }: LayoutProps) => <>{children}</>
 
   const Routes = (
     <Router>
-      <Route path="/" page={HomePage} name="home" />
+      <Route path="/" page={FakePage} name="home" />
       <Set wrap={Layout}>
-        <Route path="/one" page={Page} name="one" />
+        <Route path="/one" page={FakePage} name="one" />
       </Set>
       <Set wrap={Layout}>
-        <Route path="/two" page={Page} name="two" />
+        <Route path="/two" page={FakePage} name="two" />
       </Set>
     </Router>
   )


### PR DESCRIPTION
Mostly moving things around to group stuff better and to avoid some duplication by lifting some common code up one level for reuse