### PR TITLE
Revert "chore(deps): React beta 20240508 (#10558)"

### DIFF
--- a/__fixtures__/fragment-test-project/web/package.json
+++ b/__fixtures__/fragment-test-project/web/package.json
@@ -16,7 +16,7 @@
     "@redwoodjs/router": "7.0.0",
     "@redwoodjs/web": "7.0.0",
     "humanize-string": "2.1.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/__fixtures__/test-project-rsa/web/package.json
+++ b/__fixtures__/test-project-rsa/web/package.json
@@ -15,7 +15,7 @@
     "@redwoodjs/forms": "8.0.0-canary.144",
     "@redwoodjs/router": "8.0.0-canary.144",
     "@redwoodjs/web": "8.0.0-canary.144",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/package.json
@@ -18,7 +18,7 @@
     "@redwoodjs/web": "7.0.0-canary.1011",
     "@tobbe.dev/rsc-test": "0.0.5",
     "client-only": "0.0.1",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -16,7 +16,7 @@
     "@redwoodjs/router": "7.0.0",
     "@redwoodjs/web": "7.0.0",
     "humanize-string": "2.1.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/packages/auth-providers/auth0/web/package.json
+++ b/packages/auth-providers/auth0/web/package.json
@@ -32,7 +32,7 @@
     "@babel/cli": "7.24.1",
     "@babel/core": "^7.22.20",
     "@types/react": "^18.2.55",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },

--- a/packages/auth-providers/azureActiveDirectory/web/package.json
+++ b/packages/auth-providers/azureActiveDirectory/web/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.22.20",
     "@types/netlify-identity-widget": "1.9.6",
     "@types/react": "^18.2.55",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },

--- a/packages/auth-providers/clerk/web/package.json
+++ b/packages/auth-providers/clerk/web/package.json
@@ -33,7 +33,7 @@
     "@clerk/clerk-react": "4.30.7",
     "@clerk/types": "3.62.1",
     "@types/react": "^18.2.55",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -36,7 +36,7 @@
     "@types/react": "^18.2.55",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/auth-providers/firebase/web/package.json
+++ b/packages/auth-providers/firebase/web/package.json
@@ -34,7 +34,7 @@
     "firebase": "10.11.0",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5"
   },
   "peerDependencies": {

--- a/packages/auth-providers/netlify/web/package.json
+++ b/packages/auth-providers/netlify/web/package.json
@@ -32,7 +32,7 @@
     "@babel/core": "^7.22.20",
     "@types/netlify-identity-widget": "1.9.6",
     "@types/react": "^18.2.55",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },

--- a/packages/auth-providers/supabase/web/package.json
+++ b/packages/auth-providers/supabase/web/package.json
@@ -33,7 +33,7 @@
     "@supabase/ssr": "0.3.0",
     "@supabase/supabase-js": "2.40.0",
     "@types/react": "^18.2.55",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },

--- a/packages/auth-providers/supertokens/web/package.json
+++ b/packages/auth-providers/supertokens/web/package.json
@@ -31,7 +31,7 @@
     "@babel/cli": "7.24.1",
     "@babel/core": "^7.22.20",
     "@types/react": "^18.2.55",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "supertokens-auth-react": "0.39.1",
     "typescript": "5.4.5",
     "vitest": "1.4.0"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "core-js": "3.36.1",
-    "react": "19.0.0-beta-04b058868c-20240508"
+    "react": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {
     "@redwoodjs/framework-tools": "workspace:*",

--- a/packages/create-redwood-app/templates/js/web/package.json
+++ b/packages/create-redwood-app/templates/js/web/package.json
@@ -14,7 +14,7 @@
     "@redwoodjs/forms": "7.0.0",
     "@redwoodjs/router": "7.0.0",
     "@redwoodjs/web": "7.0.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/packages/create-redwood-app/templates/ts/web/package.json
+++ b/packages/create-redwood-app/templates/ts/web/package.json
@@ -14,7 +14,7 @@
     "@redwoodjs/forms": "7.0.0",
     "@redwoodjs/router": "7.0.0",
     "@redwoodjs/web": "7.0.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -40,13 +40,13 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "nodemon": "3.1.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },
   "peerDependencies": {
-    "react": "19.0.0-beta-04b058868c-20240508"
+    "react": "19.0.0-canary-cb151849e1-20240424"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -43,7 +43,7 @@
     "@redwoodjs/vite": "workspace:*",
     "fast-glob": "3.3.2",
     "lodash": "4.17.21",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "devDependencies": {

--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -48,7 +48,7 @@
     "vitest": "1.4.0"
   },
   "peerDependencies": {
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "externals": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -36,13 +36,13 @@
     "@types/react-dom": "^18.2.19",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424",
     "tstyche": "1.1.0",
     "typescript": "5.4.5"
   },
   "peerDependencies": {
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -77,7 +77,7 @@
     "find-my-way": "8.1.0",
     "http-proxy-middleware": "2.0.6",
     "isbot": "3.8.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-server-dom-webpack": "19.0.0-canary-cb151849e1-20240424",
     "vite": "5.2.8",
     "vite-plugin-cjs-interop": "2.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -61,14 +61,14 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "nodemon": "3.1.0",
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424",
     "tstyche": "1.1.0",
     "typescript": "5.4.5",
     "vitest": "1.4.0"
   },
   "peerDependencies": {
-    "react": "19.0.0-beta-04b058868c-20240508",
+    "react": "19.0.0-canary-cb151849e1-20240424",
     "react-dom": "19.0.0-canary-cb151849e1-20240424"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7574,7 +7574,7 @@ __metadata:
     "@redwoodjs/auth": "workspace:*"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.36.1"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
@@ -7627,7 +7627,7 @@ __metadata:
     "@types/netlify-identity-widget": "npm:1.9.6"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.36.1"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
@@ -7677,7 +7677,7 @@ __metadata:
     "@redwoodjs/auth": "workspace:*"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.36.1"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
@@ -7770,7 +7770,7 @@ __metadata:
     core-js: "npm:3.36.1"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
   languageName: unknown
   linkType: soft
@@ -7819,7 +7819,7 @@ __metadata:
     firebase: "npm:10.11.0"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
   peerDependencies:
     firebase: 10.11.0
@@ -7869,7 +7869,7 @@ __metadata:
     "@types/netlify-identity-widget": "npm:1.9.6"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.36.1"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
@@ -7939,7 +7939,7 @@ __metadata:
     "@supabase/supabase-js": "npm:2.40.0"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.36.1"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
@@ -7992,7 +7992,7 @@ __metadata:
     "@redwoodjs/auth": "workspace:*"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.36.1"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     supertokens-auth-react: "npm:0.39.1"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
@@ -8010,7 +8010,7 @@ __metadata:
     "@testing-library/react": "npm:14.3.1"
     core-js: "npm:3.36.1"
     msw: "npm:1.3.3"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     tsx: "npm:4.7.1"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
@@ -8390,13 +8390,13 @@ __metadata:
     graphql: "npm:16.8.1"
     nodemon: "npm:3.1.0"
     pascalcase: "npm:1.0.0"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     react-dom: "npm:19.0.0-canary-cb151849e1-20240424"
     react-hook-form: "npm:7.51.2"
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
-    react: 19.0.0-beta-04b058868c-20240508
+    react: 19.0.0-canary-cb151849e1-20240424
   languageName: unknown
   linkType: soft
 
@@ -8609,7 +8609,7 @@ __metadata:
     "@redwoodjs/vite": "workspace:*"
     fast-glob: "npm:3.3.2"
     lodash: "npm:4.17.21"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     react-dom: "npm:19.0.0-canary-cb151849e1-20240424"
     ts-toolbelt: "npm:9.6.0"
     tsx: "npm:4.7.1"
@@ -8643,7 +8643,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
-    react: 19.0.0-beta-04b058868c-20240508
+    react: 19.0.0-canary-cb151849e1-20240424
     react-dom: 19.0.0-canary-cb151849e1-20240424
   languageName: unknown
   linkType: soft
@@ -8724,12 +8724,12 @@ __metadata:
     core-js: "npm:3.36.1"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     react-dom: "npm:19.0.0-canary-cb151849e1-20240424"
     tstyche: "npm:1.1.0"
     typescript: "npm:5.4.5"
   peerDependencies:
-    react: 19.0.0-beta-04b058868c-20240508
+    react: 19.0.0-canary-cb151849e1-20240424
     react-dom: 19.0.0-canary-cb151849e1-20240424
   languageName: unknown
   linkType: soft
@@ -8877,7 +8877,7 @@ __metadata:
     glob: "npm:10.3.12"
     http-proxy-middleware: "npm:2.0.6"
     isbot: "npm:3.8.0"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     react-server-dom-webpack: "npm:19.0.0-canary-cb151849e1-20240424"
     rollup: "npm:4.17.2"
     tsx: "npm:4.7.1"
@@ -8936,7 +8936,7 @@ __metadata:
     graphql-sse: "npm:2.5.2"
     graphql-tag: "npm:2.12.6"
     nodemon: "npm:3.1.0"
-    react: "npm:19.0.0-beta-04b058868c-20240508"
+    react: "npm:19.0.0-canary-cb151849e1-20240424"
     react-dom: "npm:19.0.0-canary-cb151849e1-20240424"
     react-helmet-async: "npm:2.0.4"
     react-hot-toast: "npm:2.4.1"
@@ -8946,7 +8946,7 @@ __metadata:
     typescript: "npm:5.4.5"
     vitest: "npm:1.4.0"
   peerDependencies:
-    react: 19.0.0-beta-04b058868c-20240508
+    react: 19.0.0-canary-cb151849e1-20240424
     react-dom: 19.0.0-canary-cb151849e1-20240424
   bin:
     cross-env: ./dist/bins/cross-env.js
@@ -27297,10 +27297,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:19.0.0-beta-04b058868c-20240508":
-  version: 19.0.0-beta-04b058868c-20240508
-  resolution: "react@npm:19.0.0-beta-04b058868c-20240508"
-  checksum: 10c0/073bf88725c89a2b4fdaed686d5c9eac619c34e31480bcbb3f9cd362a04463da9985ac4f870869e111d3e776c52fb95a8783793c99d9951541ead67742cbf952
+"react@npm:19.0.0-canary-cb151849e1-20240424":
+  version: 19.0.0-canary-cb151849e1-20240424
+  resolution: "react@npm:19.0.0-canary-cb151849e1-20240424"
+  checksum: 10c0/dcf99a3fd550aee018c61c8b28aafacaf50fa8fbf2321c27bf56a0109ed78d01dd3ec38829f01cb6729cef3377c5401c09723738d3e95acce7a915f16328056b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts commit dbce1278db58717fc06df2a0fa12a35065f12057.

Trying to debug `Error: Currently React only supports one RSC renderer at a time.`
Feels like it started happening after this react upgrade.