### PR TITLE
chore(testing dbAuth): Remove outdated code

### DIFF
--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
@@ -63,11 +63,6 @@ mockFiles[getPaths().web.app] = actualFs
 
 describe('dbAuth', () => {
   beforeEach(() => {
-    delete mockFiles[path.join(getPaths().web.src, 'auth.ts')]
-    delete mockFiles[path.join(getPaths().web.src, 'auth.tsx')]
-    delete mockFiles[path.join(getPaths().web.src, 'auth.js')]
-    delete mockFiles[path.join(getPaths().web.src, 'auth.jsx')]
-
     vol.reset()
     vol.fromJSON(mockFiles)
   })


### PR DESCRIPTION
The tests that used this code were moved to another file (to `packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.postInstallMessage.test.js`).
So this code is not needed here anymore