### PR TITLE
fix(og-mw-setup): Fix typo in notes for og-middleware setup

### DIFF
--- a/packages/cli/src/commands/setup/middleware/ogImage/ogImageHandler.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/ogImageHandler.ts
@@ -99,7 +99,7 @@ export async function handler({ force }: { force: boolean }) {
         task: () => {
           // Note: We avoid logging in the task because it can mess up the formatting of the text and we are often looking to maintain some basic indentation and such.
           notes.push(
-            "og:image generation is almost ready to go! You'll need to add playwright as a dependency to the api side and then install the headless browser packages:",
+            "og:image generation is almost ready to go! You'll need to add playwright as a dependency to the web side and then install the headless browser packages:",
           )
           notes.push('')
           notes.push('  yarn workspace web add playwright')

--- a/packages/cli/src/commands/setup/middleware/ogImage/ogImageHandler.ts
+++ b/packages/cli/src/commands/setup/middleware/ogImage/ogImageHandler.ts
@@ -102,8 +102,8 @@ export async function handler({ force }: { force: boolean }) {
             "og:image generation is almost ready to go! You'll need to add playwright as a dependency to the api side and then install the headless browser packages:",
           )
           notes.push('')
-          notes.push('  yarn workspace api add playwright')
-          notes.push('  yarn workspace api playwright install')
+          notes.push('  yarn workspace web add playwright')
+          notes.push('  yarn workspace web playwright install')
           notes.push('')
           notes.push(
             'Depending on how your host is configured you may need to install additional dependencies first. If so, the `playwright install` step will error out and give you the command to run to install those deps.',


### PR DESCRIPTION
Found a typo when I tried this earlier, I think it the setup instructions should ask users to install on the web side, not the api :) 