### PR TITLE
chore(ci): do not enforce changeset entry for certain milestones

### DIFF
--- a/.github/actions/check_changesets/check_changesets.mjs
+++ b/.github/actions/check_changesets/check_changesets.mjs
@@ -11,6 +11,18 @@ async function main() {
     return
   }
 
+  // We only enforce changesets on PRs that are not marked as "chore" or "SSR" or "RSC"
+  const skipOnMilestone = ['chore', 'SSR', 'RSC']
+  const { milestone } = github.context.payload.pull_request
+  console.log({
+    milestone,
+    skipOnMilestone,
+  })
+  if (milestone && skipOnMilestone.includes(milestone.title)) {
+    console.log(`Skipping check because of the "${milestone.title}" milestone`)
+    return
+  }
+
   // Check if the PR adds a changeset.
   await exec('git fetch origin main', [], { silent: true })
   const { stdout } = await getExecOutput('git diff origin/main --name-only', [], { silent: true })

--- a/.github/actions/check_changesets/check_changesets.mjs
+++ b/.github/actions/check_changesets/check_changesets.mjs
@@ -14,10 +14,6 @@ async function main() {
   // We only enforce changesets on PRs that are not marked as "chore" or "SSR" or "RSC"
   const skipOnMilestone = ['chore', 'SSR', 'RSC']
   const { milestone } = github.context.payload.pull_request
-  console.log({
-    milestone,
-    skipOnMilestone,
-  })
   if (milestone && skipOnMilestone.includes(milestone.title)) {
     console.log(`Skipping check because of the "${milestone.title}" milestone`)
     return

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -2,7 +2,7 @@ name: 📝 Check changesets
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, milestoned, demilestoned]
 
 # Cancel in-progress runs of this workflow.
 # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow.


### PR DESCRIPTION
Right now the check will enforce a changeset entry for any PR. We have noticed this can be a bit excessive for the current RSC/SSR work. These features are not scheduled for stable release in the near future and so requiring a changeset on every related PR can produce changesets which are of little value - descriptions of fixes for features that have never been released in stables.