### PR TITLE
chore(tsconfig.types-cjs): Specify tsBuildInfoFile location

### DIFF
--- a/packages/auth/tsconfig.types-cjs.json
+++ b/packages/auth/tsconfig.types-cjs.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "tsBuildInfoFile": "./tsconfig.types-cjs.tsbuildinfo"
   }
 }

--- a/packages/project-config/tsconfig.types-cjs.json
+++ b/packages/project-config/tsconfig.types-cjs.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
+    "tsBuildInfoFile": "tsconfig.types-cjs.tsbuildinfo",
     "module": "commonjs",
-    "moduleResolution": "node",
-  },
+    "moduleResolution": "node"
+  }
 }

--- a/packages/web/tsconfig.types-cjs.json
+++ b/packages/web/tsconfig.types-cjs.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "tsBuildInfoFile": "tsconfig.types-cjs.tsbuildinfo"
   }
 }

--- a/tasks/clean.mjs
+++ b/tasks/clean.mjs
@@ -20,3 +20,7 @@ await rimraf('packages/**/tsconfig.tsbuildinfo', {
 await rimraf('packages/**/tsconfig.build.tsbuildinfo', {
   glob: true,
 })
+
+await rimraf('packages/**/tsconfig.types-cjs.tsbuildinfo', {
+  glob: true,
+})

--- a/tasks/framework-tools/frameworkSyncToProject.mjs
+++ b/tasks/framework-tools/frameworkSyncToProject.mjs
@@ -51,6 +51,7 @@ const ignored = [
 
   /tsconfig.tsbuildinfo/,
   /tsconfig.build.tsbuildinfo/,
+  /tsconfig.types-cjs.tsbuildinfo/,
 
   (filePath) => IGNORE_EXTENSIONS.some((ext) => filePath.endsWith(ext)),
 ]
@@ -124,7 +125,7 @@ async function main() {
           c.bgYellow(c.black('Heads up ')),
           '',
           "If this failed because Nx couldn't find its package.json file in node_modules, it's a known issue. The workaround is just trying again.",
-        ].join('\n')
+        ].join('\n'),
       )
       return
     }
@@ -140,11 +141,11 @@ async function main() {
     // Save the project's package.json so that we can restore it when this process exits.
     const redwoodProjectPackageJsonPath = path.join(
       redwoodProjectPath,
-      'package.json'
+      'package.json',
     )
     const redwoodProjectPackageJson = fs.readFileSync(
       redwoodProjectPackageJsonPath,
-      'utf-8'
+      'utf-8',
     )
 
     const viteConfigPath = resolveViteConfigPath(redwoodProjectPath)
@@ -243,7 +244,7 @@ async function main() {
           `${c.red('Warning:')} You modified a package.json file.`,
           `If you've modified the ${c.underline('dependencies')}`,
           `then you must run ${c.underline('yarn rwfw project:sync')} again.`,
-        ].join(' ')
+        ].join(' '),
       )
     }
 
@@ -256,7 +257,16 @@ async function main() {
       logStatus(`Cleaning ${c.magenta(packageName)}...`)
       await rimraf(path.join(path.dirname(packageJsonPath), 'dist'))
       await rimraf(
-        path.join(path.dirname(packageJsonPath), 'tsconfig.tsbuildinfo')
+        path.join(path.dirname(packageJsonPath), 'tsconfig.tsbuildinfo'),
+      )
+      await rimraf(
+        path.join(path.dirname(packageJsonPath), 'tsconfig.build.tsbuildinfo'),
+      )
+      await rimraf(
+        path.join(
+          path.dirname(packageJsonPath),
+          'tsconfig.types-cjs.tsbuildinfo',
+        ),
       )
 
       logStatus(`Building ${c.magenta(packageName)}...`)
@@ -324,7 +334,7 @@ function createCleanUp({
         "- remove your project's node_modules directory",
         "- run 'yarn install'",
         '',
-      ].join('\n')
+      ].join('\n'),
     )
 
     cleanedUp = true


### PR DESCRIPTION
If we don't specify the location it'll end up in `dist/` (`<outdir>/../`) and be included in our packages, which we don't want.