### PR TITLE
chore(vite): dist imports from router

### DIFF
--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -10,7 +10,7 @@ import { middlewareDefaultAuthProviderState } from '@redwoodjs/auth'
 import type { ServerAuthState } from '@redwoodjs/auth/dist/AuthProvider/ServerAuthProvider.js'
 import type { RouteSpec, RWRouteManifestItem } from '@redwoodjs/internal'
 import { getAppRouteHook, getConfig, getPaths } from '@redwoodjs/project-config'
-import { matchPath } from '@redwoodjs/router'
+import { matchPath } from '@redwoodjs/router/dist/util.js'
 import type { TagDescriptor } from '@redwoodjs/web'
 
 import { invoke } from '../middleware/invokeMiddleware.js'

--- a/packages/vite/src/streaming/triggerRouteHooks.ts
+++ b/packages/vite/src/streaming/triggerRouteHooks.ts
@@ -1,6 +1,6 @@
 import type { ViteDevServer } from 'vite'
 
-import { parseSearch } from '@redwoodjs/router'
+import { parseSearch } from '@redwoodjs/router/dist/util.js'
 import type {
   MetaHook,
   RouteHookEvent,


### PR DESCRIPTION
Don't pull in the entire router package, just the specific file we need. Small perf win, but mainly for RSC, so that I don't include client only code like `createContext`