### PR TITLE
RSC: Better typings for acorn-loose usage

### DIFF
--- a/packages/vite/modules.d.ts
+++ b/packages/vite/modules.d.ts
@@ -106,5 +106,4 @@ declare module 'react-server-dom-webpack/server' {
   ): PipeableStream
 }
 
-declare module 'acorn-loose'
 declare module 'vite-plugin-cjs-interop'

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-client.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-client.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 
+import type { Statement, ModuleDeclaration } from 'acorn'
 import * as acorn from 'acorn-loose'
 import type { Plugin } from 'vite'
 
@@ -26,7 +27,7 @@ export function rscTransformUseClientPlugin(
         return code
       }
 
-      let body
+      let body: (Statement | ModuleDeclaration)[]
 
       try {
         body = acorn.parse(code, {
@@ -125,7 +126,7 @@ function addExportNames(names: Array<string>, node: any) {
  */
 async function parseExportNamesIntoNames(
   code: string,
-  body: any,
+  body: (Statement | ModuleDeclaration)[],
   names: Array<string>,
 ): Promise<void> {
   for (let i = 0; i < body.length; i++) {
@@ -186,7 +187,7 @@ async function parseExportNamesIntoNames(
 
 async function transformClientModule(
   code: string,
-  body: any,
+  body: (Statement | ModuleDeclaration)[],
   url: string,
   clientEntryFiles: Record<string, string>,
 ): Promise<string> {


### PR DESCRIPTION
A while ago we updated acorn-loose to 8.4.0 and with that better types became available. This PR removes our own module definition for acorn-loose so that we get access to the types that now ship with the module.
Also updated our code to use those newly available types.