### PR TITLE
RSC: Externalize more modules during build

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -49,9 +49,17 @@ export async function rscBuildAnalyze() {
       // going to be RSCs
       // As of vite 5.2 `true` here means "all except node built-ins"
       noExternal: true,
-      // TODO (RSC): Figure out what the `external` list should be. Right
-      // now it's just copied from waku, plus we added prisma
-      external: ['react', 'minimatch', '@prisma/client'],
+      // Anything we know won't have "use client" or "use server" in it can
+      // safely be external. The more we can externalize the better, because
+      // it means we can skip analyzing them, which means faster build times.
+      external: [
+        'react',
+        'minimatch',
+        '@prisma/client',
+        '@prisma/fetch-engine',
+        '@prisma/internals',
+        'playwright',
+      ],
       resolve: {
         externalConditions: ['react-server'],
       },

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -45,6 +45,13 @@ export async function rscBuildForSsr({
       // Files included in `noExternal` are files we want Vite to analyze
       // As of vite 5.2 `true` here means "all except node built-ins"
       noExternal: true,
+      external: [
+        'minimatch',
+        '@prisma/client',
+        '@prisma/fetch-engine',
+        '@prisma/internals',
+        'playwright',
+      ],
     },
     plugins: [
       cjsInterop({ dependencies: ['@redwoodjs/**'] }),


### PR DESCRIPTION
Externalize some more (big) packages to speed up build times, and to not try to bundle server-only stuff.

For `rscBuildAnalyze` anything we know don't have "use client" or "use server",  and that also doesn't care about the "react-server" condition is safe to externalize. The more we can externalize, the faster build times, because Vite won't have to go through the files

For `rscBuildForSsr` it's also good to externalize as much as possible. Here we need to be really mindful about the react-server condition. Everything that's externalized will be imported in an environment with the react-server condition set.