### PR TITLE
debug(ci): Print publishing command output

### DIFF
--- a/.github/scripts/publish_canary.sh
+++ b/.github/scripts/publish_canary.sh
@@ -33,6 +33,12 @@ args+=(
 #   final number that lerna will use when publishing the canary packages.
 echo 'n' \
   | yarn lerna publish "${args[@]}" 2>&1 \
+  > publish_output
+echo "Publish output:"
+echo "---------------\n"
+cat publish_output
+echo "---------------\n"
+cat publish_output \
   | grep '\-canary\.' \
   | tail -n 1 \
   | sed 's/.*=> //' \


### PR DESCRIPTION
Print output of `yarn lerna publish` to see if I can determine what's going wrong in the `publish_canary.sh` script