### PR TITLE
chore(apollo client): Add types for cjs imports

### DIFF
--- a/packages/web/modules.d.ts
+++ b/packages/web/modules.d.ts
@@ -1,0 +1,31 @@
+declare module '@apollo/client/cache/cache.cjs' {
+  export * from '@apollo/client/cache'
+}
+
+declare module '@apollo/client/core/core.cjs' {
+  export * from '@apollo/client/core'
+}
+
+declare module '@apollo/client/link/context/context.cjs' {
+  export * from '@apollo/client/link/context'
+}
+
+declare module '@apollo/client/link/core/core.cjs' {
+  export * from '@apollo/client/link/core'
+}
+
+declare module '@apollo/client/link/http/http.cjs' {
+  export * from '@apollo/client/link/http'
+}
+
+declare module '@apollo/client/link/persisted-queries/persisted-queries.cjs' {
+  export * from '@apollo/client/link/persisted-queries'
+}
+
+declare module '@apollo/client/react/hooks/hooks.cjs' {
+  export * from '@apollo/client/react/hooks'
+}
+
+declare module '@apollo/client/utilities/utilities.cjs' {
+  export * from '@apollo/client/utilities'
+}

--- a/packages/web/src/apollo/fragmentRegistry.ts
+++ b/packages/web/src/apollo/fragmentRegistry.ts
@@ -1,9 +1,7 @@
 import * as apolloClient from '@apollo/client'
 import type { UseFragmentResult } from '@apollo/client'
-// @ts-expect-error Force import cjs module
 import { createFragmentRegistry } from '@apollo/client/cache/cache.cjs'
 import type { FragmentRegistryAPI } from '@apollo/client/cache/index.js'
-// @ts-expect-error Force import cjs module
 import { getFragmentDefinitions } from '@apollo/client/utilities/utilities.cjs'
 import type { DocumentNode } from 'graphql'
 

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -15,13 +15,9 @@ import {
   InMemoryCache,
   split,
 } from '@apollo/client'
-// @ts-expect-error Force import cjs module
 import { setLogVerbosity as apolloSetLogVerbosity } from '@apollo/client/core/core.cjs'
-// @ts-expect-error Force import cjs module
 import { setContext } from '@apollo/client/link/context/context.cjs'
-// @ts-expect-error Force import cjs module
 import { HttpLink } from '@apollo/client/link/http/http.cjs'
-// @ts-expect-error Force import cjs module
 import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries/persisted-queries.cjs'
 import {
   useQuery,
@@ -30,9 +26,7 @@ import {
   useBackgroundQuery,
   useReadQuery,
   useSuspenseQuery,
-  // @ts-expect-error Force import cjs module
 } from '@apollo/client/react/hooks/hooks.cjs'
-// @ts-expect-error Force import cjs module
 import { getMainDefinition } from '@apollo/client/utilities/utilities.cjs'
 import { fetch as crossFetch } from '@whatwg-node/fetch'
 import { print } from 'graphql/language/printer.js'

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -240,7 +240,6 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
               definition.operation === 'subscription'
             )
           },
-          // @ts-expect-error  Due to CJS imports
           new SSELink({
             url: uri,
             auth: { authProviderType, tokenFn: getToken },

--- a/packages/web/src/apollo/sseLink.ts
+++ b/packages/web/src/apollo/sseLink.ts
@@ -1,8 +1,6 @@
 import type { HttpOptions } from '@apollo/client'
 import type { Operation, FetchResult } from '@apollo/client/core'
-// @ts-expect-error Force import cjs module
 import { ApolloLink } from '@apollo/client/link/core/core.cjs'
-// @ts-expect-error Force import cjs module
 import { Observable } from '@apollo/client/utilities/utilities.cjs'
 import { print } from 'graphql'
 import type { ClientOptions, Client, Sink } from 'graphql-sse'
@@ -95,7 +93,7 @@ class SSELink extends ApolloLink {
   }
 
   public request(operation: Operation): Observable<FetchResult> {
-    return new Observable((sink: Sink) => {
+    return new Observable<FetchResult>((sink: Sink) => {
       return this.client.subscribe<FetchResult>(
         { ...operation, query: print(operation.query) },
         {

--- a/packages/web/src/apollo/useCache.ts
+++ b/packages/web/src/apollo/useCache.ts
@@ -1,7 +1,6 @@
 import type { ApolloCache, Reference, StoreObject } from '@apollo/client'
 import type { NormalizedCacheObject } from '@apollo/client/cache/inmemory/types.js'
 import type { ApolloQueryResult } from '@apollo/client/core'
-// @ts-expect-error Force import cjs module
 import { useApolloClient } from '@apollo/client/react/hooks/hooks.cjs'
 
 type useCacheType = {

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -1,7 +1,6 @@
 import React, { Suspense } from 'react'
 
 import type { OperationVariables, QueryReference } from '@apollo/client'
-// @ts-expect-error Force import cjs module
 import { useApolloClient } from '@apollo/client/react/hooks/hooks.cjs'
 
 import { useBackgroundQuery, useReadQuery } from '../GraphQLHooksProvider.js'

--- a/packages/web/tsconfig.build.json
+++ b/packages/web/tsconfig.build.json
@@ -5,11 +5,12 @@
     "outDir": "dist",
     "esModuleInterop": true,
     "moduleResolution": "NodeNext",
-    "module": "NodeNext",
+    "module": "NodeNext"
   },
   "include": [
     "./src/**/*",
     "ambient.d.ts",
+    "modules.d.ts",
     "testing-library.d.ts"
   ],
   "references": [


### PR DESCRIPTION
Add a modules.d.ts file with types for our *.cjs apollo imports
Thanks to @dac09 for the idea! (From https://github.com/redwoodjs/redwood/pull/10934/files#diff-8ff13b447e3c78e853b6cecf7f208c8e8230d1ce8553091ca8f43f96f2f66fd6R115)