### PR TITLE
RSC: Add auth support to ClientRouter

### DIFF
--- a/packages/vite/src/ClientRouter.tsx
+++ b/packages/vite/src/ClientRouter.tsx
@@ -41,6 +41,7 @@ const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
   // Need to reverse the sets array when finding the private set so that we
   // find the inner-most private set first. Otherwise we could end up
   // redirecting to the wrong route.
+  // TODO (RSC): Add tests for finding the correct unauthenticated prop
   const reversedSets = requestedRoute.sets.toReversed()
 
   const privateSet = reversedSets.find((set) => set.isPrivate)
@@ -52,6 +53,7 @@ const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
         'You must specify an `unauthenticated` route when using PrivateSet',
       )
     }
+
     return (
       <AuthenticatedRoute unauthenticated={unauthenticated}>
         {rscFetch('__rwjs__Routes', { location: { pathname, search } })}

--- a/packages/vite/src/ClientRouter.tsx
+++ b/packages/vite/src/ClientRouter.tsx
@@ -36,11 +36,14 @@ const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
   // Note that the value changes at runtime
   Object.assign(namedRoutes, namedRoutesMap)
 
-  // Use results from `analyzeRoutes` to determine if the user has access to
-  // the requested route
   const requestedRoute = pathRouteMap[pathname]
 
-  const privateSet = requestedRoute.sets.find((set) => set.isPrivate)
+  // Need to reverse the sets array when finding the private set so that we
+  // find the inner-most private set first. Otherwise we could end up
+  // redirecting to the wrong route.
+  const reversedSets = requestedRoute.sets.toReversed()
+
+  const privateSet = reversedSets.find((set) => set.isPrivate)
 
   if (privateSet) {
     const unauthenticated = privateSet.props.unauthenticated

--- a/packages/vite/src/ClientRouter.tsx
+++ b/packages/vite/src/ClientRouter.tsx
@@ -8,35 +8,53 @@ import { AuthenticatedRoute } from '@redwoodjs/router/dist/AuthenticatedRoute'
 import { LocationProvider, useLocation } from '@redwoodjs/router/dist/location'
 import { namedRoutes } from '@redwoodjs/router/dist/namedRoutes'
 import type { RouterProps } from '@redwoodjs/router/dist/router'
+import { RouterContextProvider } from '@redwoodjs/router/dist/router-context'
 
 import { rscFetch } from './rsc/rscFetchForClientRouter'
 
-export const Router = ({ paramTypes, children }: RouterProps) => {
+export const Router = ({ useAuth, paramTypes, children }: RouterProps) => {
   return (
     // Wrap it in the provider so that useLocation can be used
     <LocationProvider>
-      <LocationAwareRouter paramTypes={paramTypes}>
+      <LocationAwareRouter paramTypes={paramTypes} useAuth={useAuth}>
         {children}
       </LocationAwareRouter>
     </LocationProvider>
   )
 }
 
-const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
+const LocationAwareRouter = ({
+  useAuth,
+  paramTypes,
+  children,
+}: RouterProps) => {
   const { pathname, search } = useLocation()
 
-  const { namedRoutesMap, pathRouteMap } = useMemo(() => {
+  const analyzeRoutesResult = useMemo(() => {
     return analyzeRoutes(children, {
       currentPathName: pathname,
       userParamTypes: paramTypes,
     })
   }, [pathname, children, paramTypes])
 
+  const { namedRoutesMap, pathRouteMap, activeRoutePath } = analyzeRoutesResult
+
   // Assign namedRoutes so it can be imported like import {routes} from 'rwjs/router'
   // Note that the value changes at runtime
   Object.assign(namedRoutes, namedRoutesMap)
 
-  const requestedRoute = pathRouteMap[pathname]
+  // No activeRoutePath basically means 404.
+  // TODO (RSC): Add tests for this
+  // TODO (RSC): Figure out how to handle this case better
+  if (!activeRoutePath) {
+    // throw new Error(
+    //   'No route found for the current URL. Make sure you have a route ' +
+    //     'defined for the root of your React app.',
+    // )
+    return rscFetch('__rwjs__Routes', { location: { pathname, search } })
+  }
+
+  const requestedRoute = pathRouteMap[activeRoutePath]
 
   // Need to reverse the sets array when finding the private set so that we
   // find the inner-most private set first. Otherwise we could end up
@@ -55,9 +73,16 @@ const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
     }
 
     return (
-      <AuthenticatedRoute unauthenticated={unauthenticated}>
-        {rscFetch('__rwjs__Routes', { location: { pathname, search } })}
-      </AuthenticatedRoute>
+      <RouterContextProvider
+        useAuth={useAuth}
+        paramTypes={paramTypes}
+        routes={analyzeRoutesResult}
+        activeRouteName={requestedRoute.name}
+      >
+        <AuthenticatedRoute unauthenticated={unauthenticated}>
+          {rscFetch('__rwjs__Routes', { location: { pathname, search } })}
+        </AuthenticatedRoute>
+      </RouterContextProvider>
     )
   }
 

--- a/packages/vite/src/ClientRouter.tsx
+++ b/packages/vite/src/ClientRouter.tsx
@@ -3,9 +3,11 @@
 
 import React, { useMemo } from 'react'
 
+import type { GeneratedRoutesMap } from '@redwoodjs/router/dist/analyzeRoutes'
 import { analyzeRoutes } from '@redwoodjs/router/dist/analyzeRoutes'
 import { LocationProvider, useLocation } from '@redwoodjs/router/dist/location'
 import { namedRoutes } from '@redwoodjs/router/dist/namedRoutes'
+import { Redirect } from '@redwoodjs/router/dist/redirect'
 import type { RouterProps } from '@redwoodjs/router/dist/router'
 
 import { rscFetch } from './rsc/rscFetchForClientRouter'
@@ -24,7 +26,7 @@ export const Router = ({ paramTypes, children }: RouterProps) => {
 const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
   const { pathname, search } = useLocation()
 
-  const { namedRoutesMap } = useMemo(() => {
+  const { namedRoutesMap, pathRouteMap } = useMemo(() => {
     return analyzeRoutes(children, {
       currentPathName: pathname,
       userParamTypes: paramTypes,
@@ -34,6 +36,57 @@ const LocationAwareRouter = ({ paramTypes, children }: RouterProps) => {
   // Assign namedRoutes so it can be imported like import {routes} from 'rwjs/router'
   // Note that the value changes at runtime
   Object.assign(namedRoutes, namedRoutesMap)
+
+  // Use results from `analyzeRoutes` to determine if the user has access to
+  // the requested route
+  const requestedRoute = pathRouteMap[pathname]
+
+  const privateSet = requestedRoute.sets.find((set) => set.isPrivate)
+
+  if (privateSet) {
+    const redirectTarget = privateSet.props.unauthenticated
+
+    if (!redirectTarget || typeof redirectTarget !== 'string') {
+      throw new Error(
+        `Route ${pathname} is private and no unauthenticated redirect target was provided`,
+      )
+    }
+
+    // We type cast like this, because AvailableRoutes is generated in the
+    // user's project
+    const generatedRoutesMap = namedRoutes as GeneratedRoutesMap
+
+    if (!generatedRoutesMap[redirectTarget]) {
+      throw new Error(`We could not find a route named ${redirectTarget}`)
+    }
+
+    const currentLocation =
+      globalThis.location.pathname +
+      encodeURIComponent(globalThis.location.search)
+
+    let unauthenticatedPath
+
+    try {
+      unauthenticatedPath = generatedRoutesMap[redirectTarget]()
+    } catch (e) {
+      if (
+        e instanceof Error &&
+        /Missing parameter .* for route/.test(e.message)
+      ) {
+        throw new Error(
+          `Redirecting to route "${redirectTarget}" would require route ` +
+            'parameters, which currently is not supported. Please choose ' +
+            'a different route',
+        )
+      }
+
+      throw new Error(`Could not redirect to the route named ${redirectTarget}`)
+    }
+
+    return (
+      <Redirect to={`${unauthenticatedPath}?redirectTo=${currentLocation}`} />
+    )
+  }
 
   return rscFetch('__rwjs__Routes', { location: { pathname, search } })
 }

--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -26,8 +26,18 @@ test.beforeAll(async ({ browser }) => {
     // TODO (RSC): When we get toasts working we should check for a toast
     // message instead of network stuff, like in signUpTestUser()
     page.waitForResponse(async (response) => {
+      // Status >= 300 and < 400 is a redirect
+      // We get that sometimes for things like
+      // http://localhost:8910/assets/jsx-runtime-CGe0JNFD.mjs
+      if (response.status() >= 300 && response.status() < 400) {
+        return false
+      }
+
       const body = await response.body()
-      return body.includes(`Username \`${testUser.email}\` already in use`)
+      return (
+        response.url().includes('middleware') &&
+        body.includes(`Username \`${testUser.email}\` already in use`)
+      )
     }),
   ])
 


### PR DESCRIPTION
The client router will now check for private sets and redirect the user if they're not authenticated