### PR TITLE
chore(esm): Update storybook build and package.json to build dual package

### DIFF
--- a/packages/storybook/build.ts
+++ b/packages/storybook/build.ts
@@ -1,8 +1,28 @@
+import { writeFileSync } from 'node:fs'
+
 import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 await build({
   buildOptions: {
     ...defaultBuildOptions,
     format: 'esm',
+    packages: 'external',
   },
 })
+
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    outdir: 'dist/cjs',
+    format: 'cjs',
+    packages: 'external',
+  },
+})
+
+// Place a package.json file with `type: commonjs` in the dist folder so that
+// all .js files are treated as CommonJS files.
+writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
+
+// Place a package.json file with `type: module` in the dist/esm folder so that
+// all .js files are treated as ES Module files.
+writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,20 +21,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./dist/index.js",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/index.js"
     },
     "./preset": {
       "types": "./dist/preset.d.ts",
-      "require": "./dist/preset.js"
+      "require": "./dist/cjs/preset.js",
+      "import": "./dist/preset.js"
     },
-    "./dist/mocks/MockRouter": "./dist/mocks/MockRouter.js",
+    "./dist/mocks/MockRouter": {
+      "require": "./dist/cjs/mocks/MockRouter.js",
+      "import": "./dist/mocks/MockRouter.js"
+    },
     "./dist/preview.js": "./dist/preview.js",
     "./package.json": "./package.json"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/cjs/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
While doing the dual package work on `@redwoodjs/web` I noticed some misconfiguration on the storybook package. 

This PR:
1. Updates build script to produce both ESM and CJS output
2. Updates the exports fields - some of these were pointing at files that didn't exist 
