### PR TITLE
RSC: kitchen-sink: Fix css pixels unit

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/ReadFileServerCell/ReadFileServerCell.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/components/ReadFileServerCell/ReadFileServerCell.tsx
@@ -39,7 +39,7 @@ export const Success = ({ file }: SuccessProps) => {
           border: '1px solid gray',
           margin: '1em',
           background: '#ddd',
-          height: '260xp',
+          height: '260px',
           overflowY: 'scroll',
         }}
       >


### PR DESCRIPTION
Fix typo in CSS pixel unit "xp" -> "px"