### PR TITLE
docs: Clarify how to setup Docker with custom Server File

### DIFF
--- a/.changesets/10702.md
+++ b/.changesets/10702.md
@@ -1,0 +1,15 @@
+- docs(docker): Clarify how to setup Docker with custom Server File (#10702) by @dthyresson
+
+Clarify how to setup Docker with custom Server File.
+
+While the Docker documentation does instruct how to user Docker with the custom server file, the instructions could be easily missed.
+
+In the follow support issue https://community.redwoodjs.com/t/unknown-directive-live-in-docker/7150/7 redwoodJS was setup to use Docker and also GraphQL with Realtime.
+
+Realtime (and live queries) worked with rw dev, api set and also Docker dev -- but not production Docker.
+
+In production Docker, the server file was never run and therefore the plugin to setup GraphQL with the useRedwoodRealtime plugin never happened ... and thus the live directive wasn't understood nor were GraphQL subscripts added to the schema.
+
+Here api server, simply ran the GraphQL function as expected, but the plugin was never invoked so Realtime was never configured or added to the schema.
+
+This happened because by default, production Docker launch the plain vanilla api server  -- it didn't launch server file that uses `createServer` to setup a separate GraphQL server and also add in the realtime plugin.

--- a/.changesets/xxxxxx.md
+++ b/.changesets/xxxxxx.md
@@ -1,0 +1,1 @@
+- docs(docker): Clarify how to setup Docker with custom Server File (#xxxx) by @dthyresson

--- a/.changesets/xxxxxx.md
+++ b/.changesets/xxxxxx.md
@@ -1,1 +1,0 @@
-- docs(docker): Clarify how to setup Docker with custom Server File (#xxxx) by @dthyresson

--- a/packages/cli/src/commands/experimental/templates/docker/Dockerfile
+++ b/packages/cli/src/commands/experimental/templates/docker/Dockerfile
@@ -94,7 +94,15 @@ COPY --chown=node:node --from=api_build /home/node/app/node_modules/.prisma /hom
 
 ENV NODE_ENV=production
 
+# default api serve command
+# ---------
+# If you are using a custom server file, you must use the following
+# command to launch your server instead of the default api-server below.
+# This is important if you intend to configure GraphQL to use Realtime.
+#
+# CMD [ "./api/dist/server.js" ]
 CMD [ "node_modules/.bin/rw-server", "api" ]
+
 
 # web serve
 # ---------

--- a/packages/cli/src/commands/experimental/templates/docker/docker-compose.prod.yml
+++ b/packages/cli/src/commands/experimental/templates/docker/docker-compose.prod.yml
@@ -6,6 +6,11 @@ services:
       context: .
       dockerfile: ./Dockerfile
       target: api_serve
+    # Without a command specified, the Dockerfile's api_serve CMD will be used.
+    # If you are using a custom server file, you should either use the following
+    # command to launch your server or update the Dockerfile to do so.
+    # This is important if you intend to configure GraphQL to use Realtime.
+    # command: "./api/dist/server.js"
     ports:
       - "8911:8911"
     depends_on:


### PR DESCRIPTION
Clarify how to setup Docker with custom Server File.

While the Docker documentation does instruct how to user Docker with the custom server file, the instructions could be easily missed.

In the follow support issue https://community.redwoodjs.com/t/unknown-directive-live-in-docker/7150/7 redwoodJS was setup to use Docker and also GraphQL with Realtime.

Realtime (and live queries) worked with rw dev, api set and also Docker dev -- but not production Docker.

In production Docker, the server file was never run and therefore the plugin to setup GraphQL with the useRedwoodRealtime plugin never happened ... and thus the live directive wasn't understood nor were GraphQL subscripts added to the schema.

Here api server, simply ran the GraphQL function as expected, but the plugin was never invoked so Realtime was never configured or added to the schema.

This happened because by default, production Docker launch the plain vanilla api server  -- it didn't launch server file that uses `createServer` to setup a separate GraphQL server and also add in the realtime plugin.

This PR:

* adds comment to the Dockerfile to make one aware of the command change
* suggests an alternative way of not using the default command in the production docker config
* clarifies Docker docs to point to the config command change