### PR TITLE
fix(cli): Correct baremetal deploy command construction

### DIFF
--- a/.changesets/10675.md
+++ b/.changesets/10675.md
@@ -1,0 +1,3 @@
+- fix(cli): Correct baremetal deploy command construction (#10675) by @Josh-Walker-GM
+
+We correct a bug in the CLI introduced in the prior patch for baremetal deployments. 

--- a/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
+++ b/packages/cli/src/commands/deploy/baremetal/SshExecutor.js
@@ -11,7 +11,7 @@ export class SshExecutor {
    */
   async exec(path, command, args) {
     const argsString = args?.join(' ') || ''
-    const sshCommand = command + argsString
+    const sshCommand = command + (argsString ? ` ${argsString}` : '')
 
     if (this.verbose) {
       console.log(


### PR DESCRIPTION
**Problem**
We introduced an error in the fix here: #10663

**Changes**
1. We ensure a space is present in the built command.