### PR TITLE
chore(deps): Switch to smol-toml

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.22.20",
-    "@iarna/toml": "2.2.5",
     "@opentelemetry/api": "1.8.0",
     "@redwoodjs/project-config": "workspace:*",
     "@redwoodjs/telemetry": "workspace:*",
@@ -40,6 +39,7 @@
     "pascalcase": "1.0.0",
     "prettier": "3.2.5",
     "prompts": "2.4.2",
+    "smol-toml": "^1.2.1",
     "terminal-link": "2.1.1"
   },
   "devDependencies": {

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -39,7 +39,7 @@
     "pascalcase": "1.0.0",
     "prettier": "3.2.5",
     "prompts": "2.4.2",
-    "smol-toml": "^1.2.1",
+    "smol-toml": "1.2.1",
     "terminal-link": "2.1.1"
   },
   "devDependencies": {

--- a/packages/cli-helpers/src/lib/__tests__/__snapshots__/project.test.ts.snap
+++ b/packages/cli-helpers/src/lib/__tests__/__snapshots__/project.test.ts.snap
@@ -53,16 +53,18 @@ exports[`addEnvVar > addEnvVar adds environment variables as part of a setup tas
 exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds package but keeps autoInstall false 1`] = `
 "[web]
 title = "Redwood App"
-port = 8_910
+port = 8910
 apiUrl = "/.redwood/functions"
-includeEnvironmentVariables = [ ]
+includeEnvironmentVariables = []
 
 [api]
-port = 8_911
+port = 8911
 
+[experimental]
 [experimental.cli]
 autoInstall = false
-
+[experimental]
+[experimental.cli]
 [[experimental.cli.plugins]]
 package = "@example/test-package-when-autoInstall-false"
 enabled = true
@@ -72,19 +74,21 @@ enabled = true
 exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds when experimental cli has some plugins configured 1`] = `
 "[web]
 title = "Redwood App"
-port = 8_910
+port = 8910
 apiUrl = "/.redwood/functions"
-includeEnvironmentVariables = [ ]
+includeEnvironmentVariables = []
 
 [api]
-port = 8_911
+port = 8911
 
+[experimental]
 [experimental.cli]
 autoInstall = true
 
-  [[experimental.cli.plugins]]
-  package = "@existing-example/some-package-when-cli-has-some-packages-configured"
-
+[[experimental.cli.plugins]]
+package = "@existing-example/some-package-when-cli-has-some-packages-configured"
+[experimental]
+[experimental.cli]
 [[experimental.cli.plugins]]
 package = "@example/test-package-name"
 enabled = true
@@ -94,35 +98,37 @@ enabled = true
 exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds when experimental cli is not configured 1`] = `
 "[web]
 title = "Redwood App"
-port = 8_910
+port = 8910
 apiUrl = "/.redwood/functions"
-includeEnvironmentVariables = [ ]
+includeEnvironmentVariables = []
 
 [api]
-port = 8_911
-
+port = 8911
+[experimental]
 [experimental.cli]
 autoInstall = true
 
-  [[experimental.cli.plugins]]
-  package = "@example/test-package-when-cli-not-configured"
-  enabled = true
+[[experimental.cli.plugins]]
+package = "@example/test-package-when-cli-not-configured"
+enabled = true
 "
 `;
 
 exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > adds when experimental cli is setup but has no plugins configured 1`] = `
 "[web]
 title = "Redwood App"
-port = 8_910
+port = 8910
 apiUrl = "/.redwood/functions"
-includeEnvironmentVariables = [ ]
+includeEnvironmentVariables = []
 
 [api]
-port = 8_911
+port = 8911
 
+[experimental]
 [experimental.cli]
 autoInstall = true
-
+[experimental]
+[experimental.cli]
 [[experimental.cli.plugins]]
 package = "@example/test-package-when-no-plugins-configured"
 enabled = true
@@ -132,18 +138,18 @@ enabled = true
 exports[`updateTomlConfig > updateTomlConfig configures a new CLI plugin > does not add duplicate place when experimental cli has that plugin configured 1`] = `
 "[web]
 title = "Redwood App"
-port = 8_910
+port = 8910
 apiUrl = "/.redwood/functions"
-includeEnvironmentVariables = [ ]
+includeEnvironmentVariables = []
 
 [api]
-port = 8_911
+port = 8911
 
+[experimental]
 [experimental.cli]
 autoInstall = true
 
-  [[experimental.cli.plugins]]
-  package = "@existing-example/some-package-name-already-exists"
-
+[[experimental.cli.plugins]]
+package = "@existing-example/some-package-name-already-exists"
 "
 `;

--- a/packages/cli-helpers/src/lib/__tests__/project.test.ts
+++ b/packages/cli-helpers/src/lib/__tests__/project.test.ts
@@ -9,7 +9,7 @@ vi.mock('node:fs', async () => {
 
 import * as fs from 'node:fs'
 
-import * as toml from '@iarna/toml'
+import * as toml from 'smol-toml'
 import { vi, describe, beforeEach, afterEach, it, expect } from 'vitest'
 
 import { updateTomlConfig, addEnvVar } from '../project.js'

--- a/packages/cli-helpers/src/lib/project.ts
+++ b/packages/cli-helpers/src/lib/project.ts
@@ -1,9 +1,8 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 
-import type { JsonMap } from '@iarna/toml'
-import toml from '@iarna/toml'
 import dotenv from 'dotenv'
+import toml from 'smol-toml'
 
 import type { Config } from '@redwoodjs/project-config'
 import {
@@ -55,7 +54,7 @@ export const updateTomlConfig = (packageName: string) => {
   const redwoodTomlPath = getConfigPath()
   const originalTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
 
-  let tomlToAppend = {} as JsonMap
+  let tomlToAppend: toml.TomlPrimitive = {}
 
   const config = getConfig(redwoodTomlPath)
 
@@ -94,7 +93,12 @@ export const updateTomlConfig = (packageName: string) => {
     }
   }
 
-  const newConfig = originalTomlContent + '\n' + toml.stringify(tomlToAppend)
+  const newConfig =
+    originalTomlContent +
+    '\n' +
+    (Object.keys(tomlToAppend).length > 0
+      ? toml.stringify(tomlToAppend) + '\n'
+      : '')
 
   return fs.writeFileSync(redwoodTomlPath, newConfig, 'utf-8')
 }
@@ -207,11 +211,13 @@ export function setTomlSetting(
   const redwoodTomlPath = getConfigPath()
   const originalTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
 
-  // Can't type toml.parse because this PR has not been included in a released yet
-  // https://github.com/iarna/iarna-toml/commit/5a89e6e65281e4544e23d3dbaf9e8428ed8140e9
-  const redwoodTomlObject = toml.parse(originalTomlContent) as any
+  const redwoodTomlObject = toml.parse(originalTomlContent)
+  const sectionValue = redwoodTomlObject[section]
 
-  const existingValue = redwoodTomlObject?.[section]?.[setting]
+  const existingValue =
+    // I don't like this type cast, but I couldn't come up with a much better
+    // solution
+    (sectionValue as Record<string, toml.TomlPrimitive> | undefined)?.[setting]
 
   // If the setting already exists in the given section, and has the given
   // value already, just return

--- a/packages/cli-helpers/src/lib/project.ts
+++ b/packages/cli-helpers/src/lib/project.ts
@@ -54,7 +54,7 @@ export const updateTomlConfig = (packageName: string) => {
   const redwoodTomlPath = getConfigPath()
   const originalTomlContent = fs.readFileSync(redwoodTomlPath, 'utf-8')
 
-  let tomlToAppend: toml.TomlPrimitive = {}
+  let tomlToAppend: Record<string, toml.TomlPrimitive> = {}
 
   const config = getConfig(redwoodTomlPath)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.5",
-    "@iarna/toml": "2.2.5",
     "@opentelemetry/api": "1.8.0",
     "@opentelemetry/core": "1.22.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
@@ -75,6 +74,7 @@
     "prompts": "2.4.2",
     "rimraf": "5.0.7",
     "semver": "7.6.2",
+    "smol-toml": "^1.2.1",
     "string-env-interpolation": "1.0.1",
     "systeminformation": "5.22.9",
     "terminal-link": "2.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,7 +74,7 @@
     "prompts": "2.4.2",
     "rimraf": "5.0.7",
     "semver": "7.6.2",
-    "smol-toml": "^1.2.1",
+    "smol-toml": "1.2.1",
     "string-env-interpolation": "1.0.1",
     "systeminformation": "5.22.9",
     "terminal-link": "2.1.1",

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -1,9 +1,9 @@
 import path from 'path'
 
-import toml from '@iarna/toml'
 import boxen from 'boxen'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
+import toml from 'smol-toml'
 import { env as envInterpolation } from 'string-env-interpolation'
 import terminalLink from 'terminal-link'
 import { titleCase } from 'title-case'

--- a/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
+++ b/packages/cli/src/commands/setup/deploy/providers/coherenceHandler.js
@@ -1,9 +1,9 @@
 import path from 'path'
 
-import toml from '@iarna/toml'
 import { getSchema, getConfig } from '@prisma/internals'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
+import toml from 'smol-toml'
 
 import {
   colors as c,

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -29,7 +29,6 @@
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime-corejs3": "7.24.5",
     "@babel/traverse": "^7.22.20",
-    "@iarna/toml": "2.2.5",
     "@redwoodjs/project-config": "workspace:*",
     "@svgr/core": "8.1.0",
     "@svgr/plugin-jsx": "8.1.0",

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -27,9 +27,9 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@iarna/toml": "2.2.5",
     "deepmerge": "4.3.1",
     "fast-glob": "3.3.2",
+    "smol-toml": "^1.2.1",
     "string-env-interpolation": "1.0.1"
   },
   "devDependencies": {

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "deepmerge": "4.3.1",
     "fast-glob": "3.3.2",
-    "smol-toml": "^1.2.1",
+    "smol-toml": "1.2.1",
     "string-env-interpolation": "1.0.1"
   },
   "devDependencies": {

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 
-import toml from '@iarna/toml'
 import merge from 'deepmerge'
+import toml from 'smol-toml'
 import { env as envInterpolation } from 'string-env-interpolation'
 
 import { getConfigPath } from './configPath.js'

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -43,7 +43,7 @@
     "lodash-decorators": "6.0.1",
     "lru-cache": "10.2.2",
     "proxyquire": "2.1.3",
-    "smol-toml": "^1.2.1",
+    "smol-toml": "1.2.1",
     "ts-morph": "15.1.0",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-textdocument": "1.0.11",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.5",
-    "@iarna/toml": "2.2.5",
     "@prisma/internals": "5.14.0",
     "@redwoodjs/project-config": "workspace:*",
     "@types/line-column": "1.0.2",
@@ -44,6 +43,7 @@
     "lodash-decorators": "6.0.1",
     "lru-cache": "10.2.2",
     "proxyquire": "2.1.3",
+    "smol-toml": "^1.2.1",
     "ts-morph": "15.1.0",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-textdocument": "1.0.11",

--- a/packages/structure/src/model/RWTOML.ts
+++ b/packages/structure/src/model/RWTOML.ts
@@ -1,5 +1,4 @@
-import type { JsonMap } from '@iarna/toml'
-import { parse as parseTOML } from '@iarna/toml'
+import toml from 'smol-toml'
 import { Range } from 'vscode-languageserver-types'
 
 import { FileNode } from '../ide'
@@ -20,13 +19,10 @@ export class RWTOML extends FileNode {
   // }
   // TODO: diagnostics
   @lazy() get parsedTOML() {
-    return parseTOML(this.text)
+    return toml.parse(this.text)
   }
   @lazy() get web_includeEnvironmentVariables(): string[] | undefined {
-    return (
-      ((this.parsedTOML?.web as JsonMap)
-        ?.includeEnvironmentVariables as string[]) ?? []
-    )
+    return this.parsedTOML?.web?.['includeEnvironmentVariables'] ?? []
   }
   *diagnostics() {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4894,13 +4894,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iarna/toml@npm:2.2.5":
-  version: 2.2.5
-  resolution: "@iarna/toml@npm:2.2.5"
-  checksum: 10c0/d095381ad4554aca233b7cf5a91f243ef619e5e15efd3157bc640feac320545450d14b394aebbf6f02a2047437ced778ae598d5879a995441ab7b6c0b2c2f201
-  languageName: node
-  linkType: hard
-
 "@ioredis/commands@npm:^1.1.1":
   version: 1.2.0
   resolution: "@ioredis/commands@npm:1.2.0"
@@ -7931,7 +7924,6 @@ __metadata:
   resolution: "@redwoodjs/cli-helpers@workspace:packages/cli-helpers"
   dependencies:
     "@babel/core": "npm:^7.22.20"
-    "@iarna/toml": "npm:2.2.5"
     "@opentelemetry/api": "npm:1.8.0"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/telemetry": "workspace:*"
@@ -7946,6 +7938,7 @@ __metadata:
     pascalcase: "npm:1.0.0"
     prettier: "npm:3.2.5"
     prompts: "npm:2.4.2"
+    smol-toml: "npm:^1.2.1"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.10.3"
     typescript: "npm:5.4.5"
@@ -8003,7 +7996,6 @@ __metadata:
     "@babel/cli": "npm:7.24.5"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.24.5"
-    "@iarna/toml": "npm:2.2.5"
     "@opentelemetry/api": "npm:1.8.0"
     "@opentelemetry/core": "npm:1.22.0"
     "@opentelemetry/exporter-trace-otlp-http": "npm:0.49.1"
@@ -8052,6 +8044,7 @@ __metadata:
     prompts: "npm:2.4.2"
     rimraf: "npm:5.0.7"
     semver: "npm:7.6.2"
+    smol-toml: "npm:^1.2.1"
     string-env-interpolation: "npm:1.0.1"
     systeminformation: "npm:5.22.9"
     terminal-link: "npm:2.1.1"
@@ -8078,7 +8071,6 @@ __metadata:
     "@babel/plugin-transform-typescript": "npm:^7.22.15"
     "@babel/runtime-corejs3": "npm:7.24.5"
     "@babel/traverse": "npm:^7.22.20"
-    "@iarna/toml": "npm:2.2.5"
     "@redwoodjs/project-config": "workspace:*"
     "@svgr/core": "npm:8.1.0"
     "@svgr/plugin-jsx": "npm:8.1.0"
@@ -8518,11 +8510,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/project-config@workspace:packages/project-config"
   dependencies:
-    "@iarna/toml": "npm:2.2.5"
     "@redwoodjs/framework-tools": "workspace:*"
     deepmerge: "npm:4.3.1"
     fast-glob: "npm:3.3.2"
     rimraf: "npm:5.0.7"
+    smol-toml: "npm:^1.2.1"
     string-env-interpolation: "npm:1.0.1"
     tsx: "npm:4.10.3"
     typescript: "npm:5.4.5"
@@ -8607,7 +8599,6 @@ __metadata:
     "@babel/cli": "npm:7.24.5"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.24.5"
-    "@iarna/toml": "npm:2.2.5"
     "@prisma/internals": "npm:5.14.0"
     "@redwoodjs/project-config": "workspace:*"
     "@types/fs-extra": "npm:11.0.4"
@@ -8629,6 +8620,7 @@ __metadata:
     lodash-decorators: "npm:6.0.1"
     lru-cache: "npm:10.2.2"
     proxyquire: "npm:2.1.3"
+    smol-toml: "npm:^1.2.1"
     ts-morph: "npm:15.1.0"
     typescript: "npm:5.4.5"
     vitest: "npm:1.6.0"
@@ -28741,6 +28733,13 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"smol-toml@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "smol-toml@npm:1.2.1"
+  checksum: 10c0/ef713022d327493b6680ba51b9651abbb9c5abf2199e03faaa98ea49ad96ab9336bb4edafa6c70bdb2f1399f709f92a576b026e75cfd32066f3ec1c6fea797fb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7938,7 +7938,7 @@ __metadata:
     pascalcase: "npm:1.0.0"
     prettier: "npm:3.2.5"
     prompts: "npm:2.4.2"
-    smol-toml: "npm:^1.2.1"
+    smol-toml: "npm:1.2.1"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.10.3"
     typescript: "npm:5.4.5"
@@ -8044,7 +8044,7 @@ __metadata:
     prompts: "npm:2.4.2"
     rimraf: "npm:5.0.7"
     semver: "npm:7.6.2"
-    smol-toml: "npm:^1.2.1"
+    smol-toml: "npm:1.2.1"
     string-env-interpolation: "npm:1.0.1"
     systeminformation: "npm:5.22.9"
     terminal-link: "npm:2.1.1"
@@ -8514,7 +8514,7 @@ __metadata:
     deepmerge: "npm:4.3.1"
     fast-glob: "npm:3.3.2"
     rimraf: "npm:5.0.7"
-    smol-toml: "npm:^1.2.1"
+    smol-toml: "npm:1.2.1"
     string-env-interpolation: "npm:1.0.1"
     tsx: "npm:4.10.3"
     typescript: "npm:5.4.5"
@@ -8620,7 +8620,7 @@ __metadata:
     lodash-decorators: "npm:6.0.1"
     lru-cache: "npm:10.2.2"
     proxyquire: "npm:2.1.3"
-    smol-toml: "npm:^1.2.1"
+    smol-toml: "npm:1.2.1"
     ts-morph: "npm:15.1.0"
     typescript: "npm:5.4.5"
     vitest: "npm:1.6.0"
@@ -28736,7 +28736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smol-toml@npm:^1.2.1":
+"smol-toml@npm:1.2.1":
   version: 1.2.1
   resolution: "smol-toml@npm:1.2.1"
   checksum: 10c0/ef713022d327493b6680ba51b9651abbb9c5abf2199e03faaa98ea49ad96ab9336bb4edafa6c70bdb2f1399f709f92a576b026e75cfd32066f3ec1c6fea797fb


### PR DESCRIPTION
Switching to https://github.com/squirrelchat/smol-toml

We were using https://github.com/iarna/iarna-toml, but we were getting warnings:
```
../node_modules/@iarna/toml/lib/toml-parser.js (178:22): Use of eval in "../node_modules/@iarna/toml/lib/toml-parser.js" is strongly discouraged as it poses security risks and may cause issues with minification.
```

And also

```
rendering chunks (64)...● [DEBUG] Using direct eval with a bundler is not recommended and may cause problems [direct-eval]

   assets/Routes-!~{00n}~.mjs:2466:22:
     2466 │   const utilInspect = eval("require('util').inspect");
```

Plus, `@iarna/toml` hasn't had a new release in over 4 years and there are lots of open Issues and PRs on the repo. So it feels pretty abandoned.

`smol-toml` on the other hand had activity just last week

There are some differences in the output `@iarna/toml` and `smol-toml` generates. And honestly I probably prefer what `@iarna/toml` generates. But I think the other benefits of switching to `smol-toml` outweighs this.
See https://github.com/squirrelchat/smol-toml/issues/1#issuecomment-1557146255 for more info on what the differences are