### PR TITLE
chore(fixtures): use canary instead of latest

### DIFF
--- a/__fixtures__/empty-project/api/package.json
+++ b/__fixtures__/empty-project/api/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "@redwoodjs/api": "latest",
-    "@redwoodjs/graphql-server": "latest"
+    "@redwoodjs/api": "canary",
+    "@redwoodjs/graphql-server": "canary"
   }
 }

--- a/__fixtures__/empty-project/package.json
+++ b/__fixtures__/empty-project/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "devDependencies": {
-    "@redwoodjs/core": "latest"
+    "@redwoodjs/core": "canary"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config",

--- a/__fixtures__/empty-project/web/package.json
+++ b/__fixtures__/empty-project/web/package.json
@@ -13,9 +13,9 @@
     ]
   },
   "dependencies": {
-    "@redwoodjs/forms": "latest",
-    "@redwoodjs/router": "latest",
-    "@redwoodjs/web": "latest",
+    "@redwoodjs/forms": "canary",
+    "@redwoodjs/router": "canary",
+    "@redwoodjs/web": "canary",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/__fixtures__/example-todo-main-with-errors/api/package.json
+++ b/__fixtures__/example-todo-main-with-errors/api/package.json
@@ -3,6 +3,6 @@
   "name": "api",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/api": "latest"
+    "@redwoodjs/api": "canary"
   }
 }

--- a/__fixtures__/example-todo-main-with-errors/package.json
+++ b/__fixtures__/example-todo-main-with-errors/package.json
@@ -5,7 +5,7 @@
     "web"
   ],
   "devDependencies": {
-    "@redwoodjs/core": "latest"
+    "@redwoodjs/core": "canary"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config"

--- a/__fixtures__/example-todo-main-with-errors/web/package.json
+++ b/__fixtures__/example-todo-main-with-errors/web/package.json
@@ -3,8 +3,8 @@
   "name": "web",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/router": "latest",
-    "@redwoodjs/web": "latest",
+    "@redwoodjs/router": "canary",
+    "@redwoodjs/web": "canary",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/__fixtures__/example-todo-main/api/package.json
+++ b/__fixtures__/example-todo-main/api/package.json
@@ -3,6 +3,6 @@
   "name": "api",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/api": "latest"
+    "@redwoodjs/api": "canary"
   }
 }

--- a/__fixtures__/example-todo-main/package.json
+++ b/__fixtures__/example-todo-main/package.json
@@ -6,7 +6,7 @@
     "../../packages/*"
   ],
   "devDependencies": {
-    "@redwoodjs/core": "latest"
+    "@redwoodjs/core": "canary"
   },
   "eslintConfig": {
     "extends": "@redwoodjs/eslint-config"

--- a/__fixtures__/example-todo-main/web/package.json
+++ b/__fixtures__/example-todo-main/web/package.json
@@ -3,8 +3,8 @@
   "name": "web",
   "version": "0.0.0",
   "dependencies": {
-    "@redwoodjs/router": "latest",
-    "@redwoodjs/web": "latest",
+    "@redwoodjs/router": "canary",
+    "@redwoodjs/web": "canary",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Follow up to #10832. Use `canary` instead of `latest` because we still get security alerts until our merged changes are released. Moving to `canary` will mean that these will be dismissed more quickly. 