### PR TITLE
Docs: Correcting the prop name to `roles` from `hasRoles` for the `PrivateSet` component in the Authentication doc 

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -139,7 +139,7 @@ const Routes = () => {
 }
 ```
 
-You can also restrict access by role by passing a role or an array of roles to the `PrivateSet` component's `hasRole` prop:
+You can also restrict access by role by passing a role or an array of roles to the `PrivateSet` component's `roles` prop:
 
 ```tsx title="web/src/Routes.tsx"
 import { Router, Route, PrivateSet } from '@redwoodjs/router'
@@ -156,12 +156,12 @@ const Routes = () => {
       </PrivateSet>
 
       // highlight-next-line
-      <PrivateSet unauthenticated="forbidden" hasRole="admin">
+      <PrivateSet unauthenticated="forbidden" roles="admin">
         <Route path="/admin" page={AdminPage} name="admin" />
       </PrivateSet>
 
       // highlight-next-line
-      <PrivateSet unauthenticated="forbidden" hasRole={['author', 'editor']}>
+      <PrivateSet unauthenticated="forbidden" roles={['author', 'editor']}>
         <Route path="/posts" page={PostsPage} name="posts" />
       </PrivateSet>
     </Router>

--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -169,6 +169,10 @@ const Routes = () => {
 }
 ```
 
+:::note Note about roles
+A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor"]`.
+:::
+
 ### api-side currentUser
 
 We briefly mentioned that GraphQL requests include an `Authorization` header in every request when a user is authenticated.

--- a/docs/docs/router.md
+++ b/docs/docs/router.md
@@ -199,7 +199,13 @@ To protect private routes for access by multiple roles:
 </Router>
 ```
 
+:::note Note about roles
+A route is permitted when authenticated and user has **any** of the provided roles such as `"admin"` or `["admin", "editor", "publisher"]`.
+:::
+
+
 Redwood uses the `useAuth` hook under the hood to determine if the user is authenticated. Read more about authentication in Redwood [here](tutorial/chapter4/authentication.md).
+
 
 ## Link and named route functions
 


### PR DESCRIPTION
Hi! While I was reading the Authentication doc, I noticed that the role setting for the `PrivateSet` component was mentioned as `hasRole`, but I think it should be `roles`, so submitting this pull request. Hope it helps!