### PR TITLE
RSC: Add `<App>` to kitchen-sink test project

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/entry.server.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/entry.server.tsx
@@ -1,5 +1,6 @@
 import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
 
+import App from './App'
 import { Document } from './Document'
 import Routes from './Routes'
 
@@ -16,7 +17,9 @@ interface Props {
 export const ServerEntry: React.FC<Props> = ({ css, meta, location }) => {
   return (
     <Document css={css} meta={meta}>
-      <Routes location={location} />
+      <App>
+        <Routes location={location} />
+      </App>
     </Document>
   )
 }


### PR DESCRIPTION
Now with the new build process (https://github.com/redwoodjs/redwood/pull/10688) we can finally have `<App>` also in `entry.server.tsx`
