### PR TITLE
feat(baremetal): Check for setup before running deploy

### DIFF
--- a/.changesets/10922.md
+++ b/.changesets/10922.md
@@ -1,0 +1,4 @@
+- feat(baremetal): Check for setup before running deploy (#10922) by @Tobbe
+
+Print a helpful error message if baremetal has not been setup before running
+`yarn rw deploy baremetal`.

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -672,6 +672,20 @@ export const handler = async (yargs) => {
     verbose: yargs.verbose,
   })
 
+  // Check if baremetal has been setup
+  const tomlPath = path.join(getPaths().base, 'deploy.toml')
+  const ecosystemPath = path.join(getPaths().base, 'ecosystem.config.js')
+
+  if (!fs.existsSync(tomlPath) || !fs.existsSync(ecosystemPath)) {
+    console.error(
+      c.error('Error: Baremetal deploy has not been properly setup.\n'),
+    )
+    console.error(
+      c.error('Please run `yarn rw setup deploy baremetal` before deploying'),
+    )
+    process.exit(1)
+  }
+
   const ssh = new SshExecutor(yargs.verbose)
 
   try {

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -678,10 +678,8 @@ export const handler = async (yargs) => {
 
   if (!fs.existsSync(tomlPath) || !fs.existsSync(ecosystemPath)) {
     console.error(
-      c.error('\nError: Baremetal deploy has not been properly setup.'),
-    )
-    console.error(
-      'Please run `yarn rw setup deploy baremetal` before deploying',
+      c.error('\nError: Baremetal deploy has not been properly setup.\n') +
+        'Please run `yarn rw setup deploy baremetal` before deploying',
     )
     process.exit(1)
   }

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -678,10 +678,10 @@ export const handler = async (yargs) => {
 
   if (!fs.existsSync(tomlPath) || !fs.existsSync(ecosystemPath)) {
     console.error(
-      c.error('Error: Baremetal deploy has not been properly setup.\n'),
+      c.error('\nError: Baremetal deploy has not been properly setup.'),
     )
     console.error(
-      c.error('Please run `yarn rw setup deploy baremetal` before deploying'),
+      'Please run `yarn rw setup deploy baremetal` before deploying',
     )
     process.exit(1)
   }


### PR DESCRIPTION
The first command we show in the baremetal docs is the `deploy` command
![image](https://github.com/redwoodjs/redwood/assets/30793/893ac4db-7d13-4dfc-95bf-0c7d8cd71d69)

A sloppy reader might just naively copy and run that command (who would ever?! 🙄 😛), thinking that's what you do to get started. If they do, they'll be greeted by this:

![image](https://github.com/redwoodjs/redwood/assets/30793/3068409f-ff90-461d-a80a-dababb032679)

Not very nice, right? And definitely not very helpful.

With this PR we'll instead print a helpful error message
![image](https://github.com/redwoodjs/redwood/assets/30793/cb60eb24-a8ea-48f4-aafd-4b1eb445363e)

