### PR TITLE
fix(cli): Directive generator command was not creating files

### DIFF
--- a/.changesets/10698.md
+++ b/.changesets/10698.md
@@ -1,0 +1,19 @@
+- fix(cli): Directive generator command was not creating files (#10698) by @dthyresson
+
+Fixes: https://github.com/redwoodjs/redwood/issues/10694
+
+The PR fixes a regression in the directive generator where files were not created.
+
+At some point the method to construct files became async. Thus while the command attempted to construct the directive files and write them to the directive directory, it never did.
+
+With this fix, file are written:
+
+```bash
+✔ Generating directive file ...
+  ✔ Successfully wrote file
+    `./api/src/directives/requireEmailValidation/requireEmailValidation.test.ts`
+  ✔ Successfully wrote file
+    `./api/src/directives/requireEmailValidation/requireEmailValidation.ts`
+✔ Generating TypeScript definitions and GraphQL schemas ...
+✔ Next steps...
+```

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -162,8 +162,9 @@ export const handler = async (args) => {
     [
       {
         title: 'Generating directive file ...',
-        task: () => {
-          return writeFilesTask(files({ ...args, type: directiveType }), {
+        task: async () => {
+          const f = await files({ ...args, type: directiveType })
+          return writeFilesTask(f, {
             overwriteExisting: args.force,
           })
         },

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -291,6 +291,7 @@ export const writeFilesTask = (files, options) => {
   return new Listr(
     Object.keys(files).map((file) => {
       const contents = files[file]
+      console.log(`Writing THHHHEEE file: ${file}`)
       return {
         title: `...waiting to write file \`./${path.relative(base, file)}\`...`,
         task: (ctx, task) => writeFile(file, contents, options, task),

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -291,7 +291,6 @@ export const writeFilesTask = (files, options) => {
   return new Listr(
     Object.keys(files).map((file) => {
       const contents = files[file]
-      console.log(`Writing THHHHEEE file: ${file}`)
       return {
         title: `...waiting to write file \`./${path.relative(base, file)}\`...`,
         task: (ctx, task) => writeFile(file, contents, options, task),


### PR DESCRIPTION
Fixes: https://github.com/redwoodjs/redwood/issues/10694

The PR fixes a regression in the directive generator where files were not created.

At some point the method to construct files became async. Thus while the command attempted to construct the directive files and write them to the directive directory, it never did.

With this fix, file are written:

```bash
✔ Generating directive file ...
  ✔ Successfully wrote file
    `./api/src/directives/requireEmailValidation/requireEmailValidation.test.ts`
  ✔ Successfully wrote file
    `./api/src/directives/requireEmailValidation/requireEmailValidation.ts`
✔ Generating TypeScript definitions and GraphQL schemas ...
✔ Next steps...
```

Note, the test didn't catch this regression because it in fact awaited file creation:

```ts
  const output = await directive.files({
    name: 'bazinga-foo_bar', // checking camel casing too!
    typescript: true,
    tests: true,
    type: 'transformer',
  })
```