### PR TITLE
chore(web): tsconfig.build.json

### DIFF
--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -7,7 +7,7 @@
   },
   "include": ["./src/**/*", "ambient.d.ts"],
   "references": [
-    { "path": "../web" },
+    { "path": "../web/tsconfig.build.json" },
     { "path": "../router" },
     { "path": "../internal" },
     { "path": "../project-config" },

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -2,17 +2,15 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist"
   },
-  "include": [
-    "src",
-  ],
+  "include": ["src"],
   "references": [
     { "path": "../router" },
     { "path": "../babel-config" },
     { "path": "../project-config" },
-    { "path": "../web" },
+    { "path": "../web/tsconfig.build.json" },
     { "path": "../auth/tsconfig.build.json" },
-    { "path": "../graphql-server" },
+    { "path": "../graphql-server" }
   ]
 }

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -11,6 +11,6 @@
     { "path": "../project-config" },
     { "path": "../router" },
     { "path": "../server-store" },
-    { "path": "../web" }
+    { "path": "../web/tsconfig.build.json" }
   ]
 }

--- a/packages/web/build.ts
+++ b/packages/web/build.ts
@@ -21,7 +21,7 @@ await build({
   },
   buildOptions: {
     ...defaultBuildOptions,
-    // ⭐ No special build tsconfig in this package
+    tsconfig: 'tsconfig.build.json',
     outdir: 'dist/cjs',
     packages: 'external',
   },
@@ -36,7 +36,7 @@ await build({
   },
   buildOptions: {
     ...defaultBuildOptions,
-    // ⭐ No special build tsconfig in this package
+    tsconfig: 'tsconfig.build.json',
     format: 'esm',
     packages: 'external',
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -128,7 +128,7 @@
   "scripts": {
     "build": "tsx ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-web.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
+    "build:types": "tsc --build --verbose ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",

--- a/packages/web/tsconfig.build.json
+++ b/packages/web/tsconfig.build.json
@@ -1,15 +1,18 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "isolatedModules": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
     "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "outDir": "dist"
   },
-  "include": ["."],
-  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],
+  "include": [
+    "./src/**/*",
+    "ambient.d.ts",
+    "testing-library.d.ts"
+  ],
   "references": [
-    { "path": "../framework-tools" },
     { "path": "../internal" }
   ]
 }

--- a/packages/web/tsconfig.types-cjs.json
+++ b/packages/web/tsconfig.types-cjs.json
@@ -1,8 +1,8 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
     "module": "commonjs",
-    "moduleResolution": "node",
-  },
+    "moduleResolution": "node"
+  }
 }


### PR DESCRIPTION
Create a sparate tsconfig for building so that we can have the main/standard `tsconfig.json` configured to make VSCode syntax check the build script, the attw script, our tests etc