### PR TITLE
Cleanup `DISABLE_REPLAY_UPLOAD` logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,8 +585,6 @@ jobs:
         env:
           REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
           REDWOOD_DISABLE_TELEMETRY: 1
-          # Temp workaround for Replay specific failing tests
-          DISABLE_REPLAY_UPLOAD: 1
           REPLAY_API_KEY: ${{ secrets.REPLAY_API_KEY }}
 
       - name: Build for production
@@ -601,8 +599,6 @@ jobs:
         env:
           REDWOOD_TEST_PROJECT_PATH: '${{ steps.set-up-test-project.outputs.test-project-path }}'
           REDWOOD_DISABLE_TELEMETRY: 1
-          # Temp workaround for Replay specific failing tests
-          DISABLE_REPLAY_UPLOAD: 1
           REPLAY_API_KEY: ${{ secrets.REPLAY_API_KEY }}
 
   ssr-smoke-tests-skip:

--- a/tasks/smoke-tests/basePlaywright.config.ts
+++ b/tasks/smoke-tests/basePlaywright.config.ts
@@ -42,7 +42,7 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
   reporter: [
     replayReporter({
       apiKey: process.env.REPLAY_API_KEY,
-      upload: !!process.env.CI || !!process.env.DISABLE_REPLAY_UPLOAD,
+      upload: !!process.env.CI,
     }),
     ['line'],
   ],


### PR DESCRIPTION
This is cleanup PR for left out lines in #10664. We are not recording streaming ssr at all (using vanilla chromium), so we don't need to have this logic. (Related https://github.com/redwoodjs/redwood/pull/10704#discussion_r1621737295)

Would need a rebase after getting #10704 in.