### PR TITLE
chore(structure): Remove obsolete placeholder implementation

### DIFF
--- a/packages/structure/src/model/RWRoute.ts
+++ b/packages/structure/src/model/RWRoute.ts
@@ -147,11 +147,6 @@ export class RWRoute extends BaseNode {
     return this.prerender
   }
 
-  @lazy() get hasPreRenderInfo() {
-    // TODO: this is just a placeholder / reminder
-    return false
-  }
-
   @lazy() get outlineLabel(): string {
     if (this.isNotFound) {
       return '404'
@@ -282,12 +277,6 @@ export class RWRoute extends BaseNode {
       yield err(
         this.path_literal_node!,
         "The 'Not Found' page cannot have a path",
-      )
-    }
-    if (this.hasPreRenderInfo && !this.hasParameters) {
-      yield err(
-        this.jsxNode!,
-        `Only routes with parameters can have associated prerender information`,
       )
     }
   }


### PR DESCRIPTION
We don't put pre-render info on the routes. (We use the `routeHooks` file for that). So the `hasPreRenderInfo` method should not exist on `RWRoute`.

(Instead, if/when we want to improve the diagnostics command we should have it look at the routeHooks file and map it to the routes and highlight in the metaData file if it's missing prerender data, or providing data to routes that don't accept it)