### PR TITLE
fix(cli): Handle case for no arguments for verbose baremetal deploy 

### DIFF
--- a/.changesets/10663.md
+++ b/.changesets/10663.md
@@ -1,0 +1,4 @@
+- fix(cli): Handle case for no arguments for verbose baremetal deploy  (#10663) by @Josh-Walker-GM
+
+The change corrects a bug during baremetal deployments when using the `--verbose` flag. See #10654 for more details.
+

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -12,13 +12,16 @@ export class SshExecutor {
   async exec(path, command, args) {
     let sshCommand = command
 
+    const argsString = args?.join(' ')
     if (args) {
-      sshCommand += ` ${args.join(' ')}`
+      sshCommand += ` ${argsString}`
     }
 
     if (this.verbose) {
       console.log(
-        `SshExecutor::exec running command \`${command} ${args.join(' ')}\` in ${path}`,
+        `SshExecutor::exec running command \`${command} ${
+          args ? argsString : ''
+        }\` in ${path}`
       )
     }
 
@@ -28,8 +31,9 @@ export class SshExecutor {
 
     if (result.code !== 0) {
       const error = new Error(
-        `Error while running command \`${command} ${args.join(' ')}\` in ${path}\n` +
-          result.stderr,
+        `Error while running command \`${command} ${
+          args ? argsString : ''
+        }\` in ${path}\n` + result.stderr
       )
       error.exitCode = result.code
       throw error

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -12,16 +12,14 @@ export class SshExecutor {
   async exec(path, command, args) {
     let sshCommand = command
 
-    const argsString = args?.join(' ')
+    const argsString = args?.join(' ') || ''
     if (args) {
       sshCommand += ` ${argsString}`
     }
 
     if (this.verbose) {
       console.log(
-        `SshExecutor::exec running command \`${command} ${
-          args ? argsString : ''
-        }\` in ${path}`
+        `SshExecutor::exec running command \`${command} ${argsString}\` in ${path}`
       )
     }
 
@@ -31,9 +29,8 @@ export class SshExecutor {
 
     if (result.code !== 0) {
       const error = new Error(
-        `Error while running command \`${command} ${
-          args ? argsString : ''
-        }\` in ${path}\n` + result.stderr
+        `Error while running command \`${command} ${argsString}\` in ${path}\n` +
+          result.stderr
       )
       error.exitCode = result.code
       throw error

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -10,16 +10,12 @@ export class SshExecutor {
    * the exit code with the same code returned from the SSH command.
    */
   async exec(path, command, args) {
-    let sshCommand = command
-
     const argsString = args?.join(' ') || ''
-    if (args) {
-      sshCommand += ` ${argsString}`
-    }
+    const sshCommand = command + argsString
 
     if (this.verbose) {
       console.log(
-        `SshExecutor::exec running command \`${command} ${argsString}\` in ${path}`
+        `SshExecutor::exec running command \`${sshCommand}\` in ${path}`,
       )
     }
 
@@ -29,8 +25,8 @@ export class SshExecutor {
 
     if (result.code !== 0) {
       const error = new Error(
-        `Error while running command \`${command} ${argsString}\` in ${path}\n` +
-          result.stderr
+        `Error while running command \`${sshCommand}\` in ${path}\n` +
+          result.stderr,
       )
       error.exitCode = result.code
       throw error


### PR DESCRIPTION
**Problem**
We recently improved the verbose output of the baremetal deployment process. It looks like this improvement has introduced a small bug. See #10654 for more details.

**Changes**
1. Guard against `args` being undefined.

