### PR TITLE
RSC: kitchen-sink: Use `<Link>` from @redwoodjs/router

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/EmptyUser/EmptyUsersCell/EmptyUsersCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/EmptyUser/EmptyUsersCell/EmptyUsersCell.tsx
@@ -2,9 +2,7 @@
 
 import type { FindEmptyUsers, FindEmptyUsersVariables } from 'types/graphql'
 
-// TODO (RSC): Use Link from '@redwoodjs/router'
-// import { Link, routes } from '@redwoodjs/router'
-import { routes } from '@redwoodjs/router'
+import { Link, routes } from '@redwoodjs/router'
 import type {
   CellSuccessProps,
   CellFailureProps,
@@ -12,10 +10,6 @@ import type {
 } from '@redwoodjs/web'
 
 import EmptyUsers from 'src/components/EmptyUser/EmptyUsers'
-
-const Link = (props: any) => {
-  return <a href={props.to}>{props.children}</a>
-}
 
 export const QUERY: TypedDocumentNode<FindEmptyUsers, FindEmptyUsersVariables> =
   gql`

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@redwoodjs/router/dist/link'
 import { namedRoutes as routes } from '@redwoodjs/router/dist/namedRoutes'
 
 import ReadFileServerCell from 'src/components/ReadFileServerCell'
@@ -7,10 +8,6 @@ import './NavigationLayout.css'
 type NavigationLayoutProps = {
   children?: React.ReactNode
   rnd?: number
-}
-
-const Link = (props: any) => {
-  return <a href={props.to}>{props.children}</a>
 }
 
 const NavigationLayout = ({ children, rnd }: NavigationLayoutProps) => {


### PR DESCRIPTION
With some of the recent changes that have gone in it's now possible to use the `<Link>` component from @redwoodjs/router. When doing so (using the router Link component) clicking on a link is no longer a full-page refresh, but rather just fetching the new stuff from our RSC endpoint.

This PR updates the kitchen-sink test project to take advantage of this. 