### PR TITLE
RSC: kitchen-sink: Make it more clear where layout ends and main content starts

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.tsx
@@ -34,6 +34,8 @@ const NavigationLayout = ({ children, rnd }: NavigationLayoutProps) => {
         </ul>
       </nav>
       <div id="rnd">{Math.round(rnd * 100)}</div>
+      <p>Layout end</p>
+      <hr />
       <main>{children}</main>
     </div>
   )


### PR DESCRIPTION
Visual update in prep for work in #10557 