### PR TITLE
chore(prerender types): Remove `any` type

### DIFF
--- a/packages/prerender/src/runPrerender.tsx
+++ b/packages/prerender/src/runPrerender.tsx
@@ -157,7 +157,11 @@ function insertChunkLoadingScript(
 ) {
   const prerenderRoutes = detectPrerenderRoutes()
 
-  const route = prerenderRoutes.find((route: any) => {
+  const route = prerenderRoutes.find((route) => {
+    if (!route.routePath) {
+      return false
+    }
+
     return matchPath(route.routePath, renderPath).match
   })
 


### PR DESCRIPTION
Just stumbled upon this when I was checking to make sure the `matchPath` types were still working when importing from router/dist. 