### PR TITLE
chore: upgrade TSTyche to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ora": "7.0.1",
     "prompts": "2.4.2",
     "rimraf": "5.0.7",
-    "tstyche": "1.1.0",
+    "tstyche": "2.0.0",
     "tsx": "4.10.3",
     "typescript": "5.4.5",
     "vitest": "1.6.0",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -38,7 +38,7 @@
     "@types/react-dom": "^18.2.19",
     "react": "19.0.0-beta-04b058868c-20240508",
     "react-dom": "19.0.0-beta-04b058868c-20240508",
-    "tstyche": "1.1.0",
+    "tstyche": "2.0.0",
     "typescript": "5.4.5",
     "vitest": "1.6.0"
   },

--- a/packages/router/src/__typetests__/routeParamsTypes.test.ts
+++ b/packages/router/src/__typetests__/routeParamsTypes.test.ts
@@ -130,19 +130,19 @@ describe('RouteParams<>', () => {
 
 describe('ParamType<>', () => {
   test('Float', () => {
-    expect<ParamType<'Float'>>().type.toBeAssignable(1.02)
+    expect<ParamType<'Float'>>().type.toBeAssignableWith(1.02)
   })
 
   test('Boolean', () => {
-    expect<ParamType<'Boolean'>>().type.toBeAssignable(true)
-    expect<ParamType<'Boolean'>>().type.toBeAssignable(false)
+    expect<ParamType<'Boolean'>>().type.toBeAssignableWith(true)
+    expect<ParamType<'Boolean'>>().type.toBeAssignableWith(false)
   })
 
   test('Int', () => {
-    expect<ParamType<'Int'>>().type.toBeAssignable(51)
+    expect<ParamType<'Int'>>().type.toBeAssignableWith(51)
   })
 
   test('String', () => {
-    expect<ParamType<'String'>>().type.toBeAssignable('bazinga')
+    expect<ParamType<'String'>>().type.toBeAssignableWith('bazinga')
   })
 })

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -63,7 +63,7 @@
     "nodemon": "3.1.0",
     "react": "19.0.0-beta-04b058868c-20240508",
     "react-dom": "19.0.0-beta-04b058868c-20240508",
-    "tstyche": "1.1.0",
+    "tstyche": "2.0.0",
     "typescript": "5.4.5",
     "vitest": "1.6.0"
   },

--- a/packages/web/src/__typetests__/cellProps.test.tsx
+++ b/packages/web/src/__typetests__/cellProps.test.tsx
@@ -68,7 +68,7 @@ describe('CellProps mapper type', () => {
         ExampleQueryVariables
       >
 
-      expect<CellInputs>().type.toBeAssignable({
+      expect<CellInputs>().type.toBeAssignableWith({
         customProp: 55,
         category: 'Dinner',
         saved: true,
@@ -83,7 +83,7 @@ describe('CellProps mapper type', () => {
         EmptyVariables
       >
 
-      expect<CellWithoutVariablesInputs>().type.toBeAssignable({
+      expect<CellWithoutVariablesInputs>().type.toBeAssignableWith({
         customProp: 55,
       })
     })
@@ -111,7 +111,7 @@ describe('CellProps mapper type', () => {
       >
 
       // Note that the gql variables are no longer required here
-      expect<CellWithBeforeQueryInputs>().type.toBeAssignable({
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableWith({
         word: 'abracadabra',
         customProp: 99,
       })
@@ -134,7 +134,7 @@ describe('CellProps mapper type', () => {
         EmptyVariables
       >
 
-      expect<CellWithBeforeQueryInputs>().type.toBeAssignable({
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableWith({
         fetchPolicy: 'cache-only',
         customProp: 55,
       })
@@ -163,7 +163,7 @@ describe('CellProps mapper type', () => {
       >
 
       // Note that the gql variables are no longer required here
-      expect<CellWithBeforeQueryInputs>().type.toBeAssignable({
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableWith({
         customProp: 99,
       })
     })
@@ -185,7 +185,7 @@ describe('CellProps mapper type', () => {
         EmptyVariables
       >
 
-      expect<CellWithBeforeQueryInputs>().type.toBeAssignable({
+      expect<CellWithBeforeQueryInputs>().type.toBeAssignableWith({
         customProp: 55,
       })
     })

--- a/packages/web/src/__typetests__/cellSuccessData.test.tsx
+++ b/packages/web/src/__typetests__/cellSuccessData.test.tsx
@@ -9,13 +9,13 @@ describe('CellSuccessData', () => {
         foo: '',
       }
 
-      expect(value).type.toEqual<{ foo: string }>()
+      expect(value).type.toBe<{ foo: string }>()
     })
 
     it('removes null and undefined from properties', () => {
       const value: CellSuccessData<{ foo?: string | null }> = { foo: '' }
 
-      expect(value).type.toEqual<{ foo: string }>()
+      expect(value).type.toBe<{ foo: string }>()
     })
   })
 
@@ -30,7 +30,7 @@ describe('CellSuccessData', () => {
         bar: '',
       }
 
-      expect(value).type.toEqual<{ foo: string; bar: string }>()
+      expect(value).type.toBe<{ foo: string; bar: string }>()
     })
 
     it('does not remove null or undefined from properties', () => {
@@ -42,7 +42,7 @@ describe('CellSuccessData', () => {
         bar: '',
       }
 
-      expect(value).type.toEqual<{ foo?: string | null; bar?: string | null }>()
+      expect(value).type.toBe<{ foo?: string | null; bar?: string | null }>()
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8599,7 +8599,7 @@ __metadata:
     core-js: "npm:3.37.1"
     react: "npm:19.0.0-beta-04b058868c-20240508"
     react-dom: "npm:19.0.0-beta-04b058868c-20240508"
-    tstyche: "npm:1.1.0"
+    tstyche: "npm:2.0.0"
     typescript: "npm:5.4.5"
     vitest: "npm:1.6.0"
   peerDependencies:
@@ -8835,7 +8835,7 @@ __metadata:
     react-hot-toast: "npm:2.4.1"
     stacktracey: "npm:2.1.8"
     ts-toolbelt: "npm:9.6.0"
-    tstyche: "npm:1.1.0"
+    tstyche: "npm:2.0.0"
     typescript: "npm:5.4.5"
     vitest: "npm:1.6.0"
   peerDependencies:
@@ -28162,7 +28162,7 @@ __metadata:
     ora: "npm:7.0.1"
     prompts: "npm:2.4.2"
     rimraf: "npm:5.0.7"
-    tstyche: "npm:1.1.0"
+    tstyche: "npm:2.0.0"
     tsx: "npm:4.10.3"
     typescript: "npm:5.4.5"
     vitest: "npm:1.6.0"
@@ -30378,17 +30378,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:1.1.0":
-  version: 1.1.0
-  resolution: "tstyche@npm:1.1.0"
+"tstyche@npm:2.0.0":
+  version: 2.0.0
+  resolution: "tstyche@npm:2.0.0"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
     typescript:
       optional: true
   bin:
-    tstyche: build/bin.js
-  checksum: 10c0/4a54afed4c8081baaa13a1b5eb7e2eff1a39dbede912986b5f32c7af723eb4580acaf9aacfb3fd034705126df3491d61dcf09f3c1344d15cd617c813ea9f0be6
+    tstyche: ./build/bin.js
+  checksum: 10c0/3688e63b0b5ba3b58417b8e515ce4bc3d2ca53357914028d954cda83d14d169d091cf8f28bb02371120d3363d183821d554c6c031cf74f28ff443d065c8e5695
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TSTyche 2 shipped today. Now it has watch mode! You can run `yarn test:types --watch`.

Also matchers got improved / renamed. For instance, assignability can be checked both ways using `.toBeAssignableTo()` and `.toBeAssignableWith()`.

I have updated the type tests with the new names accordingly.