### PR TITLE
chore(comment): Remove comment that's wrong

### DIFF
--- a/packages/router/src/AuthenticatedRoute.tsx
+++ b/packages/router/src/AuthenticatedRoute.tsx
@@ -29,7 +29,6 @@ export const AuthenticatedRoute: React.FC<AuthenticatedRouteProps> = ({
     return !(isAuthenticated && (!roles || hasRole(roles)))
   }, [isAuthenticated, roles, hasRole])
 
-  // Make sure `wrappers` is always an array with at least one wrapper component
   if (unauthorized()) {
     if (authLoading) {
       return whileLoadingAuth?.() || null


### PR DESCRIPTION
Removing a comment that is wrong (looks like a copy/paste misstake)

But mostly doing this to get a new canary to publish, to fix an issue with our latest npm package(s)