### PR TITLE
chore(crwa): Remove unused jest dev dependency

### DIFF
--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -40,7 +40,6 @@
     "envinfo": "7.13.0",
     "execa": "5.1.1",
     "fs-extra": "11.2.0",
-    "jest": "29.7.0",
     "klaw-sync": "6.0.0",
     "semver": "7.6.2",
     "systeminformation": "5.22.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15027,7 +15027,6 @@ __metadata:
     envinfo: "npm:7.13.0"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.2.0"
-    jest: "npm:29.7.0"
     klaw-sync: "npm:6.0.0"
     semver: "npm:7.6.2"
     systeminformation: "npm:5.22.9"


### PR DESCRIPTION
**Problem**
Looks like we don't need the jest dev dependency here.

**Changes**
1. Removes the jest dev dependency from create redwood app package.