### PR TITLE
fix(vite): Rename `serverAuthContext` to `serverAuthState`

### DIFF
--- a/packages/vite/src/middleware/invokeMiddleware.ts
+++ b/packages/vite/src/middleware/invokeMiddleware.ts
@@ -55,7 +55,7 @@ export const invoke = async (
     // @TODO catch the error here, and see if its a short-circuit
     // A shortcircuit will prevent execution of all other middleware down the chain, and prevent react rendering
     if (e instanceof MiddlewareShortCircuit) {
-      return [e.mwResponse, mwReq.serverAuthContext.get()]
+      return [e.mwResponse, mwReq.serverAuthState.get()]
     }
 
     console.error('Error executing middleware > \n')


### PR DESCRIPTION
**Problem**
https://github.com/redwoodjs/redwood/pull/10643 did some renaming but looks like there was just one more `serverAuthContext` that needed switched over to `serverAuthState`. I noticed this just because the CI was failing on renovate PRs.

**Note**
I'll merge this now and we can discuss retroactively if I misinterpreted anything since I haven't been in the middleware space as much. It's awesome work can't wait for all this to get out into stable for people to enjoy!