### PR TITLE
RSC: vite auto-loader: Spell out 'path' and other chores

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
@@ -98,19 +98,20 @@ export function rscRoutesAutoLoader(): Plugin {
       // We have to filter out any pages which the user has already explicitly imported
       // in the routes file otherwise there would be conflicts.
       const importedNames = new Set<string>()
+
       traverse(ast, {
-        ImportDeclaration(p) {
-          const importPath = p.node.source.value
+        ImportDeclaration(path) {
+          const importPath = path.node.source.value
           if (importPath === null) {
             return
           }
 
           const userImportRelativePath = getPathRelativeToSrc(
-            importStatementPath(p.node.source?.value),
+            importStatementPath(path.node.source?.value),
           )
 
-          const defaultSpecifier = p.node.specifiers.filter((specifiers) =>
-            t.isImportDefaultSpecifier(specifiers),
+          const defaultSpecifier = path.node.specifiers.filter((specifier) =>
+            t.isImportDefaultSpecifier(specifier),
           )[0]
 
           if (userImportRelativePath && defaultSpecifier) {
@@ -118,6 +119,7 @@ export function rscRoutesAutoLoader(): Plugin {
           }
         },
       })
+
       const nonImportedPages = pages.filter(
         (page) => !importedNames.has(page.importName),
       )

--- a/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
@@ -102,6 +102,7 @@ export function rscRoutesAutoLoader(): Plugin {
       traverse(ast, {
         ImportDeclaration(path) {
           const importPath = path.node.source.value
+
           if (importPath === null) {
             return
           }

--- a/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-routes-auto-loader.ts
@@ -108,7 +108,7 @@ export function rscRoutesAutoLoader(): Plugin {
           }
 
           const userImportRelativePath = getPathRelativeToSrc(
-            importStatementPath(path.node.source?.value),
+            importStatementPath(importPath),
           )
 
           const defaultSpecifier = path.node.specifiers.filter((specifier) =>


### PR DESCRIPTION
AST stuff is difficult as it is, don't need to add one-letter-variable names to the list of things that makes them hard to read :)  This PR spells out `p` as `path`.
This is also what babel does in their own docs https://babeljs.io/docs/babel-helper-environment-visitor