### PR TITLE
feat(dbAuth): Prompt to generate dbAuth pages

### DIFF
--- a/.changesets/10865.md
+++ b/.changesets/10865.md
@@ -1,0 +1,3 @@
+- feat(dbAuth): Prompt to generate dbAuth pages (#10865) by @Tobbe
+
+When setting up dbAuth we'll now prompt if the user also wants to generate pages for login, signup, password reset etc. We only prompt if no existing pages exist.

--- a/packages/auth-providers/dbAuth/setup/src/setup.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setup.ts
@@ -24,6 +24,12 @@ export function builder(yargs: yargs.Argv) {
       description: 'Create a User database model',
       type: 'boolean',
     })
+    .option('generateAuthPages', {
+      alias: 'g',
+      default: null,
+      description: 'Generate auth pages (login, signup, etc.)',
+      type: 'boolean',
+    })
     .epilogue(
       `Also see the ${terminalLink(
         'Redwood CLI Reference',
@@ -35,6 +41,7 @@ export function builder(yargs: yargs.Argv) {
 export interface Args {
   webauthn: boolean | null
   createUserModel: boolean | null
+  generateAuthPages: boolean | null
   force: boolean
 }
 

--- a/packages/auth-providers/dbAuth/setup/src/setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupData.ts
@@ -92,11 +92,6 @@ export const notes = [
   'change this secret to a new value and deploy. To create a new secret, run:',
   '',
   '  yarn rw generate secret',
-  '',
-  "Need simple Login, Signup and Forgot Password pages? We've got a generator",
-  'for those as well:',
-  '',
-  '  yarn rw generate dbAuth',
 ]
 
 export const notesCreatedUserModel = [

--- a/packages/auth-providers/dbAuth/setup/src/setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupData.ts
@@ -117,6 +117,9 @@ export const notesCreatedUserModel = [
   'change this secret to a new value and deploy. To create a new secret, run:',
   '',
   '  yarn rw generate secret',
+]
+
+export const noteGenerate = [
   '',
   "Need simple Login, Signup and Forgot Password pages? We've got a generator",
   'for those as well:',

--- a/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
+++ b/packages/auth-providers/dbAuth/setup/src/setupHandler.ts
@@ -38,13 +38,13 @@ export async function handler({
   const createDbUserModel = await shouldCreateUserModel(createUserModel)
   const generateDbAuthPages = await shouldGenerateDbAuthPages(generateAuthPages)
 
-  let oneMoreThing: string[] = []
+  const oneMoreThing: string[] = []
 
   if (webAuthn) {
     if (createDbUserModel) {
-      oneMoreThing = webAuthnNotesCreatedUserModel
+      oneMoreThing.push(...webAuthnNotesCreatedUserModel)
     } else {
-      oneMoreThing = webAuthnNotes
+      oneMoreThing.push(...webAuthnNotes)
     }
 
     if (!generateDbAuthPages) {
@@ -52,9 +52,9 @@ export async function handler({
     }
   } else {
     if (createDbUserModel) {
-      oneMoreThing = notesCreatedUserModel
+      oneMoreThing.push(...notesCreatedUserModel)
     } else {
-      oneMoreThing = notes
+      oneMoreThing.push(...notes)
     }
 
     if (!generateDbAuthPages) {

--- a/packages/auth-providers/dbAuth/setup/src/shared.ts
+++ b/packages/auth-providers/dbAuth/setup/src/shared.ts
@@ -1,8 +1,10 @@
 import fs from 'node:fs'
 
 import { getDMMF } from '@prisma/internals'
+import execa from 'execa'
 
 import { getPaths } from '@redwoodjs/cli-helpers'
+import { processPagesDir } from '@redwoodjs/project-config'
 
 export const libPath = getPaths().api.lib.replace(getPaths().base, '')
 export const functionsPath = getPaths().api.functions.replace(
@@ -36,4 +38,55 @@ export function addModels(models: string) {
   const schemaWithUser = schema + models
 
   fs.writeFileSync(getPaths().api.dbSchema, schemaWithUser)
+}
+
+export function hasAuthPages() {
+  const routes = fs.readFileSync(getPaths().web.routes, 'utf-8')
+
+  // If the user already has a route for /login, /signin, or /signup, we
+  // assume auth pages are already set up
+  if (/path={?['"]\/(login|signin|signup)['"]}? /i.test(routes)) {
+    return true
+  }
+
+  return processPagesDir().some((page) => {
+    if (
+      page.importName === 'LoginPage' ||
+      page.importName === 'LogInPage' ||
+      page.importName === 'SigninPage' ||
+      page.importName === 'SignInPage' ||
+      page.importName === 'SignupPage' ||
+      page.importName === 'SignUpPage'
+    ) {
+      return true
+    }
+
+    return false
+  })
+}
+
+export function generateAuthPagesTask(generatingUserModel: boolean) {
+  return {
+    title: 'Adding dbAuth pages...',
+    task: async () => {
+      const rwjsPaths = getPaths()
+
+      const args = ['rw', 'g', 'dbAuth']
+
+      if (generatingUserModel) {
+        args.push(
+          '--username-label',
+          'username',
+          '--password-label',
+          'password',
+        )
+      }
+
+      await execa('yarn', args, {
+        stdio: 'inherit',
+        shell: true,
+        cwd: rwjsPaths.base,
+      })
+    },
+  }
 }

--- a/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
@@ -145,6 +145,9 @@ export const notesCreatedUserModel = [
   'change this secret to a new value and deploy. To create a new secret, run:',
   '',
   '  yarn rw generate secret',
+]
+
+export const noteGenerate = [
   '',
   'Need simple Login, Signup, Forgot Password pages and WebAuthn prompts?',
   "We've got a generator for those as well:",

--- a/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
+++ b/packages/auth-providers/dbAuth/setup/src/webAuthn.setupData.ts
@@ -117,11 +117,6 @@ export const notes = [
   'change this secret to a new value and deploy. To create a new secret, run:',
   '',
   '  yarn rw generate secret',
-  '',
-  'Need simple Login, Signup, Forgot Password pages and WebAuthn prompts?',
-  "We've got a generator for those as well:",
-  '',
-  '  yarn rw generate dbAuth',
 ]
 
 // Only thing different here compared to the notes for when *not* setting up

--- a/packages/cli-helpers/src/auth/setupHelpers.ts
+++ b/packages/cli-helpers/src/auth/setupHelpers.ts
@@ -44,7 +44,7 @@ export const standardAuthBuilder = (yargs: Argv) => {
     )
 }
 
-interface Args {
+export interface AuthHandlerArgs {
   basedir: string
   forceArg: boolean
   provider: string
@@ -79,7 +79,7 @@ export const standardAuthHandler = async ({
   extraTasks,
   notes,
   verbose,
-}: Args) => {
+}: AuthHandlerArgs) => {
   // @TODO detect if auth already setup. If it is, ask how to proceed:
   // How would you like to proceed?
   // 1. Replace existing auth provider with <provider>

--- a/packages/cli-helpers/src/index.ts
+++ b/packages/cli-helpers/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/paths.js'
 export * from './lib/project.js'
 export * from './lib/version.js'
 export * from './auth/setupHelpers.js'
+export type { AuthHandlerArgs } from './auth/setupHelpers.js'
 
 export * from './lib/installHelpers.js'
 

--- a/packages/cli/src/commands/setup/auth/auth.js
+++ b/packages/cli/src/commands/setup/auth/auth.js
@@ -110,6 +110,12 @@ export async function builder(yargs) {
             description: 'Create a User database model',
             type: 'boolean',
           })
+          .option('generateAuthPages', {
+            alias: 'g',
+            default: null,
+            description: 'Generate auth pages (login, signup, etc.)',
+            type: 'boolean',
+          })
       },
       async (args) => {
         recordTelemetryAttributes({


### PR DESCRIPTION
When setting up dbAuth we'll now prompt if the user also wants to generate pages for login, signup, password reset etc. We only prompt if no existing pages exist.