### PR TITLE
chore(logging): Remove overly verbose logging

### DIFF
--- a/packages/vite/src/clientSsr.ts
+++ b/packages/vite/src/clientSsr.ts
@@ -58,7 +58,6 @@ function resolveClientEntryForProd(
   const filePathSlash = filePath.replaceAll('\\', '/')
   const clientEntry = absoluteClientEntries[filePathSlash]
 
-  console.log('absoluteClientEntries', absoluteClientEntries)
   console.log('resolveClientEntryForProd during SSR - filePath', clientEntry)
 
   if (!clientEntry) {


### PR DESCRIPTION
This was getting too noisy, drowning out other console logs that are more relevant at this point