### PR TITLE
RSC: Wrap App around Routes in ServerEntry

### DIFF
--- a/__fixtures__/test-project-rsa/web/src/entry.server.tsx
+++ b/__fixtures__/test-project-rsa/web/src/entry.server.tsx
@@ -1,5 +1,6 @@
 import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
 
+import App from './App'
 import { Document } from './Document'
 import Routes from './Routes'
 
@@ -16,7 +17,9 @@ interface Props {
 export const ServerEntry: React.FC<Props> = ({ css, meta, location }) => {
   return (
     <Document css={css} meta={meta}>
-      <Routes location={location} />
+      <App>
+        <Routes location={location} />
+      </App>
     </Document>
   )
 }

--- a/packages/cli/src/commands/experimental/templates/rsc/entry.server.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/entry.server.tsx.template
@@ -1,5 +1,6 @@
 import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
 
+import App from './App'
 import { Document } from './Document'
 import Routes from './Routes'
 
@@ -16,7 +17,9 @@ interface Props {
 export const ServerEntry: React.FC<Props> = ({ css, meta, location }) => {
   return (
     <Document css={css} meta={meta}>
-      <Routes location={location} />
+      <App>
+        <Routes location={location} />
+      </App>
     </Document>
   )
 }


### PR DESCRIPTION
I already did this for the kitchen-sink test project in https://github.com/redwoodjs/redwood/pull/10742
Now I'm following up with the setup command template and the other RSC test project