### PR TITLE
RSC: externalize modules for dbAuth

### DIFF
--- a/packages/vite/src/rsc/rscBuildAnalyze.ts
+++ b/packages/vite/src/rsc/rscBuildAnalyze.ts
@@ -53,14 +53,17 @@ export async function rscBuildAnalyze() {
       // safely be external. The more we can externalize the better, because
       // it means we can skip analyzing them, which means faster build times.
       external: [
-        'react',
-        'minimatch',
         '@prisma/client',
         '@prisma/fetch-engine',
         '@prisma/internals',
-        'playwright',
+        '@redwoodjs/auth-dbauth-api',
         '@redwoodjs/cookie-jar',
         '@redwoodjs/server-store',
+        '@simplewebauthn/server',
+        'graphql-scalars',
+        'minimatch',
+        'playwright',
+        'react',
       ],
       resolve: {
         externalConditions: ['react-server'],

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -55,9 +55,16 @@ export async function rscBuildForServer(
       // Server store has to be externalized, because it's a singleton (shared between FW and App)
       external: [
         '@prisma/client',
-        'react-dom',
+        '@prisma/fetch-engine',
+        '@prisma/internals',
+        '@redwoodjs/auth-dbauth-api',
         '@redwoodjs/cookie-jar',
         '@redwoodjs/server-store',
+        '@simplewebauthn/server',
+        'graphql-scalars',
+        'minimatch',
+        'playwright',
+        'react-dom',
       ],
       resolve: {
         // These conditions are used in the plugin pipeline, and only affect non-externalized


### PR DESCRIPTION
A few more modules needed to be externalized for dbAuth to work. Plus I had to add this horrible "fix" for graphql-scalars where I rewrite the built files 😭  I really hope there is a better way to handle this. But I couldn't think of anything else right now

This is the error I was getting
```
file:///Users/tobbe/tmp/test-project-rsc-kitchen-sink-mw/web/dist/ssr/entry.server.mjs:58
import require$$0$9 from "graphql-scalars";
       ^^^^^^^^^^^^
SyntaxError: The requested module 'graphql-scalars' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:132:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:214:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:431:15)
    at async createMiddlewareRouter (/Users/tobbe/tmp/test-project-rsc-kitchen-sink-mw/node_modules/@redwoodjs/vite/dist/middleware/register.js:93:87)
    at async runFeServer (/Users/tobbe/tmp/test-project-rsc-kitchen-sink-mw/node_modules/@redwoodjs/vite/dist/runFeServer.js:82:28)
```

Manually changing to `import * as requi...` fixed it, so I added that as a post-build step. But I'd much rather understand exactly why this happens, and what the proper solution for it is.