### PR TITLE
chore(testing): Remove unused member in Props interface

### DIFF
--- a/packages/testing/src/web/MockParamsProvider.tsx
+++ b/packages/testing/src/web/MockParamsProvider.tsx
@@ -3,23 +3,15 @@ import React from 'react'
 import { useLocation, ParamsContext, parseSearch } from '@redwoodjs/router'
 
 interface Props {
-  path?: string
   children?: React.ReactNode
 }
 
 export const MockParamsProvider: React.FC<Props> = ({ children }) => {
   const location = useLocation()
-
   const searchParams = parseSearch(location.search)
 
   return (
-    <ParamsContext.Provider
-      value={{
-        params: {
-          ...searchParams,
-        },
-      }}
-    >
+    <ParamsContext.Provider value={{ params: { ...searchParams } }}>
       {children}
     </ParamsContext.Provider>
   )


### PR DESCRIPTION
```
interface Props {
  path?: string
  children?: React.ReactNode
}
```

`path` is not used, so no need to have it in the interface