### PR TITLE
RSC: Remove commented code related to prefixToRemove transform()

### DIFF
--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -6,7 +6,6 @@
 import type { Buffer } from 'node:buffer'
 import { Server } from 'node:http'
 import path from 'node:path'
-// import { Transform, Writable } from 'node:stream'
 import { Writable } from 'node:stream'
 import { parentPort } from 'node:worker_threads'
 
@@ -408,6 +407,12 @@ async function renderRsc(input: RenderInput): Promise<PipeableStream> {
       createElement(serverRoutes, input.props),
       getBundlerConfig(config),
     )
+    // TODO (RSC): We used to transform() the stream here to remove
+    // "prefixToRemove", which was the common base path to all filenames. We
+    // then added it back in handleRsa with a simple
+    // `path.join(config.root, fileId)`. I removed all of that for now to
+    // simplify the code. But if we wanted to add it back in the future to save
+    // some bytes in all the Flight data we could.
   }
 
   const component = await getFunctionComponent(input.rscId)
@@ -416,7 +421,6 @@ async function renderRsc(input: RenderInput): Promise<PipeableStream> {
     createElement(component, input.props),
     getBundlerConfig(config),
   )
-  // ).pipe(transformRsfId(config.root))
 }
 
 interface SerializedFormData {
@@ -437,10 +441,9 @@ async function handleRsa(input: RenderInput): Promise<PipeableStream> {
 
   const config = await getViteConfig()
 
-  const [fileId, name] = input.rsfId.split('#')
-  const fname = fileId // path.join(config.root, fileId)
-  console.log('Server Action, fileId', fileId, 'name', name, 'fname', fname)
-  const module = await loadServerFile(fname)
+  const [fileName, actionName] = input.rsfId.split('#')
+  console.log('Server Action fileName', fileName, 'actionName', actionName)
+  const module = await loadServerFile(fileName)
 
   if (isSerializedFormData(input.args[0])) {
     const formData = new FormData()
@@ -458,40 +461,6 @@ async function handleRsa(input: RenderInput): Promise<PipeableStream> {
     input.args[0] = formData
   }
 
-  const data = await (module[name] || module)(...input.args)
+  const data = await (module[actionName] || module)(...input.args)
   return renderToPipeableStream(data, getBundlerConfig(config))
 }
-
-// HACK Patching stream is very fragile.
-// TODO (RSC): Sanitize prefixToRemove to make sure it's safe to use in a
-// RegExp (CodeQL is complaining on GitHub)
-// TODO (RSC): Figure out if this is needed. Seems to remove config.root
-// but then we add it back again in handleRsa()
-// function transformRsfId(prefixToRemove: string) {
-//   // Should be something like /home/runner/work/redwood/test-project-rsa
-//   console.log('prefixToRemove', prefixToRemove)
-
-//   return new Transform({
-//     transform(chunk, encoding, callback) {
-//       if (encoding !== ('buffer' as any)) {
-//         throw new Error('Unknown encoding')
-//       }
-
-//       const data = chunk.toString()
-//       const lines = data.split('\n')
-//       console.log('lines', lines)
-
-//       let changed = false
-//       for (let i = 0; i < lines.length; ++i) {
-//         const match = lines[i].match(
-//           new RegExp(`^([0-9]+):{"id":"${prefixToRemove}(.*?)"(.*)$`),
-//         )
-//         if (match) {
-//           lines[i] = `${match[1]}:{"id":"${match[2]}"${match[3]}`
-//           changed = true
-//         }
-//       }
-//       callback(null, changed ? Buffer.from(lines.join('\n')) : chunk)
-//     },
-//   })
-// }


### PR DESCRIPTION
As part of the PR for #10557 I commented out some code. In hindsight I should have made a separate PR to just totally get rid of it that I merged before #10557, but here it is - after the fact instead. Not as good, but at least I'm cleaning up commented out code, because no one wants to read that!

To explain what's going on I'll just copy/paste the comment I left in the code
```
    // TODO (RSC): We used to transform() the stream here to remove
    // "prefixToRemove", which was the common base path to all filenames. We
    // then added it back in handleRsa with a simple
    // `path.join(config.root, fileId)`. I removed all of that for now to
    // simplify the code. But if we wanted to add it back in the future to save
    // some bytes in all the Flight data we could.
```