### PR TITLE
RSC: Silence unsupported-dynamic-import warning

### DIFF
--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -111,6 +111,9 @@ export async function rscBuildForSsr({
     },
     esbuild: {
       logLevel: verbose ? 'debug' : 'silent',
+      logOverride: {
+        'unsupported-dynamic-import': 'silent',
+      },
     },
     logLevel: verbose ? 'info' : 'silent',
   })


### PR DESCRIPTION
We were getting a bunch of warnings like these
<img width="794" alt="image" src="https://github.com/redwoodjs/redwood/assets/30793/4d35504e-3727-4f1a-9b0f-dad8e1474a4b">

```
● [DEBUG] This "import" expression will not be bundled because the argument is not a string literal [unsupported-dynamic-import]

    assets/Routes-!~{00n}~.mjs:12137:18:
      12137 │     return (await import(rdServerPath)).default;
```

Adding `/* @vite-ignore */` doesn't help, because this is an esbuild warning.

There are a lot of issues on the esbuild repo about this warning. https://github.com/evanw/esbuild/pull/1155 is one, and it also lists a whole bunch of others.
Here's an open issue about adding support for comments, like the vite one I've already tried with, for esbuild: https://github.com/evanw/esbuild/issues/1240. When/if that issue gets resolved we should move to using that. For now I'm silencing all "unsupported-dynamic-import" warnings, which isn't ideal, but will have to do for now.
Here's a vite issue about silencing an esbuild warning https://github.com/vitejs/vite/issues/14768, and the answer there is to use `esbuild.logLevel`, which is what I also do in this PR