### PR TITLE
RSC: Rename dist/client to dist/browser

### DIFF
--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -156,7 +156,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distClient: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distSsrDocument: path.join(
@@ -440,7 +440,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distClient: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distRscEntries: path.join(
@@ -765,7 +765,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distClient: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distRscEntries: path.join(
@@ -1043,7 +1043,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distClient: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distRscEntries: path.join(

--- a/packages/project-config/src/__tests__/paths.test.ts
+++ b/packages/project-config/src/__tests__/paths.test.ts
@@ -156,7 +156,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'browser'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distSsrDocument: path.join(
@@ -440,7 +440,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'browser'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distRscEntries: path.join(
@@ -765,7 +765,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'browser'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distRscEntries: path.join(
@@ -1043,7 +1043,7 @@ describe('paths', () => {
             'ssr',
             'routeHooks',
           ),
-          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'client'),
+          distBrowser: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'browser'),
           distRsc: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'rsc'),
           distSsr: path.join(FIXTURE_BASEDIR, 'web', 'dist', 'ssr'),
           distRscEntries: path.join(

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -48,7 +48,7 @@ export interface WebPaths {
   storybookPreviewConfig: string | null
   storybookManagerConfig: string
   dist: string
-  distClient: string
+  distBrowser: string
   distRsc: string
   distSsr: string
   distSsrDocument: string
@@ -126,7 +126,7 @@ const PATH_WEB_DIR_CONFIG_STORYBOOK_MANAGER = 'web/config/storybook.manager.js'
 const PATH_WEB_DIR_DIST = 'web/dist'
 
 // Used by Streaming & RSC builds to output to their individual folders
-const PATH_WEB_DIR_DIST_CLIENT = 'web/dist/client'
+const PATH_WEB_DIR_DIST_BROWSER = 'web/dist/browser'
 const PATH_WEB_DIR_DIST_RSC = 'web/dist/rsc'
 const PATH_WEB_DIR_DIST_SSR = 'web/dist/ssr'
 
@@ -243,7 +243,7 @@ export const getPaths = (BASE_DIR: string = getBaseDir()): Paths => {
         PATH_WEB_DIR_CONFIG_STORYBOOK_MANAGER,
       ),
       dist: path.join(BASE_DIR, PATH_WEB_DIR_DIST),
-      distClient: path.join(BASE_DIR, PATH_WEB_DIR_DIST_CLIENT),
+      distBrowser: path.join(BASE_DIR, PATH_WEB_DIR_DIST_BROWSER),
       distRsc: path.join(BASE_DIR, PATH_WEB_DIR_DIST_RSC),
       distSsr: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR),
       distSsrDocument: path.join(BASE_DIR, PATH_WEB_DIR_DIST_SSR_DOCUMENT),

--- a/packages/vite/src/buildRouteManifest.ts
+++ b/packages/vite/src/buildRouteManifest.ts
@@ -17,7 +17,7 @@ export async function buildRouteManifest() {
   const rwPaths = getPaths()
 
   const buildManifestUrl = url.pathToFileURL(
-    path.join(getPaths().web.distClient, 'client-build-manifest.json'),
+    path.join(getPaths().web.distBrowser, 'client-build-manifest.json'),
   ).href
   const clientBuildManifest: ViteBuildManifest = (
     await import(buildManifestUrl, { with: { type: 'json' } })

--- a/packages/vite/src/clientSsr.ts
+++ b/packages/vite/src/clientSsr.ts
@@ -108,7 +108,7 @@ export async function renderRoutesFromDist<TProps extends Record<string, any>>(
         const id = resolveClientEntryForProd(filePath, clientEntries)
 
         console.log('clientSsr.ts::Proxy id', id)
-        // id /Users/tobbe/tmp/test-project-rsc-kitchen-sink/web/dist/client/assets/rsc-AboutCounter.tsx-1-4kTKU8GC.mjs
+        // id /Users/tobbe/tmp/test-project-rsc-kitchen-sink/web/dist/browser/assets/rsc-AboutCounter.tsx-1-4kTKU8GC.mjs
         return { id, chunks: [id], name, async: true }
       },
     },

--- a/packages/vite/src/lib/getMergedConfig.ts
+++ b/packages/vite/src/lib/getMergedConfig.ts
@@ -115,9 +115,8 @@ export function getMergedConfig(rwConfig: Config, rwPaths: Paths) {
         minify: false,
         // NOTE this gets overridden when build gets called anyway!
         outDir:
-          // @MARK: For RSC and Streaming, we build to dist/client directory
           streamingSsrEnabled || rscEnabled
-            ? rwPaths.web.distClient
+            ? rwPaths.web.distBrowser
             : rwPaths.web.dist,
         emptyOutDir: true,
         manifest: !env.isSsrBuild ? 'client-build-manifest.json' : undefined,

--- a/packages/vite/src/rsc/rscBuildClient.ts
+++ b/packages/vite/src/rsc/rscBuildClient.ts
@@ -37,7 +37,7 @@ export async function rscBuildClient(clientEntryFiles: Record<string, string>) {
     build: {
       // TODO (RSC): Remove `minify: false` when we don't need to debug as often
       minify: false,
-      outDir: rwPaths.web.distClient,
+      outDir: rwPaths.web.distBrowser,
       emptyOutDir: true, // Needed because `outDir` is not inside `root`
       rollupOptions: {
         onwarn: onWarn,

--- a/packages/vite/src/rsc/rscBuildCopyCssAssets.ts
+++ b/packages/vite/src/rsc/rscBuildCopyCssAssets.ts
@@ -30,7 +30,7 @@ export function rscBuildCopyCssAssets(
       .map((cssAsset) => {
         return fs.copyFile(
           path.join(rwPaths.web.distRsc, cssAsset.fileName),
-          path.join(rwPaths.web.distClient, cssAsset.fileName),
+          path.join(rwPaths.web.distBrowser, cssAsset.fileName),
         )
       }),
   )

--- a/packages/vite/src/rsc/rscBuildEntriesFile.ts
+++ b/packages/vite/src/rsc/rscBuildEntriesFile.ts
@@ -87,7 +87,7 @@ export async function rscBuildEntriesMappings(
 
   await fs.appendFile(
     rwPaths.web.distRscEntries,
-    '// client component mapping (dist/rsc -> dist/client)\n' +
+    '// client component mapping (dist/rsc -> dist/browser)\n' +
       `export const clientEntries = ${JSON.stringify(clientEntries, undefined, 2)};\n\n`,
   )
   await fs.appendFile(

--- a/packages/vite/src/rsc/rscCss.ts
+++ b/packages/vite/src/rsc/rscCss.ts
@@ -13,7 +13,7 @@ import { getPaths } from '@redwoodjs/project-config'
 // streams - which was too difficult to resolve at that time.
 export function getRscStylesheetLinkGenerator(existingLinks?: string[]) {
   const clientBuildManifestPath = path.join(
-    getPaths().web.distClient,
+    getPaths().web.distBrowser,
     'client-build-manifest.json',
   )
   const clientBuildManifest = JSON.parse(

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -73,7 +73,7 @@ export async function runFeServer() {
   ).default
 
   const clientBuildManifestUrl = url.pathToFileURL(
-    path.join(rwPaths.web.distClient, 'client-build-manifest.json'),
+    path.join(rwPaths.web.distBrowser, 'client-build-manifest.json'),
   ).href
   const clientBuildManifest: ViteBuildManifest = (
     await import(clientBuildManifestUrl, { with: { type: 'json' } })
@@ -129,7 +129,7 @@ export async function runFeServer() {
   // For CF workers, we'd need an equivalent of this
   app.use(
     '/assets',
-    express.static(rwPaths.web.distClient + '/assets', { index: false }),
+    express.static(rwPaths.web.distBrowser + '/assets', { index: false }),
   )
 
   app.use('*', (req, _res, next) => {
@@ -174,7 +174,7 @@ export async function runFeServer() {
   // otherwise it will catch all requests for static assets and return a 404.
   // Placing this here defines our precedence for static asset handling - that we favor
   // the static assets over any application routing.
-  app.use(express.static(rwPaths.web.distClient, { index: false }))
+  app.use(express.static(rwPaths.web.distBrowser, { index: false }))
 
   const getStylesheetLinks = rscEnabled
     ? getRscStylesheetLinkGenerator(clientEntry.css)


### PR DESCRIPTION
Rename `dist/client` to `dist/browser`

There are two clients, one for SSR and one for users browsing the page (their browser). To make it clear which one these files are used for I decided to rename it to "browser".

There's also "client" as part of the `'use client'` directive. Those client components are built to both the `dist/ssr` and `dist/browser` directories because they're used by both those clients.