### PR TITLE
patch(crwa): Fix small annoyances (formatting, spell-check)

### DIFF
--- a/.changesets/10651.md
+++ b/.changesets/10651.md
@@ -1,0 +1,14 @@
+- patch(crwa): Fix small annoyances (formatting, spell-check) (#10651) by @Tobbe
+
+cSpell was complaining about "prerendering". I added it to the dictionary in
+project workspace settings. This gets rid of the blue squiggles for the RW
+project, but not for any user project. I could also have changed it to
+"pre-rendering", but we call the feature "prerender", so it didn't feel right
+to change it to "pre-rendering". So this will have to do for now.
+
+Also formatted the source code to me more narrow.
+
+Honestly this is more of a chore than a fix. But it does affect user projects
+(at least new user projects). So I marked it "patch". But no change needed for
+existing projects unless they really want (and haven't already done it
+themselves).

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "opentelemetry",
     "pino",
     "Pistorius",
+    "prerendering",
     "redwoodjs",
     "rsdw",
     "RWJS",

--- a/__fixtures__/test-project/web/src/entry.client.tsx
+++ b/__fixtures__/test-project/web/src/entry.client.tsx
@@ -13,7 +13,8 @@ const redwoodAppElement = document.getElementById('redwood-app')
 
 if (!redwoodAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it exists in your 'web/src/index.html' file."
+    "Could not find an element with ID 'redwood-app'. Please ensure it " +
+      "exists in your 'web/src/index.html' file."
   )
 }
 

--- a/packages/create-redwood-app/templates/js/web/src/entry.client.jsx
+++ b/packages/create-redwood-app/templates/js/web/src/entry.client.jsx
@@ -13,7 +13,8 @@ const redwoodAppElement = document.getElementById('redwood-app')
 
 if (!redwoodAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it exists in your 'web/src/index.html' file."
+    "Could not find an element with ID 'redwood-app'. Please ensure it " +
+      "exists in your 'web/src/index.html' file."
   )
 }
 

--- a/packages/create-redwood-app/templates/ts/web/src/entry.client.tsx
+++ b/packages/create-redwood-app/templates/ts/web/src/entry.client.tsx
@@ -13,7 +13,8 @@ const redwoodAppElement = document.getElementById('redwood-app')
 
 if (!redwoodAppElement) {
   throw new Error(
-    "Could not find an element with ID 'redwood-app'. Please ensure it exists in your 'web/src/index.html' file."
+    "Could not find an element with ID 'redwood-app'. Please ensure it " +
+      "exists in your 'web/src/index.html' file."
   )
 }
 


### PR DESCRIPTION
cSpell was complaining about "prerendering". I added it to the dictionary in project workspace settings. This gets rid of the blue squiggles for the RW project, but not for any user project. I could also have changed it to "pre-rendering", but we call the feature "prerender", so it didn't feel right to change it to "pre-rendering". So this will have to do for now.

Also formatted the source code to me more narrow.

Honestly this is more of a chore than a fix. But it does affect user projects (at least new user projects). So I marked it "patch". But no change needed for existing projects unless they really want (and haven't already done it themselves).