### PR TITLE
chore(esm): Fix project-config dual packaging

### DIFF
--- a/packages/project-config/build.ts
+++ b/packages/project-config/build.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from 'node:fs'
+
 import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 // ESM build
@@ -19,6 +21,15 @@ await build({
     bundle: true,
     entryPoints: ['./src/index.ts'],
     outExtension: { '.js': '.cjs' },
+    outdir: 'dist/cjs',
     packages: 'external',
   },
 })
+
+// Place a package.json file with `type: commonjs` in the dist folder so that
+// all .js files are treated as CommonJS files.
+writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
+
+// Place a package.json file with `type: module` in the dist/esm folder so that
+// all .js files are treated as ES Module files.
+writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))

--- a/packages/project-config/build.ts
+++ b/packages/project-config/build.ts
@@ -9,7 +9,6 @@ await build({
     bundle: true,
     entryPoints: ['./src/index.ts'],
     format: 'esm',
-    outExtension: { '.js': '.mjs' },
     packages: 'external',
   },
 })
@@ -20,7 +19,6 @@ await build({
     ...defaultBuildOptions,
     bundle: true,
     entryPoints: ['./src/index.ts'],
-    outExtension: { '.js': '.cjs' },
     outdir: 'dist/cjs',
     packages: 'external',
   },

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -9,9 +9,16 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "default": "./dist/index.cjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
   },
   "types": "./dist/index.d.ts",
   "files": [
@@ -20,7 +27,7 @@
   "scripts": {
     "build": "tsx ./build.ts && run build:types",
     "build:pack": "yarn pack -o redwoodjs-project-config.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -16,7 +16,7 @@
       },
       "require": {
         "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.cjs"
+        "default": "./dist/cjs/index.js"
       }
     }
   },

--- a/packages/project-config/tsconfig.types-cjs.json
+++ b/packages/project-config/tsconfig.types-cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "commonjs",
+    "moduleResolution": "node",
+  },
+}


### PR DESCRIPTION
This PR changes the build and exports for `@redwoodjs/project-config`.

**Before**
❌ trying to import project-config with `moduleResolution: next` 

**Now**
✅ Can import

This also brings it inline with how we're doing dual packages elsewhere, where we output `dist/*.js` for ESM and `dist/cjs/*.js` for CJS. 