### PR TITLE
chore(esm/cjs): Make dbauth middleware a dual package

### DIFF
--- a/packages/auth-providers/dbAuth/middleware/build.mts
+++ b/packages/auth-providers/dbAuth/middleware/build.mts
@@ -29,3 +29,5 @@ writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
 // Place a package.json file with `type: module` in the dist/esm folder so that
 // all .js files are treated as ES Module files.
 writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))
+
+writeFileSync('dist/cjs/index.d.ts', 'export type * from "../index.d.ts"')

--- a/packages/auth-providers/dbAuth/middleware/build.mts
+++ b/packages/auth-providers/dbAuth/middleware/build.mts
@@ -1,3 +1,31 @@
-import { build } from '@redwoodjs/framework-tools'
+import {
+  build,
+  defaultBuildOptions,
+} from '@redwoodjs/framework-tools'
+import { writeFileSync } from 'node:fs'
 
-await build()
+// CJS build
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    outdir: 'dist/cjs',
+    packages: 'external',
+  },
+})
+
+// ESM build
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    format: 'esm',
+    packages: 'external',
+  },
+})
+
+// Place a package.json file with `type: commonjs` in the dist folder so that
+// all .js files are treated as CommonJS files.
+writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
+
+// Place a package.json file with `type: module` in the dist/esm folder so that
+// all .js files are treated as ES Module files.
+writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))

--- a/packages/auth-providers/dbAuth/middleware/build.mts
+++ b/packages/auth-providers/dbAuth/middleware/build.mts
@@ -2,6 +2,8 @@ import {
   build,
   defaultBuildOptions,
 } from '@redwoodjs/framework-tools'
+
+import { generateCjsTypes} from '@redwoodjs/framework-tools/cjsTypes'
 import { writeFileSync } from 'node:fs'
 
 // CJS build
@@ -22,12 +24,12 @@ await build({
   },
 })
 
-// Place a package.json file with `type: commonjs` in the dist folder so that
+// Place a package.json file with `type: commonjs` in the dist/cjs folder so that
 // all .js files are treated as CommonJS files.
 writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
 
-// Place a package.json file with `type: module` in the dist/esm folder so that
+// Place a package.json file with `type: module` in the dist folder so that
 // all .js files are treated as ES Module files.
 writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))
 
-writeFileSync('dist/cjs/index.d.ts', 'export type * from "../index.d.ts"')
+await generateCjsTypes()

--- a/packages/auth-providers/dbAuth/middleware/cjsWrappers/plugin.js
+++ b/packages/auth-providers/dbAuth/middleware/cjsWrappers/plugin.js
@@ -1,4 +1,0 @@
-/* eslint-env node */
-
-module.exports =
-  require('../dist/vite-plugin-auth-dbauth-middleware.js').default

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -30,9 +30,11 @@
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "vitest run",
+    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
     "test:attw": "yarn attw -P",
+    "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
     "test:publint": "yarn publint",
+    "test:vitest": "vitest run",
     "test:watch": "vitest watch"
   },
   "dependencies": {
@@ -40,14 +42,15 @@
     "@redwoodjs/web": "workspace:*"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "0.15.3",
     "@redwoodjs/api": "workspace:*",
     "@redwoodjs/framework-tools": "workspace:*",
     "@redwoodjs/graphql-server": "workspace:*",
     "@types/aws-lambda": "8.10.138",
+    "concurrently": "8.2.2",
+    "publint": "0.2.8",
     "ts-toolbelt": "9.6.0",
     "tsx": "4.15.6",
-    "@arethetypeswrong/cli": "0.15.3",
-    "publint": "0.2.8",
     "typescript": "5.4.5",
     "vitest": "1.6.0"
   },

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@redwoodjs/auth-dbauth-middleware",
+  "type": "module",
   "version": "7.0.0",
   "repository": {
     "type": "git",
@@ -7,25 +8,27 @@
     "directory": "packages/auth-providers/dbAuth/middleware"
   },
   "license": "MIT",
-  "exports": {
-    ".": {
-      "default": "./dist/index.js"
-    },
-    "./plugin": {
-      "import": "./dist/vite-plugin-auth-dbauth-middleware.js",
-      "default": "./cjsWrappers/plugin.js"
-    }
-  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "cjsWrappers"
+    "dist"
   ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
   "scripts": {
     "build": "tsx ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-middleware.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",
     "test:watch": "vitest watch"

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -28,9 +28,11 @@
   "scripts": {
     "build": "tsx ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-middleware.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
+    "build:types": "tsc --build --verbose ./tsconfig.json",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",
+    "test:attw": "yarn attw -P",
+    "test:publint": "yarn publint",
     "test:watch": "vitest watch"
   },
   "dependencies": {
@@ -44,6 +46,8 @@
     "@types/aws-lambda": "8.10.138",
     "ts-toolbelt": "9.6.0",
     "tsx": "4.15.6",
+    "@arethetypeswrong/cli": "0.15.3",
+    "publint": "0.2.8",
     "typescript": "5.4.5",
     "vitest": "1.6.0"
   },

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/initDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/initDbAuthMiddleware.test.ts
@@ -23,22 +23,24 @@ beforeAll(() => {
   vi.mock('@redwoodjs/auth-dbauth-api', async (importOriginal) => {
     const original = (await importOriginal()) as any
     return {
-      ...original,
-      dbAuthSession: vi.fn().mockImplementation((req, cookieName) => {
-        if (
-          req.headers
-            .get('Cookie')
-            .includes(`${cookieName}=this_is_the_only_correct_session`)
-        ) {
-          return {
-            currentUser: {
-              email: 'user-1@example.com',
-              id: 'mocked-current-user-1',
-            },
-            mockedSession: 'this_is_the_only_correct_session',
+      default: {
+        ...original,
+        dbAuthSession: vi.fn().mockImplementation((req, cookieName) => {
+          if (
+            req.headers
+              .get('Cookie')
+              .includes(`${cookieName}=this_is_the_only_correct_session`)
+          ) {
+            return {
+              currentUser: {
+                email: 'user-1@example.com',
+                id: 'mocked-current-user-1',
+              },
+              mockedSession: 'this_is_the_only_correct_session',
+            }
           }
-        }
-      }),
+        }),
+      },
     }
   })
 })

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -1,18 +1,14 @@
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 
 import type { DbAuthResponse } from '@redwoodjs/auth-dbauth-api'
-import {
-  cookieName as cookieNameCreator,
-  dbAuthSession,
-} from '@redwoodjs/auth-dbauth-api'
+import dbAuthApi from '@redwoodjs/auth-dbauth-api'
+// ^^ above package is still CJS, and named exports aren't supported in import statements
+const { dbAuthSession, cookieName: cookieNameCreator } = dbAuthApi
 import type { GetCurrentUser } from '@redwoodjs/graphql-server'
-import { MiddlewareResponse } from '@redwoodjs/web/dist/server/middleware'
-import type {
-  Middleware,
-  MiddlewareRequest,
-} from '@redwoodjs/web/middleware' with { 'resolution-mode': 'import' }
+import { MiddlewareResponse } from '@redwoodjs/web/middleware'
+import type { Middleware, MiddlewareRequest } from '@redwoodjs/web/middleware'
 
-import { defaultGetRoles } from './defaultGetRoles'
+import { defaultGetRoles } from './defaultGetRoles.js'
 
 export interface DbAuthMiddlewareOptions {
   cookieName?: string

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.types-cjs.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.types-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "tsBuildInfoFile": "./tsconfig.types-cjs.tsbuildinfo"
+  }
+}

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.types-cjs.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.types-cjs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+  },
+}

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.types-cjs.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.types-cjs.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/cjs",
-  },
-}

--- a/packages/framework-tools/src/cjsTypes.ts
+++ b/packages/framework-tools/src/cjsTypes.ts
@@ -32,11 +32,10 @@ export const generateCjsTypes = async () => {
 
   try {
     await $`yarn build:types-cjs`
-  } catch (e) {
-    console.error('Could not build CJS types')
-    console.error(e)
-
-    process.exit(1)
+  } catch (e: any) {
+    console.error('---- Error building CJS types ----')
+    process.exitCode = e.exitCode
+    throw new Error(e)
   } finally {
     await $`mv package.json.bak package.json`
   }

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -84,11 +84,12 @@ async function createServer() {
     plugins: [
       cjsInterop({
         dependencies: [
-          // Skip ESM modules: rwjs/auth, rwjs/web
+          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware
           '@redwoodjs/forms',
           '@redwoodjs/prerender/*',
           '@redwoodjs/router',
-          '@redwoodjs/auth-*',
+          '@redwoodjs/auth-*-api',
+          '@redwoodjs/auth-*-web',
         ],
       }),
       rscEnabled && rscRoutesAutoLoader(),

--- a/packages/vite/src/rsc/rscBuildForSsr.ts
+++ b/packages/vite/src/rsc/rscBuildForSsr.ts
@@ -63,12 +63,13 @@ export async function rscBuildForSsr({
     plugins: [
       cjsInterop({
         dependencies: [
-          // Skip ESM modules: rwjs/auth, rwjs/web
+          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware
           '@redwoodjs/forms',
           '@redwoodjs/prerender/*',
           '@redwoodjs/router',
           '@redwoodjs/router/*',
-          '@redwoodjs/auth-*',
+          '@redwoodjs/auth-*-api',
+          '@redwoodjs/auth-*-web',
         ],
       }),
       rscRoutesAutoLoader(),

--- a/packages/vite/src/streaming/buildForStreamingServer.ts
+++ b/packages/vite/src/streaming/buildForStreamingServer.ts
@@ -20,11 +20,12 @@ export async function buildForStreamingServer({
     plugins: [
       cjsInterop({
         dependencies: [
-          // Skip ESM modules: rwjs/auth, rwjs/web
+          // Skip ESM modules: rwjs/auth, rwjs/web, rwjs/auth-*-middleware
           '@redwoodjs/forms',
           '@redwoodjs/prerender/*',
           '@redwoodjs/router',
-          '@redwoodjs/auth-*',
+          '@redwoodjs/auth-*-api',
+          '@redwoodjs/auth-*-web',
         ],
       }),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7551,6 +7551,7 @@ __metadata:
     "@redwoodjs/graphql-server": "workspace:*"
     "@redwoodjs/web": "workspace:*"
     "@types/aws-lambda": "npm:8.10.138"
+    concurrently: "npm:8.2.2"
     publint: "npm:0.2.8"
     ts-toolbelt: "npm:9.6.0"
     tsx: "npm:4.15.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7531,12 +7531,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/auth-dbauth-middleware@workspace:packages/auth-providers/dbAuth/middleware"
   dependencies:
+    "@arethetypeswrong/cli": "npm:0.15.3"
     "@redwoodjs/api": "workspace:*"
     "@redwoodjs/auth-dbauth-api": "workspace:*"
     "@redwoodjs/framework-tools": "workspace:*"
     "@redwoodjs/graphql-server": "workspace:*"
     "@redwoodjs/web": "workspace:*"
     "@types/aws-lambda": "npm:8.10.138"
+    publint: "npm:0.2.8"
     ts-toolbelt: "npm:9.6.0"
     tsx: "npm:4.15.6"
     typescript: "npm:5.4.5"


### PR DESCRIPTION
Outstanding:

- [x] Excluding dbauth-mw from cjsInterop 
- [x] Generate CTS types the same way as rwjs/vite?