### PR TITLE
chore(vite): Don't exclude Router in attw check

### DIFF
--- a/packages/vite/attw.ts
+++ b/packages/vite/attw.ts
@@ -6,17 +6,14 @@ interface Problem {
   resolutionKind?: string
 }
 
-/***
- * Excluded entry points:
- * - ./bins/rw-vite-build.mjs: this is only used in the build handler
- * - SsrRouter, Router: this should be moved out of the Vite package anyway, and is only used in ESM
- * - ./react-node-loader: used to run the Worker
- * -
- */
+// Excluded entry points:
+// - ./bins/rw-vite-build.mjs: this is only used in the build handler
+// - ./SsrRouter: this should be moved out of the Vite package anyway, and is only used in ESM
+// - ./react-node-loader: used to run the Worker
 
 await $({
   nothrow: true,
-})`yarn attw -P --exclude-entrypoints ./bins/rw-vite-build.mjs ./SsrRouter ./Router ./react-node-loader -f json > .attw.json`
+})`yarn attw -P --exclude-entrypoints ./bins/rw-vite-build.mjs ./SsrRouter ./react-node-loader -f json > .attw.json`
 const output = await $`cat .attw.json`
 await $`rm .attw.json`
 


### PR DESCRIPTION
attw didn't have any issues with Router (except for node10, but we don't care about that). So we might as well include it in the checks. Ideally Router will move to another package, but for now it's in the vite package and no reason to not have the package.json exports be correct when there's no extra effort in doing so.