### PR TITLE
chore(ssr): Make entry.client.tsx better match standard entry.client

### DIFF
--- a/packages/cli/src/commands/experimental/templates/streamingSsr/entry.client.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/entry.client.tsx.template
@@ -12,6 +12,13 @@ import Routes from './Routes'
  */
 const redwoodAppElement = document.getElementById('redwood-app')
 
+if (!redwoodAppElement) {
+  throw new Error(
+    "Could not find an element with ID 'redwood-app'. Please ensure it " +
+      "exists in your 'web/src/index.html' file."
+  )
+}
+
 if (redwoodAppElement.children?.length > 0) {
   hydrateRoot(
     document,


### PR DESCRIPTION
A while ago a check for `null` app element was added to the standard `entry.client.tsx` file. This PR adds that same check to the version of `entry.client.tsx` that's used when setting up SSR