### PR TITLE
chore(graphql-server): Fix ts-refs, a comment and imports

### DIFF
--- a/packages/graphql-server/src/rootSchema.ts
+++ b/packages/graphql-server/src/rootSchema.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   BigIntResolver,
   DateResolver,
@@ -10,11 +9,8 @@ import {
 } from 'graphql-scalars'
 import gql from 'graphql-tag'
 
+import { prismaVersion, redwoodVersion } from '@redwoodjs/api'
 import type { GlobalContext } from '@redwoodjs/context'
-
-// @TODO move prismaVersion & redwoodVersion to internal?
-// We don't want a circular dependency here..
-const { prismaVersion, redwoodVersion } = require('@redwoodjs/api')
 
 /**
  * This adds scalar types for dealing with Date, Time, DateTime, and JSON.

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -7,5 +7,6 @@
   "include": ["ambient.d.ts", "src/**/*"],
   "references": [
     { "path": "../api" },
+    { "path": "../context" },
   ]
 }


### PR DESCRIPTION
We had this:
```
// We don't want a circular dependency here..
const { prismaVersion, redwoodVersion } = require('@redwoodjs/api')
```
But when I checked `@redwoodjs/api` I couldn't see that it was importing from `@redwoodjs/graphql-server`, or, in fact, any other RW package. So no risk of circular dependencies. Guessing this was an old comment that's not relevant anymore.

There was also a comment configuring eslint that also didn't seem relevant anymore.

And finally this package was missing a tsconfig ref to `@redwoodjs/context`