### PR TITLE
chore(serverAuth): Rename serverAuthContext to serverAuthState where relevant

### DIFF
--- a/.changesets/10499.md
+++ b/.changesets/10499.md
@@ -6,7 +6,7 @@ Implement Supabase Auth Middleware to authenticate server-side requests.
 * createSupabaseAuthMiddleware is responsible for authenticating Supabase requests
 * It does so by checking if the request has a supabase auth-provider header, and then uses the authDecoder to verify the session cookie using the Supabase ServerAuthClient and returning a decoded access token -- or throwing an exception if the session cookie is invalid
 * Once the middleware has the decoded JWT, it hands that to the provided getCurrentUser from he user's project to return the information about authenticated user
-* Lastly, it sets serverAuthContext with user and metadata info to know the request isAuthenticated
-* If the session is invalid or the cookie tampered with such that the access token cannot be verified, serverAuthContext is cleared as are the auth provider and Supabase cookies
+* Lastly, it sets serverAuthState with user and metadata info to know the request isAuthenticated
+* If the session is invalid or the cookie tampered with such that the access token cannot be verified, serverAuthState is cleared as are the auth provider and Supabase cookies
 
 

--- a/.changesets/10643.md
+++ b/.changesets/10643.md
@@ -1,0 +1,9 @@
+- chore(serverAuth): Rename serverAuthContext to serverAuthState where relevant (#10643) by @dac09
+
+**Why?**
+As we make auth available on RSC, we want to avoid the use of the word "context"
+
+1. Because context is over used
+2. It's confusing because RSCs don't support React.context
+
+This PR renames `serverAuthContext` -> `serverAuthState`. The only case it doesn't change it is the _actual_ ServerAuthContext which is a React context we use for SSR/Streaming

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/createDbAuthMiddleware.test.ts
@@ -74,7 +74,7 @@ describe('createDbAuthMiddleware()', () => {
 
     const res = await middleware(mwReq)
 
-    expect(mwReq.serverAuthContext.get()).toEqual({
+    expect(mwReq.serverAuthState.get()).toEqual({
       cookieHeader:
         'session=ko6iXKV11DSjb6kFJ4iwcf1FEqa5wPpbL1sdtKiV51Y=|cQaYkOPG/r3ILxWiFiz90w==',
       currentUser: {
@@ -314,12 +314,12 @@ describe('createDbAuthMiddleware()', () => {
       const res = await middleware(req)
       expect(res).toBeDefined()
 
-      const serverAuthContext = req.serverAuthContext.get()
-      expect(serverAuthContext.isAuthenticated).toBe(true)
-      expect(serverAuthContext.currentUser).toEqual({
+      const serverAuthState = req.serverAuthState.get()
+      expect(serverAuthState.isAuthenticated).toBe(true)
+      expect(serverAuthState.currentUser).toEqual({
         user: { id: 100, email: 'tolkienUser@example.com' },
       })
-      expect(serverAuthContext.cookieHeader).toBe(cookieHeader)
+      expect(serverAuthState.cookieHeader).toBe(cookieHeader)
     })
     it('handles a validateResetToken request', async () => {
       const request = new Request(
@@ -355,8 +355,8 @@ describe('createDbAuthMiddleware()', () => {
         JSON.stringify({ user: { id: 100, email: 'reset@example.com' } }),
       )
 
-      const serverAuthContext = req.serverAuthContext.get()
-      expect(serverAuthContext.isAuthenticated).toBe(false)
+      const serverAuthState = req.serverAuthState.get()
+      expect(serverAuthState.isAuthenticated).toBe(false)
     })
     it('handles a webAuthnRegOptions request', async () => {
       const body = JSON.stringify({
@@ -490,8 +490,8 @@ describe('createDbAuthMiddleware()', () => {
       expect(res.headers.get('one')).toBe('header-one')
       expect(res.headers.get('two')).toBe('header-two')
 
-      const serverAuthContext = req.serverAuthContext.get()
-      expect(serverAuthContext).toHaveProperty('isAuthenticated', false)
+      const serverAuthState = req.serverAuthState.get()
+      expect(serverAuthState).toHaveProperty('isAuthenticated', false)
     })
     it('handles a GET request with correct cookies', async () => {
       // encrypted session taken fom dbAuth tests
@@ -527,11 +527,11 @@ describe('createDbAuthMiddleware()', () => {
       const middleware = createDbAuthMiddleware(options)
 
       const res = await middleware(req)
-      const serverAuthContext = req.serverAuthContext.get()
+      const serverAuthState = req.serverAuthState.get()
 
       expect(res).toBeDefined()
-      expect(serverAuthContext.isAuthenticated).toBe(true)
-      expect(serverAuthContext.currentUser).toEqual({
+      expect(serverAuthState.isAuthenticated).toBe(true)
+      expect(serverAuthState.currentUser).toEqual({
         user: { id: 100, email: 'hello@example.com' },
       })
     })
@@ -568,8 +568,8 @@ describe('createDbAuthMiddleware()', () => {
       const res = await middleware(mwReq)
       expect(res).toBeDefined()
 
-      const serverAuthContext = mwReq.serverAuthContext.get()
-      expect(serverAuthContext).toBeNull()
+      const serverAuthState = mwReq.serverAuthState.get()
+      expect(serverAuthState).toBeNull()
 
       expect(res.toResponse().headers.getSetCookie()).toEqual([
         // Expired cookies, will be removed by browser
@@ -604,8 +604,8 @@ describe('createDbAuthMiddleware()', () => {
       const res = await middleware(req)
       expect(res).toBeDefined()
 
-      const serverAuthContext = req.serverAuthContext.get()
-      expect(serverAuthContext).toHaveProperty('isAuthenticated', false)
+      const serverAuthState = req.serverAuthState.get()
+      expect(serverAuthState).toHaveProperty('isAuthenticated', false)
     })
   })
 })

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -89,7 +89,7 @@ export const createDbAuthMiddleware = ({
         return new MiddlewareResponse(JSON.stringify({ currentUser }))
       }
 
-      req.serverAuthContext.set({
+      req.serverAuthState.set({
         currentUser,
         loading: false,
         isAuthenticated: !!currentUser,
@@ -100,7 +100,7 @@ export const createDbAuthMiddleware = ({
     } catch (e) {
       // Clear server auth context
       console.error(e, 'Error decrypting dbAuth cookie')
-      req.serverAuthContext.set(null)
+      req.serverAuthState.set(null)
 
       // Note we have to use ".unset" and not ".clear"
       // because we want to remove these cookies from the browser

--- a/packages/auth-providers/supabase/middleware/src/__tests__/createSupabaseAuthMiddleware.test.ts
+++ b/packages/auth-providers/supabase/middleware/src/__tests__/createSupabaseAuthMiddleware.test.ts
@@ -89,8 +89,8 @@ describe('createSupabaseAuthMiddleware()', () => {
     expect(result).toHaveProperty('body', undefined)
     expect(result).toHaveProperty('status', 200)
 
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toEqual(middlewareDefaultAuthProviderState)
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toEqual(middlewareDefaultAuthProviderState)
   })
 
   it('passes through non-authenticated requests', async () => {
@@ -106,8 +106,8 @@ describe('createSupabaseAuthMiddleware()', () => {
     expect(result).toEqual(res)
     expect(result.body).toEqual('original response body')
 
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toEqual(middlewareDefaultAuthProviderState)
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toEqual(middlewareDefaultAuthProviderState)
   })
   it('passes through when no auth-provider cookie', async () => {
     const middleware = createSupabaseAuthMiddleware(options)
@@ -126,8 +126,8 @@ describe('createSupabaseAuthMiddleware()', () => {
     expect(result).toEqual(res)
     expect(result.body).toEqual('original response body when no auth provider')
 
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toEqual(middlewareDefaultAuthProviderState)
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toEqual(middlewareDefaultAuthProviderState)
   })
 
   it('passes through when unsupported auth-provider', async () => {
@@ -146,8 +146,8 @@ describe('createSupabaseAuthMiddleware()', () => {
     expect(result.body).toEqual(
       'original response body for unsupported provider',
     )
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toEqual(middlewareDefaultAuthProviderState)
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toEqual(middlewareDefaultAuthProviderState)
   })
 
   it('handles current user GETs', async () => {
@@ -170,8 +170,8 @@ describe('createSupabaseAuthMiddleware()', () => {
     )
 
     expect(req.url).toContain('/middleware/supabase/currentUser')
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toEqual(middlewareDefaultAuthProviderState)
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toEqual(middlewareDefaultAuthProviderState)
   })
 
   it('authenticated request sets currentUser', async () => {
@@ -189,11 +189,11 @@ describe('createSupabaseAuthMiddleware()', () => {
     expect(result).toBeDefined()
     expect(req).toBeDefined()
 
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toBeDefined()
-    expect(serverAuthContext).toHaveProperty('currentUser')
-    expect(serverAuthContext.isAuthenticated).toEqual(true)
-    expect(serverAuthContext.currentUser).toEqual({
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toBeDefined()
+    expect(serverAuthState).toHaveProperty('currentUser')
+    expect(serverAuthState.isAuthenticated).toEqual(true)
+    expect(serverAuthState.currentUser).toEqual({
       id: 1,
       email: 'user-1@example.com',
     })
@@ -230,16 +230,16 @@ describe('createSupabaseAuthMiddleware()', () => {
       expect.anything(),
     )
 
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toBeDefined()
-    expect(serverAuthContext).toHaveProperty('currentUser')
-    expect(serverAuthContext.isAuthenticated).toEqual(true)
-    expect(serverAuthContext.userMetadata).toEqual({
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toBeDefined()
+    expect(serverAuthState).toHaveProperty('currentUser')
+    expect(serverAuthState.isAuthenticated).toEqual(true)
+    expect(serverAuthState.userMetadata).toEqual({
       favoriteColor: 'yellow',
     })
   })
 
-  it('an exception when getting the currentUser clears out serverAuthContext and cookies', async () => {
+  it('an exception when getting the currentUser clears out serverAuthState and cookies', async () => {
     const optionsWithUserMetadata: SupabaseAuthMiddlewareOptions = {
       getCurrentUser: async () => {
         // this simulates a decoding error or some other issue like tampering with the cookie so the Supabase session is invalid
@@ -266,9 +266,9 @@ describe('createSupabaseAuthMiddleware()', () => {
     expect(req).toBeDefined()
 
     // when an exception is thrown, such as when tampering with the cookie,
-    //the serverAuthContext should be cleared
-    const serverAuthContext = req.serverAuthContext.get()
-    expect(serverAuthContext).toBeNull()
+    //the serverAuthState should be cleared
+    const serverAuthState = req.serverAuthState.get()
+    expect(serverAuthState).toBeNull()
 
     // the auth-provider cookie should be cleared from the response
     const authProviderCookie = res.cookies.get('auth-provider')

--- a/packages/auth-providers/supabase/middleware/src/index.ts
+++ b/packages/auth-providers/supabase/middleware/src/index.ts
@@ -13,7 +13,7 @@ export interface SupabaseAuthMiddlewareOptions {
 }
 
 /**
- * Create Supabase Auth Middleware that sets the `serverAuthContext` based on the Supabase cookie.
+ * Create Supabase Auth Middleware that sets the `serverAuthState` based on the Supabase cookie.
  */
 const createSupabaseAuthMiddleware = ({
   getCurrentUser,
@@ -62,7 +62,7 @@ const createSupabaseAuthMiddleware = ({
       const userMetadata =
         typeof currentUser === 'string' ? null : currentUser?.['user_metadata']
 
-      req.serverAuthContext.set({
+      req.serverAuthState.set({
         currentUser,
         loading: false,
         isAuthenticated: !!currentUser,

--- a/packages/auth-providers/supabase/middleware/src/util.ts
+++ b/packages/auth-providers/supabase/middleware/src/util.ts
@@ -61,7 +61,7 @@ export const clearAuthState = (
   res: MiddlewareResponse,
 ) => {
   // Clear server auth context
-  req.serverAuthContext.set(null)
+  req.serverAuthState.set(null)
 
   // clear supabase cookies
   // We can't call .signOut() because that revokes all refresh tokens,

--- a/packages/vite/src/middleware/MiddlewareRequest.test.ts
+++ b/packages/vite/src/middleware/MiddlewareRequest.test.ts
@@ -59,8 +59,8 @@ describe('MiddlewareRequest', () => {
     }
     const mReq = createMiddlewareRequest(req)
 
-    mReq.serverAuthContext.set(FAKE_AUTH_CONTEXT)
+    mReq.serverAuthState.set(FAKE_AUTH_CONTEXT)
 
-    expect(mReq.serverAuthContext.get()).toStrictEqual(FAKE_AUTH_CONTEXT)
+    expect(mReq.serverAuthState.get()).toStrictEqual(FAKE_AUTH_CONTEXT)
   })
 })

--- a/packages/vite/src/middleware/MiddlewareRequest.ts
+++ b/packages/vite/src/middleware/MiddlewareRequest.ts
@@ -7,7 +7,7 @@ import {
 
 import { CookieJar } from './CookieJar.js'
 
-class ServerAuthJar<T> {
+class AuthStateJar<T> {
   private _data: T
 
   constructor(data?: T) {
@@ -25,12 +25,12 @@ class ServerAuthJar<T> {
 
 export class MiddlewareRequest extends WhatWgRequest {
   cookies: CookieJar
-  serverAuthState: ServerAuthJar<ServerAuthState>
+  serverAuthState: AuthStateJar<ServerAuthState>
 
   constructor(input: Request) {
     super(input)
     this.cookies = new CookieJar(input.headers.get('Cookie'))
-    this.serverAuthState = new ServerAuthJar(middlewareDefaultAuthProviderState)
+    this.serverAuthState = new AuthStateJar(middlewareDefaultAuthProviderState)
   }
 }
 

--- a/packages/vite/src/middleware/MiddlewareRequest.ts
+++ b/packages/vite/src/middleware/MiddlewareRequest.ts
@@ -7,7 +7,7 @@ import {
 
 import { CookieJar } from './CookieJar.js'
 
-class ContextJar<T> {
+class ServerAuthJar<T> {
   private _data: T
 
   constructor(data?: T) {
@@ -25,18 +25,18 @@ class ContextJar<T> {
 
 export class MiddlewareRequest extends WhatWgRequest {
   cookies: CookieJar
-  serverAuthContext: ContextJar<ServerAuthState>
+  serverAuthState: ServerAuthJar<ServerAuthState>
 
   constructor(input: Request) {
     super(input)
     this.cookies = new CookieJar(input.headers.get('Cookie'))
-    this.serverAuthContext = new ContextJar(middlewareDefaultAuthProviderState)
+    this.serverAuthState = new ServerAuthJar(middlewareDefaultAuthProviderState)
   }
 }
 
 /**
  * Converts a Web API Request object to a MiddlewareRequest object.
- * Also ensures that serverAuthContext is fresh for each request
+ * Also ensures that serverAuthState is fresh for each request
  * (assuming that it is a new instance for each request)
  */
 export const createMiddlewareRequest = (req: Request) => {

--- a/packages/vite/src/middleware/invokeMiddleware.test.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.test.ts
@@ -17,7 +17,7 @@ describe('Invoke middleware', () => {
   test('extracts auth state correctly, and always returns a MWResponse', async () => {
     const BOB = { name: 'Bob', occupation: 'The builder' }
     const fakeMiddleware = (req: MiddlewareRequest) => {
-      req.serverAuthContext.set({
+      req.serverAuthState.set({
         user: BOB,
       })
     }

--- a/packages/vite/src/middleware/invokeMiddleware.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.ts
@@ -55,7 +55,7 @@ export const invoke = async (
     console.error('~'.repeat(80))
   } finally {
     // This one is for the server. The worker serverStore is initialized in the worker itself!
-    setupServerStore(req, mwReq.serverAuthContext.get())
+    setupServerStore(req, mwReq.serverAuthState.get())
   }
 
   return [mwRes, mwReq.serverAuthState.get()]

--- a/packages/vite/src/middleware/invokeMiddleware.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.ts
@@ -51,5 +51,5 @@ export const invoke = async (
     console.error('~'.repeat(80))
   }
 
-  return [mwRes, mwReq.serverAuthContext.get()]
+  return [mwRes, mwReq.serverAuthState.get()]
 }


### PR DESCRIPTION
**Why?**
As we make auth available on RSC, we want to avoid the use of the word "context"

1. Because context is over used
2. It's confusing because RSCs don't support React.context

This PR renames `serverAuthContext` -> `serverAuthState`. The only case it doesn't change it is the _actual_ ServerAuthContext which we use for SSR/Streaming