### PR TITLE
fix(functions-test): Fix mockHttpEvent for null bodies

### DIFF
--- a/.changesets/10570.md
+++ b/.changesets/10570.md
@@ -1,0 +1,5 @@
+- fix(functions-test): Fix mockHttpEvent for null bodies (#10570) by @Tobbe
+
+With an empty/null payload (which it is by default) the body should be empty, not the string `'null'`
+
+This is a breaking change for anyone who was depending on the current "null" behavior in their api function tests. More specifically, if you're **NOT** passing `body` or `payload` to `mockHttpEvent({ ... })` or if you're trying to explicitly set `payload` to `null` you might have to update your tests. 

--- a/packages/testing/src/api/apiFunction.ts
+++ b/packages/testing/src/api/apiFunction.ts
@@ -43,9 +43,12 @@ export const mockHttpEvent = ({
   const payloadAsString =
     typeof payload === 'string' ? payload : JSON.stringify(payload)
 
-  const body = isBase64Encoded
-    ? Buffer.from(payloadAsString || '').toString('base64')
-    : payloadAsString
+  const body =
+    payload === null
+      ? null
+      : isBase64Encoded
+        ? Buffer.from(payloadAsString || '').toString('base64')
+        : payloadAsString
 
   return {
     body,


### PR DESCRIPTION
With an empty/null payload (which it is by default) the body should be empty, not the string `'null'`

This is a breaking change for anyone who was depending on the current "null" behavior in their api function tests. More specifically, if you're **NOT** passing `body` or `payload` to `mockHttpEvent({ ... })` or if you're trying to explicitly set `payload` to `null` you might have to update your tests. 