### PR TITLE
chore(ci): Track `@redwoodjs/router` in RSC CI

### DIFF
--- a/.github/actions/detect-changes/cases/rsc.mjs
+++ b/.github/actions/detect-changes/cases/rsc.mjs
@@ -21,6 +21,7 @@ export function rscChanged(changedFiles){
       changedFile.startsWith('packages/project-config/') ||
       changedFile.startsWith('packages/web/') ||
       changedFile.startsWith('packages/vite/') ||
+      changedFile.startsWith('packages/router/') ||
       changedFile.startsWith('__fixtures__/test-project-rsa') ||
       changedFile.startsWith('__fixtures__/test-project-rsc-kitchen-sink')
     ) {


### PR DESCRIPTION
We want to ensure changes to the `@redwoodjs/router` package trigger the RSC CI.