### PR TITLE
chore(ci): Use more supported syntax in publish_canary script

### DIFF
--- a/.github/scripts/publish_canary.sh
+++ b/.github/scripts/publish_canary.sh
@@ -26,14 +26,14 @@ args+=(
 
 # `echo 'n'` to answer "no" to the "Are you sure you want to publish these
 #   packages?" prompt.
-# `|&` to pipe both stdout and stderr to grep. Mostly do this keep the github
+# `2>&1` to pipe both stdout and stderr to grep. Mostly do this keep the github
 #   action output clean.
 # At the end we use awk to increase the commit count by 1, because we'll commit
 #   updated package.jsons in the next step, which will increase increase the
 #   final number that lerna will use when publishing the canary packages.
 echo 'n' \
-  | yarn lerna publish "${args[@]}" \
-  |& grep '\-canary\.' \
+  | yarn lerna publish "${args[@]}" 2>&1 \
+  | grep '\-canary\.' \
   | tail -n 1 \
   | sed 's/.*=> //' \
   | sed 's/\+.*//' \


### PR DESCRIPTION
Switching to a more widely supported syntax in one of the commands in the `publish_canary.sh` script to more easily run/debug the script on everyones own computers.

We used to use `|&` which is just shorthand syntax for `2>&1 |`

> If ‘|&’ is used, command1’s standard error, in addition to its standard output, is connected to command2’s standard input through the pipe; it is shorthand for 2>&1 |. This implicit redirection of the standard error to the standard output is performed after any redirections specified by command1.

https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Pipelines

This shorthand syntax was added in bash 4.0.0 https://github.com/bminor/bash/blob/bash-4.0/CHANGES#L607
MacOS is still on bash 3.2