### PR TITLE
chore(auth): build tweaks and add missing devdep

### DIFF
--- a/packages/auth/build.ts
+++ b/packages/auth/build.ts
@@ -19,7 +19,7 @@ await build({
 await build({
   buildOptions: {
     ...defaultBuildOptions,
-    tsconfig: 'tsconfig.build-cjs.json',
+    tsconfig: 'tsconfig.build.json',
     outdir: 'dist/cjs',
     packages: 'external',
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -78,7 +78,7 @@
     "build": "tsx ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-auth.tgz",
     "build:types": "tsc --build --verbose tsconfig.build.json",
-    "build:types-cjs": "tsc --build --verbose tsconfig.build-cjs.json",
+    "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "concurrently \"npm:test:publint\" \"npm:test:vitest\" npm:test:attw",
@@ -100,6 +100,7 @@
     "msw": "1.3.3",
     "publint": "0.2.8",
     "tsx": "4.15.6",
+    "type-fest": "3.13.0",
     "typescript": "5.4.5",
     "vitest": "1.6.0"
   },

--- a/packages/auth/tsconfig.types-cjs.json
+++ b/packages/auth/tsconfig.types-cjs.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "dist/cjs",
-  },
+    "outDir": "dist/cjs"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7825,6 +7825,7 @@ __metadata:
     publint: "npm:0.2.8"
     react: "npm:19.0.0-beta-04b058868c-20240508"
     tsx: "npm:4.15.6"
+    type-fest: "npm:3.13.0"
     typescript: "npm:5.4.5"
     vitest: "npm:1.6.0"
   languageName: unknown


### PR DESCRIPTION
* Use `tsconfig.build.json` for both ESM and CJS
* Use `tsconfig.types-cjs.json` for generating types for CJS
* Add missing `type-fest` dev dependency to `@redwoodjs/auth`
    * Pinned it to version 3.13.0 to not introduce any new package versions in our dependency tree. `type-fest` is used by a lot of packages. The package with the most recent version was `resend`, and they used `3.13.0`