### PR TITLE
RSC: Make the kitchen-sink smoke-test more robust/resilient

### DIFF
--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -9,7 +9,10 @@ test('Client components should work', async ({ page }) => {
 
   await page.locator('button').filter({ hasText: 'Increment' }).click()
 
-  const count = await page.locator('p').nth(2).innerText()
+  const count = await page
+    .locator('p')
+    .filter({ hasText: /Count: \d/ })
+    .innerText()
   expect(count).toMatch('Count: 1')
 
   page.close()
@@ -52,11 +55,13 @@ test('Submitting the form should return a response', async ({ page }) => {
   await expect(submittedPageText).toHaveText(/This form has been sent 1 times/)
 
   // Expect an echo of our message back from the server
-  const echo = await page.locator('p').nth(1).innerText()
-  expect(echo).toMatch('Hello World')
+  await expect(page.locator('p').getByText('Hello World')).toBeVisible()
 
   // Expect to get five (random) words back from the server
-  const words = await page.locator('p').nth(1).innerText()
+  const words = await page
+    .locator('p')
+    .filter({ hasText: /Hello World/ })
+    .innerText()
   expect(words.split('Hello World: ')[1].split(' ')).toHaveLength(5)
 
   page.close()
@@ -100,8 +105,8 @@ test("'use client' cell navigation", async ({ page }) => {
   page.waitForURL('/empty-users/new')
 
   await expect(page.getByText('New EmptyUser')).toBeVisible()
-  await expect(page.getByText('Email')).toBeVisible()
-  await expect(page.getByText('Name')).toBeVisible()
+  await expect(page.getByLabel('Email')).toBeVisible()
+  await expect(page.getByLabel('Name')).toBeVisible()
   await expect(page.getByText('Save')).toBeVisible()
 
   page.close()


### PR DESCRIPTION
Use more idiomatic playwright functions (`getByLabel` vs `getByText`) and also make other checks less sensitive to other (irrelevant) changes to the page 