### PR TITLE
chore(client-entry): Slight tweaks around entry.client handling

### DIFF
--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -44,7 +44,7 @@ export async function rscBuildClient(clientEntryFiles: Record<string, string>) {
         input: {
           // @MARK: temporary hack to find the entry client so we can get the
           // index.css bundle but we don't actually want this on an rsc page!
-          'rwjs-client-entry': rwPaths.web.entryClient,
+          __rwjs__client_entry: rwPaths.web.entryClient,
           // we need this, so that the output contains rsc-specific bundles
           // for the client-only components. They get loaded once the page is
           // rendered

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -64,7 +64,7 @@ export async function rscBuildForSsr({
           // index.css bundle but we don't actually want this on an rsc page!
           // TODO (RSC): Look into if we can remove this (and perhaps instead
           // use entry.server)
-          'rwjs-client-entry': rwPaths.web.entryClient,
+          __rwjs__client_entry: rwPaths.web.entryClient,
           'entry.server': rwPaths.web.entryServer,
           // we need this, so that the output contains rsc-specific bundles
           // for the client-only components. They get loaded once the page is

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -79,14 +79,14 @@ export async function runFeServer() {
     await import(clientBuildManifestUrl, { with: { type: 'json' } })
   ).default
 
-  // Even though entry.server.tsx is the main entry point for SSR, we still
-  // need to read the client build manifest and find entry.client.tsx to get
+  // Even though `entry.server.tsx` is the main entry point for SSR, we still
+  // need to read the client build manifest and find `entry.client.tsx` to get
   // the correct links to insert for the initial CSS files that will eventually
   // be rendered when the finalized html output is being streamed to the
-  // browser. We also need it to tell React what JS bundle contains hydrateRoot
-  // when it'll eventually get to hydrating things in the browser
+  // browser. We also need it to tell React what JS bundle contains
+  // `hydrateRoot` when it'll eventually get to hydrating things in the browser
   //
-  // So, clientEntry is used to find the initial JS bundle to load in the
+  // So, `clientEntry` is used to find the initial JS bundle to load in the
   // browser and also to discover CSS files that will be needed to render the
   // initial page.
   //

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -79,9 +79,19 @@ export async function runFeServer() {
     await import(clientBuildManifestUrl, { with: { type: 'json' } })
   ).default
 
-  // clientEntry is used to find the initial JS bundle to send to the client
-  // and also to discover CSS files that will be passed to all middleware and
-  // also used for the initial render of the current page
+  // Even though entry.server.tsx is the main entry point for SSR, we still
+  // need to read the client build manifest and find entry.client.tsx to get
+  // the correct links to insert for the initial CSS files that will eventually
+  // be rendered when the finalized html output is being streamed to the
+  // browser. We also need it to tell React what JS bundle contains hydrateRoot
+  // when it'll eventually get to hydrating things in the browser
+  //
+  // So, clientEntry is used to find the initial JS bundle to load in the
+  // browser and also to discover CSS files that will be needed to render the
+  // initial page.
+  //
+  // In addition to all the above the discovered CSS files are also passed to
+  // all middleware that have been registered
   const clientEntry = rscEnabled
     ? clientBuildManifest['entry.client.tsx'] ||
       clientBuildManifest['entry.client.jsx']

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -92,12 +92,18 @@ export const createReactStreamingHandler = async (
         route.pathDefinition,
         currentUrl.pathname,
       )
+
       if (match) {
         currentRoute = route
         parsedParams = rest
+
         break
       }
     }
+
+    // Using a function to get the CSS links because we need to wait for the
+    // vite dev server to analyze the module graph
+    const cssLinks = getStylesheetLinks(currentRoute)
 
     // ~~~ Middleware Handling ~~~
     if (middlewareRouter) {
@@ -107,7 +113,7 @@ export const createReactStreamingHandler = async (
         matchedMw?.handler as Middleware | undefined,
         {
           route: currentRoute,
-          cssPaths: getStylesheetLinks(currentRoute),
+          cssPaths: cssLinks,
           params: matchedMw?.params,
           viteDevServer,
         },
@@ -172,19 +178,14 @@ export const createReactStreamingHandler = async (
 
     metaTags = routeHookOutput.meta
 
-    // @MARK @TODO(RSC_DC): the entry path for RSC will be different,
-    // because we don't want to inject a full bundle, just a slice of it
-    // I'm not sure what though....
-    const jsBundles = [
-      clientEntryPath, // @NOTE: must have slash in front
-      currentRoute.bundle && '/' + currentRoute.bundle,
-    ].filter(Boolean) as string[]
+    // TODO (RSC): Do we really want to inject the full bundle here, or is
+    // there a smaller slice of it we can inject?
+    const jsBundles = ['/' + clientEntryPath]
+    if (currentRoute.bundle) {
+      jsBundles.push('/' + currentRoute.bundle)
+    }
 
     const isSeoCrawler = isbot(req.headers.get('user-agent') || '')
-
-    // Using a function to get the CSS links because we need to wait for the
-    // vite dev server to analyze the module graph
-    const cssLinks = getStylesheetLinks(currentRoute)
 
     const reactResponse = await reactRenderToStreamResponse(
       mwResponse,

--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -262,6 +262,7 @@ export async function reactRenderToStreamResponse(
     clearTimeout(timeoutHandle)
   }
 }
+
 function applyStreamTransforms(
   reactStream: ReactDOMServerReadableStream,
   transformsToApply: (TransformStream | false)[],


### PR DESCRIPTION
I was trying to better understand how `entry.client.tsx` was used during SSR, and when following the code I found a few things I wanted to change to, in my opinion, make the code easier to read, understand and follow.

Even though `entry.server.tsx` is the main entry point for SSR, we still need to read the client build manifest and find `entry.client.tsx` to get the correct links to insert for the initial CSS files the browser will eventually render when the finalized html output is being streamed to the browser. We also need it to tell React what JS bundle contains `hydrateRoot` when it'll eventually get to hydrating things in the browser