### PR TITLE
chore(project-config): Verify package.json with publint and attw

### DIFF
--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -30,7 +30,10 @@
     "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "vitest run",
+    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
+    "test:vitest": "vitest run",
+    "test:attw": "yarn attw -P",
+    "test:publint": "yarn publint",
     "test:watch": "vitest watch"
   },
   "dependencies": {
@@ -40,7 +43,10 @@
     "string-env-interpolation": "1.0.1"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "0.15.3",
     "@redwoodjs/framework-tools": "workspace:*",
+    "concurrently": "8.2.2",
+    "publint": "0.2.8",
     "rimraf": "5.0.7",
     "tsx": "4.15.6",
     "typescript": "5.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,9 +8500,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/project-config@workspace:packages/project-config"
   dependencies:
+    "@arethetypeswrong/cli": "npm:0.15.3"
     "@redwoodjs/framework-tools": "workspace:*"
+    concurrently: "npm:8.2.2"
     deepmerge: "npm:4.3.1"
     fast-glob: "npm:3.3.2"
+    publint: "npm:0.2.8"
     rimraf: "npm:5.0.7"
     smol-toml: "npm:1.2.2"
     string-env-interpolation: "npm:1.0.1"


### PR DESCRIPTION
Verify (using publint and attw) that our package.json is correct for dual mode CJS+ESM publishing