### PR TITLE
fix(tw): settings key should be "tailwindCSS.classAttributes"

### DIFF
--- a/__fixtures__/test-project/.vscode/settings.json
+++ b/__fixtures__/test-project/.vscode/settings.json
@@ -8,12 +8,10 @@
   "[prisma]": {
     "editor.formatOnSave": true
   },
-  "tailwindCSS": {
-    "classAttributes": [
-      "class",
-      "className",
-      "activeClassName",
-      "errorClassName"
-    ]
-  }
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "activeClassName",
+    "errorClassName"
+  ]
 }

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -2,6 +2,7 @@ import path from 'path'
 
 import { camelCase } from 'camel-case'
 import Enquirer from 'enquirer'
+import execa from 'execa'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import terminalLink from 'terminal-link'
@@ -395,6 +396,12 @@ const tasks = ({
       {
         title: 'Adding scaffold import...',
         task: () => addScaffoldImport(),
+      },
+      {
+        title: 'Generate types...',
+        task: () => {
+          execa.commandSync('yarn rw g types')
+        },
       },
       {
         title: 'One more thing...',

--- a/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
+++ b/packages/cli/src/commands/setup/ui/__tests__/tailwindcss.test.ts
@@ -222,14 +222,14 @@ describe('tailwindcss intellisense settings', () => {
     await handler({})
 
     const settingsJson = JSON.parse(readVsCodeSettings())
-    const tailwindCSS = settingsJson['tailwindCSS']
+    const twClassAttributes = settingsJson['tailwindCSS.classAttributes']
 
-    expect(Array.isArray(tailwindCSS.classAttributes)).toBe(true)
-    expect(tailwindCSS.classAttributes).toContain('class')
-    expect(tailwindCSS.classAttributes).toContain('className')
-    expect(tailwindCSS.classAttributes).toContain('activeClassName')
-    expect(tailwindCSS.classAttributes).toContain('errorClassName')
-    expect(tailwindCSS.classAttributes.length).toBe(4)
+    expect(Array.isArray(twClassAttributes)).toBe(true)
+    expect(twClassAttributes).toContain('class')
+    expect(twClassAttributes).toContain('className')
+    expect(twClassAttributes).toContain('activeClassName')
+    expect(twClassAttributes).toContain('errorClassName')
+    expect(twClassAttributes.length).toBe(4)
   })
 
   it('adds to existing empty settings file', async () => {
@@ -240,16 +240,15 @@ describe('tailwindcss intellisense settings', () => {
     await handler({})
 
     const settingsJson = JSON.parse(readVsCodeSettings())
-    const tailwindCSS = settingsJson['tailwindCSS']
+    const twClassAttributes = settingsJson['tailwindCSS.classAttributes']
 
     expect(Object.keys(settingsJson).length).toBe(1)
-    expect(Object.keys(tailwindCSS).length).toBe(1)
-    expect(Array.isArray(tailwindCSS.classAttributes)).toBe(true)
-    expect(tailwindCSS.classAttributes).toContain('class')
-    expect(tailwindCSS.classAttributes).toContain('className')
-    expect(tailwindCSS.classAttributes).toContain('activeClassName')
-    expect(tailwindCSS.classAttributes).toContain('errorClassName')
-    expect(tailwindCSS.classAttributes.length).toBe(4)
+    expect(Array.isArray(twClassAttributes)).toBe(true)
+    expect(twClassAttributes).toContain('class')
+    expect(twClassAttributes).toContain('className')
+    expect(twClassAttributes).toContain('activeClassName')
+    expect(twClassAttributes).toContain('errorClassName')
+    expect(twClassAttributes.length).toBe(4)
   })
 
   it('adds to existing settings file without any tailwindCSS settings', async () => {
@@ -267,16 +266,15 @@ describe('tailwindcss intellisense settings', () => {
     await handler({})
 
     const settingsJson = JSON.parse(readVsCodeSettings())
-    const tailwindCSS = settingsJson['tailwindCSS']
+    const twClassAttributes = settingsJson['tailwindCSS.classAttributes']
 
     expect(Object.keys(settingsJson).length).toBe(3)
-    expect(Object.keys(tailwindCSS).length).toBe(1)
-    expect(Array.isArray(tailwindCSS.classAttributes)).toBe(true)
-    expect(tailwindCSS.classAttributes).toContain('class')
-    expect(tailwindCSS.classAttributes).toContain('className')
-    expect(tailwindCSS.classAttributes).toContain('activeClassName')
-    expect(tailwindCSS.classAttributes).toContain('errorClassName')
-    expect(tailwindCSS.classAttributes.length).toBe(4)
+    expect(Array.isArray(twClassAttributes)).toBe(true)
+    expect(twClassAttributes).toContain('class')
+    expect(twClassAttributes).toContain('className')
+    expect(twClassAttributes).toContain('activeClassName')
+    expect(twClassAttributes).toContain('errorClassName')
+    expect(twClassAttributes.length).toBe(4)
   })
 
   it('adds to existing settings file with existing tailwindCSS settings', async () => {
@@ -287,9 +285,7 @@ describe('tailwindcss intellisense settings', () => {
         '  "editor.codeActionsOnSave": {',
         '    "source.fixAll.eslint": "explicit"',
         '  },',
-        '  "tailwindCSS": {',
-        '    "emmetCompletions": true',
-        '  }',
+        '  "tailwindCSS.emmetCompletions": true',
         '}',
       ].join('\n'),
     })
@@ -297,17 +293,16 @@ describe('tailwindcss intellisense settings', () => {
     await handler({})
 
     const settingsJson = JSON.parse(readVsCodeSettings())
-    const tailwindCSS = settingsJson['tailwindCSS']
+    const twClassAttributes = settingsJson['tailwindCSS.classAttributes']
 
-    expect(Object.keys(settingsJson).length).toBe(3)
-    expect(Object.keys(tailwindCSS).length).toBe(2)
-    expect(tailwindCSS.emmetCompletions).toBeTruthy()
-    expect(Array.isArray(tailwindCSS.classAttributes)).toBe(true)
-    expect(tailwindCSS.classAttributes).toContain('class')
-    expect(tailwindCSS.classAttributes).toContain('className')
-    expect(tailwindCSS.classAttributes).toContain('activeClassName')
-    expect(tailwindCSS.classAttributes).toContain('errorClassName')
-    expect(tailwindCSS.classAttributes.length).toBe(4)
+    expect(Object.keys(settingsJson).length).toBe(4)
+    expect(settingsJson['tailwindCSS.emmetCompletions']).toBeTruthy()
+    expect(Array.isArray(twClassAttributes)).toBe(true)
+    expect(twClassAttributes).toContain('class')
+    expect(twClassAttributes).toContain('className')
+    expect(twClassAttributes).toContain('activeClassName')
+    expect(twClassAttributes).toContain('errorClassName')
+    expect(twClassAttributes.length).toBe(4)
   })
 
   // This is what I decided to do now. If good arguments are made to change
@@ -320,10 +315,12 @@ describe('tailwindcss intellisense settings', () => {
         '  "editor.codeActionsOnSave": {',
         '    "source.fixAll.eslint": "explicit"',
         '  },',
-        '  "tailwindCSS": {',
-        '    "emmetCompletions": true,',
-        '    "classAttributes": ["class", "className", "ngClass"]',
-        '  }',
+        '  "tailwindCSS.emmetCompletions": true,',
+        '  "tailwindCSS.classAttributes": [',
+        '    "class",',
+        '    "className",',
+        '    "ngClass"',
+        '  ]',
         '}',
       ].join('\n'),
     })
@@ -331,18 +328,17 @@ describe('tailwindcss intellisense settings', () => {
     await handler({})
 
     const settingsJson = JSON.parse(readVsCodeSettings())
-    const tailwindCSS = settingsJson['tailwindCSS']
+    const twClassAttributes = settingsJson['tailwindCSS.classAttributes']
 
-    expect(Object.keys(settingsJson).length).toBe(3)
-    expect(Object.keys(tailwindCSS).length).toBe(2)
-    expect(tailwindCSS.emmetCompletions).toBeTruthy()
-    expect(Array.isArray(tailwindCSS.classAttributes)).toBe(true)
-    expect(tailwindCSS.classAttributes).toContain('class')
-    expect(tailwindCSS.classAttributes).toContain('className')
-    expect(tailwindCSS.classAttributes).toContain('ngClass')
-    expect(tailwindCSS.classAttributes).toContain('activeClassName')
-    expect(tailwindCSS.classAttributes).toContain('errorClassName')
-    expect(tailwindCSS.classAttributes.length).toBe(5)
+    expect(Object.keys(settingsJson).length).toBe(4)
+    expect(settingsJson['tailwindCSS.emmetCompletions']).toBeTruthy()
+    expect(Array.isArray(twClassAttributes)).toBe(true)
+    expect(twClassAttributes).toContain('class')
+    expect(twClassAttributes).toContain('className')
+    expect(twClassAttributes).toContain('ngClass')
+    expect(twClassAttributes).toContain('activeClassName')
+    expect(twClassAttributes).toContain('errorClassName')
+    expect(twClassAttributes.length).toBe(5)
   })
 })
 

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -323,9 +323,12 @@ export const handler = async ({ force, install }) => {
         skip: () => !usingVSCode() && "Looks like you're not using VS Code",
         task: () => {
           // Adds support for Redwood specific className props to tailwind intellisense
-          //   "tailwindCSS": {
-          //     "classAttributes": ["class", "className", "activeClassName", "errorClassName"]
-          //   }
+          //   "tailwindCSS.classAttributes": [
+          //     "class",
+          //     "className",
+          //     "activeClassName",
+          //     "errorClassName"
+          //   ]
           // The default value for this setting is:
           //   ["class", "className", "ngClass", "class:list"]
 
@@ -334,16 +337,16 @@ export const handler = async ({ force, install }) => {
             '.vscode/settings.json',
           )
 
-          const newTwSettingsJson = {
-            classAttributes: [
-              'class',
-              'className',
-              'activeClassName',
-              'errorClassName',
-            ],
-          }
+          const classAttributes = [
+            'class',
+            'className',
+            'activeClassName',
+            'errorClassName',
+          ]
 
-          let newSettingsJson = { tailwindCSS: { ...newTwSettingsJson } }
+          let newSettingsJson = {
+            ['tailwindCSS.classAttributes']: classAttributes,
+          }
 
           if (fs.existsSync(VS_CODE_SETTINGS_PATH)) {
             const originalSettingsFile = fs.readFileSync(
@@ -353,30 +356,16 @@ export const handler = async ({ force, install }) => {
             const originalSettingsJson = JSON.parse(
               originalSettingsFile || '{}',
             )
-            const originalTwSettingsJson = originalSettingsJson['tailwindCSS']
+            const originalTwClassAttributesJson =
+              originalSettingsJson['tailwindCSS.classAttributes'] || []
 
-            if (originalTwSettingsJson) {
-              const mergedClassAttributes = Array.from(
-                new Set([
-                  ...newTwSettingsJson.classAttributes,
-                  ...(originalTwSettingsJson.classAttributes || []),
-                ]),
-              )
+            const mergedClassAttributes = Array.from(
+              new Set([...classAttributes, ...originalTwClassAttributesJson]),
+            )
 
-              newSettingsJson = {
-                ...originalSettingsJson,
-                tailwindCSS: {
-                  ...originalTwSettingsJson,
-                  classAttributes: mergedClassAttributes,
-                },
-              }
-            } else {
-              newSettingsJson = {
-                ...originalSettingsJson,
-                tailwindCSS: {
-                  ...newTwSettingsJson,
-                },
-              }
+            newSettingsJson = {
+              ...originalSettingsJson,
+              ['tailwindCSS.classAttributes']: mergedClassAttributes,
             }
           }
 


### PR DESCRIPTION
Fixes the VSCode settings for our TailwindCSS setup

Issue first reported here: https://community.redwoodjs.com/t/redwood-v7-0-0-upgrade-guide/5713/78?u=tobbe

If you already have TW setup you need to manually edit your `.vscode/settings.json` file.
This is the change you need to make
```diff
     "editor.formatOnSave": true
   },
-  "tailwindCSS": {
-    "classAttributes": [
-      "class",
-      "className",
-      "activeClassName",
-      "errorClassName"
-    ]
-  }
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "activeClassName",
+    "errorClassName"
+  ]
 }
 ```