### PR TITLE
fix(dbAuth): Generate types to make `routes.pageName()` work

### DIFF
--- a/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
+++ b/packages/cli/src/commands/generate/dbAuth/__tests__/dbAuth.test.js
@@ -1,6 +1,7 @@
 global.__dirname = __dirname
 
 vi.mock('fs-extra')
+vi.mock('execa')
 
 import path from 'path'
 

--- a/packages/cli/src/commands/generate/dbAuth/dbAuth.js
+++ b/packages/cli/src/commands/generate/dbAuth/dbAuth.js
@@ -2,6 +2,7 @@ import path from 'path'
 
 import { camelCase } from 'camel-case'
 import Enquirer from 'enquirer'
+import execa from 'execa'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
 import terminalLink from 'terminal-link'
@@ -395,6 +396,12 @@ const tasks = ({
       {
         title: 'Adding scaffold import...',
         task: () => addScaffoldImport(),
+      },
+      {
+        title: 'Generate types...',
+        task: () => {
+          execa.commandSync('yarn rw g types')
+        },
       },
       {
         title: 'One more thing...',


### PR DESCRIPTION
Need to run `yarn rw g` after adding new pages and routes to update the types for `routes.pageName()`