### PR TITLE
chore(auth): Fix auth build

### DIFF
--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -11,7 +11,7 @@
     { "path": "../router" },
     { "path": "../internal" },
     { "path": "../project-config" },
-    { "path": "../auth" },
+    { "path": "../auth/tsconfig.build.json" },
     { "path": "../structure" }
   ]
 }

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -6,6 +6,6 @@
   },
   "include": ["src", "./ambient.d.ts"],
   "references": [
-    { "path": "../auth" },
+    { "path": "../auth/tsconfig.build.json" },
   ]
 }

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -12,7 +12,7 @@
     { "path": "../babel-config" },
     { "path": "../project-config" },
     { "path": "../web" },
-    { "path": "../auth" },
+    { "path": "../auth/tsconfig.build.json" },
     { "path": "../graphql-server" },
   ]
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["./src/**/*", "ambient.d.ts", "testing-library.d.ts"],
-  "references": [{ "path": "../auth" }]
+  "references": [{ "path": "../auth/tsconfig.build.json" }]
 }

--- a/tasks/clean.mjs
+++ b/tasks/clean.mjs
@@ -16,3 +16,7 @@ await rimraf('packages/**/dist', {
 await rimraf('packages/**/tsconfig.tsbuildinfo', {
   glob: true,
 })
+
+await rimraf('packages/**/tsconfig.build.tsbuildinfo', {
+  glob: true,
+})

--- a/tasks/framework-tools/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/frameworkSyncToProject.mjs
@@ -50,6 +50,7 @@ const ignored = [
   /meta.(\w*\.?)json/,
 
   /tsconfig.tsbuildinfo/,
+  /tsconfig.build.tsbuildinfo/,
 
   (filePath) => IGNORE_EXTENSIONS.some((ext) => filePath.endsWith(ext)),
 ]


### PR DESCRIPTION
Packages depending on `@redwoodjs/auth` were failing to build for me after a "git clean". This PR hopes to fix that.

```
"references": [
  { "path": "../auth/tsconfig.build.json" },
]
```
By specifying a specific tsconfig file, and not just a path, we can tell TS what config file to use when building dependents. If no file is specified it'll default to `tsconfig.json`