### PR TITLE
feat(cli-helpers): Add loadEnvFiles

### DIFF
--- a/packages/api-server/tsconfig.json
+++ b/packages/api-server/tsconfig.json
@@ -11,7 +11,8 @@
     { "path": "../internal" },
     { "path": "../project-config" },
     { "path": "../adapters/fastify/web" },
-    { "path": "../web-server" }
+    { "path": "../web-server" },
+    { "path": "../realtime" }
   ],
   "exclude": [
     "dist",

--- a/packages/cli-helpers/build.ts
+++ b/packages/cli-helpers/build.ts
@@ -4,8 +4,6 @@ import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 await build({
   buildOptions: {
     ...defaultBuildOptions,
-    bundle: true,
-    entryPoints: ['./src/index.ts'],
     format: 'esm',
     outExtension: { '.js': '.mjs' },
     packages: 'external',
@@ -16,8 +14,6 @@ await build({
 await build({
   buildOptions: {
     ...defaultBuildOptions,
-    bundle: true,
-    entryPoints: ['./src/index.ts'],
     outExtension: { '.js': '.cjs' },
     packages: 'external',
   },

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -9,9 +9,16 @@
   "license": "MIT",
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "default": "./dist/index.cjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.cjs"
+    },
+    "./loadEnvFiles": {
+      "types": "./dist/lib/loadEnvFiles.d.ts",
+      "import": "./dist/lib/loadEnvFiles.mjs",
+      "default": "./dist/lib/loadEnvFiles.cjs"
+    }
   },
   "types": "./dist/index.d.ts",
   "files": [
@@ -43,9 +50,11 @@
     "terminal-link": "2.1.1"
   },
   "devDependencies": {
+    "@types/dotenv-defaults": "^2.0.4",
     "@types/lodash": "4.17.5",
     "@types/pascalcase": "1.0.3",
     "@types/yargs": "17.0.32",
+    "dotenv-defaults": "5.0.2",
     "tsx": "4.15.6",
     "typescript": "5.4.5",
     "vitest": "1.6.0"

--- a/packages/cli-helpers/src/lib/loadEnvFiles.ts
+++ b/packages/cli-helpers/src/lib/loadEnvFiles.ts
@@ -1,0 +1,70 @@
+import path from 'path'
+
+import { config as dotenvConfig } from 'dotenv'
+import { config as dotenvDefaultsConfig } from 'dotenv-defaults'
+import fs from 'fs-extra'
+import { hideBin, Parser } from 'yargs/helpers'
+
+import { getPaths } from '@redwoodjs/project-config'
+
+export function loadEnvFiles() {
+  if (process.env.REDWOOD_ENV_FILES_LOADED) {
+    return
+  }
+
+  const { base } = getPaths()
+
+  loadDefaultEnvFiles(base)
+  loadNodeEnvDerivedEnvFile(base)
+
+  const { loadEnvFiles } = Parser.default(hideBin(process.argv), {
+    array: ['load-env-files'],
+    default: {
+      loadEnvFiles: [],
+    },
+  })
+  if (loadEnvFiles.length > 0) {
+    loadUserSpecifiedEnvFiles(base, loadEnvFiles)
+  }
+
+  process.env.REDWOOD_ENV_FILES_LOADED = 'true'
+}
+
+export function loadDefaultEnvFiles(cwd: string) {
+  dotenvDefaultsConfig({
+    path: path.join(cwd, '.env'),
+    defaults: path.join(cwd, '.env.defaults'),
+    // @ts-expect-error - Old typings. @types/dotenv-defaults depends on dotenv
+    // v8. dotenv-defaults uses dotenv v14
+    multiline: true,
+  })
+}
+
+export function loadNodeEnvDerivedEnvFile(cwd: string) {
+  if (!process.env.NODE_ENV) {
+    return
+  }
+
+  const nodeEnvDerivedEnvFilePath = path.join(
+    cwd,
+    `.env.${process.env.NODE_ENV}`,
+  )
+  if (!fs.existsSync(nodeEnvDerivedEnvFilePath)) {
+    return
+  }
+
+  dotenvConfig({ path: nodeEnvDerivedEnvFilePath, override: true })
+}
+
+export function loadUserSpecifiedEnvFiles(cwd: string, loadEnvFiles: string[]) {
+  for (const suffix of loadEnvFiles) {
+    const envPath = path.join(cwd, `.env.${suffix}`)
+    if (!fs.pathExistsSync(envPath)) {
+      throw new Error(
+        `Couldn't find an .env file at '${envPath}' as specified by '--load-env-files'`,
+      )
+    }
+
+    dotenvConfig({ path: envPath, override: true })
+  }
+}

--- a/packages/cli-helpers/tsconfig.build.json
+++ b/packages/cli-helpers/tsconfig.build.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
   },

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["./"],
   "references": [
     { "path": "../telemetry" },
     { "path": "../project-config" }

--- a/packages/cli-packages/dataMigrate/src/bin.ts
+++ b/packages/cli-packages/dataMigrate/src/bin.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 
-// @ts-expect-error not sure; other packages use this and don't provide the types
 import { config } from 'dotenv-defaults'
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
@@ -14,6 +13,8 @@ if (!process.env.REDWOOD_ENV_FILES_LOADED) {
   config({
     path: path.join(getPaths().base, '.env'),
     defaults: path.join(getPaths().base, '.env.defaults'),
+    // @ts-expect-error - Old typings. @types/dotenv-defaults depends on dotenv
+    // v8. dotenv-defaults uses dotenv v14
     multiline: true,
   })
 

--- a/packages/internal/src/routes.ts
+++ b/packages/internal/src/routes.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 
 import { getPaths, getRouteHookForPage } from '@redwoodjs/project-config'
 import { getRouteRegexAndParams } from '@redwoodjs/router'
-import { getProject } from '@redwoodjs/structure/dist/index'
+import { getProject } from '@redwoodjs/structure/dist/index.js'
 import type { RWRoute } from '@redwoodjs/structure/dist/model/RWRoute'
 
 export interface RouteInformation {

--- a/packages/structure/src/model/RWEnvHelper.ts
+++ b/packages/structure/src/model/RWEnvHelper.ts
@@ -88,7 +88,7 @@ export class RWEnvHelper extends BaseNode {
     if (!existsSync(file)) {
       return undefined
     }
-    return dotenv.parse(readFileSync(file))
+    return dotenv.parse(readFileSync(file, 'utf-8'))
   }
 
   @lazy() get env_available_to_api() {

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -9,7 +9,6 @@ import path from 'node:path'
 import url from 'node:url'
 
 import { createServerAdapter } from '@whatwg-node/server'
-// @ts-expect-error We will remove dotenv-defaults from this package anyway
 import { config as loadDotEnv } from 'dotenv-defaults'
 import express from 'express'
 import type { HTTPMethod } from 'find-my-way'
@@ -47,6 +46,8 @@ import { convertExpressHeaders, getFullUrl } from './utils.js'
 loadDotEnv({
   path: path.join(getPaths().base, '.env'),
   defaults: path.join(getPaths().base, '.env.defaults'),
+  // @ts-expect-error - Old typings. @types/dotenv-defaults depends on dotenv
+  // v8. dotenv-defaults uses dotenv v14
   multiline: true,
 })
 // ------------------------------------------------

--- a/yarn.lock
+++ b/yarn.lock
@@ -7858,11 +7858,13 @@ __metadata:
     "@opentelemetry/api": "npm:1.8.0"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/telemetry": "workspace:*"
+    "@types/dotenv-defaults": "npm:^2.0.4"
     "@types/lodash": "npm:4.17.5"
     "@types/pascalcase": "npm:1.0.3"
     "@types/yargs": "npm:17.0.32"
     chalk: "npm:4.1.2"
     dotenv: "npm:16.4.5"
+    dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
     listr2: "npm:6.6.1"
     lodash: "npm:4.17.21"
@@ -10768,6 +10770,16 @@ __metadata:
   version: 0.0.9
   resolution: "@types/doctrine@npm:0.0.9"
   checksum: 10c0/cdaca493f13c321cf0cacd1973efc0ae74569633145d9e6fc1128f32217a6968c33bea1f858275239fe90c98f3be57ec8f452b416a9ff48b8e8c1098b20fa51c
+  languageName: node
+  linkType: hard
+
+"@types/dotenv-defaults@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@types/dotenv-defaults@npm:2.0.4"
+  dependencies:
+    "@types/node": "npm:*"
+    dotenv: "npm:^8.2.0"
+  checksum: 10c0/7d7ebdd696318d5f9a510d1d0b5fa262e240a377056d6ce7ed8984fb222d472732bf27f8d16726879531706030f1aa0879e65e711dbda17ad4d0be138d9d118b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds `loadEnvFiles` to `@redwoodjs/cli-helpers` so that it's easier to use from other TypeScript packages.

Also added types from DefinitelyTyped for dotenv-defaults which had some ripple effects in other packages that I had to take care of too.