### PR TITLE
feat(router): Navigate to splash page using routes.home()

### DIFF
--- a/.changesets/10874.md
+++ b/.changesets/10874.md
@@ -1,0 +1,4 @@
+- feat(router): Navigate to splash page using routes.home() (#10874) by @Tobbe
+
+This PR makes it so that `routes.home()` works even when there's no actual `/`
+route in the `Routes.tsx` file if navigating to `/` would show the splash page.

--- a/packages/internal/src/generate/typeDefinitions.ts
+++ b/packages/internal/src/generate/typeDefinitions.ts
@@ -241,12 +241,18 @@ const writeTypeDefIncludeFile = (
 
 export const generateTypeDefRouterRoutes = () => {
   const ast = fileToAst(getPaths().web.routes)
+  let hasRootRoute = false
   const routes = getJsxElements(ast, 'Route').filter((x) => {
     // All generated "routes" should have a "name" and "path" prop-value
-    return (
+    const isValidRoute =
       typeof x.props?.path !== 'undefined' &&
       typeof x.props?.name !== 'undefined'
-    )
+
+    if (isValidRoute && x.props.path === '/') {
+      hasRootRoute = true
+    }
+
+    return isValidRoute
   })
 
   // Generate declaration mapping for improved go-to-definition behaviour
@@ -286,6 +292,17 @@ export const generateTypeDefRouterRoutes = () => {
       "Couldn't generate a definition map for web-routerRoutes.d.ts:",
     )
     console.error(error)
+  }
+
+  if (!hasRootRoute) {
+    routes.push({
+      name: 'splashPage route',
+      location: { line: -1, column: -1 },
+      props: {
+        path: '/',
+        name: 'home',
+      },
+    })
   }
 
   return writeTypeDefIncludeFile('web-routerRoutes.d.ts.template', { routes })

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -36,12 +36,12 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
     </Router>
   )
 
-  const { pathRouteMap, namedRoutesMap, hasHomeRoute, NotFoundPage } =
+  const { pathRouteMap, namedRoutesMap, hasRootRoute, NotFoundPage } =
     analyzeRoutes(CheckRoutes.props.children, {
       currentPathName: '/',
     })
 
-  test('Should return namePathMap and hasHomeRoute correctly', () => {
+  test('Should return namePathMap and hasRootRoute correctly', () => {
     expect(Object.keys(pathRouteMap)).toEqual([
       '/hello',
       '/world',
@@ -74,7 +74,7 @@ describe('AnalyzeRoutes: with homePage and Children', () => {
       }),
     )
 
-    expect(hasHomeRoute).toBe(true)
+    expect(hasRootRoute).toBe(true)
   })
 
   test('Should return namedRoutesMap correctly', () => {
@@ -377,15 +377,15 @@ describe('setWrapper', () => {
   })
 })
 
-test('No home Route', () => {
+test('No root Route', () => {
   const CheckRoutes = (
     <Router>
-      <Route path="/iGots" name="iGots" page={FakePage} />
-      <Route path="/noHome" name="noHome" page={FakePage} />
+      <Route path="/home" name="home" page={FakePage} />
+      <Route path="/away" name="away" page={FakePage} />
     </Router>
   )
 
-  const { pathRouteMap, namedRoutesMap, hasHomeRoute } = analyzeRoutes(
+  const { pathRouteMap, namedRoutesMap, hasRootRoute } = analyzeRoutes(
     CheckRoutes.props.children,
     {
       currentPathName: '/',
@@ -394,7 +394,45 @@ test('No home Route', () => {
 
   expect(Object.keys(namedRoutesMap).length).toEqual(2)
   expect(Object.keys(pathRouteMap).length).toEqual(2)
-  expect(hasHomeRoute).toBe(false)
+  expect(hasRootRoute).toBe(false)
+})
+
+test('Root Route named "root"', () => {
+  const CheckRoutes = (
+    <Router>
+      <Route path="/" name="root" page={FakePage} />
+    </Router>
+  )
+
+  const { pathRouteMap, namedRoutesMap, hasRootRoute } = analyzeRoutes(
+    CheckRoutes.props.children,
+    {
+      currentPathName: '/',
+    },
+  )
+
+  expect(Object.keys(namedRoutesMap).length).toEqual(1)
+  expect(Object.keys(pathRouteMap).length).toEqual(1)
+  expect(hasRootRoute).toBe(true)
+})
+
+test('Root Route named "home"', () => {
+  const CheckRoutes = (
+    <Router>
+      <Route path="/" name="home" page={FakePage} />
+    </Router>
+  )
+
+  const { pathRouteMap, namedRoutesMap, hasRootRoute } = analyzeRoutes(
+    CheckRoutes.props.children,
+    {
+      currentPathName: '/',
+    },
+  )
+
+  expect(Object.keys(namedRoutesMap).length).toEqual(1)
+  expect(Object.keys(pathRouteMap).length).toEqual(1)
+  expect(hasRootRoute).toBe(true)
 })
 
 test('Handles Private', () => {

--- a/packages/router/src/analyzeRoutes.ts
+++ b/packages/router/src/analyzeRoutes.ts
@@ -60,7 +60,7 @@ export function analyzeRoutes(
 ) {
   const pathRouteMap: Record<RoutePath, AnalyzedRoute> = {}
   const namedRoutesMap: GeneratedRoutesMap = {}
-  let hasHomeRoute = false
+  let hasRootRoute = false
   let NotFoundPage: PageType | undefined
   let activeRoutePath: string | undefined
 
@@ -112,7 +112,7 @@ export function analyzeRoutes(
 
         // Used to decide whether to display SplashPage
         if (route.props.path === '/') {
-          hasHomeRoute = true
+          hasRootRoute = true
         }
 
         if (isRedirectRoute(route)) {
@@ -225,7 +225,7 @@ export function analyzeRoutes(
   return {
     pathRouteMap,
     namedRoutesMap,
-    hasHomeRoute,
+    hasRootRoute,
     NotFoundPage,
     activeRoutePath,
   }

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -65,24 +65,28 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
 
   const {
     pathRouteMap,
-    hasHomeRoute,
+    hasRootRoute,
     namedRoutesMap,
     NotFoundPage,
     activeRoutePath,
   } = analyzeRoutesResult
 
+  const hasGeneratedRoutes = hasCustomRoutes(namedRoutesMap)
+  const splashPageExists = typeof SplashPage !== 'undefined'
+  const isOnNonExistentRootRoute = !hasRootRoute && location.pathname === '/'
+
+  if (!hasRootRoute && splashPageExists) {
+    namedRoutesMap['home'] = () => '/'
+  }
+
   // Assign namedRoutes so it can be imported like import {routes} from 'rwjs/router'
   // Note that the value changes at runtime
   Object.assign(namedRoutes, namedRoutesMap)
 
-  // The user has not generated routes if the only route that exists is the
-  // not found page, and that page is not part of the namedRoutes object
-  const hasGeneratedRoutes = Object.keys(namedRoutes).length > 0
-
   const shouldShowSplash =
-    (!hasHomeRoute && location.pathname === '/') || !hasGeneratedRoutes
+    (isOnNonExistentRootRoute || !hasGeneratedRoutes) && splashPageExists
 
-  if (shouldShowSplash && typeof SplashPage !== 'undefined') {
+  if (shouldShowSplash) {
     return (
       <SplashPage
         hasGeneratedRoutes={hasGeneratedRoutes}
@@ -251,3 +255,13 @@ const WrappedPage = memo(({ sets, children }: WrappedPageProps) => {
     return wrapped
   }, children)
 })
+
+function hasCustomRoutes(obj: Record<string, unknown>) {
+  for (const prop in obj) {
+    if (Object.hasOwn(obj, prop)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/packages/router/src/server-router.tsx
+++ b/packages/router/src/server-router.tsx
@@ -32,7 +32,7 @@ export const Router: React.FC<RouterProps> = ({ paramTypes, children }) => {
 
   const {
     pathRouteMap,
-    hasHomeRoute,
+    hasRootRoute,
     namedRoutesMap,
     NotFoundPage,
     activeRoutePath,
@@ -47,7 +47,7 @@ export const Router: React.FC<RouterProps> = ({ paramTypes, children }) => {
   const hasGeneratedRoutes = Object.keys(namedRoutes).length > 0
 
   const shouldShowSplash =
-    (!hasHomeRoute && location.pathname === '/') || !hasGeneratedRoutes
+    (!hasRootRoute && location.pathname === '/') || !hasGeneratedRoutes
 
   if (shouldShowSplash && typeof SplashPage !== 'undefined') {
     return (


### PR DESCRIPTION
This PR makes it so that `routes.home()` works even when there's no actual `/` route in the `Routes.tsx` file if navigating to `/` would show the splash page.

Note: This might be a little tricky to cherry-pick to `next` because it modifies a file that's scheduled for RSC. But just ignore the server-router file and it should all be fine