### PR TITLE
chore(cli-helpers): Fix dual package build. Align with new pattern

### DIFF
--- a/packages/cli-helpers/build.ts
+++ b/packages/cli-helpers/build.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from 'node:fs'
+
 import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
 
 // ESM build
@@ -7,7 +9,6 @@ await build({
     bundle: true,
     entryPoints: ['./src/index.ts'],
     format: 'esm',
-    outExtension: { '.js': '.mjs' },
     packages: 'external',
   },
 })
@@ -18,7 +19,15 @@ await build({
     ...defaultBuildOptions,
     bundle: true,
     entryPoints: ['./src/index.ts'],
-    outExtension: { '.js': '.cjs' },
+    outdir: 'dist/cjs',
     packages: 'external',
   },
 })
+
+// Place a package.json file with `type: commonjs` in the dist folder so that
+// all .js files are treated as CommonJS files.
+writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
+
+// Place a package.json file with `type: module` in the dist/esm folder so that
+// all .js files are treated as ES Module files.
+writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -43,6 +43,7 @@
     "terminal-link": "2.1.1"
   },
   "devDependencies": {
+    "@redwoodjs/framework-tools": "workspace:*",
     "@types/lodash": "4.17.5",
     "@types/pascalcase": "1.0.3",
     "@types/yargs": "17.0.32",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -10,8 +10,8 @@
   "type": "module",
   "exports": {
     "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "default": "./dist/index.cjs"
+    "import": "./dist/index.js",
+    "default": "./dist/cjs/index.js"
   },
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/cli-helpers/tsconfig.build.json
+++ b/packages/cli-helpers/tsconfig.build.json
@@ -9,6 +9,7 @@
   },
   "include": ["src"],
   "references": [
+    { "path": "../framework-tools" },
     { "path": "../telemetry" },
     { "path": "../project-config" }
   ],

--- a/packages/cli-helpers/tsconfig.json
+++ b/packages/cli-helpers/tsconfig.json
@@ -3,11 +3,11 @@
   "compilerOptions": {
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["."],
   "references": [
+    { "path": "../framework-tools" },
     { "path": "../telemetry" },
     { "path": "../project-config" }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7856,6 +7856,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.22.20"
     "@opentelemetry/api": "npm:1.8.0"
+    "@redwoodjs/framework-tools": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/telemetry": "workspace:*"
     "@types/lodash": "npm:4.17.5"


### PR DESCRIPTION
Fix the cli-helpers build for dual mode packages. Changes it to match the new pattern we use (see auth, project-config etc)