### PR TITLE
chore(auth): More gracefully handle build failures

### DIFF
--- a/packages/auth/build.ts
+++ b/packages/auth/build.ts
@@ -52,6 +52,16 @@ const packageJson: PackageJson = JSON.parse(
 packageJson.type = 'commonjs'
 writeFileSync('./package.json', JSON.stringify(packageJson, null, 2))
 
-await $`yarn build:types-cjs`
+try {
+  await $`yarn build:types-cjs`
+} catch (e) {
+  console.error('Could not build CJS types')
+  console.error(e)
+
+  // Restore the original package.json
+  await $`mv package.json.bak package.json`
+
+  process.exit(1)
+}
 
 await $`mv package.json.bak package.json`


### PR DESCRIPTION
Previously if the CJS types failed to build you'd be left with a misconfigured package.json file, which was annoying. So now I try/catch that step, so I get a chance to restore the original package.json before exiting the build script