### PR TITLE
chore: spelling, comment

### DIFF
--- a/packages/auth/src/AuthProvider/AuthProvider.tsx
+++ b/packages/auth/src/AuthProvider/AuthProvider.tsx
@@ -133,7 +133,7 @@ export function createAuthProvider<
 
         await authImplementation.restoreAuthState?.()
 
-        // If the inital state didn't come from the server (or was restored before)
+        // If the initial state didn't come from the server (or was restored before)
         // reauthenticate will make an API call to the middleware to receive the current user
         // (instead of called the graphql endpoint with currentUser)
         if (!serverAuthState) {

--- a/packages/cli/src/commands/serveBothHandler.js
+++ b/packages/cli/src/commands/serveBothHandler.js
@@ -86,7 +86,7 @@ export const bothSsrRscServerHandler = async (argv) => {
     port: argv.apiPort,
   })
 
-  // TODO More gracefully handle Ctrl-C
+  // TODO (RSC): More gracefully handle Ctrl-C
   // Right now you get a big red error box when you kill the process
   const fePromise = execa('yarn', ['rw-serve-fe'], {
     cwd: getPaths().web.base,

--- a/packages/vite/src/clientSsr.ts
+++ b/packages/vite/src/clientSsr.ts
@@ -123,9 +123,9 @@ export function renderFromDist<TProps extends Record<string, any>>(
     const { renderToReadableStream }: RSDWServerType =
       await importModule('rsdw-server')
 
-    // We're in client.ts, but we're supposed to be pretending we're in the
-    // RSC server "world" and that `stream` comes from `fetch`. So this is
-    // us emulating the reply (stream) you'd get from a fetch call.
+    // We're in clientSsr.ts, but we're supposed to be pretending we're in the
+    // RSC server "world" and that `stream` comes from `fetch`. So this is us
+    // emulating the reply (stream) you'd get from a fetch call.
     const stream = renderToReadableStream(
       // createElement(layout, undefined, createElement(page, props)),
       // @ts-expect-error - WIP


### PR DESCRIPTION
Improve two comments and fix a spelling misstake

 * `packages/auth/src/AuthProvider/AuthProvider.tsx`
 * `packages/cli/src/commands/serveBothHandler.js`
 * `packages/vite/src/clientSsr.ts`
