### PR TITLE
chore(tests): Fix failing kitchen-sink tests by logging in

### DIFF
--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -107,6 +107,8 @@ test('Submitting the form should return a response', async ({ page }) => {
 })
 
 test('Page with Cell', async ({ page }) => {
+  await loginAsTestUser({ page, ...testUser })
+
   await page.goto('/user-examples')
 
   const h1 = await page.locator('h1').innerHTML()
@@ -118,6 +120,8 @@ test('Page with Cell', async ({ page }) => {
 })
 
 test("'use client' cell Empty state", async ({ page }) => {
+  await loginAsTestUser({ page, ...testUser })
+
   await page.goto('/empty-users')
 
   const h1 = await page.locator('h1').innerHTML()
@@ -132,6 +136,8 @@ test("'use client' cell Empty state", async ({ page }) => {
 })
 
 test("'use client' cell navigation", async ({ page }) => {
+  await loginAsTestUser({ page, ...testUser })
+
   await page.goto('/empty-users')
 
   await expect(page.getByText('No emptyUsers yet.')).toBeVisible()


### PR DESCRIPTION
Navigate to the login page and enter email and password followed by finally signing in.