### PR TITLE
fix(deps): Remove @swc/core resolution

### DIFF
--- a/.changesets/10718.md
+++ b/.changesets/10718.md
@@ -1,0 +1,8 @@
+- fix(deps): Remove @swc/core resolution (#10718) by @Tobbe
+
+This PR removes the resolutions set for `@swc/core` as they're not needed anymore. A newer, fixed, version of SWC was released.
+See https://github.com/swc-project/swc/issues/8988
+
+The resolutions were added in https://github.com/redwoodjs/redwood/pull/10690
+
+This was never part of a proper Redwood release, only canary builds. So no users should be affected, except for those few who might have installed using the canary version of CRWA, but if you do that you have to know what you're getting yourself into 😄 

--- a/__fixtures__/fragment-test-project/package.json
+++ b/__fixtures__/fragment-test-project/package.json
@@ -20,8 +20,5 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.1.1",
-  "resolutions": {
-    "@swc/core": "1.5.7"
-  }
+  "packageManager": "yarn@4.1.1"
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -23,7 +23,6 @@
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
     "@apollo/client/rehackt": "0.1.0",
-    "@swc/core": "1.5.7",
     "react-is": "19.0.0-beta-04b058868c-20240508"
   }
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -24,7 +24,6 @@
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
     "@apollo/client/rehackt": "0.1.0",
-    "@swc/core": "1.5.7",
     "react-is": "19.0.0-beta-04b058868c-20240508"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -24,7 +24,6 @@
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
     "@apollo/client/rehackt": "0.1.0",
-    "@swc/core": "1.5.7",
     "react-is": "19.0.0-beta-04b058868c-20240508"
   }
 }

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -24,7 +24,6 @@
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
     "@apollo/client/rehackt": "0.1.0",
-    "@swc/core": "1.5.7",
     "react-is": "19.0.0-beta-04b058868c-20240508"
   }
 }

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -24,7 +24,6 @@
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
     "@apollo/client/rehackt": "0.1.0",
-    "@swc/core": "1.5.7",
     "react-is": "19.0.0-beta-04b058868c-20240508"
   }
 }


### PR DESCRIPTION
This PR removes the resolutions set for `@swc/core` as they're not needed anymore. A newer, fixed, version of SWC was released.
See https://github.com/swc-project/swc/issues/8988

The resolutions were added in https://github.com/redwoodjs/redwood/pull/10690

This was never part of a proper Redwood release, only canary builds. So no users should be affected, except for those few who might have installed using the canary version of CRWA, but if you do that you have to know what you're getting yourself into 😄 