### PR TITLE
chore(formatting): Fix "check annotations" in mock-router

### DIFF
--- a/packages/storybook/src/plugins/mock-router.ts
+++ b/packages/storybook/src/plugins/mock-router.ts
@@ -8,7 +8,7 @@ export function mockRouter(): PluginOption {
       if (id.includes('src')) {
         code = code.replace(
           "'@redwoodjs/router'",
-          "'storybook-framework-redwoodjs-vite/dist/mocks/MockRouter'"
+          "'storybook-framework-redwoodjs-vite/dist/mocks/MockRouter'",
         )
       }
       return code


### PR DESCRIPTION
Fixing this
![image](https://github.com/redwoodjs/redwood/assets/30793/9306fa8f-0c35-4f63-827a-2e91235a8630)
