### PR TITLE
chore(auth): Separate AuthProviderState export

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,6 +14,16 @@
       "import": "./dist/index.js",
       "default": "./dist/cjs/index.js"
     },
+    "./AuthProviderState": {
+      "types": "./dist/AuthProvider/AuthProviderState.d.ts",
+      "import": "./dist/AuthProvider/AuthProviderState.js",
+      "default": "./dist/cjs/AuthProvider/AuthProviderState.js"
+    },
+    "./dist/AuthProvider/AuthProviderState.js": {
+      "types": "./dist/AuthProvider/AuthProviderState.d.ts",
+      "import": "./dist/AuthProvider/AuthProviderState.js",
+      "default": "./dist/cjs/AuthProvider/AuthProviderState.js"
+    },
     "./ServerAuthProvider": {
       "types": "./dist/AuthProvider/ServerAuthProvider.d.ts",
       "import": "./dist/AuthProvider/ServerAuthProvider.js",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -5,6 +5,10 @@ export { createAuthentication } from './authFactory.js'
 export type { CustomProviderHooks } from './authFactory.js'
 export type { AuthImplementation } from './AuthImplementation.js'
 
-export * from './AuthProvider/AuthProviderState.js'
+export {
+  spaDefaultAuthProviderState,
+  middlewareDefaultAuthProviderState,
+} from './AuthProvider/AuthProviderState.js'
+export type { AuthProviderState } from './AuthProvider/AuthProviderState.js'
 
-export * from './getCurrentUserFromMiddleware.js'
+export { getCurrentUserFromMiddleware } from './getCurrentUserFromMiddleware.js'

--- a/packages/vite/src/middleware/MiddlewareRequest.ts
+++ b/packages/vite/src/middleware/MiddlewareRequest.ts
@@ -1,6 +1,6 @@
 import { Request as WhatWgRequest } from '@whatwg-node/fetch'
 
-import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth'
+import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth/dist/AuthProvider/AuthProviderState.js'
 import type { ServerAuthState } from '@redwoodjs/auth/dist/AuthProvider/ServerAuthProvider.js'
 
 import { CookieJar } from './CookieJar.js'

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -6,7 +6,7 @@ import type { HTTPMethod } from 'find-my-way'
 import { createIsbotFromList, list as isbotList } from 'isbot'
 import type { ViteDevServer } from 'vite'
 
-import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth'
+import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth/dist/AuthProvider/AuthProviderState.js'
 import type { ServerAuthState } from '@redwoodjs/auth/dist/AuthProvider/ServerAuthProvider.js'
 import type { RouteSpec, RWRouteManifestItem } from '@redwoodjs/internal'
 import { getAppRouteHook, getConfig, getPaths } from '@redwoodjs/project-config'


### PR DESCRIPTION
Similar to https://github.com/redwoodjs/redwood/pull/10711
Here I'm creating a separate export for AuthProviderState so that I can import just that one file and not the entire package. This will be needed for RSC where we don't want to also pull in client-only code like `createContext`