### PR TITLE
chore(deps): Remove unused deps from prerender

### DIFF
--- a/packages/prerender/package.json
+++ b/packages/prerender/package.json
@@ -26,8 +26,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.1",
-    "@redwoodjs/auth": "workspace:*",
-    "@redwoodjs/internal": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",
     "@redwoodjs/router": "workspace:*",
     "@redwoodjs/structure": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8433,8 +8433,6 @@ __metadata:
     "@babel/cli": "npm:7.24.1"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.24.1"
-    "@redwoodjs/auth": "workspace:*"
-    "@redwoodjs/internal": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/router": "workspace:*"
     "@redwoodjs/structure": "workspace:*"


### PR DESCRIPTION
The `package.json` file in `@redwoodjs/prerender` listed a couple of dependencies it didn't actually use. This PR simply removes those