### PR TITLE
Define `process.env.NODE_ENV` in build process.

### DIFF
--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -31,6 +31,9 @@ export async function rscBuildClient(clientEntryFiles: Record<string, string>) {
 
   const clientBuildOutput = await viteBuild({
     envFile: false,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    },
     build: {
       // TODO (RSC): Remove `minify: false` when we don't need to debug as often
       minify: false,

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -36,6 +36,9 @@ export async function rscBuildForServer(
   // TODO (RSC): No redwood-vite plugin, add it in here
   const rscServerBuildOutput = await viteBuild({
     envFile: false,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    },
     ssr: {
       // Inline every file apart from node built-ins. We want vite/rollup to
       // inline dependencies in the server bundle. This gets round runtime

--- a/packages/vite/src/streaming/buildForStreamingServer.ts
+++ b/packages/vite/src/streaming/buildForStreamingServer.ts
@@ -35,6 +35,9 @@ export async function buildForStreamingServer({
       emptyOutDir: true,
     },
     envFile: false,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    },
     logLevel: verbose ? 'info' : 'warn',
   })
 }


### PR DESCRIPTION
This fixes a bug where RSC would complain about the Client using the development version of React whilst the server was using the production version. The reason for this is 
that Vite's bundling process it replaces "process.env.NODE_ENV" with the values specified in the define configuration. Supplying this configuration option during the build 
process ensures that we're using the same version of React.

<img width="1431" alt="image" src="https://github.com/redwoodjs/redwood/assets/44849/dc52f8e1-19c9-466d-9fe8-409b05673675">

