### PR TITLE
Add missing rwjs/auth deps

### DIFF
--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@redwoodjs/api": "workspace:*",
+    "@redwoodjs/auth": "workspace:*",
     "@redwoodjs/framework-tools": "workspace:*",
     "@redwoodjs/graphql-server": "workspace:*",
     "@redwoodjs/vite": "workspace:*",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -59,6 +59,7 @@
     "@babel/generator": "7.24.1",
     "@babel/parser": "^7.22.16",
     "@babel/traverse": "^7.22.20",
+    "@redwoodjs/auth": "workspace:*",
     "@redwoodjs/babel-config": "workspace:*",
     "@redwoodjs/internal": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7900,6 +7900,7 @@ __metadata:
   resolution: "@redwoodjs/auth-supabase-middleware@workspace:packages/auth-providers/supabase/middleware"
   dependencies:
     "@redwoodjs/api": "workspace:*"
+    "@redwoodjs/auth": "workspace:*"
     "@redwoodjs/auth-supabase-api": "workspace:*"
     "@redwoodjs/framework-tools": "workspace:*"
     "@redwoodjs/graphql-server": "workspace:*"
@@ -8853,6 +8854,7 @@ __metadata:
     "@babel/generator": "npm:7.24.1"
     "@babel/parser": "npm:^7.22.16"
     "@babel/traverse": "npm:^7.22.20"
+    "@redwoodjs/auth": "workspace:*"
     "@redwoodjs/babel-config": "workspace:*"
     "@redwoodjs/internal": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"


### PR DESCRIPTION
https://github.com/redwoodjs/redwood/pull/10585 added usage of `@redwoodjs/auth` to `@redwoodjs/vite` and https://github.com/redwoodjs/redwood/pull/10499 added it to `@redwoodjs/auth-supabase-middleware` 

This PR also adds it to the `package.json` files of those projects to make sure dependencies are up to date with usage