### PR TITLE
chore(ci): Fix set-up-job description

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -1,7 +1,7 @@
 name: Set up job
 description: >
   Everything you need to run a job in CI.
-  Checkout this repo (redwoodjs/redwood), set up Node.js, yarn install, and build.
+  Enable corepack, set up Node.js, yarn install, and build.
 
 inputs:
   set-up-yarn-cache:


### PR DESCRIPTION
The description for the "Set up job" action wasn't up-to-date anymore. This PR Fixes that