### PR TITLE
chore(testing dbAuth): Add "yes" prompt testing for WebAuthn

### DIFF
--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.js
@@ -13,7 +13,15 @@ import '../../../../lib/test'
 const actualFs = await vi.importActual('fs-extra')
 import Enquirer from 'enquirer'
 import { vol } from 'memfs'
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest'
 
 import { getPaths } from '../../../../lib'
 import * as dbAuth from '../dbAuth'
@@ -101,6 +109,14 @@ mockFiles[getPaths().web.app] = actualFs
     ),
   )
   .toString()
+
+beforeAll(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterAll(() => {
+  vi.mocked(console).log.mockRestore?.()
+})
 
 describe('dbAuth', () => {
   beforeEach(() => {

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
@@ -11,7 +11,15 @@ const actualFs = await vi.importActual('fs-extra')
 import Enquirer from 'enquirer'
 import fs from 'fs-extra'
 import { vol } from 'memfs'
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import {
+  vi,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+  beforeAll,
+} from 'vitest'
 
 import { getPaths } from '../../../../lib'
 import * as dbAuth from '../dbAuth'
@@ -60,6 +68,14 @@ mockFiles[getPaths().web.app] = actualFs
     ),
   )
   .toString()
+
+beforeAll(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterAll(() => {
+  vi.mocked(console).log.mockRestore?.()
+})
 
 describe('dbAuth', () => {
   beforeEach(() => {


### PR DESCRIPTION
Make sure to test prompt answer "yes" and "no" for the WebAuthn prompt. This required pretty involved mocking of Listr2 that I hope we can reuse for other tests as well in the future