### PR TITLE
fix(cli): Add check for excessively long route

### DIFF
--- a/.changesets/10830.md
+++ b/.changesets/10830.md
@@ -1,0 +1,3 @@
+- fix(cli): Add check for excessively long route (#10830) by @Josh-Walker-GM
+
+This change adds an additional internal check to protect against route definitions which are preposterously long. 

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -406,9 +406,12 @@ export const addRoutesToRouterTask = (routes, layout, setProps = {}) => {
       // newRoutes will be something like:
       // ['<Route path="/foo" page={FooPage} name="foo"/>']
       // and we need to replace `path="/foo"` with `path="/foo/"`
-      newRoutes = newRoutes.map((route) =>
-        route.replace(/ path="(.+?)" /, ' path="$1/" '),
-      )
+      newRoutes = newRoutes.map((route) => {
+        if (route.length > 2000) {
+          throw new Error(`Route is too long to process:\n${route}`)
+        }
+        return route.replace(/ path="(.+?)" /, ' path="$1/" ')
+      })
     }
 
     const routesBatch = layout


### PR DESCRIPTION
**Problem**
Code scanning is alerting to the "Polynomial regular expression used on uncontrolled data" issue associated with that route processing. 

It isn't really that big a problem. This is CLI code which operates on your own project. It is not really any kinda of attack vector which would let someone harm someones project/code/product.

**Changes**
1. Adds a length check to the route string. We assume all well behaved route definitions are less than 2000 characters - an absurdly generous limit.