### PR TITLE
chore(web): Use attw args instead of custom output parsing

### DIFF
--- a/packages/web/attw.ts
+++ b/packages/web/attw.ts
@@ -6,7 +6,9 @@ interface Problem {
   resolutionKind?: string
 }
 
-await $({ nothrow: true })`yarn attw -P -f json > .attw.json`
+await $({
+  nothrow: true,
+})`yarn attw -P --exclude-entrypoints webpackEntry forceEsmApollo -f json > .attw.json`
 const output = await $`cat .attw.json`
 await $`rm .attw.json`
 
@@ -19,13 +21,10 @@ if (!json.analysis.problems || json.analysis.problems.length === 0) {
 
 if (
   json.analysis.problems.every(
-    (problem: Problem) =>
-      problem.resolutionKind === 'node10' ||
-      problem.entrypoint === './webpackEntry' ||
-      problem.entrypoint === './forceEsmApollo',
+    (problem: Problem) => problem.resolutionKind === 'node10',
   )
 ) {
-  console.log("Only found problems we don't care about")
+  console.log("Only found node10 problems, which we don't care about")
   process.exit(0)
 }
 


### PR DESCRIPTION
Using the arethetypeswrong `--exclude-entrypoints` arg to tell it to ignore webpackEntry and forceEsmApollo. Feels more robust than using our own custom code to ignore errors for those entrypoints. My hope is that attw will eventually add a cli flag to ignore node10. And at that point we can entirely get rid of our custom attw script.