### PR TITLE
chore(yarn): Remove studio workspace reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "packages/cli-packages/*",
     "packages/mailer/core",
     "packages/mailer/handlers/*",
-    "packages/mailer/renderers/*",
-    "packages/studio/web"
+    "packages/mailer/renderers/*"
   ],
   "scripts": {
     "build": "nx run-many -t build",


### PR DESCRIPTION
Studio has moved to a separate repo and is not a workspace in this repo anymore, so should not be listed under "workspaces"