### PR TITLE
fix(dbauth): multiValueHeaders

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/__tests__/buildDbAuthResponse.test.ts
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/buildDbAuthResponse.test.ts
@@ -1,9 +1,10 @@
+import type { APIGatewayProxyEvent } from 'aws-lambda'
 import { describe, it, expect } from 'vitest'
 
-import { buildDbAuthResponse } from '../shared'
+import { getDbAuthResponseBuilder } from '../shared'
 
 describe('buildDbAuthResponse', () => {
-  it('should add cors headers and set-cookie as array to the response', () => {
+  it('should add cors headers and set-cookie as array to the response to Requests', () => {
     const resHeaders = new Headers({
       header1: 'value1',
       header2: 'value2',
@@ -33,7 +34,48 @@ describe('buildDbAuthResponse', () => {
       },
     }
 
-    const result = buildDbAuthResponse(response, corsHeaders)
+    const createResponse = getDbAuthResponseBuilder({} as Request)
+    const result = createResponse(response, corsHeaders)
+
+    expect(result).toEqual(expectedResponse)
+  })
+
+  it('should add cors headers and set-cookie as multiValueHeaders array to the response to APIGatewayProxyEvent', () => {
+    const resHeaders = new Headers({
+      header1: 'value1',
+      header2: 'value2',
+    })
+
+    resHeaders.append('set-cookie', 'cookie1=value1')
+    resHeaders.append('set-cookie', 'cookie2=value2')
+
+    const response = {
+      statusCode: 200,
+      headers: resHeaders,
+    }
+
+    const corsHeaders = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE',
+    }
+
+    const expectedResponse = {
+      statusCode: 200,
+      headers: {
+        header1: 'value1',
+        header2: 'value2',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE',
+      },
+      multiValueHeaders: {
+        'Set-Cookie': ['cookie1=value1', 'cookie2=value2'],
+      },
+    }
+
+    const createResponse = getDbAuthResponseBuilder({
+      multiValueHeaders: {},
+    } as unknown as APIGatewayProxyEvent)
+    const result = createResponse(response, corsHeaders)
 
     expect(result).toEqual(expectedResponse)
   })
@@ -62,7 +104,8 @@ describe('buildDbAuthResponse', () => {
       },
     }
 
-    const result = buildDbAuthResponse(response, corsHeaders)
+    const createResponse = getDbAuthResponseBuilder({} as Request)
+    const result = createResponse(response, corsHeaders)
 
     expect(result).toEqual(expectedResponse)
   })

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -259,33 +259,53 @@ export const cookieName = (name: string | undefined) => {
 }
 
 /**
- * Returns a lambda response!
+ * Returns a builder for a lambda response
  *
- * This is used as the final call to return a response from the handler.
+ * This is used as the final call to return a response from the dbAuth handler
  *
- * Converts "Set-Cookie" headers to an array of strings.
+ * Converts "Set-Cookie" headers to an array of strings or a multiValueHeaders
+ * object
  */
-export const buildDbAuthResponse = (
-  response: {
-    body?: string
-    statusCode: number
-    headers?: Headers
-  },
-  corsHeaders: CorsHeaders,
-) => {
-  const setCookieHeaders = response.headers?.getSetCookie() || []
-
-  return {
-    ...response,
-    headers: {
-      ...Object.fromEntries(response.headers?.entries() || []),
-      ...(setCookieHeaders.length > 0
-        ? {
-            'set-cookie': setCookieHeaders,
-          }
-        : {}),
-      ...corsHeaders,
+export function getDbAuthResponseBuilder(
+  event: APIGatewayProxyEvent | Request,
+) {
+  return (
+    response: {
+      body?: string
+      statusCode: number
+      headers?: Headers
     },
+    corsHeaders: CorsHeaders,
+  ) => {
+    const headers: Record<string, string | Array<string>> = {
+      ...Object.fromEntries(response.headers?.entries() || []),
+      ...corsHeaders,
+    }
+
+    const dbAuthResponse: {
+      statusCode: number
+      headers: Record<string, string | Array<string>>
+      multiValueHeaders?: Record<string, Array<string>>
+      body?: string
+    } = {
+      ...response,
+      headers,
+    }
+
+    const setCookieHeaders = response.headers?.getSetCookie() || []
+
+    if (setCookieHeaders.length > 0) {
+      if ('multiValueHeaders' in event) {
+        dbAuthResponse.multiValueHeaders = {
+          'Set-Cookie': setCookieHeaders,
+        }
+        delete headers['set-cookie']
+      } else {
+        headers['set-cookie'] = setCookieHeaders
+      }
+    }
+
+    return dbAuthResponse
   }
 }
 


### PR DESCRIPTION
dbAuth errors out on Netlify if you have a header value that's an array (`set-cookie` in this case). They need us to instead use `multiValueHeaders` for any headers where the value is an array of values. They also seem to prefer `Set-Cookie` over `set-cookie`. 

See here
https://answers.netlify.com/t/multiple-set-cookie-headers-cause-netlify-lambda-to-throw-an-error/975
and here
https://answers.netlify.com/t/set-multiple-cookies-in-the-returned-response/36387/2