### PR TITLE
fix(cli): Add deprecation notice for edgio deployment

### DIFF
--- a/.changesets/10551.md
+++ b/.changesets/10551.md
@@ -1,0 +1,3 @@
+- fix(cli): Add deprecation notice for edgio deployment (#10551) by @Josh-Walker-GM
+
+This change adds notices to the CLI and our documentation site to inform you that the edgio deployment provider is now deprecated as of v7. 

--- a/docs/docs/deploy/edgio.md
+++ b/docs/docs/deploy/edgio.md
@@ -1,5 +1,14 @@
 # Deploy to Edgio
 
+>⚠️ **Deprecated**
+>
+>As of Redwood v7, we are deprecating this deploy setup as an "officially" supported provider. This means:
+>- For projects already using this deploy provider, there will be NO change at this time
+>- Both the associated `setup` and `deploy` commands will remain in the framework as is; when setup is run, there will be a “deprecation” message
+>- We will no longer run CI/CD on the Edgio deployments, which means we are no longer guaranteeing this deploy works with each new version
+>
+>If you have concerns or questions about our decision to deprecate this deploy provider please reach out to us on our [community forum](https://community.redwoodjs.com).
+
 [Edgio](https://edg.io) extends the capabilities of a traditional CDN by not only hosting your static content, but also providing server-side rendering for progressive web applications as well as caching both your APIs and HTML at the network edge to provide your users with the fastest browsing experience.
 
 ## Edgio Deploy Setup

--- a/packages/cli/src/commands/deploy/edgio.js
+++ b/packages/cli/src/commands/deploy/edgio.js
@@ -14,6 +14,7 @@ import { deployBuilder, deployHandler } from './helpers/helpers'
 
 export const command = 'edgio [...commands]'
 export const description = 'Build command for Edgio deploy'
+export const deprecated = true
 
 export const builder = async (yargs) => {
   const { builder: edgioBuilder } = require('@edgio/cli/commands/deploy')

--- a/packages/cli/src/commands/setup/deploy/providers/edgio.js
+++ b/packages/cli/src/commands/setup/deploy/providers/edgio.js
@@ -13,9 +13,15 @@ import {
 import { preRequisiteCheckTask } from '../helpers'
 
 export const command = 'edgio'
-export const description = 'Setup Edgio deploy'
+export const description = '[DEPRECATED]\nSetup Edgio deploy'
+export const deprecated = true
 
 const notes = [
+  c.error('DEPRECATED option not officially supported'),
+  '',
+  'For more information:',
+  'https://redwoodjs.com/docs/deploy/edgio',
+  '',
   'You are almost ready to deploy to Edgio!',
   '',
   'See https://redwoodjs.com/docs/deploy#edgio-deploy for the remaining',


### PR DESCRIPTION
**Changes**
1. Adds a deprecation notice to the cli for the setup and deploy commands for the edgio deployment provider.
2. Adds a deprecation notice to the edgio deployment documentation. 

**Notes**
1. On the documentation change: I didn't explicitly create a forum post to provide insight into this decision instead I simply asked anyone who has input to do so.
2. I used both the yargs `deprecated` config and also used the same style of adding `DEPRECATED` to the setup command description that had been used for the serverless deploy deprecation notice.