### PR TITLE
RSC: Add 'use client' to remaining client cells in kitchen-sink

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/EmptyUser/EditEmptyUserCell/EditEmptyUserCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/EmptyUser/EditEmptyUserCell/EditEmptyUserCell.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type {
   EditEmptyUserById,
   UpdateEmptyUserInput,

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/EmptyUser/EmptyUserCell/EmptyUserCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/EmptyUser/EmptyUserCell/EmptyUserCell.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import type {
   FindEmptyUserById,
   FindEmptyUserByIdVariables,


### PR DESCRIPTION
Thought I got them all in https://github.com/redwoodjs/redwood/pull/10659 but there were two more