### PR TITLE
RSC: kitchen-sink: Make the ReadFileServerCell output take up less space

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/ReadFileServerCell/ReadFileServerCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/ReadFileServerCell/ReadFileServerCell.tsx
@@ -35,7 +35,13 @@ export const Success = ({ file }: SuccessProps) => {
     <div className="read-file-server-cell">
       <p>The source of this server cell:</p>
       <pre
-        style={{ border: '1px solid gray', margin: '1em', background: '#ddd' }}
+        style={{
+          border: '1px solid gray',
+          margin: '1em',
+          background: '#ddd',
+          height: '260xp',
+          overflowY: 'scroll',
+        }}
       >
         <code>{file}</code>
       </pre>


### PR DESCRIPTION
The ReadFileServerCell output was almost a full screen height, especially on a laptop screen. This was getting annoying, so I'm making it shorter by adding a scrollbar to it

Before

![image](https://github.com/redwoodjs/redwood/assets/30793/69e1e2f7-ab42-473d-b455-fd2d732c7464)


After

![image](https://github.com/redwoodjs/redwood/assets/30793/a3f830f0-58a9-44d1-8521-fb42cb21a884)
