### PR TITLE
chore(testing dbAuth): provide mock implementations

### DIFF
--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
@@ -94,8 +94,10 @@ describe('dbAuth', () => {
 
   describe('handler', () => {
     it('exits when all files are skipped', async () => {
-      const mockExit = vi.spyOn(process, 'exit').mockImplementation()
-      const mockConsoleInfo = vi.spyOn(console, 'info').mockImplementation()
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {})
+      const mockConsoleInfo = vi
+        .spyOn(console, 'info')
+        .mockImplementation(() => {})
 
       await dbAuth.handler({
         listr2: { silentRendererCondition: true },


### PR DESCRIPTION
When running the dbAuth tests for `yarn rw g dbAuth` you'd get these scary looking red console printouts
<img width="720" alt="image" src="https://github.com/redwoodjs/redwood/assets/30793/e3c398c3-8db7-4933-84cc-9ebb81feff3d">

This PR adds mock implementations for `process.exit` and `console.info` to silence that output