### PR TITLE
fix(cli-helpers): Fix CJS support

### DIFF
--- a/packages/cli-helpers/build.ts
+++ b/packages/cli-helpers/build.ts
@@ -15,8 +15,6 @@ await build({
 await build({
   buildOptions: {
     ...defaultBuildOptions,
-    bundle: true,
-    entryPoints: ['./src/index.ts'],
     outdir: 'dist/cjs',
     packages: 'external',
   },

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -18,6 +18,16 @@
       "types": "./dist/lib/loadEnvFiles.d.ts",
       "import": "./dist/lib/loadEnvFiles.js",
       "default": "./dist/cjs/lib/loadEnvFiles.js"
+    },
+    "./dist/lib/loadEnvFiles.js": {
+      "types": "./dist/lib/loadEnvFiles.d.ts",
+      "import": "./dist/lib/loadEnvFiles.js",
+      "default": "./dist/cjs/lib/loadEnvFiles.js"
+    },
+    "./dist/cjs/lib/loadEnvFiles.js": {
+      "types": "./dist/lib/loadEnvFiles.d.ts",
+      "import": "./dist/lib/loadEnvFiles.js",
+      "default": "./dist/cjs/lib/loadEnvFiles.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -23,11 +23,6 @@
       "types": "./dist/lib/loadEnvFiles.d.ts",
       "import": "./dist/lib/loadEnvFiles.js",
       "default": "./dist/cjs/lib/loadEnvFiles.js"
-    },
-    "./dist/cjs/lib/loadEnvFiles.js": {
-      "types": "./dist/lib/loadEnvFiles.d.ts",
-      "import": "./dist/lib/loadEnvFiles.js",
-      "default": "./dist/cjs/lib/loadEnvFiles.js"
     }
   },
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Create an export that matches dist import used in CJS packages. Also don't bundle CJS builds