### PR TITLE
feat(link): Pass options to navigate()

### DIFF
--- a/.changesets/11058.md
+++ b/.changesets/11058.md
@@ -1,0 +1,3 @@
+- feat(link): Pass options to navigate() (#11058) by @Tobbe
+
+Allow passing `NavigateOptions` (which for now is just `replace`) from a `<Link>` and `<NavLink>` to `navigate()` by setting an `options` prop on the link component.

--- a/packages/router/src/__tests__/history.test.tsx
+++ b/packages/router/src/__tests__/history.test.tsx
@@ -174,3 +174,20 @@ describe('blocking', () => {
     })
   })
 })
+
+describe('navigate options', () => {
+  describe('replace', () => {
+    it('should let us navigate without adding to history length', () => {
+      const initialHistoryLength = globalThis.history.length
+
+      navigate('/test-1')
+      expect(globalThis.history.length).toEqual(initialHistoryLength + 1)
+      navigate('/test-2')
+      expect(globalThis.history.length).toEqual(initialHistoryLength + 2)
+      navigate('/test-3', { replace: true })
+      expect(globalThis.history.length).toEqual(initialHistoryLength + 2)
+      navigate('/test-4', { replace: true })
+      expect(globalThis.history.length).toEqual(initialHistoryLength + 2)
+    })
+  })
+})

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -285,7 +285,7 @@ describe('<NavLink />', () => {
 describe('<Link />', () => {
   describe('options', () => {
     describe('replace', () => {
-      it('should let us navigate without adding to history length', async () => {
+      it('should let us replace history when clicking on a link', async () => {
         const HomePage = () => (
           <>
             <h1>Home Page</h1>

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -284,48 +284,46 @@ describe('<NavLink />', () => {
 
 describe('<Link />', () => {
   describe('options', () => {
-    describe('replace', () => {
-      it('should let us replace history when clicking on a link', async () => {
-        const HomePage = () => (
-          <>
-            <h1>Home Page</h1>
-            <Link to="/about">About-link</Link>
-          </>
-        )
-        const AboutPage = () => (
-          <>
-            <h1>About Page</h1>
-            <Link to="/contact" options={{ replace: true }}>
-              Contact-link
-            </Link>
-          </>
-        )
-        const ContactPage = () => <h1>Contact Page</h1>
+    it('should let us replace history when clicking on a link', async () => {
+      const HomePage = () => (
+        <>
+          <h1>Home Page</h1>
+          <Link to="/about">About-link</Link>
+        </>
+      )
+      const AboutPage = () => (
+        <>
+          <h1>About Page</h1>
+          <Link to="/contact" options={{ replace: true }}>
+            Contact-link
+          </Link>
+        </>
+      )
+      const ContactPage = () => <h1>Contact Page</h1>
 
-        const TestRouter = () => (
-          <Router>
-            <Route path="/" page={HomePage} name="home" />
-            <Route path="/about" page={AboutPage} name="about" />
-            <Route path="/contact" page={ContactPage} name="about" />
-          </Router>
-        )
+      const TestRouter = () => (
+        <Router>
+          <Route path="/" page={HomePage} name="home" />
+          <Route path="/about" page={AboutPage} name="about" />
+          <Route path="/contact" page={ContactPage} name="about" />
+        </Router>
+      )
 
-        const screen = render(<TestRouter />)
+      const screen = render(<TestRouter />)
 
-        // starts on home page
-        await waitFor(() => screen.getByText('Home Page'))
+      // starts on home page
+      await waitFor(() => screen.getByText('Home Page'))
 
-        fireEvent.click(screen.getByText('About-link'))
-        await waitFor(() => screen.getByText('About Page'))
+      fireEvent.click(screen.getByText('About-link'))
+      await waitFor(() => screen.getByText('About Page'))
 
-        fireEvent.click(screen.getByText('Contact-link'))
-        await waitFor(() => screen.getByText('Contact Page'))
+      fireEvent.click(screen.getByText('Contact-link'))
+      await waitFor(() => screen.getByText('Contact Page'))
 
-        // Going back here skips the About page because the link on the About
-        // page had the replace option
-        act(() => back())
-        await waitFor(() => screen.getByText('Home Page'))
-      })
+      // Going back here skips the About page because the link on the About
+      // page had the replace option
+      act(() => back())
+      await waitFor(() => screen.getByText('Home Page'))
     })
   })
 })

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 
-import { render } from '@testing-library/react'
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 
+import { back, navigate, Route, Router } from '../index'
+import { Link } from '../link'
 import { LocationProvider } from '../location'
 import { NavLink } from '../navLink'
 
@@ -277,5 +279,53 @@ describe('<NavLink />', () => {
     )
 
     expect(getByText(/Dunder Mifflin/)).not.toHaveClass('activeTest')
+  })
+})
+
+describe('<Link />', () => {
+  describe('options', () => {
+    describe('replace', () => {
+      it('should let us navigate without adding to history length', async () => {
+        const HomePage = () => (
+          <>
+            <h1>Home Page</h1>
+            <Link to="/about">About-link</Link>
+          </>
+        )
+        const AboutPage = () => (
+          <>
+            <h1>About Page</h1>
+            <Link to="/contact" options={{ replace: true }}>
+              Contact-link
+            </Link>
+          </>
+        )
+        const ContactPage = () => <h1>Contact Page</h1>
+
+        const TestRouter = () => (
+          <Router>
+            <Route path="/" page={HomePage} name="home" />
+            <Route path="/about" page={AboutPage} name="about" />
+            <Route path="/contact" page={ContactPage} name="about" />
+          </Router>
+        )
+
+        const screen = render(<TestRouter />)
+
+        // starts on home page
+        await waitFor(() => screen.getByText('Home Page'))
+
+        fireEvent.click(screen.getByText('About-link'))
+        await waitFor(() => screen.getByText('About Page'))
+
+        fireEvent.click(screen.getByText('Contact-link'))
+        await waitFor(() => screen.getByText('Contact Page'))
+
+        // Going back here skips the About page because the link on the About
+        // page had the replace option
+        act(() => back())
+        await waitFor(() => screen.getByText('Home Page'))
+      })
+    })
   })
 })

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 
-import { back, navigate, Route, Router } from '../index'
+import { back, Route, Router } from '../index'
 import { Link } from '../link'
 import { LocationProvider } from '../location'
 import { NavLink } from '../navLink'

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -6,16 +6,18 @@
 import React, { forwardRef } from 'react'
 
 import { navigate } from './history.js'
+import type { NavigateOptions } from './history.js'
 
 export interface LinkProps {
   to: string
   onClick?: React.MouseEventHandler<HTMLAnchorElement>
+  options?: NavigateOptions
 }
 
 export const Link = forwardRef<
   HTMLAnchorElement,
   LinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement>
->(({ to, onClick, ...rest }, ref) => (
+>(({ to, onClick, options, ...rest }, ref) => (
   <a
     href={to}
     ref={ref}
@@ -36,10 +38,10 @@ export const Link = forwardRef<
       if (onClick) {
         const result = onClick(event)
         if (typeof result !== 'boolean' || result) {
-          navigate(to)
+          navigate(to, options)
         }
       } else {
-        navigate(to)
+        navigate(to, options)
       }
     }}
   />


### PR DESCRIPTION
Allow passing `NavigateOptions` (which for now is just `replace`) from a `<Link>` and `<NavLink>` to `navigate()` by setting an `options` prop on the link component.

This came up during the implementation and review of https://github.com/redwoodjs/redwood/pull/10873