### PR TITLE
feat(g dbAuth): Detect WebAuthn support

### DIFF
--- a/.changesets/10864.md
+++ b/.changesets/10864.md
@@ -1,0 +1,3 @@
+- feat(g dbAuth): Detect WebAuthn support (#10864) by @Tobbe
+
+Automatically add WebAuthn support to generated pages when WebAuthn is enabled for dbAuth

--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.mockListr.test.js
@@ -63,7 +63,6 @@ vi.mock('listr2', async () => {
                 }
               },
               skip: (msg) => {
-                console.log('skipping task', msg)
                 mockSkippedTaskTitles.push(msg || task.title)
               },
             }

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -317,8 +317,17 @@ const tasks = ({
       },
       {
         title: 'Querying WebAuthn addition...',
+        hide: (ctx) => {
+          ctx.webauthn = webauthn = isWebAuthnEnabled()
+          return webauthn
+        },
         task: async (ctx, task) => {
           if (webauthn != null) {
+            // We enter here if the user passed the `--webauthn` flag. The flag
+            // always takes precedence.
+
+            ctx.webauthn = webauthn
+
             task.skip(
               `Querying WebAuthn addition: argument webauthn passed, WebAuthn${
                 webauthn ? '' : ' not'
@@ -326,13 +335,36 @@ const tasks = ({
             )
             return
           }
+
+          if (isDbAuthSetup()) {
+            if (isWebAuthnEnabled()) {
+              ctx.webauthn = webauthn = true
+
+              task.skip(
+                'Querying WebAuthn addition: webauthn setup detected, ' +
+                  'WebAuthn support will be included in pages',
+              )
+            } else {
+              ctx.webauthn = webauthn = false
+
+              task.skip(
+                'Querying WebAuthn addition: webauthn is not setup for ' +
+                  'dbAuth, WebAuthn support will not be included in pages',
+              )
+            }
+
+            return
+          }
+
           const response = await task.prompt({
             type: 'confirm',
             name: 'answer',
             message: `Enable WebAuthn support (TouchID/FaceID) on LoginPage? See https://redwoodjs.com/docs/auth/dbAuth#webAuthn`,
             default: false,
           })
+
           ctx.webauthn = webauthn = response
+
           task.title = `Querying WebAuthn addition: WebAuthn addition${
             webauthn ? '' : ' not'
           } included`
@@ -435,4 +467,13 @@ function isDbAuthSetup() {
   }
 
   return false
+}
+
+function isWebAuthnEnabled() {
+  const webPackageJson = fs.readFileSync(
+    path.join(getPaths().web.base, 'package.json'),
+    'utf-8',
+  )
+
+  return webPackageJson.includes('"@simplewebauthn/browser": ')
 }

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -317,10 +317,6 @@ const tasks = ({
       },
       {
         title: 'Querying WebAuthn addition...',
-        hide: (ctx) => {
-          ctx.webauthn = webauthn = isWebAuthnEnabled()
-          return webauthn
-        },
         task: async (ctx, task) => {
           if (webauthn != null) {
             // We enter here if the user passed the `--webauthn` flag. The flag
@@ -341,15 +337,15 @@ const tasks = ({
               ctx.webauthn = webauthn = true
 
               task.skip(
-                'Querying WebAuthn addition: webauthn setup detected, ' +
-                  'WebAuthn support will be included in pages',
+                'Querying WebAuthn addition: WebAuthn setup detected - ' +
+                  'support will be included in pages',
               )
             } else {
               ctx.webauthn = webauthn = false
 
               task.skip(
-                'Querying WebAuthn addition: webauthn is not setup for ' +
-                  'dbAuth, WebAuthn support will not be included in pages',
+                'Querying WebAuthn addition: No WebAuthn setup detected - ' +
+                  'support will not be included in pages',
               )
             }
 

--- a/packages/cli/src/lib/test.js
+++ b/packages/cli/src/lib/test.js
@@ -48,6 +48,7 @@ vi.mock('@redwoodjs/project-config', async (importOriginal) => {
           functions: path.join(BASE_PATH, './api/src/functions'),
         },
         web: {
+          base: path.join(BASE_PATH, './web'),
           config: path.join(BASE_PATH, './web/config'),
           src: path.join(BASE_PATH, './web/src'),
           generators: path.join(BASE_PATH, './web/generators'),


### PR DESCRIPTION
When generating dbAuth pages (login, signup, etc) we used to always prompt for WebAuthn support. But I figured if WebAuthn was setup for dbAuth it'd make sense to just also automatically add support for it to the generated pages.
And vice versa – if WebAuthn support is not enabled for dbAuth it doesn't make much sense to have it on the generated pages either.

If dbAuth is not setup at all we'll still prompt for WebAuthn support.

And if the `--webauthn` flag is passed that takes precedence 