### PR TITLE
RSC: Make `rw g page` work for RSC projects

### DIFF
--- a/packages/cli/src/commands/destroy/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/destroy/page/__tests__/page.test.js
@@ -8,38 +8,51 @@ vi.mock('../../../../lib', async (importOriginal) => {
   }
 })
 
-vi.mock('fs', async (importOriginal) => {
-  const originalFs = await importOriginal()
-  const mockFiles = {
-    '/redwood.toml': '[web]\n  title = "Redwood App"\n',
-  }
-
-  return {
-    default: {
-      ...originalFs,
-      existsSync: (...args) => {
-        if (mockFiles[args[0]]) {
-          return true
-        }
-
-        return originalFs.existsSync.apply(null, args)
-      },
-      readFileSync: (path) => {
-        if (mockFiles[path]) {
-          return mockFiles[path]
-        }
-
-        return originalFs.readFileSync
-      },
-    },
-  }
-})
-
 import fs from 'fs-extra'
 import { vol } from 'memfs'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
 
-import '../../../../lib/test'
+import '../../../../lib/mockTelemetry'
+
+vi.mock('@redwoodjs/project-config', async (importOriginal) => {
+  const path = require('path')
+  const originalProjectConfig = await importOriginal()
+  return {
+    getPaths: () => {
+      const BASE_PATH = '/path/to/project'
+
+      return {
+        base: BASE_PATH,
+        web: {
+          generators: path.join(BASE_PATH, './web/generators'),
+          routes: path.join(BASE_PATH, 'web/src/Routes.js'),
+          pages: path.join(BASE_PATH, '/web/src/pages'),
+        },
+      }
+    },
+    getConfig: () => ({}),
+    findUp: originalProjectConfig.findUp,
+    ensurePosixPath: originalProjectConfig.ensurePosixPath,
+    resolveFile: originalProjectConfig.resolveFile,
+  }
+})
+
+vi.mock('@redwoodjs/cli-helpers', async (importOriginal) => {
+  const originalCliHelpers = await importOriginal()
+
+  return {
+    ...originalCliHelpers,
+    isTypeScriptProject: () => false,
+  }
+})
+
+vi.mock('@redwoodjs/internal/dist/generate/generate', () => {
+  return {
+    generate: () => {
+      return { errors: [] }
+    },
+  }
+})
 
 import { getPaths } from '../../../../lib'
 import { files } from '../../../generate/page/page'

--- a/packages/cli/src/commands/destroy/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/destroy/page/__tests__/page.test.js
@@ -8,6 +8,33 @@ vi.mock('../../../../lib', async (importOriginal) => {
   }
 })
 
+vi.mock('fs', async (importOriginal) => {
+  const originalFs = await importOriginal()
+  const mockFiles = {
+    '/redwood.toml': '[web]\n  title = "Redwood App"\n',
+  }
+
+  return {
+    default: {
+      ...originalFs,
+      existsSync: (...args) => {
+        if (mockFiles[args[0]]) {
+          return true
+        }
+
+        return originalFs.existsSync.apply(null, args)
+      },
+      readFileSync: (path) => {
+        if (mockFiles[path]) {
+          return mockFiles[path]
+        }
+
+        return originalFs.readFileSync
+      },
+    },
+  }
+})
+
 import fs from 'fs-extra'
 import { vol } from 'memfs'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'

--- a/packages/cli/src/commands/generate/__tests__/helpers.test.js
+++ b/packages/cli/src/commands/generate/__tests__/helpers.test.js
@@ -89,7 +89,10 @@ test('templateForComponentFile creates a proper output path for files', async ()
       webPathSection: 'pages',
       generator: 'page',
       templatePath: 'page.tsx.template',
-      templateVars: page.paramVariants(helpers.pathName(undefined, name)),
+      templateVars: {
+        ...page.paramVariants(helpers.pathName(undefined, name)),
+        rscEnabled: false,
+      },
     })
 
     expect(output[0]).toEqual(
@@ -108,7 +111,10 @@ test('templateForComponentFile creates a proper output path for files with all c
       webPathSection: 'pages',
       generator: 'page',
       templatePath: 'page.tsx.template',
-      templateVars: page.paramVariants(helpers.pathName(undefined, name)),
+      templateVars: {
+        ...page.paramVariants(helpers.pathName(undefined, name)),
+        rscEnabled: false,
+      },
     })
 
     expect(output[0]).toEqual(
@@ -127,7 +133,10 @@ test('templateForComponentFile creates a proper output path for files for starti
       webPathSection: 'pages',
       generator: 'page',
       templatePath: 'page.tsx.template',
-      templateVars: page.paramVariants(helpers.pathName(undefined, name)),
+      templateVars: {
+        ...page.paramVariants(helpers.pathName(undefined, name)),
+        rscEnabled: false,
+      },
     })
 
     expect(output[0]).toEqual(
@@ -146,7 +155,10 @@ test('templateForComponentFile creates a proper output path for files with upper
       webPathSection: 'pages',
       generator: 'page',
       templatePath: 'page.tsx.template',
-      templateVars: page.paramVariants(helpers.pathName(undefined, name)),
+      templateVars: {
+        ...page.paramVariants(helpers.pathName(undefined, name)),
+        rscEnabled: false,
+      },
     })
 
     expect(output[0]).toEqual(
@@ -162,7 +174,10 @@ test('templateForComponentFile can create a path in /web', async () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.tsx.template',
-    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
+    templateVars: {
+      ...page.paramVariants(helpers.pathName(undefined, 'Home')),
+      rscEnabled: false,
+    },
   })
 
   expect(output[0]).toEqual(
@@ -177,7 +192,10 @@ test('templateForComponentFile can create a path in /api', async () => {
     apiPathSection: 'services',
     generator: 'page',
     templatePath: 'page.tsx.template',
-    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
+    templateVars: {
+      ...page.paramVariants(helpers.pathName(undefined, 'Home')),
+      rscEnabled: false,
+    },
   })
 
   expect(output[0]).toEqual(
@@ -192,7 +210,10 @@ test('templateForComponentFile can override generated component name', async () 
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.tsx.template',
-    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
+    templateVars: {
+      ...page.paramVariants(helpers.pathName(undefined, 'Home')),
+      rscEnabled: false,
+    },
   })
 
   expect(output[0]).toEqual(
@@ -208,7 +229,10 @@ test('templateForComponentFile can override file extension', async () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.tsx.template',
-    templateVars: page.paramVariants(helpers.pathName(undefined, 'Home')),
+    templateVars: {
+      ...page.paramVariants(helpers.pathName(undefined, 'Home')),
+      rscEnabled: false,
+    },
   })
 
   expect(output[0]).toEqual(
@@ -238,7 +262,10 @@ test('templateForComponentFile creates a template', async () => {
     webPathSection: 'pages',
     generator: 'page',
     templatePath: 'page.tsx.template',
-    templateVars: page.paramVariants(helpers.pathName(undefined, 'fooBar')),
+    templateVars: {
+      ...page.paramVariants(helpers.pathName(undefined, 'fooBar')),
+      rscEnabled: false,
+    },
   })
 
   expect(output[1]).toEqual(PAGE_TEMPLATE_OUTPUT)

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -6,12 +6,11 @@ import { Listr } from 'listr2'
 import pascalcase from 'pascalcase'
 import terminalLink from 'terminal-link'
 
-import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
 import {
-  getConfig,
-  ensurePosixPath,
+  recordTelemetryAttributes,
   isTypeScriptProject,
-} from '@redwoodjs/project-config'
+} from '@redwoodjs/cli-helpers'
+import { getConfig, ensurePosixPath } from '@redwoodjs/project-config'
 import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { generateTemplate, getPaths, writeFilesTask } from '../../lib'

--- a/packages/cli/src/commands/generate/helpers.js
+++ b/packages/cli/src/commands/generate/helpers.js
@@ -7,12 +7,15 @@ import pascalcase from 'pascalcase'
 import terminalLink from 'terminal-link'
 
 import { recordTelemetryAttributes } from '@redwoodjs/cli-helpers'
-import { getConfig, ensurePosixPath } from '@redwoodjs/project-config'
+import {
+  getConfig,
+  ensurePosixPath,
+  isTypeScriptProject,
+} from '@redwoodjs/project-config'
 import { errorTelemetry } from '@redwoodjs/telemetry'
 
 import { generateTemplate, getPaths, writeFilesTask } from '../../lib'
 import c from '../../lib/colors'
-import { isTypeScriptProject } from '../../lib/project'
 import { prepareForRollback } from '../../lib/rollback'
 import { pluralize, isPlural, isSingular } from '../../lib/rwPluralize'
 

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -1,7 +1,33 @@
 globalThis.__dirname = __dirname
 
 globalThis.mockFs = false
-let mockFiles = {}
+let mockFiles = {
+  '/redwood.toml': '[web]\n  title = "Redwood App"\n',
+}
+
+vi.mock('fs', async (importOriginal) => {
+  const originalFs = await importOriginal()
+
+  return {
+    default: {
+      ...originalFs,
+      existsSync: (...args) => {
+        if (mockFiles[args[0]]) {
+          return true
+        }
+
+        return originalFs.existsSync.apply(null, args)
+      },
+      readFileSync: (path) => {
+        if (mockFiles[path]) {
+          return mockFiles[path]
+        }
+
+        return originalFs.readFileSync
+      },
+    },
+  }
+})
 
 vi.mock('fs-extra', async (importOriginal) => {
   const originalFsExtra = await importOriginal()

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -89,6 +89,14 @@ vi.mock('@redwoodjs/project-config', async (importOriginal) => {
     getConfig: () => ({}),
     ensurePosixPath: originalProjectConfig.ensurePosixPath,
     resolveFile: originalProjectConfig.resolveFile,
+  }
+})
+
+vi.mock('@redwoodjs/cli-helpers', async (importOriginal) => {
+  const originalCliHelpers = await importOriginal()
+
+  return {
+    ...originalCliHelpers,
     isTypeScriptProject: () => false,
   }
 })

--- a/packages/cli/src/commands/generate/page/__tests__/page.test.js
+++ b/packages/cli/src/commands/generate/page/__tests__/page.test.js
@@ -12,6 +12,7 @@ vi.mock('fs', async (importOriginal) => {
     default: {
       ...originalFs,
       existsSync: (...args) => {
+        console.log('existsSync', args)
         if (mockFiles[args[0]]) {
           return true
         }
@@ -375,6 +376,10 @@ describe('handler', () => {
   afterEach(() => {
     console.info.mockRestore()
     console.log.mockRestore()
+
+    mockFiles = {
+      '/redwood.toml': '[web]\n  title = "Redwood App"\n',
+    }
   })
 
   test('file generation', async () => {
@@ -393,6 +398,7 @@ describe('handler', () => {
         '',
         'export default Routes',
       ].join('\n'),
+      '/redwood.toml': '[web]\n  title = "Redwood App"\n',
     }
 
     const spy = vi.spyOn(fs, 'writeFileSync')
@@ -438,6 +444,7 @@ describe('handler', () => {
         '',
         'export default Routes',
       ].join('\n'),
+      '/redwood.toml': '[web]\n  title = "Redwood App"\n',
     }
 
     const spy = vi.spyOn(fs, 'writeFileSync')

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -237,6 +237,7 @@ export const handler = async ({
             stories,
             typescript,
             ...paramVariants(path),
+            rscEnabled: getConfig().experimental?.rsc?.enabled,
           })
           return writeFilesTask(f, { overwriteExisting: force })
         },

--- a/packages/cli/src/commands/generate/page/page.js
+++ b/packages/cli/src/commands/generate/page/page.js
@@ -94,7 +94,10 @@ export const files = async ({ name, tests, stories, typescript, ...rest }) => {
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'page',
     templatePath: 'page.tsx.template',
-    templateVars: rest,
+    templateVars: {
+      rscEnabled: getConfig().experimental?.rsc?.enabled,
+      ...rest,
+    },
   })
 
   const testFile = await templateForComponentFile({
@@ -237,7 +240,6 @@ export const handler = async ({
             stories,
             typescript,
             ...paramVariants(path),
-            rscEnabled: getConfig().experimental?.rsc?.enabled,
           })
           return writeFilesTask(f, { overwriteExisting: force })
         },

--- a/packages/cli/src/commands/generate/page/templates/page.tsx.template
+++ b/packages/cli/src/commands/generate/page/templates/page.tsx.template
@@ -1,5 +1,12 @@
+<% if (rscEnabled) { %>
+import { Link } from '@redwoodjs/router/dist/link'
+import { namedRoutes as routes } from '@redwoodjs/router/dist/namedRoutes'
+import { Metadata } from '@redwoodjs/web/dist/components/Metadata'
+<% } else { %>
 import { Link, routes } from '@redwoodjs/router'
 import { Metadata } from '@redwoodjs/web'
+<% } %>
+
 <% if (paramName !== '') { %>
 type ${pascalName}PageProps = {
   ${paramName}: ${paramType}

--- a/packages/cli/src/lib/test.js
+++ b/packages/cli/src/lib/test.js
@@ -72,6 +72,15 @@ vi.mock('@redwoodjs/project-config', async (importOriginal) => {
   }
 })
 
+vi.mock('@redwoodjs/cli-helpers', async (importOriginal) => {
+  const originalCliHelpers = await importOriginal()
+
+  return {
+    ...originalCliHelpers,
+    isTypeScriptProject: () => false,
+  }
+})
+
 vi.mock('./project', () => ({
   isTypeScriptProject: () => false,
   sides: () => ['web', 'api'],


### PR DESCRIPTION
When RSC is enabled pages are rendered on the server by default, and so can't use features that are available on the client side only. When importing from `@redwoodjs/web` things like React contexts will also be imported, which doesn't work when rendering on the server. So we need to be more specific about our imports. 

Right now the imports are fairly ugly, but they work, which is most important. Hopefully we can clean them up in the future.