### PR TITLE
RSC: Separate RSC and RSA handling

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -2,7 +2,8 @@ import { cache, use, useEffect, useState } from 'react'
 import type { ReactElement } from 'react'
 
 import type { Options } from 'react-server-dom-webpack/client'
-import { createFromFetch, encodeReply } from 'react-server-dom-webpack/client'
+// import { createFromFetch, encodeReply } from 'react-server-dom-webpack/client'
+import { createFromFetch } from 'react-server-dom-webpack/client'
 
 import { StatusError } from './lib/StatusError.js'
 
@@ -19,6 +20,10 @@ const checkStatus = async (
 }
 
 const BASE_PATH = '/rw-rsc/'
+
+function setRerender() {
+  return () => {}
+}
 
 export function renderFromRscServer<TProps>(rscId: string) {
   console.log('serve rscId (renderFromRscServer)', rscId)
@@ -40,16 +45,16 @@ export function renderFromRscServer<TProps>(rscId: string) {
     ): readonly [Thenable<ReactElement>, SetRerender] => {
       console.log('fetchRSC serializedProps', serializedProps)
 
-      let rerender:
-        | ((next: [Thenable<ReactElement>, string]) => void)
-        | undefined
+      // let rerender:
+      //   | ((next: [Thenable<ReactElement>, string]) => void)
+      //   | undefined
 
-      const setRerender: SetRerender = (fn) => {
-        rerender = fn
-        return () => {
-          rerender = undefined
-        }
-      }
+      // const setRerender: SetRerender = (fn) => {
+      //   rerender = fn
+      //   return () => {
+      //     rerender = undefined
+      //   }
+      // }
 
       const searchParams = new URLSearchParams()
       searchParams.set('props', serializedProps)
@@ -57,37 +62,31 @@ export function renderFromRscServer<TProps>(rscId: string) {
       const options: Options<unknown[], ReactElement> = {
         // `args` is often going to be an array with just a single element,
         // and that element will be FormData
-        callServer: async function (rsfId: string, args: unknown[]) {
-          console.log('client.ts :: callServer rsfId', rsfId, 'args', args)
-
-          const isMutating = !!mutationMode
-          const searchParams = new URLSearchParams()
-          searchParams.set('action_id', rsfId)
-          let id: string
-
-          if (isMutating) {
-            id = rscId
-            searchParams.set('props', serializedProps)
-          } else {
-            id = '_'
-          }
-
-          const response = fetch(BASE_PATH + id + '?' + searchParams, {
-            method: 'POST',
-            body: await encodeReply(args),
-            headers: {
-              'rw-rsc': '1',
-            },
-          })
-
-          const data = createFromFetch(response, options)
-
-          if (isMutating) {
-            rerender?.([data, serializedProps])
-          }
-
-          return data
-        },
+        // callServer: async function (rsfId: string, args: unknown[]) {
+        //   console.log('client.ts :: callServer rsfId', rsfId, 'args', args)
+        //   const isMutating = !!mutationMode
+        //   const searchParams = new URLSearchParams()
+        //   searchParams.set('action_id', rsfId)
+        //   let id: string
+        //   if (isMutating) {
+        //     id = rscId
+        //     searchParams.set('props', serializedProps)
+        //   } else {
+        //     id = '_'
+        //   }
+        //   const response = fetch(BASE_PATH + id + '?' + searchParams, {
+        //     method: 'POST',
+        //     body: await encodeReply(args),
+        //     headers: {
+        //       'rw-rsc': '1',
+        //     },
+        //   })
+        //   const data = createFromFetch(response, options)
+        //   if (isMutating) {
+        //     rerender?.([data, serializedProps])
+        //   }
+        //   return data
+        // },
       }
 
       const prefetched = (globalThis as any).__WAKU_PREFETCHED__?.[rscId]?.[
@@ -159,7 +158,7 @@ export function renderFromRscServer<TProps>(rscId: string) {
 let mutationMode = 0
 
 export function mutate(fn: () => void) {
-  ++mutationMode
+  mutationMode = mutationMode + 1
   fn()
-  --mutationMode
+  mutationMode = mutationMode - 1
 }


### PR DESCRIPTION
If we can have separate functions for RSC and RSA the RSC-related code could be much simpler.

This is the error you get if you don't have `callServer` in `options`
![image](https://github.com/redwoodjs/redwood/assets/30793/f2b88d6c-dac3-4ec1-809e-0455edb57e1c)

```
Error: Trying to call a function from "use server" but the callServer option was not implemented in your router runtime.
    at missingCall (rwjs-client-entry-BZUmHrig.mjs:36782:9)
    at proxy (rwjs-client-entry-BZUmHrig.mjs:36660:10)
    at action (rsc-Form.tsx-0-DxH1A6tL.mjs:17:15)
    at rwjs-client-entry-BZUmHrig.mjs:4966:14
    at startTransition (rwjs-client-entry-BZUmHrig.mjs:4934:23)
    at startHostTransition (rwjs-client-entry-BZUmHrig.mjs:4959:3)
    at listener (rwjs-client-entry-BZUmHrig.mjs:1990:17)
    at processDispatchQueue (rwjs-client-entry-BZUmHrig.mjs:2113:13)
    at rwjs-client-entry-BZUmHrig.mjs:2494:5
    at batchedUpdates$1 (rwjs-client-entry-BZUmHrig.mjs:1374:36)
```

It seems we need to pass `callServer` when getting the initial page that will eventually call the server action and React or react-server-dom-webpack will hold on to it and use it when RSAs are invoked.