### PR TITLE
chore(eslint-config): Remove `jest` devDep

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@babel/cli": "7.24.5",
-    "jest": "29.7.0",
     "typescript": "5.4.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8138,7 +8138,6 @@ __metadata:
     eslint-plugin-prettier: "npm:5.1.3"
     eslint-plugin-react: "npm:7.34.2"
     eslint-plugin-react-hooks: "npm:4.6.0"
-    jest: "npm:29.7.0"
     prettier: "npm:3.3.2"
     typescript: "npm:5.4.5"
   languageName: unknown


### PR DESCRIPTION
We don't use jest for testing in this package - there aren't even any tests. I think this is an unneeded devDep.