### PR TITLE
chore(publint): fix concurrently usage

### DIFF
--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -30,7 +30,7 @@
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-middleware.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "check:attw": "yarn attw -P",
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
     "test": "vitest run",

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -34,7 +34,7 @@
     "check:attw": "yarn attw -P",
     "test": "vitest run",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -81,7 +81,7 @@
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "test": "vitest run",
     "check:attw": "tsx ./attw.ts",
     "test:watch": "vitest watch"

--- a/packages/project-config/package.json
+++ b/packages/project-config/package.json
@@ -30,7 +30,7 @@
     "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "test": "vitest run",
     "check:attw": "yarn attw -P",
     "test:watch": "vitest watch"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -68,7 +68,7 @@
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "check:attw": "tsx ./attw.ts",
     "test": "vitest run",
-    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "test:watch": "vitest watch"
   },
   "dependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -130,7 +130,7 @@
     "build:types": "tsc --build --verbose ./tsconfig.build.json ./tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "check:package": "concurrently npm:check:attw yarn publint",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "test": "vitest run",
     "check:attw": "tsx ./attw.ts",
     "test:types": "tstyche",


### PR DESCRIPTION
CI is flaky on the new `check:package`. I think this is because of how the command is written with concurrently. Currently it is written as `"concurrently npm:check:attw yarn publint"` which is running 3 commands as `yarn publint` is not quoted and so isn't being treated as one single command. I've updated the format to be: `"concurrently npm:check:attw yarn:publint"` which works locally and I hope will fix CI.