### PR TITLE
Updates document template to use exports field for htmlTags

### DIFF
--- a/__fixtures__/test-project-rsa/web/src/Document.tsx
+++ b/__fixtures__/test-project-rsa/web/src/Document.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import { Css, Meta } from '@redwoodjs/web/dist/components/htmlTags'
-import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
+import { Css, Meta } from '@redwoodjs/web/htmlTags'
+
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 interface DocumentProps {
   children: React.ReactNode

--- a/__fixtures__/test-project-rsa/web/src/Document.tsx
+++ b/__fixtures__/test-project-rsa/web/src/Document.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { Css, Meta } from '@redwoodjs/web/htmlTags'
-
 import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 interface DocumentProps {

--- a/__fixtures__/test-project-rsa/web/src/entry.server.tsx
+++ b/__fixtures__/test-project-rsa/web/src/entry.server.tsx
@@ -1,4 +1,4 @@
-import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 import App from './App'
 import { Document } from './Document'

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/Document.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/Document.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import { Css, Meta } from '@redwoodjs/web/dist/components/htmlTags'
-import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
+import { Css, Meta } from '@redwoodjs/web/htmlTags'
+
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 interface DocumentProps {
   children: React.ReactNode

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/entry.server.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/entry.server.tsx
@@ -1,4 +1,4 @@
-import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 import App from './App'
 import { Document } from './Document'

--- a/packages/cli/src/commands/experimental/templates/rsc/Document.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Document.tsx.template
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import { Css, Meta } from '@redwoodjs/web/dist/components/htmlTags'
-import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
+import { Css, Meta } from '@redwoodjs/web/htmlTags'
+
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 interface DocumentProps {
   children: React.ReactNode

--- a/packages/cli/src/commands/experimental/templates/rsc/Document.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Document.tsx.template
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { Css, Meta } from '@redwoodjs/web/htmlTags'
-
 import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 interface DocumentProps {

--- a/packages/cli/src/commands/experimental/templates/rsc/entry.server.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/entry.server.tsx.template
@@ -1,4 +1,4 @@
-import type { TagDescriptor } from '@redwoodjs/web/dist/components/htmlTags'
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 import App from './App'
 import { Document } from './Document'

--- a/packages/cli/src/commands/experimental/templates/streamingSsr/Document.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/streamingSsr/Document.tsx.template
@@ -1,7 +1,7 @@
 import React from 'react'
 
-import { Css, Meta } from '@redwoodjs/web'
-import type { TagDescriptor } from '@redwoodjs/web'
+import { Css, Meta } from '@redwoodjs/web/htmlTags'
+import type { TagDescriptor } from '@redwoodjs/web/htmlTags'
 
 interface DocumentProps {
   children: React.ReactNode

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -41,6 +41,10 @@
       "require": "./dist/cjs/components/*.js",
       "import": "./dist/components/*.js"
     },
+    "./htmlTags": {
+      "require": "./dist/cjs/components/htmlTags.js",
+      "import": "./dist/components/htmlTags.js"
+    },
     "./dist/apollo/suspense": {
       "require": "./dist/cjs/apollo/suspense.js",
       "import": "./dist/apollo/suspense.js"


### PR DESCRIPTION
Since we have the exports field, we can avoid using `@redwoodjs/web/dist` - specifically in SSR and RSC templates.

I haven't gone as far as removing the export from the web/index.ts yet though.