### PR TITLE
chore(naming): Rename variable to match usage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
     "Flightcontrol",
     "graphiql",
     "memfs",
+    "mojombo",
     "OGIMAGE",
     "opentelemetry",
     "pino",

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.mts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-route-auto-loader.test.mts
@@ -1,11 +1,12 @@
 import path from 'node:path'
+
 import { vol } from 'memfs'
 import { normalizePath } from 'vite'
 
 import { afterAll, beforeAll, describe, it, expect, vi, Mock, beforeEach, afterEach } from 'vitest'
 
 import { processPagesDir } from '@redwoodjs/project-config'
-import type ProjectConfig from '@redwoodjs/project-config'
+import type * as ProjectConfig from '@redwoodjs/project-config'
 
 import { rscRoutesAutoLoader } from '../vite-plugin-rsc-routes-auto-loader'
 
@@ -14,14 +15,14 @@ vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
 const RWJS_CWD = process.env.RWJS_CWD
 
 vi.mock('@redwoodjs/project-config', async (importOriginal) => {
-  const originalGetPaths = await importOriginal<typeof ProjectConfig>()
+  const originalProjectConfig = await importOriginal<typeof ProjectConfig>()
   return {
-    ...originalGetPaths,
+    ...originalProjectConfig,
     getPaths: () => {
       return {
-        ...originalGetPaths.getPaths(),
+        ...originalProjectConfig.getPaths(),
         web: {
-          ...originalGetPaths.getPaths().web,
+          ...originalProjectConfig.getPaths().web,
           routes: '/Users/mojombo/rw-app/web/src/Routes.tsx',
         },
       }


### PR DESCRIPTION
Rename import variable to match what we're importing

(Also fixed a red squiggly and added an empty line to group imports)