### PR TITLE
chore(ServerInject): Named imports and source format

### DIFF
--- a/packages/web/src/components/ServerInject.tsx
+++ b/packages/web/src/components/ServerInject.tsx
@@ -1,28 +1,24 @@
-import type { ReactNode } from 'react'
-import React, { Fragment, useContext, useId } from 'react'
+import React, { Fragment, createContext, useContext, useId } from 'react'
 
 /**
- *
  * Inspired by Next's useServerInsertedHTML, originally designed for CSS-in-JS
  * for now it seems the only way to inject html with streaming is to use a context
  *
  * We use this for <head> tags, and for apollo cache hydration
  *
  * Until https://github.com/reactjs/rfcs/pull/219 makes it into react
- *
  */
 
-export type RenderCallback = () => ReactNode
+export type RenderCallback = () => React.ReactNode
 
-export const ServerHtmlContext = React.createContext<
+export const ServerHtmlContext = createContext<
   (callback: RenderCallback) => void
 >(() => {})
 
 /**
- *
- *  Use this factory, once per request.
- *  This is to ensure that injectionState is isolated to the request
- *  and not shared between requests.
+ * Use this factory, once per request.
+ * This is to ensure that injectionState is isolated to the request
+ * and not shared between requests.
  */
 export const createInjector = () => {
   const injectionState: Set<RenderCallback> = new Set([])


### PR DESCRIPTION
Use named imports (aka destructuring imports) so it's more obvious, right at the top of the file, what potential client-only imports from React the file uses

Also did some source comment formatting