### PR TITLE
chore(fixtures): change redwood versions in fixtures

### DIFF
--- a/__fixtures__/empty-project/api/package.json
+++ b/__fixtures__/empty-project/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "0.49.1",
-    "@redwoodjs/graphql-server": "0.49.1"
+    "@redwoodjs/api": "latest",
+    "@redwoodjs/graphql-server": "latest"
   }
 }

--- a/__fixtures__/empty-project/package.json
+++ b/__fixtures__/empty-project/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "0.49.1"
+    "@redwoodjs/core": "latest"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/empty-project/web/package.json
+++ b/__fixtures__/empty-project/web/package.json
@@ -13,9 +13,9 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "0.49.1",
-    "@redwoodjs/router": "0.49.1",
-    "@redwoodjs/web": "0.49.1",
+    "@redwoodjs/forms": "latest",
+    "@redwoodjs/router": "latest",
+    "@redwoodjs/web": "latest",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/__fixtures__/example-todo-main-with-errors/api/package.json
+++ b/__fixtures__/example-todo-main-with-errors/api/package.json
@@ -3,6 +3,6 @@
   "name": "api",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/api": "0.7.0"
+    "@redwoodjs/api": "latest"
   }
 }

--- a/__fixtures__/example-todo-main-with-errors/package.json
+++ b/__fixtures__/example-todo-main-with-errors/package.json
@@ -5,7 +5,7 @@
     "web"
   ],
   "devDependencies": {
-    "@redwoodjs/core": "0.7.0"
+    "@redwoodjs/core": "latest"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config"

--- a/__fixtures__/example-todo-main-with-errors/web/package.json
+++ b/__fixtures__/example-todo-main-with-errors/web/package.json
@@ -3,8 +3,8 @@
   "name": "web",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/router": "0.7.0",
-    "@redwoodjs/web": "0.7.0",
+    "@redwoodjs/router": "latest",
+    "@redwoodjs/web": "latest",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/__fixtures__/example-todo-main/api/package.json
+++ b/__fixtures__/example-todo-main/api/package.json
@@ -3,6 +3,6 @@
   "name": "api",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/api": "0.32.2"
+    "@redwoodjs/api": "latest"
   }
 }

--- a/__fixtures__/example-todo-main/package.json
+++ b/__fixtures__/example-todo-main/package.json
@@ -6,7 +6,7 @@
     "../../packages/*"
   ],
   "devDependencies": {
-    "@redwoodjs/core": "0.32.2"
+    "@redwoodjs/core": "latest"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config"

--- a/__fixtures__/example-todo-main/web/package.json
+++ b/__fixtures__/example-todo-main/web/package.json
@@ -3,8 +3,8 @@
   "name": "web",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/router": "0.32.2",
-    "@redwoodjs/web": "0.32.2",
+    "@redwoodjs/router": "latest",
+    "@redwoodjs/web": "latest",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
**Problem**
Security alerts are firing on the fixture projects. These projects list very old versions of redwoodjs and as such are triggering warnings for old transient dependencies.

**Changes**
1. Switch to the "latest" tag in these fixtures.

**Notes**
It would be ideal if these fixtures were kept up to date like our main test project fixture. The fixtures changed here are used only for their structure and content - they don't currently undergo any yarn installs.

In the future I would suggest we remove these fixtures entirely if it is possible and convenient to do so. 