### PR TITLE
chore(testing dbAuth): Consistent naming and fix blue squiggles

### DIFF
--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
@@ -7,7 +7,7 @@ import path from 'path'
 // Load mocks
 import '../../../../lib/test'
 
-const realfs = await vi.importActual('fs-extra')
+const actualFs = await vi.importActual('fs-extra')
 import Enquirer from 'enquirer'
 import fs from 'fs-extra'
 import { vol } from 'memfs'
@@ -27,14 +27,14 @@ const dbAuthTemplateFiles = [
   'signup.tsx.template',
 ]
 dbAuthTemplateFiles.forEach((templateFilename) => {
-  mockFiles[path.join(__dirname, `../templates/${templateFilename}`)] = realfs
+  mockFiles[path.join(__dirname, `../templates/${templateFilename}`)] = actualFs
     .readFileSync(path.join(__dirname, `../templates/${templateFilename}`))
     .toString()
 })
 
 mockFiles[
   path.join(__dirname, `../../scaffold/templates/assets/scaffold.css.template`)
-] = realfs
+] = actualFs
   .readFileSync(
     path.join(
       __dirname,
@@ -43,7 +43,7 @@ mockFiles[
   )
   .toString()
 
-mockFiles[getPaths().web.routes] = realfs
+mockFiles[getPaths().web.routes] = actualFs
   .readFileSync(
     path.join(
       __dirname,
@@ -52,7 +52,7 @@ mockFiles[getPaths().web.routes] = realfs
   )
   .toString()
 
-mockFiles[getPaths().web.app] = realfs
+mockFiles[getPaths().web.app] = actualFs
   .readFileSync(
     path.join(
       __dirname,


### PR DESCRIPTION
We try to name the variables we assign the return value of `vi.importActual` to `actualWhatever`. So this PR renames `realfs` to `actualFs`, which both makes the code follow that naming convention and also fixes the blue squiggly 

<img width="317" alt="image" src="https://github.com/redwoodjs/redwood/assets/30793/4ac6ff56-00f2-4f31-8b31-bedabd32e6fc">
