### PR TITLE
chore(ci): Disable Replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   YARN_ENABLE_HARDENED_MODE: 0
-  BROWSER_INSTALL_CMD: npx playwright install --with-deps chromium
+  BROWSER_INSTALL_CMD: npx playwright install --with-deps chromium && npx replayio install
   PLAYWRIGHT_CMD: 'npx playwright test --project chromium'
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   YARN_ENABLE_HARDENED_MODE: 0
+  BROWSER_INSTALL_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright install --with-deps chromium' || 'npx replayio install' }}
+  # PLAYWRIGHT_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright test --project chromium' || 'npx playwright test --project replay-chromium' }}
+  PLAYWRIGHT_CMD: 'npx playwright test --project chromium'
 
 jobs:
   detect-changes:
@@ -203,8 +206,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      BROWSER_INSTALL_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright install --with-deps chromium' || 'npx replayio install' }}
-      PLAYWRIGHT_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright test --project chromium' || 'npx playwright test --project replay-chromium' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -451,8 +452,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      BROWSER_INSTALL_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright install --with-deps chromium' || 'npx replayio install' }}
-      PLAYWRIGHT_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright test --project chromium' || 'npx playwright test --project replay-chromium' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -552,9 +551,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      # Temp workaround for Replay specific failing tests
-      BROWSER_INSTALL_CMD: 'npx playwright install --with-deps chromium && npx replayio install'
-      PLAYWRIGHT_CMD: npx playwright test --project chromium
 
     steps:
       - uses: actions/checkout@v4
@@ -629,8 +625,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      BROWSER_INSTALL_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright install --with-deps chromium' || 'npx replayio install' }}
-      PLAYWRIGHT_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright test --project chromium' || 'npx playwright test --project replay-chromium' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ concurrency:
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   YARN_ENABLE_HARDENED_MODE: 0
-  BROWSER_INSTALL_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright install --with-deps chromium' || 'npx replayio install' }}
-  # PLAYWRIGHT_CMD: ${{ matrix.os == 'windows-latest' && 'npx playwright test --project chromium' || 'npx playwright test --project replay-chromium' }}
+  BROWSER_INSTALL_CMD: npx playwright install --with-deps chromium
   PLAYWRIGHT_CMD: 'npx playwright test --project chromium'
 
 jobs:

--- a/tasks/smoke-tests/basePlaywright.config.ts
+++ b/tasks/smoke-tests/basePlaywright.config.ts
@@ -39,11 +39,5 @@ export const basePlaywrightConfig: PlaywrightTestConfig = {
     // },
   ],
 
-  reporter: [
-    replayReporter({
-      apiKey: process.env.REPLAY_API_KEY,
-      upload: !!process.env.CI,
-    }),
-    ['line'],
-  ],
+  reporter: 'list',
 }


### PR DESCRIPTION
CI are currently failing because there's a problem with the Replay API key.
See for example here https://github.com/redwoodjs/redwood/actions/runs/9317301327/job/25647341074?pr=10706
```
Run npx playwright test --project replay-chromium
Error: `@replayio/playwright/reporter` requires an API key to upload recordings. Either pass a value to the apiKey plugin configuration or set the REPLAY_API_KEY environment variable
    at ReplayReporter.parseConfig (/home/runner/work/redwood/redwood/node_modules/@replayio/test-utils/src/reporter.ts:296:13)
    at new ReplayReporter (/home/runner/work/redwood/redwood/node_modules/@replayio/test-utils/src/reporter.ts:213:12)
    at new ReplayPlaywrightReporter (/home/runner/work/redwood/redwood/node_modules/@replayio/playwright/src/reporter.ts:103:21)
```

A fix is in the works here https://github.com/redwoodjs/redwood/pull/10704

But until we've figured out what the best solution is I'm temporarily disabling Replay