### PR TITLE
POC: Avoid bundling middleware using react-server export conditions and vite plugin

### DIFF
--- a/packages/ogimage-gen/empty.js
+++ b/packages/ogimage-gen/empty.js
@@ -1,0 +1,9 @@
+// This file is intentionally left empty, because we do not want to bundle middleware
+
+export default function empty() {
+  console.log(`
+  _______ _     _ _______ _______ _______ _______ _______ _______
+ |______ |_____| |______ |______ |______ |______ |______ |______
+ ______| |     | |______ ______| ______| ______| ______| ______|
+`)
+}

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -14,6 +14,7 @@
       "types": "./dist/vite-plugin-ogimage-gen.d.ts"
     },
     "./middleware": {
+      "react-server": "./empty.js",
       "import": "./dist/OgImageMiddleware.js",
       "default": "./cjsWrappers/middleware.js",
       "types": "./dist/OgImageMiddleware.d.ts"
@@ -26,6 +27,7 @@
   },
   "files": [
     "dist",
+    "empty.js",
     "cjsWrappers"
   ],
   "scripts": {

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -172,20 +172,13 @@ function getRollupInput(ssr: boolean): InputOption | undefined {
   }
 
   const ssrEnabled = rwConfig.experimental?.streamingSsr?.enabled
-  const rscEnabled = rwConfig.experimental?.rsc?.enabled
 
   // @NOTE once streaming ssr is out of experimental, this will become the
   // default
   if (ssrEnabled) {
     if (ssr) {
-      if (rscEnabled) {
-        return {
-          Document: rwPaths.web.document,
-        }
-      }
-
       if (!rwPaths.web.entryServer) {
-        throw new Error('entryServer not defined')
+        throw new Error('entryServer not found')
       }
 
       return {

--- a/packages/vite/src/middleware/register.ts
+++ b/packages/vite/src/middleware/register.ts
@@ -1,8 +1,8 @@
-import fmw from 'find-my-way'
 import type Router from 'find-my-way'
+import fmw from 'find-my-way'
 import type { ViteDevServer } from 'vite'
 
-import { getConfig, getPaths } from '@redwoodjs/project-config'
+import { getPaths } from '@redwoodjs/project-config'
 
 import type { EntryServer } from '../types'
 import { makeFilePath, ssrLoadEntryServer } from '../utils'
@@ -104,25 +104,15 @@ export const createMiddlewareRouter = async (
   vite?: ViteDevServer,
 ): Promise<Router.Instance<any>> => {
   const rwPaths = getPaths()
-  const rwConfig = getConfig()
-  const rscEnabled = rwConfig.experimental?.rsc?.enabled
 
   let entryServerImport: EntryServer
 
   if (vite) {
+    // For Dev Server
     entryServerImport = await ssrLoadEntryServer(vite)
   } else {
     // This imports from dist!
-
-    if (rscEnabled) {
-      entryServerImport = await import(
-        makeFilePath(rwPaths.web.distRscEntryServer)
-      )
-    } else {
-      entryServerImport = await import(
-        makeFilePath(rwPaths.web.distEntryServer)
-      )
-    }
+    entryServerImport = await import(makeFilePath(rwPaths.web.distEntryServer))
   }
 
   const { registerMiddleware } = entryServerImport

--- a/packages/vite/src/plugins/vite-plugin-remove-registerMiddlware.ts
+++ b/packages/vite/src/plugins/vite-plugin-remove-registerMiddlware.ts
@@ -1,0 +1,35 @@
+import * as babel from '@babel/core'
+import type { NodePath } from '@babel/traverse'
+import type * as t from '@babel/types'
+import { createFilter } from 'vite'
+
+import { getPaths } from '@redwoodjs/project-config'
+
+const plugin = () => ({
+  visitor: {
+    VariableDeclarator(path: NodePath<t.VariableDeclarator>) {
+      // @ts-expect-error fggg
+      if (path.node.id.name === 'registerMiddleware') {
+        path.remove()
+      }
+    },
+  },
+})
+
+export default function removeRegisterMiddleware() {
+  const filter = createFilter(getPaths().web.entryServer, 'node_modules/**')
+
+  return {
+    name: 'remove-register-middleware',
+    transform: async (code: string, id: string) => {
+      if (filter(id)) {
+        const result = await babel.transformAsync(code, {
+          plugins: [plugin],
+        })
+        return result?.code
+      }
+
+      return null
+    },
+  }
+}

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -4,6 +4,7 @@ import { getPaths } from '@redwoodjs/project-config'
 
 import { getEntries } from '../lib/entries.js'
 import { onWarn } from '../lib/onWarn.js'
+import removeRegisterMiddleware from '../plugins/vite-plugin-remove-registerMiddlware.js'
 import { rscRoutesImports } from '../plugins/vite-plugin-rsc-routes-imports.js'
 import { rscTransformUseClientPlugin } from '../plugins/vite-plugin-rsc-transform-client.js'
 import { rscTransformUseServerPlugin } from '../plugins/vite-plugin-rsc-transform-server.js'
@@ -68,6 +69,7 @@ export async function rscBuildForServer(
       rscTransformUseClientPlugin(clientEntryFiles),
       rscTransformUseServerPlugin(),
       rscRoutesImports(),
+      removeRegisterMiddleware(),
     ],
     build: {
       // TODO (RSC): Remove `minify: false` when we don't need to debug as often


### PR DESCRIPTION
This is PoC (draft) - because we need to decide the direction we are going in with server routing.


**Allows running OgGen middleware**
This fixes running the OG Gen middleware partially i.e. it will build and run successfully, if I mock the App out like this:

```diff
- import App from './App'

export const registerMiddleware = async () => {
  const ogMw = new OgImageMiddleware({
- App,
+    App: ({ children }) => <>{children}</>,
    Document,
  })

  return [ogMw]
}
```

It achieves this by:

**1. setting the react-server export condition in the middleware**
This implies that all middleware, including auth middleware, will need to have these export conditions set inorder to work under the current RSC build system.

**2. Adds a plugin to remove the `registerMiddleware` function from RSC Builds** 
(1) is not enough, Vite will still try to bundle 


**What doesn't work?**
The OG Image middleware relies on us having access to `App` importing this in entry.server still causes build failures (due to React.context). 

This could be resolved in one of two ways:

a) @Tobbe mention re-introducing App back into entry server (or some form of it)
If we have another change in the way server router works, this may be resolved, but I'm unsure how to proceed right now. 

**b) Maybe we need to fix all the imports from App from `rwjs/auth`, `rwjs/web`** 
This will allow us to import App under server conditions without blowing up. 



