### PR TITLE
fix(functions): Fix context variable warning/error

### DIFF
--- a/.changesets/10556.md
+++ b/.changesets/10556.md
@@ -1,0 +1,7 @@
+- fix(functions): Fix context variable warning/error (#10556) by @Tobbe
+
+In a newly generated function there's a warning/error in the JSDoc that also prevents VSCode from showing the correct information. See screenshot below
+![image](https://github.com/redwoodjs/redwood/assets/30793/8f1debf5-295a-4f82-9b13-c072236d0393)
+
+And with the fix:
+![image](https://github.com/redwoodjs/redwood/assets/30793/bebf2c6f-0d45-42e1-9bfe-e67f07fccad6)

--- a/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
+++ b/packages/cli/src/commands/generate/function/__tests__/__snapshots__/function.test.ts.snap
@@ -57,7 +57,7 @@ exports[`Single word default files > creates a single word function file 1`] = `
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
  * @typedef { import('aws-lambda').Context } Context
  * @param { APIGatewayEvent } event - an object which contains information from the invoker.
- * @param { Context } context - contains information about the invocation,
+ * @param { Context } _context - contains information about the invocation,
  * function, and execution environment.
  */
 export const handler = async (event, _context) => {
@@ -92,7 +92,7 @@ exports[`creates a .js file if --javascript=true 1`] = `
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
  * @typedef { import('aws-lambda').Context } Context
  * @param { APIGatewayEvent } event - an object which contains information from the invoker.
- * @param { Context } context - contains information about the invocation,
+ * @param { Context } _context - contains information about the invocation,
  * function, and execution environment.
  */
 export const handler = async (event, _context) => {
@@ -129,7 +129,7 @@ import { logger } from 'src/lib/logger'
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
  * @typedef { import('aws-lambda').Context } Context
  * @param { APIGatewayEvent } event - an object which contains information from the invoker.
- * @param { Context } context - contains information about the invocation,
+ * @param { Context } _context - contains information about the invocation,
  * function, and execution environment.
  */
 export const handler = async (event: APIGatewayEvent, _context: Context) => {
@@ -164,7 +164,7 @@ exports[`creates a multi word function file 1`] = `
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
  * @typedef { import('aws-lambda').Context } Context
  * @param { APIGatewayEvent } event - an object which contains information from the invoker.
- * @param { Context } context - contains information about the invocation,
+ * @param { Context } _context - contains information about the invocation,
  * function, and execution environment.
  */
 export const handler = async (event, _context) => {

--- a/packages/cli/src/commands/generate/function/templates/function.ts.template
+++ b/packages/cli/src/commands/generate/function/templates/function.ts.template
@@ -15,7 +15,7 @@ import { logger } from 'src/lib/logger'
  * @typedef { import('aws-lambda').APIGatewayEvent } APIGatewayEvent
  * @typedef { import('aws-lambda').Context } Context
  * @param { APIGatewayEvent } event - an object which contains information from the invoker.
- * @param { Context } context - contains information about the invocation,
+ * @param { Context } _context - contains information about the invocation,
  * function, and execution environment.
  */
 export const handler = async (event: APIGatewayEvent, _context: Context) => {


### PR DESCRIPTION
In a newly generated function there's a warning/error in the JSDoc that also prevents VSCode from showing the correct information. See screenshot below
![image](https://github.com/redwoodjs/redwood/assets/30793/8f1debf5-295a-4f82-9b13-c072236d0393)

And with the fix:
![image](https://github.com/redwoodjs/redwood/assets/30793/bebf2c6f-0d45-42e1-9bfe-e67f07fccad6)
