### PR TITLE
RSC: Add 'use client' to all client cells in kitchen-sink

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/UserExample/EditUserExampleCell/EditUserExampleCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/UserExample/EditUserExampleCell/EditUserExampleCell.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { EditUserExampleById, UpdateUserExampleInput } from 'types/graphql'
 
 import { navigate, routes } from '@redwoodjs/router'

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/UserExample/UserExampleCell/UserExampleCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/UserExample/UserExampleCell/UserExampleCell.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type { FindUserExampleById } from 'types/graphql'
 
 import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'


### PR DESCRIPTION
For now we're adding 'use client' to all client cells. Technically they could probably be rendered as server components, but for now this is easier