### PR TITLE
feat(colors): Add more chalk colors. And prepare for chalk upgrade

### DIFF
--- a/.changesets/10939.md
+++ b/.changesets/10939.md
@@ -1,0 +1,6 @@
+- feat(colors): Add more chalk colors. And prepare for chalk upgrade (#10939) by @Tobbe
+
+Add more colors to `@redwoodjs/cli-helpers`.
+
+Breaking: No longer exporting `green` as a color. Use `tip` or `success`
+instead depending on what you want to convey.

--- a/packages/api-server/src/logFormatter/formatters.ts
+++ b/packages/api-server/src/logFormatter/formatters.ts
@@ -125,7 +125,8 @@ export const formatMessage = (logData: any) => {
     pretty = chalk.white(msg)
   }
   if (level === 'warn') {
-    pretty = chalk.magenta(msg)
+    const orange = '#ffa500'
+    pretty = chalk.hex(orange)(msg)
   }
   if (level === 'debug') {
     pretty = chalk.yellow(msg)

--- a/packages/cli-helpers/src/lib/colors.ts
+++ b/packages/cli-helpers/src/lib/colors.ts
@@ -14,9 +14,9 @@ export const colors = {
   info: chalk.grey,
   bold: chalk.bold,
   underline: chalk.underline,
-
   note: chalk.blue,
   tip: chalk.green,
-  important: chalk.cyan,
+  important: chalk.magenta,
   caution: chalk.red,
+  link: chalk.hex('#e8e8e8'),
 }

--- a/packages/cli-helpers/src/lib/colors.ts
+++ b/packages/cli-helpers/src/lib/colors.ts
@@ -2,20 +2,21 @@ import chalk from 'chalk'
 
 /**
  * To keep a consistent color/style palette between cli packages, such as
- * @redwood/cli and @redwood/create-redwood-app, please keep them compatible
- * with one and another. We'll might split up and refactor these into a
- * separate package when there is a strong motivation behind it.
- *
- * Current files:
- *
- * - packages/cli/src/lib/colors.js (this file)
- * - packages/create-redwood-app/src/create-redwood-app.js
+ * @redwood/cli and @redwood/create-redwood-app, please only use the colors
+ * defined here. If you *really* can't find a color that fits your needs,
+ * it's better to add it here than to introduce a new one-off color in whatever
+ * package you're going to use it in.
  */
 export const colors = {
   error: chalk.bold.red,
-  warning: chalk.keyword('orange'),
-  green: chalk.green,
+  warning: chalk.hex('#ffa500'),
+  success: chalk.green,
   info: chalk.grey,
   bold: chalk.bold,
   underline: chalk.underline,
+
+  note: chalk.blue,
+  tip: chalk.green,
+  important: chalk.cyan,
+  caution: chalk.red,
 }

--- a/packages/cli-packages/dataMigrate/src/commands/upHandler.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/upHandler.ts
@@ -50,7 +50,7 @@ export async function handler({
   const pendingDataMigrations = await getPendingDataMigrations(db)
 
   if (!pendingDataMigrations.length) {
-    console.info(c.green(`\n${NO_PENDING_MIGRATIONS_MESSAGE}\n`))
+    console.info(c.success(`\n${NO_PENDING_MIGRATIONS_MESSAGE}\n`))
     process.exitCode = 0
     return
   }
@@ -221,7 +221,7 @@ function reportDataMigrations(counters: {
 }) {
   if (counters.run) {
     console.info(
-      c.green(`${counters.run} data migration(s) completed successfully.`),
+      c.success(`${counters.run} data migration(s) completed successfully.`),
     )
   }
   if (counters.error) {

--- a/packages/cli-packages/dataMigrate/src/lib/colors.ts
+++ b/packages/cli-packages/dataMigrate/src/lib/colors.ts
@@ -1,11 +1,18 @@
-// This file will eventually be deduplicated across the framework
+// TODO: This file should be deduplicated across the framework
 // when we take the time to make architectural changes.
 
 import chalk from 'chalk'
 
 export default {
   error: chalk.bold.red,
-  warning: chalk.keyword('orange'),
-  green: chalk.green,
+  warning: chalk.hex('#ffa500'),
+  success: chalk.green,
+  info: chalk.grey,
   bold: chalk.bold,
+  underline: chalk.underline,
+
+  note: chalk.blue,
+  tip: chalk.green,
+  important: chalk.cyan,
+  caution: chalk.red,
 }

--- a/packages/cli-packages/dataMigrate/src/lib/colors.ts
+++ b/packages/cli-packages/dataMigrate/src/lib/colors.ts
@@ -10,9 +10,9 @@ export default {
   info: chalk.grey,
   bold: chalk.bold,
   underline: chalk.underline,
-
   note: chalk.blue,
   tip: chalk.green,
-  important: chalk.cyan,
+  important: chalk.magenta,
   caution: chalk.red,
+  link: chalk.hex('#e8e8e8'),
 }

--- a/packages/cli/src/commands/deploy/helpers/helpers.js
+++ b/packages/cli/src/commands/deploy/helpers/helpers.js
@@ -47,7 +47,7 @@ export const deployHandler = async ({ build, prisma, dm: dataMigrate }) => {
 
   const joinedCommands = commandSet.join(' && ')
 
-  console.log(c.green(`\nRunning:\n`) + `${joinedCommands} \n`)
+  console.log(c.note(`\nRunning:\n`) + `${joinedCommands} \n`)
 
   return execa(joinedCommands, {
     shell: true,

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -1,7 +1,6 @@
 import path from 'path'
 
 import camelcase from 'camelcase'
-import chalk from 'chalk'
 import execa from 'execa'
 import { Listr } from 'listr2'
 import prompts from 'prompts'

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -1,6 +1,7 @@
 import path from 'path'
 
 import camelcase from 'camelcase'
+import chalk from 'chalk'
 import execa from 'execa'
 import { Listr } from 'listr2'
 import prompts from 'prompts'

--- a/packages/cli/src/commands/generate/directive/directive.js
+++ b/packages/cli/src/commands/generate/directive/directive.js
@@ -114,19 +114,19 @@ export const handler = async (args) => {
     rollback: args.rollback,
   })
 
-  const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.warning(
+  const POST_RUN_INSTRUCTIONS = `Next steps...\n\n   ${c.note(
     'After modifying your directive, you can add it to your SDLs e.g.:',
   )}
     ${c.info('// example todo.sdl.js')}
     ${c.info('# Option A: Add it to a field')}
     type Todo {
       id: Int!
-      body: String! ${c.green(`@${args.name}`)}
+      body: String! ${c.tip(`@${args.name}`)}
     }
 
     ${c.info('# Option B: Add it to query/mutation')}
     type Query {
-      todos: [Todo] ${c.green(`@${args.name}`)}
+      todos: [Todo] ${c.tip(`@${args.name}`)}
     }
 `
 

--- a/packages/cli/src/commands/prismaHandler.js
+++ b/packages/cli/src/commands/prismaHandler.js
@@ -61,7 +61,7 @@ export const handler = async ({ _, $0, commands = [], ...options }) => {
   }
 
   console.log()
-  console.log(c.green('Running Prisma CLI...'))
+  console.log(c.note('Running Prisma CLI...'))
   console.log(c.underline('$ yarn prisma ' + args.join(' ')))
   console.log()
 

--- a/packages/cli/src/commands/setup/cache/cacheHandler.js
+++ b/packages/cli/src/commands/setup/cache/cacheHandler.js
@@ -1,6 +1,5 @@
 import path from 'path'
 
-import chalk from 'chalk'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
@@ -57,7 +56,7 @@ export const handler = async ({ client, force }) => {
       task: (_ctx, task) => {
         task.title = `One more thing...\n
           ${c.tip('Check out the Service Cache docs for config and usage:')}
-          ${chalk.hex('#e8e8e8')('https://redwoodjs.com/docs/services#caching')}
+          ${c.link('https://redwoodjs.com/docs/services#caching')}
         `
       },
     },

--- a/packages/cli/src/commands/setup/cache/cacheHandler.js
+++ b/packages/cli/src/commands/setup/cache/cacheHandler.js
@@ -56,7 +56,7 @@ export const handler = async ({ client, force }) => {
       title: 'One more thing...',
       task: (_ctx, task) => {
         task.title = `One more thing...\n
-          ${c.green('Check out the Service Cache docs for config and usage:')}
+          ${c.tip('Check out the Service Cache docs for config and usage:')}
           ${chalk.hex('#e8e8e8')('https://redwoodjs.com/docs/services#caching')}
         `
       },

--- a/packages/cli/src/commands/setup/custom-web-index/custom-web-index-handler.js
+++ b/packages/cli/src/commands/setup/custom-web-index/custom-web-index-handler.js
@@ -1,6 +1,5 @@
 import path from 'path'
 
-import chalk from 'chalk'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
@@ -51,7 +50,7 @@ export const handler = async ({ force }) => {
           ${c.tip(
             'Quick link to the docs on configuring a custom entry point for your RW app',
           )}
-          ${chalk.hex('#e8e8e8')('https://redwoodjs.com/docs/custom-web-index')}
+          ${c.link('https://redwoodjs.com/docs/custom-web-index')}
         `
         },
       },

--- a/packages/cli/src/commands/setup/custom-web-index/custom-web-index-handler.js
+++ b/packages/cli/src/commands/setup/custom-web-index/custom-web-index-handler.js
@@ -48,7 +48,7 @@ export const handler = async ({ force }) => {
         title: 'One more thing...',
         task: (_ctx, task) => {
           task.title = `One more thing...\n
-          ${c.green(
+          ${c.tip(
             'Quick link to the docs on configuring a custom entry point for your RW app',
           )}
           ${chalk.hex('#e8e8e8')('https://redwoodjs.com/docs/custom-web-index')}

--- a/packages/cli/src/commands/setup/i18n/i18nHandler.js
+++ b/packages/cli/src/commands/setup/i18n/i18nHandler.js
@@ -1,6 +1,5 @@
 import path from 'path'
 
-import chalk from 'chalk'
 import execa from 'execa'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
@@ -179,9 +178,7 @@ export const handler = async ({ force }) => {
         task: (_ctx, task) => {
           task.title = `One more thing...\n
           ${c.tip('Quick link to the docs:')}\n
-          ${chalk.hex('#e8e8e8')(
-            'https://react.i18next.com/guides/quick-start/',
-          )}
+          ${c.link('https://react.i18next.com/guides/quick-start/')}
         `
         },
       },

--- a/packages/cli/src/commands/setup/i18n/i18nHandler.js
+++ b/packages/cli/src/commands/setup/i18n/i18nHandler.js
@@ -178,7 +178,7 @@ export const handler = async ({ force }) => {
         title: 'One more thing...',
         task: (_ctx, task) => {
           task.title = `One more thing...\n
-          ${c.green('Quick link to the docs:')}\n
+          ${c.tip('Quick link to the docs:')}\n
           ${chalk.hex('#e8e8e8')(
             'https://react.i18next.com/guides/quick-start/',
           )}

--- a/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
+++ b/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
@@ -144,7 +144,7 @@ export const handler = async ({ force }: Args) => {
       title: 'One more thing...',
       task: (ctx) => {
         notes.push(
-          colors.green(
+          colors.important(
             'You will need to add `SENTRY_DSN` to `includeEnvironmentVariables` in redwood.toml.',
           ),
         )

--- a/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
+++ b/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
@@ -50,7 +50,7 @@ export const handler = async ({ force }) => {
         title: 'One more thing...',
         task: (_ctx, task) => {
           task.title = `One more thing...\n
-          ${c.green('Quick link to the docs on configuring TypeScript')}
+          ${c.tip('Quick link to the docs on configuring TypeScript')}
           ${chalk.hex('#e8e8e8')('https://redwoodjs.com/docs/typescript')}
         `
         },

--- a/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
+++ b/packages/cli/src/commands/setup/tsconfig/tsconfigHandler.js
@@ -1,6 +1,5 @@
 import path from 'path'
 
-import chalk from 'chalk'
 import { Listr } from 'listr2'
 
 import { errorTelemetry } from '@redwoodjs/telemetry'
@@ -51,7 +50,7 @@ export const handler = async ({ force }) => {
         task: (_ctx, task) => {
           task.title = `One more thing...\n
           ${c.tip('Quick link to the docs on configuring TypeScript')}
-          ${chalk.hex('#e8e8e8')('https://redwoodjs.com/docs/typescript')}
+          ${c.link('https://redwoodjs.com/docs/typescript')}
         `
         },
       },

--- a/packages/cli/src/commands/setup/webpack/webpackHandler.js
+++ b/packages/cli/src/commands/setup/webpack/webpackHandler.js
@@ -1,6 +1,5 @@
 import path from 'path'
 
-import chalk from 'chalk'
 import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
@@ -39,7 +38,7 @@ export const handler = async ({ force }) => {
           ${c.tip(
             'Quick link to the docs on configuring custom webpack config:',
           )}
-          ${chalk.hex('#e8e8e8')(
+          ${c.link(
             'https://redwoodjs.com/docs/webpack-configuration#configuring-webpack',
           )}
         `

--- a/packages/cli/src/commands/setup/webpack/webpackHandler.js
+++ b/packages/cli/src/commands/setup/webpack/webpackHandler.js
@@ -36,7 +36,7 @@ export const handler = async ({ force }) => {
         title: 'One more thing...',
         task: (_ctx, task) => {
           task.title = `One more thing...\n
-          ${c.green(
+          ${c.tip(
             'Quick link to the docs on configuring custom webpack config:',
           )}
           ${chalk.hex('#e8e8e8')(

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -33,7 +33,7 @@ export const builder = (yargs) => {
       default: true,
     })
     .epilogue(
-      `For all available flags, run jest cli directly ${c.green(
+      `For all available flags, run jest cli directly ${c.tip(
         'yarn jest --help',
       )}\n\nAlso see the ${terminalLink(
         'Redwood CLI Reference',

--- a/packages/cli/src/lib/colors.js
+++ b/packages/cli/src/lib/colors.js
@@ -18,9 +18,9 @@ export default {
   info: chalk.grey,
   bold: chalk.bold,
   underline: chalk.underline,
-
   note: chalk.blue,
   tip: chalk.green,
-  important: chalk.cyan,
+  important: chalk.magenta,
   caution: chalk.red,
+  link: chalk.hex('#e8e8e8'),
 }

--- a/packages/cli/src/lib/colors.js
+++ b/packages/cli/src/lib/colors.js
@@ -13,9 +13,14 @@ import chalk from 'chalk'
  */
 export default {
   error: chalk.bold.red,
-  warning: chalk.keyword('orange'),
-  green: chalk.green,
+  warning: chalk.hex('#ffa500'),
+  success: chalk.green,
   info: chalk.grey,
   bold: chalk.bold,
   underline: chalk.underline,
+
+  note: chalk.blue,
+  tip: chalk.green,
+  important: chalk.cyan,
+  caution: chalk.red,
 }

--- a/packages/cli/src/middleware/checkNodeVersion.js
+++ b/packages/cli/src/middleware/checkNodeVersion.js
@@ -18,7 +18,7 @@ export function checkNodeVersion() {
   checks.message = [
     `Your Node.js version is ${c.warning(
       pVersion,
-    )}, but Redwood requires ${c.green(`>=${LOWER_BOUND}`)}.`,
+    )}, but Redwood requires ${c.important(`>=${LOWER_BOUND}`)}.`,
     'Upgrade your Node.js version using `nvm` or a similar tool. See https://redwoodjs.com/docs/how-to/using-nvm.',
   ].join('\n')
 


### PR DESCRIPTION
Instead of (ab)using `colors.error` just to get a red color, `colors.warning` just to get an orange color etc, let's define a few more useful colors.

The names I've chosen for the colors are from https://github.com/orgs/community/discussions/16925
<img width="566" alt="image" src="https://github.com/user-attachments/assets/1c7dced8-ee77-4948-85be-cf46a32ca501">
And that also includes some good guidelines/hints on how/when to use the different colors.

This is what the different colors look like in my terminal. Depending on your selected color scheme they might be different for you
![image](https://github.com/user-attachments/assets/dee3887a-bf1d-4f07-9300-e49cf1a168d3)


In addition to all this I also stopped using `keyword` as chalk v4 (which we're using) is the last version to support that. So for upgrading to v6 (current latest) we can't use that anymore. The hex code I picked is what chalk use in [their docs/code](https://github.com/chalk/chalk/pull/433/files#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L139) as an equivalent to `keyword('orange')`.

And for completeness, here are the rest of the colors
![image](https://github.com/user-attachments/assets/972600c7-ea08-4a09-bd29-a4279986efed)
