### PR TITLE
fix(functions): Mock context in function test template

### DIFF
--- a/.changesets/10555.md
+++ b/.changesets/10555.md
@@ -1,0 +1,12 @@
+- fix(functions): Mock context in function test template (#10555) by @Tobbe
+
+Currently if you switch on TypeScript strict mode in a Redwood project you will
+get red squiggles in our default function tests that we create when users
+generate new functions.
+
+It looks like this
+![image](https://github.com/redwoodjs/redwood/assets/30793/b604b9c9-78f1-4e3f-b42f-0f1c1a0d5078)
+
+The fix is simple, and is the right thing to do no matter if TS strict mode is
+enabled or not (or if it's even a TS project or a JS project). We already have
+a function to properly mock the Context, so let's just use that!

--- a/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
@@ -9,7 +9,7 @@ exports[`Single word default files > creates a single word function file > Scena
 `;
 
 exports[`Single word default files > creates a single word function file > Test snapshot 1`] = `
-"import { mockHttpEvent, mockContext() } from '@redwoodjs/testing/api'
+"import { mockHttpEvent, mockContext } from '@redwoodjs/testing/api'
 
 import { handler } from './foo'
 

--- a/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
@@ -9,7 +9,7 @@ exports[`Single word default files > creates a single word function file > Scena
 `;
 
 exports[`Single word default files > creates a single word function file > Test snapshot 1`] = `
-"import { mockHttpEvent } from '@redwoodjs/testing/api'
+"import { mockHttpEvent, mockContext() } from '@redwoodjs/testing/api'
 
 import { handler } from './foo'
 
@@ -24,7 +24,7 @@ describe('foo function', () => {
       },
     })
 
-    const response = await handler(httpEvent, null)
+    const response = await handler(httpEvent, mockContext())
     const { data } = JSON.parse(response.body)
 
     expect(response.statusCode).toBe(200)

--- a/packages/cli/src/commands/generate/function/templates/test.ts.template
+++ b/packages/cli/src/commands/generate/function/templates/test.ts.template
@@ -1,4 +1,4 @@
-import { mockHttpEvent } from '@redwoodjs/testing/api'
+import { mockHttpEvent, mockContext } from '@redwoodjs/testing/api'
 
 import { handler } from './${name}'
 
@@ -14,7 +14,7 @@ describe('${name} function', () => {
       },
     })
 
-    const response = await handler(httpEvent, null)
+    const response = await handler(httpEvent, mockContext())
     const { data } = JSON.parse(response.body)
 
     expect(response.statusCode).toBe(200)


### PR DESCRIPTION
Currently if you switch on TypeScript strict mode in a Redwood project you will get red squiggles in our default function tests that we create when users generate new functions.

It looks like this
![image](https://github.com/redwoodjs/redwood/assets/30793/b604b9c9-78f1-4e3f-b42f-0f1c1a0d5078)

The fix is simple, and is the right thing to do no matter if TS strict mode is enabled or not (or if it's even a TS project or a JS project). We already have a function to properly mock the Context, so let's just use that!