### PR TITLE
fix(web): Re-add generating ESM types

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -128,7 +128,7 @@
   "scripts": {
     "build": "tsx ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-web.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.types-cjs.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",


### PR DESCRIPTION
Fix generating ESM types for `@redwoodjs/web`. 
We did it like this before, but this got lost somewhere along the way. Just adding back in code we had in place last week.