### PR TITLE
fix(dbauth): Don't duplicate authDecoder creation

### DIFF
--- a/.changesets/10791.md
+++ b/.changesets/10791.md
@@ -1,0 +1,3 @@
+- fix(dbauth): Don't duplicate authDecoder creation (#10791) by @Tobbe
+
+Make it possible to run the dbAuth setup command more than once without getting invalid code

--- a/packages/auth-providers/dbAuth/setup/jest.config.js
+++ b/packages/auth-providers/dbAuth/setup/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = {
+  testEnvironment: 'jest-environment-node',
+  testPathIgnorePatterns: ['fixtures', 'dist'],
+}

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -18,7 +18,9 @@
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-setup.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
-    "prepublishOnly": "NODE_ENV=production yarn build"
+    "prepublishOnly": "NODE_ENV=production yarn build",
+    "test": "jest src",
+    "test:watch": "yarn test --watch"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.24.5",
@@ -33,6 +35,8 @@
     "@babel/core": "^7.22.20",
     "@simplewebauthn/typescript-types": "7.4.0",
     "@types/yargs": "17.0.32",
+    "jest": "29.7.0",
+    "jest-environment-node": "29.7.0",
     "typescript": "5.4.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/__snapshots__/setup.test.ts.snap
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/__snapshots__/setup.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dbAuth setup command does not duplicate authDecoder creation 1`] = `
+"
+import { createGraphQLHandler } from '@redwoodjs/graphql-server'
+
+import directives from 'src/directives/**/*.{js,ts}'
+import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
+
+import { cookieName, getCurrentUser } from 'src/lib/auth'
+import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
+
+const authDecoder = createAuthDecoder(cookieName)
+
+export const handler = createGraphQLHandler({
+  getCurrentUser,
+  loggerConfig: { logger, options: {} },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+})
+        "
+`;

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/setup.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/setup.test.ts
@@ -1,0 +1,90 @@
+import path from 'node:path'
+
+import { vol } from 'memfs'
+
+jest.mock('fs', () => require('memfs').fs)
+
+import { createAuthDecoderFunction } from '../setupHandler'
+
+const RWJS_CWD = process.env.RWJS_CWD
+const redwoodProjectPath = '/redwood-app'
+
+jest.mock('../setupData', () => ({
+  notes: '',
+  extraTask: undefined,
+}))
+
+jest.mock('@redwoodjs/cli-helpers', () => {
+  return {
+    getGraphqlPath: () => {
+      return redwoodProjectPath + '/api/src/functions/graphql.ts'
+    },
+    getPaths: () => ({
+      base: redwoodProjectPath,
+    }),
+    colors: {
+      error: (str: string) => str,
+      warning: (str: string) => str,
+      green: (str: string) => str,
+      info: (str: string) => str,
+      bold: (str: string) => str,
+      underline: (str: string) => str,
+    },
+  }
+})
+
+beforeAll(() => {
+  process.env.RWJS_CWD = redwoodProjectPath
+})
+
+afterAll(() => {
+  process.env.RWJS_CWD = RWJS_CWD
+})
+
+describe('dbAuth setup command', () => {
+  it('does not duplicate authDecoder creation', async () => {
+    vol.fromJSON(
+      {
+        [path.resolve(__dirname, '../../package.json')]:
+          '{ "version": "0.0.0" }',
+        'api/src/functions/graphql.ts': `
+import { createGraphQLHandler } from '@redwoodjs/graphql-server'
+
+import directives from 'src/directives/**/*.{js,ts}'
+import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
+
+import { getCurrentUser } from 'src/lib/auth'
+import { db } from 'src/lib/db'
+import { logger } from 'src/lib/logger'
+
+export const handler = createGraphQLHandler({
+  getCurrentUser,
+  loggerConfig: { logger, options: {} },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+})
+        `,
+      },
+      redwoodProjectPath,
+    )
+
+    createAuthDecoderFunction.task()
+    const updatedGraphqlTs =
+      vol.toJSON()[redwoodProjectPath + '/api/src/functions/graphql.ts']
+    expect(updatedGraphqlTs).toMatch(/import { cookieName, getCurrentUser } fr/)
+    expect(updatedGraphqlTs).toMatch(/const authDecoder = createAuthDecoder\(c/)
+    expect(updatedGraphqlTs).toMatchSnapshot()
+
+    // Running again shouldn't change anything in this case
+    createAuthDecoderFunction.task()
+    const updatedGraphqlTs2 =
+      vol.toJSON()[redwoodProjectPath + '/api/src/functions/graphql.ts']
+    expect(updatedGraphqlTs).toEqual(updatedGraphqlTs2)
+  })
+})

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -14,11 +14,11 @@ import {
   apiPackages as webAuthnApiPackages,
 } from './webAuthn.setupData'
 
-const { version } = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
-)
-
 export async function handler({ webauthn, force: forceArg }: Args) {
+  const { version } = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+  )
+
   const webAuthn = await shouldIncludeWebAuthn(webauthn)
 
   standardAuthHandler({
@@ -72,18 +72,29 @@ export const createAuthDecoderFunction = {
       throw new Error('Could not find your graphql file path')
     }
 
+    const authDecoderCreation =
+      'const authDecoder = createAuthDecoder(cookieName)'
+
     const content = fs.readFileSync(graphqlPath, 'utf-8')
 
-    const newContent = content
-      .replace(
-        'import { getCurrentUser } from',
-        'import { cookieName, getCurrentUser } from',
-      )
-      .replace(
+    let newContent = content.replace(
+      'import { getCurrentUser } from',
+      'import { cookieName, getCurrentUser } from',
+    )
+
+    const authDecoderCreationRegexp = new RegExp(
+      '^' + escapeRegExp(authDecoderCreation),
+      'm',
+    )
+
+    if (!authDecoderCreationRegexp.test(newContent)) {
+      newContent = newContent.replace(
         'export const handler = createGraphQLHandler({',
-        'const authDecoder = createAuthDecoder(cookieName)\n\n' +
+        authDecoderCreation +
+          '\n\n' +
           'export const handler = createGraphQLHandler({',
       )
+    }
 
     if (!newContent.includes('import { cookieName')) {
       throw new Error('Failed to import cookieName')
@@ -91,4 +102,9 @@ export const createAuthDecoderFunction = {
 
     fs.writeFileSync(graphqlPath, newContent)
   },
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7590,6 +7590,8 @@ __metadata:
     "@simplewebauthn/typescript-types": "npm:7.4.0"
     "@types/yargs": "npm:17.0.32"
     core-js: "npm:3.37.1"
+    jest: "npm:29.7.0"
+    jest-environment-node: "npm:29.7.0"
     prompts: "npm:2.4.2"
     terminal-link: "npm:2.1.1"
     typescript: "npm:5.4.5"
@@ -21118,7 +21120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^29.7.0":
+"jest-environment-node@npm:29.7.0, jest-environment-node@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-environment-node@npm:29.7.0"
   dependencies:


### PR DESCRIPTION
An extra `const authDecoder = createAuthDecoder(cookieName)` would be inserted every time you'd run `yarn rw setup auth dbAuth -f`, resulting in code with syntax errors (duplicate `authDecoder` variables). This PR fixes this by first checking if that line already exists. If it does it's not inserted again.