### PR TITLE
chore(check:pkg): Make all ESM packages have check:package script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: 🔎 Lint
         run: yarn lint
 
+      - name: 🥡 Check packaging and attw
+        run: yarn check:package
+
       - name: 🌡 Test Types
         run: yarn test:types
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:watch": "lerna run build:watch --parallel; tsc --build",
     "changesets": "tsx ./tasks/changesets/changesets.mts",
     "check": "node ./tasks/check/check.mjs",
+    "check:package": "nx run-many -t check:package --output-style static",
     "clean:prisma": "rimraf node_modules/.prisma/client && node node_modules/@prisma/client/scripts/postinstall.js",
     "e2e": "node ./tasks/run-e2e",
     "generate-dependency-graph": "node ./tasks/generateDependencyGraph.mjs",

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -30,11 +30,10 @@
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
-    "test:attw": "yarn attw -P",
+    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:attw": "yarn attw -P",
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
-    "test:publint": "yarn publint",
-    "test:vitest": "vitest run",
+    "test": "vitest run",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -31,11 +31,10 @@
     "build:pack": "yarn pack -o redwoodjs-auth-supabase-middleware.tgz",
     "build:types": "tsc --build --verbose",
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
-    "test:attw": "yarn attw -P",
-    "test:publint": "yarn publint",
-    "test:vitest": "vitest run",
+    "check:attw": "yarn attw -P",
+    "test": "vitest run",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
+    "check:package": "concurrently npm:check:attw yarn publint",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -81,10 +81,9 @@
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "concurrently \"npm:test:publint\" \"npm:test:vitest\" npm:test:attw",
-    "test:publint": "yarn publint",
-    "test:vitest": "vitest run",
-    "test:attw": "tsx ./attw.ts",
+    "check:package": "concurrently npm:check:attw yarn publint",
+    "test": "vitest run",
+    "check:attw": "tsx ./attw.ts",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -30,10 +30,9 @@
     "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
-    "test:vitest": "vitest run",
-    "test:attw": "yarn attw -P",
-    "test:publint": "yarn publint",
+    "check:package": "concurrently npm:check:attw yarn publint",
+    "test": "vitest run",
+    "check:attw": "yarn attw -P",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -62,10 +62,9 @@
     "build": "tsx build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-vite.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
-    "test:attw": "tsx ./attw.ts",
-    "test:publint": "yarn publint",
-    "test:vitest": "vitest run",
-    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
+    "check:attw": "tsx ./attw.ts",
+    "test": "vitest run",
+    "check:package": "concurrently npm:check:attw yarn publint",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -131,10 +131,9 @@
     "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "concurrently npm:test:vitest npm:test:attw npm:test:publint",
-    "test:vitest": "vitest run",
-    "test:attw": "tsx ./attw.ts",
-    "test:publint": "yarn publint",
+    "check:package": "concurrently npm:check:attw yarn publint",
+    "test": "vitest run",
+    "check:attw": "tsx ./attw.ts",
     "test:types": "tstyche",
     "test:watch": "vitest watch"
   },


### PR DESCRIPTION
.... and run it in CI with NX

This is just naming of scripts, and running it in CI.

Note that nx will only run `check:package` in packages that have that script defined (currently 6!) 