### PR TITLE
Rename og component assets from *.png.jsx to just *.og.jsx

### DIFF
--- a/.changesets/10542.md
+++ b/.changesets/10542.md
@@ -1,0 +1,5 @@
+- Rename og component assets from *.png.jsx to just*.og.jsx (#10542) by @cannikin
+
+We ran into a conflict where you could name your component file something like `AboutPage.png.jsx` (where the returned content-type would be image/png). But, when you invoke `useOgImage()` to actually create the URL for a `<meta>` tag, you could instead use a different extension, like `.jpg`. Which one should win?
+
+After discussion with @dac09 and @mojombo we decided that the extension returned by `useOgImage()` would be the correct one, and that the filename of the component itself should become generic and not imply any specific file format.

--- a/packages/ogimage-gen/src/OgImageMiddleware.test.ts
+++ b/packages/ogimage-gen/src/OgImageMiddleware.test.ts
@@ -81,7 +81,7 @@ describe('OgImageMiddleware', () => {
       {
         'redwood.toml': '',
         'web/src/pages/Contact/ContactPage.jsx': 'ContactPage',
-        'web/src/pages/Contact/ContactPage.png.jsx': 'ContactOG',
+        'web/src/pages/Contact/ContactPage.og.jsx': 'ContactOG',
       },
       '/redwood-app',
     )
@@ -170,12 +170,11 @@ describe('OgImageMiddleware', () => {
       ),
     }
 
-    const extension = 'png'
     const expectedFilePath =
-      '/redwood-app/web/dist/server/ogImage/pages/Contact/ContactPage/ContactPage.png.mjs'
+      '/redwood-app/web/dist/server/ogImage/pages/Contact/ContactPage/ContactPage.og.mjs'
 
-    const tsxResult = middleware.getOgComponentPath(tsxRoute, extension)
-    const jsxResult = middleware.getOgComponentPath(jsxRoute, extension)
+    const tsxResult = middleware.getOgComponentPath(tsxRoute)
+    const jsxResult = middleware.getOgComponentPath(jsxRoute)
 
     expect(ensurePosixPath(tsxResult)).toBe(expectedFilePath)
     expect(ensurePosixPath(jsxResult)).toBe(expectedFilePath)
@@ -228,7 +227,7 @@ describe('OgImageMiddleware', () => {
     // The memfs mocks don't seem to work for this file
 
     vi.mock(
-      '/redwood-app/web/dist/server/ogImage/pages/Contact/ContactPage/ContactPage.png.mjs',
+      '/redwood-app/web/dist/server/ogImage/pages/Contact/ContactPage/ContactPage.og.mjs',
       () => ({
         data: () => 'mocked data function',
         output: () => 'Mocked component render',
@@ -263,7 +262,7 @@ describe('OgImageMiddleware', () => {
 
     // The memfs mocks don't seem to work for this file
     vi.mock(
-      '/redwood-app/web/dist/server/ogImage/pages/HomePage/HomePage.jpg.mjs',
+      '/redwood-app/web/dist/server/ogImage/pages/HomePage/HomePage.og.mjs',
       () => ({
         data: () => 'mocked data function',
         output: () => 'Mocked component render',
@@ -290,7 +289,7 @@ describe('OgImageMiddleware', () => {
 
     // The memfs mocks don't seem to work for this file
     vi.mock(
-      '/redwood-app/web/dist/server/ogImage/pages/HomePage/HomePage.png.mjs',
+      '/redwood-app/web/dist/server/ogImage/pages/HomePage/HomePage.og.mjs',
       () => ({
         data: () => 'mocked data function',
         output: () => 'Mocked component render',
@@ -315,7 +314,7 @@ describe('OgImageMiddleware', () => {
     // The memfs mocks don't seem to work for this file
 
     vi.mock(
-      '/redwood-app/web/dist/server/ogImage/pages/Contact/ContactPage/ContactPage.png.mjs',
+      '/redwood-app/web/dist/server/ogImage/pages/Contact/ContactPage/ContactPage.og.mjs',
       () => ({
         data: () => 'mocked data function',
         output: () => 'Mocked component render',

--- a/packages/ogimage-gen/src/OgImageMiddleware.ts
+++ b/packages/ogimage-gen/src/OgImageMiddleware.ts
@@ -131,7 +131,7 @@ export default class OgImageMiddleware {
       height: this.imageProps.height,
     }
 
-    const ogImgFilePath = this.getOgComponentPath(currentRoute, extension)
+    const ogImgFilePath = this.getOgComponentPath(currentRoute)
 
     const { data, Component } = await this.importComponent(
       ogImgFilePath,
@@ -225,21 +225,18 @@ export default class OgImageMiddleware {
     },
   )
 
-  public getOgComponentPath(
-    currentRoute: RWRouteManifestItem,
-    extension: SUPPORTED_EXT,
-  ) {
+  public getOgComponentPath(currentRoute: RWRouteManifestItem) {
     if (process.env.NODE_ENV === 'development') {
       return path.join(
         getPaths().web.src,
-        currentRoute.relativeFilePath.replace(/\.([jt]sx)/, `.${extension}.$1`),
+        currentRoute.relativeFilePath.replace(/\.([jt]sx)/, `.og.$1`),
       )
     } else {
       return `${path.join(
         getPaths().web.distServer,
         'ogImage',
         currentRoute.relativeFilePath.replace(/\.([jt]sx)/, ''),
-      )}.${extension}.mjs` // @MARK: Hardcoded mjs!
+      )}.og.mjs` // @MARK: Hardcoded mjs!
     }
   }
 

--- a/packages/ogimage-gen/src/hooks.ts
+++ b/packages/ogimage-gen/src/hooks.ts
@@ -60,6 +60,7 @@ export const useOgImage = (options?: OgImageUrlOptions) => {
           height: height || OGIMAGE_DEFAULTS.height,
         },
       ],
+      // TODO: Haven't determined if this is required for Twitter to pick up the og:image. Needs some testing.
       // twitter: { image: { src: output.join('') } },
     },
   }

--- a/packages/ogimage-gen/src/vite-plugin-ogimage-gen.test.ts
+++ b/packages/ogimage-gen/src/vite-plugin-ogimage-gen.test.ts
@@ -11,9 +11,9 @@ vi.mock('fs', () => ({ ...memfs, default: { ...memfs } }))
 vi.mock('node:fs', () => ({ ...memfs, default: { ...memfs } }))
 
 /**
- *   +   "ogImage/pages\\About\\AboutPage.jpg": "/redwood-app/web/src/pages/About/AboutPage.jpg.jsx",
-  +   "ogImage/pages\\Contact\\ContactPage.png": "/redwood-app/web/src/pages/Contact/ContactPage.png.jsx",
-  +   "ogGen\\pages\\Posts\\PostsPage\\PostsPage.png": "/redwood-app/web/src/pages/Posts/PostsPage/PostsPage.png.tsx",
+  +   "ogImage/pages\\About\\AboutPage.og":           "/redwood-app/web/src/pages/About/AboutPage.og.jsx",
+  +   "ogImage/pages\\Contact\\ContactPage.og":       "/redwood-app/web/src/pages/Contact/ContactPage.og.jsx",
+  +   "ogGen\\pages\\Posts\\PostsPage\\PostsPage.og": "/redwood-app/web/src/pages/Posts/PostsPage/PostsPage.og.tsx",
  */
 
 describe('vitePluginOgGen', () => {
@@ -26,9 +26,9 @@ describe('vitePluginOgGen', () => {
     vol.fromJSON(
       {
         'redwood.toml': '',
-        'web/src/pages/Posts/PostsPage/PostsPage.png.tsx': 'PostsOG',
-        'web/src/pages/About/AboutPage.jpg.jsx': 'AboutOG',
-        'web/src/pages/Contact/ContactPage.png.jsx': 'ContactOG',
+        'web/src/pages/Posts/PostsPage/PostsPage.og.tsx': 'PostsOG',
+        'web/src/pages/About/AboutPage.og.jsx': 'AboutOG',
+        'web/src/pages/Contact/ContactPage.og.jsx': 'ContactOG',
       },
       '/redwood-app',
     )
@@ -58,26 +58,26 @@ describe('vitePluginOgGen', () => {
 
     expect(inputKeys).toEqual(
       expect.arrayContaining([
-        'ogImage/pages/Posts/PostsPage/PostsPage.png',
-        'ogImage/pages/About/AboutPage.jpg',
-        'ogImage/pages/Contact/ContactPage.png',
+        'ogImage/pages/Posts/PostsPage/PostsPage.og',
+        'ogImage/pages/About/AboutPage.og',
+        'ogImage/pages/Contact/ContactPage.og',
       ]),
     )
 
     // For windows, we do the conversion before the test
     expect(
       ensurePosixPath(
-        rollupInputs['ogImage/pages/Posts/PostsPage/PostsPage.png'],
+        rollupInputs['ogImage/pages/Posts/PostsPage/PostsPage.og'],
       ),
-    ).toMatch('/redwood-app/web/src/pages/Posts/PostsPage/PostsPage.png.tsx')
+    ).toMatch('/redwood-app/web/src/pages/Posts/PostsPage/PostsPage.og.tsx')
 
     expect(
-      ensurePosixPath(rollupInputs['ogImage/pages/About/AboutPage.jpg']),
-    ).toMatch('/redwood-app/web/src/pages/About/AboutPage.jpg.jsx')
+      ensurePosixPath(rollupInputs['ogImage/pages/About/AboutPage.og']),
+    ).toMatch('/redwood-app/web/src/pages/About/AboutPage.og.jsx')
 
     expect(
-      ensurePosixPath(rollupInputs['ogImage/pages/Contact/ContactPage.png']),
-    ).toMatch('/redwood-app/web/src/pages/Contact/ContactPage.png.jsx')
+      ensurePosixPath(rollupInputs['ogImage/pages/Contact/ContactPage.og']),
+    ).toMatch('/redwood-app/web/src/pages/Contact/ContactPage.og.jsx')
   })
 
   test('returns the correct Vite plugin object', async () => {

--- a/packages/ogimage-gen/src/vite-plugin-ogimage-gen.ts
+++ b/packages/ogimage-gen/src/vite-plugin-ogimage-gen.ts
@@ -17,7 +17,7 @@ type ConfigPlugin = O.Required<VitePlugin, 'config'>
 function vitePluginOgImageGen(): ConfigPlugin {
   const rwPaths = getPaths()
 
-  const allOgComponents = fg.sync('pages/**/*.{png,jpg}.{jsx,tsx}', {
+  const allOgComponents = fg.sync('pages/**/*.og.{jsx,tsx}', {
     cwd: rwPaths.web.src,
     absolute: true,
     // @MARK This allows us to mock the fs module in tests


### PR DESCRIPTION
We ran into a conflict where you could name your component file something like `AboutPage.png.jsx` (where the returned format would be PNG). But, when you invoke `useOgImage()` to actually create the URL for a `<meta>` tag, you could instead use a different extension, like `.jpg`. Which one should win?

After discussion with @dac09 and @mojombo we decided that the extension returned by `useOgImage()` would be the correct one, and that the filename of the component itself should become generic.

This PR requires that the og:image components be named something like `AboutPage.og.jsx`. Vite will now look for this extension, and the middleware will find it and end up rendering whatever format is present in the extension when invoked:

```
https://example.com/about.png -> content-type: image/png
https://example.com/about.jpg -> content-type: image/jpeg
```