### PR TITLE
chore(vite): attw: Update outdated comment

### DIFF
--- a/packages/vite/attw.ts
+++ b/packages/vite/attw.ts
@@ -8,7 +8,6 @@ interface Problem {
 
 // Excluded entry points:
 // - ./bins/rw-vite-build.mjs: this is only used in the build handler
-// - ./SsrRouter: this should be moved out of the Vite package anyway, and is only used in ESM
 // - ./react-node-loader: used to run the Worker
 
 await $({


### PR DESCRIPTION
The comment was referencing an entry point that doesn't exist anymore. It's been moved to the router package