### PR TITLE
fix(dbAuthMw): Update and fix logic related to dbAuth "verbs" and decryptionErrors

### DIFF
--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -6,11 +6,11 @@ import {
   dbAuthSession,
 } from '@redwoodjs/auth-dbauth-api'
 import type { GetCurrentUser } from '@redwoodjs/graphql-server'
-import type { Middleware } from '@redwoodjs/vite/middleware'
+import type { Middleware, MiddlewareRequest } from '@redwoodjs/vite/middleware'
 import { MiddlewareResponse } from '@redwoodjs/vite/middleware'
 
 export interface DbAuthMiddlewareOptions {
-  cookieName: string
+  cookieName?: string
   dbAuthUrl?: string
   // @NOTE: we never pass lambda event or contexts, when using middleware
   // this is because in existing projects have it typed api/src/functions/auth.ts
@@ -22,35 +22,42 @@ export interface DbAuthMiddlewareOptions {
 }
 
 export const initDbAuthMiddleware = ({
-  cookieName,
   dbAuthHandler,
   getCurrentUser,
+  cookieName,
   dbAuthUrl = '/middleware/dbauth',
 }: DbAuthMiddlewareOptions): [Middleware, '*'] => {
   const mw: Middleware = async (req, res = MiddlewareResponse.next()) => {
-    // Handoff POST requests to the dbAuthHandler. The url is configurable on the dbAuth client side.
-    // This is where we handle login, logout, and signup, etc., but we don't want to intercept
-    if (req.method === 'POST') {
-      if (!req.url.includes(dbAuthUrl)) {
-        // Bail if the POST request is not for the dbAuthHandler
-        return res
+    // Handoff POST and some GET requests to the dbAuthHandler. The url is configurable on the dbAuth client side.
+    // This is where we handle login, logout, and signup, etc., no need to enrich the context
+    if (req.url.includes(dbAuthUrl)) {
+      // Short circuit here ...
+      // if the call came from packages/auth-providers/dbAuth/web/src/getCurrentUserFromMiddleware.ts
+      if (req.url.includes(`${dbAuthUrl}/currentUser`)) {
+        const { currentUser } = await validateSession({
+          req,
+          cookieName,
+          getCurrentUser,
+        })
+
+        return new MiddlewareResponse(JSON.stringify({ currentUser }))
+      } else {
+        const output = await dbAuthHandler(req)
+        const finalHeaders = new Headers()
+
+        Object.entries(output.headers).forEach(([key, value]) => {
+          if (Array.isArray(value)) {
+            value.forEach((mvhHeader) => finalHeaders.append(key, mvhHeader))
+          } else {
+            finalHeaders.append(key, value)
+          }
+        })
+
+        return new MiddlewareResponse(output.body, {
+          headers: finalHeaders,
+          status: output.statusCode,
+        })
       }
-
-      const output = await dbAuthHandler(req)
-      const finalHeaders = new Headers()
-
-      Object.entries(output.headers).forEach(([key, value]) => {
-        if (Array.isArray(value)) {
-          value.forEach((mvhHeader) => finalHeaders.append(key, mvhHeader))
-        } else {
-          finalHeaders.append(key, value)
-        }
-      })
-
-      return new MiddlewareResponse(output.body, {
-        headers: finalHeaders,
-        status: output.statusCode,
-      })
     }
 
     const cookieHeader = req.headers.get('Cookie')
@@ -63,40 +70,24 @@ export const initDbAuthMiddleware = ({
     // 👇 Authenticated request
     try {
       // Call the dbAuth auth decoder. For dbAuth we have direct access to the `dbAuthSession` function.
-      // Other providers may be slightly different.
-      const decryptedSession = dbAuthSession(req as Request, cookieName)
-
-      const currentUser = await getCurrentUser(
-        decryptedSession,
-        {
-          type: 'dbAuth',
-          schema: 'cookie',
-          // @MARK: We pass the entire cookie header as a token. This isn't actually the token!
-          token: cookieHeader,
-        },
-        {
-          // MWRequest is a superset of Request
-          event: req as Request,
-        },
-      )
-
-      // Short circuit here ...
-      // if the call came from packages/auth-providers/dbAuth/web/src/getCurrentUserFromMiddleware.ts
-      if (req.url.includes(`${dbAuthUrl}/currentUser`)) {
-        return new MiddlewareResponse(JSON.stringify({ currentUser }))
-      }
+      // Other providers will be slightly different.
+      const { currentUser } = await validateSession({
+        req,
+        cookieName,
+        getCurrentUser,
+      })
 
       req.serverAuthState.set({
         currentUser,
         loading: false,
         isAuthenticated: !!currentUser,
         hasError: false,
-        userMetadata: currentUser, // Not sure!
+        userMetadata: currentUser, // dbAuth doesn't have userMetadata
         cookieHeader,
       })
     } catch (e) {
       // Clear server auth context
-      console.error(e, 'Error decrypting dbAuth cookie')
+      console.error('Error decrypting dbAuth cookie \n', e)
       req.serverAuthState.set(null)
 
       // Note we have to use ".unset" and not ".clear"
@@ -111,6 +102,46 @@ export const initDbAuthMiddleware = ({
   // Return a tuple and wildcard route pattern
   // Just to make it more difficult for user to accidentally misconfigure
   return [mw, '*']
+}
+
+interface ValidateParams {
+  req: MiddlewareRequest
+  getCurrentUser: GetCurrentUser
+  cookieName?: string
+}
+
+async function validateSession({
+  req,
+  cookieName,
+  getCurrentUser,
+}: ValidateParams) {
+  const decryptedSession = dbAuthSession(
+    req as Request,
+    cookieNameCreator(cookieName),
+  )
+
+  // So that it goes into the catch block
+  if (!decryptedSession) {
+    throw new Error(
+      `No decrypted session found. Check passed in cookie name options to middleware, looking for "${cookieName}"`,
+    )
+  }
+
+  const currentUser = await getCurrentUser(
+    decryptedSession,
+    {
+      type: 'dbAuth',
+      schema: 'cookie',
+      // @MARK: We pass the entire cookie header as a token. This isn't actually the token!
+      // At this point the Cookie header is guaranteed, because otherwise a decryptionError would be thrown
+      token: req.headers.get('Cookie') as string,
+    },
+    {
+      // MWRequest is a superset of Request
+      event: req as Request,
+    },
+  )
+  return { currentUser, decryptedSession }
 }
 
 export default initDbAuthMiddleware


### PR DESCRIPTION
I found some issues with our dbAuth MW as I was implementing a new feature. I think the problems are specific to when you use a `cookieName` which is why we didn't 

This PR does the following:
- updates the dbauth mw to correctly handle the cookieName option (it should always have been optional)
- throws an error when the `dbAuthSession` returns an empty decoded token so that it clears the authState
- we had a check for only "POST" requests to be passed to the dbAuthHandler. This was incorrect because some of the dbAuth "verbs" or actions - like `webAuthnRegOptions` - uses a GET request. 

As a result, the tests started showing failures, so I:
- added a mock for `dbAuthSession`, so we can check both happy path and unhappy paths for session decryption
- updated the tests where relevant

