### PR TITLE
RSC: Fix RscRouter import order

### DIFF
--- a/__fixtures__/test-project-rsa/web/src/Routes.tsx
+++ b/__fixtures__/test-project-rsa/web/src/Routes.tsx
@@ -8,9 +8,8 @@
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
 import { Route } from '@redwoodjs/router/Route'
-import { Set } from '@redwoodjs/router/Set'
-
 import { Router } from '@redwoodjs/router/RscRouter'
+import { Set } from '@redwoodjs/router/Set'
 
 import NavigationLayout from './layouts/NavigationLayout/NavigationLayout'
 import NotFoundPage from './pages/NotFoundPage/NotFoundPage'

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/Routes.tsx
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/Routes.tsx
@@ -8,8 +8,8 @@
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
 import { Route } from '@redwoodjs/router/Route'
-import { Set, PrivateSet } from '@redwoodjs/router/Set'
 import { Router } from '@redwoodjs/router/RscRouter'
+import { Set, PrivateSet } from '@redwoodjs/router/Set'
 
 import { useAuth } from './auth'
 import AuthLayout from './layouts/AuthLayout/AuthLayout'

--- a/packages/cli/src/commands/experimental/templates/rsc/Routes.tsx.template
+++ b/packages/cli/src/commands/experimental/templates/rsc/Routes.tsx.template
@@ -8,9 +8,8 @@
 // 'src/pages/Admin/BooksPage/BooksPage.js' -> AdminBooksPage
 
 import { Route } from '@redwoodjs/router/Route'
-import { Set } from '@redwoodjs/router/Set'
-
 import { Router } from '@redwoodjs/router/RscRouter'
+import { Set } from '@redwoodjs/router/Set'
 
 import NavigationLayout from 'src/layouts/NavigationLayout'
 import NotFoundPage from 'src/pages/NotFoundPage'


### PR DESCRIPTION
Got red squiggles for some RscRouter imports because it has moved to a new package and the linter now wants a different grouping/sorting because of the new import path