### PR TITLE
chore(router): Fix type errors in our routes tests

### DIFF
--- a/packages/internal/tsconfig.json
+++ b/packages/internal/tsconfig.json
@@ -2,13 +2,13 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "include": ["src/**/*", "./ambient.d.ts"],
   "references": [
     { "path": "../babel-config" },
     { "path": "../graphql-server" }, // ODD, but we do this so we dont have to have internal as a runtime dependency
     { "path": "../project-config" },
-    { "path": "../router" },
+    { "path": "../router/tsconfig.build.json" }
   ]
 }

--- a/packages/ogimage-gen/tsconfig.json
+++ b/packages/ogimage-gen/tsconfig.json
@@ -15,7 +15,7 @@
       "path": "../vite"
     },
     {
-      "path": "../router"
+      "path": "../router/tsconfig.build.json"
     },
     {
       "path": "../internal"

--- a/packages/prerender/tsconfig.json
+++ b/packages/prerender/tsconfig.json
@@ -8,7 +8,7 @@
   "include": ["./src/**/*", "ambient.d.ts"],
   "references": [
     { "path": "../web/tsconfig.build.json" },
-    { "path": "../router" },
+    { "path": "../router/tsconfig.build.json" },
     { "path": "../internal" },
     { "path": "../project-config" },
     { "path": "../auth/tsconfig.build.json" },

--- a/packages/router/build.ts
+++ b/packages/router/build.ts
@@ -1,15 +1,13 @@
-import {
-  build,
-  defaultBuildOptions,
-} from '@redwoodjs/framework-tools'
-
-import { generateCjsTypes} from '@redwoodjs/framework-tools/cjsTypes'
 import { writeFileSync } from 'node:fs'
+
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+import { generateCjsTypes } from '@redwoodjs/framework-tools/cjsTypes'
 
 // CJS build
 await build({
   buildOptions: {
     ...defaultBuildOptions,
+    tsconfig: 'tsconfig.build.json',
     outdir: 'dist/cjs',
     packages: 'external',
   },
@@ -19,6 +17,7 @@ await build({
 await build({
   buildOptions: {
     ...defaultBuildOptions,
+    tsconfig: 'tsconfig.build.json',
     format: 'esm',
     packages: 'external',
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -77,9 +77,9 @@
     }
   },
   "scripts": {
-    "build": "tsx ./build.mts && yarn build:types",
+    "build": "tsx ./build.ts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-router.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.types-cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "check:attw": "tsx ./attw.ts",
@@ -99,6 +99,7 @@
     "@arethetypeswrong/cli": "0.15.3",
     "@babel/cli": "7.24.8",
     "@babel/core": "^7.22.20",
+    "@redwoodjs/framework-tools": "workspace:*",
     "@testing-library/jest-dom": "6.4.6",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",

--- a/packages/router/src/__tests__/analyzeRoutes.test.tsx
+++ b/packages/router/src/__tests__/analyzeRoutes.test.tsx
@@ -2,10 +2,10 @@ import React, { isValidElement } from 'react'
 
 import { describe, test, expect } from 'vitest'
 
-import { analyzeRoutes } from '../analyzeRoutes'
-import { Route } from '../Route'
-import { Router } from '../router'
-import { Private, PrivateSet, Set } from '../Set'
+import { analyzeRoutes } from '../analyzeRoutes.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
+import { Private, PrivateSet, Set } from '../Set.js'
 
 const FakePage = () => <h1>Fake Page</h1>
 

--- a/packages/router/src/__tests__/history.test.tsx
+++ b/packages/router/src/__tests__/history.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 
-import { gHistory, navigate, back, block, unblock } from '../history'
+import { gHistory, navigate, back, block, unblock } from '../history.js'
 
 describe('navigate', () => {
   describe('does not increase history length', () => {

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -104,6 +104,7 @@ describe('<NavLink />', () => {
         <NavLink
           activeClassName="activeTest"
           to={`/pathname-params?tab=main&page=2`}
+          // @ts-expect-error TODO: Fix our types
           activeMatchParams={['tab']}
         >
           Dunder Mifflin
@@ -146,6 +147,7 @@ describe('<NavLink />', () => {
         <NavLink
           activeClassName="activeTest"
           to={`/search-params?page=3&tab=main&category=book`}
+          // @ts-expect-error TODO: Fix our types
           activeMatchParams={[{ category: 'book' }, 'page']}
         >
           Dunder Mifflin
@@ -167,6 +169,7 @@ describe('<NavLink />', () => {
         <NavLink
           activeClassName="activeTest"
           to={`/search-params?page=3&tab=main&category=magazine`}
+          // @ts-expect-error TODO: Fix our types
           activeMatchParams={[{ page: 3, category: 'magazine' }, 'tab']}
         >
           Dunder Mifflin
@@ -188,6 +191,7 @@ describe('<NavLink />', () => {
         <NavLink
           activeClassName="activeTest"
           to={`/search-params?page=3&tab=main&category=magazine`}
+          // @ts-expect-error TODO: Fix our types
           activeMatchParams={[{ page: 3 }, { category: 'magazine' }, 'tab']}
         >
           Dunder Mifflin
@@ -257,6 +261,7 @@ describe('<NavLink />', () => {
         <NavLink
           activeClassName="activeTest"
           to={`/pathname-params?tab=main&page=2`}
+          // @ts-expect-error TODO: Fix our types
           activeMatchParams={['tab']}
         >
           Dunder Mifflin

--- a/packages/router/src/__tests__/links.test.tsx
+++ b/packages/router/src/__tests__/links.test.tsx
@@ -3,27 +3,13 @@ import React from 'react'
 import { act, fireEvent, render, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 
-import { back, Route, Router } from '../index'
-import { Link } from '../link'
-import { LocationProvider } from '../location'
-import { NavLink } from '../navLink'
+import { back, Route, Router } from '../index.js'
+import { Link } from '../link.js'
+import { LocationProvider } from '../location.js'
+import { NavLink } from '../navLink.js'
 
 function createDummyLocation(pathname: string, search = '') {
-  return {
-    pathname,
-    hash: '',
-    host: '',
-    hostname: '',
-    href: '',
-    ancestorOrigins: null,
-    assign: () => null,
-    reload: () => null,
-    replace: () => null,
-    origin: '',
-    port: '',
-    protocol: '',
-    search,
-  }
+  return new URL(pathname + search, 'http://localhost/')
 }
 
 describe('<NavLink />', () => {

--- a/packages/router/src/__tests__/location.test.tsx
+++ b/packages/router/src/__tests__/location.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 
-import { LocationProvider, useLocation } from '../location'
+import { LocationProvider, useLocation } from '../location.js'
 
 describe('useLocation', () => {
   const TestComponent = () => {

--- a/packages/router/src/__tests__/nestedSets.test.tsx
+++ b/packages/router/src/__tests__/nestedSets.test.tsx
@@ -4,8 +4,8 @@ import type { ReactNode } from 'react'
 import { act, render } from '@testing-library/react'
 import { beforeEach, beforeAll, afterAll, test, expect, vi } from 'vitest'
 
-import { navigate, Route, Router } from '../'
-import { Private, Set } from '../Set'
+import { navigate, Route, Router } from '../index.js'
+import { Private, Set } from '../Set.js'
 
 // Heads-up, in this test we're not mocking LazyComponent because all the tests
 // explicitly define the pages in the router.

--- a/packages/router/src/__tests__/pageLoadingContext.test.tsx
+++ b/packages/router/src/__tests__/pageLoadingContext.test.tsx
@@ -35,10 +35,9 @@ import {
   Set,
   useParams,
 } from '..'
-import { useLocation } from '../location'
-import type Page from '../page'
-import type { Spec } from '../page'
-import { usePageLoadingContext } from '../PageLoadingContext'
+import { useLocation } from '../location.js'
+import type Page, { Spec } from '../page.js'
+import { usePageLoadingContext } from '../PageLoadingContext.js'
 
 // Running into intermittent test timeout behavior in
 // https://github.com/redwoodjs/redwood/pull/4992

--- a/packages/router/src/__tests__/pageLoadingContext.test.tsx
+++ b/packages/router/src/__tests__/pageLoadingContext.test.tsx
@@ -1,5 +1,5 @@
 let mockDelay = 0
-vi.mock('../page', async (importOriginal) => {
+vi.mock('../page.js', async (importOriginal) => {
   const actualUtil = await importOriginal<Page>()
   const { lazy } = await vi.importActual<typeof React>('react')
 
@@ -34,9 +34,10 @@ import {
   Router,
   Set,
   useParams,
-} from '..'
+} from '../index.js'
 import { useLocation } from '../location.js'
-import type Page, { Spec } from '../page.js'
+import type Page from '../page.js'
+import type { Spec } from '../page.js'
 import { usePageLoadingContext } from '../PageLoadingContext.js'
 
 // Running into intermittent test timeout behavior in

--- a/packages/router/src/__tests__/redirect.test.tsx
+++ b/packages/router/src/__tests__/redirect.test.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { act, render, waitFor } from '@testing-library/react'
 import { test } from 'vitest'
 
-import { navigate } from '../history'
-import { Route } from '../Route'
-import { Router } from '../router'
+import { navigate } from '../history.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
 
 const RedirectedRoutes = () => {
   const SimplePage = () => <h1>FindMeSimple</h1>

--- a/packages/router/src/__tests__/route-announcer.test.tsx
+++ b/packages/router/src/__tests__/route-announcer.test.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { render, waitFor, act } from '@testing-library/react'
 import { beforeEach, test, expect } from 'vitest'
 
-import { getAnnouncement } from '../a11yUtils'
-import { navigate } from '../history'
-import { namedRoutes as routes } from '../namedRoutes'
-import { Route } from '../Route'
-import RouteAnnouncement from '../route-announcement'
-import { Router } from '../router'
+import { getAnnouncement } from '../a11yUtils.js'
+import { navigate } from '../history.js'
+import { namedRoutes as routes } from '../namedRoutes.js'
+import RouteAnnouncement from '../route-announcement.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
 
 // SETUP
 const HomePage = () => <h1>Home Page</h1>

--- a/packages/router/src/__tests__/route-focus.test.tsx
+++ b/packages/router/src/__tests__/route-focus.test.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { test, beforeEach, expect } from 'vitest'
 
-import { getFocus } from '../a11yUtils'
-import { namedRoutes as routes } from '../namedRoutes'
-import { Route } from '../Route'
-import RouteFocus from '../route-focus'
-import { Router } from '../router'
+import { getFocus } from '../a11yUtils.js'
+import { namedRoutes as routes } from '../namedRoutes.js'
+import RouteFocus from '../route-focus.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
 
 // SETUP
 const RouteFocusPage = () => (

--- a/packages/router/src/__tests__/route-validators.test.tsx
+++ b/packages/router/src/__tests__/route-validators.test.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 import { describe, it, expect } from 'vitest'
 
-import { Route } from '../Route'
-import { isValidRoute } from '../route-validators'
+import { isValidRoute } from '../route-validators.js'
+import { Route } from '../Route.js'
 
 describe('isValidRoute', () => {
   it('throws if Route does not have a path', () => {

--- a/packages/router/src/__tests__/routeScrollReset.test.tsx
+++ b/packages/router/src/__tests__/routeScrollReset.test.tsx
@@ -4,10 +4,10 @@ import { act, cleanup, render, screen } from '@testing-library/react'
 import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 import type { Mock } from 'vitest'
 
-import { navigate } from '../history'
-import { namedRoutes as routes } from '../namedRoutes'
-import { Route } from '../Route'
-import { Router } from '../router'
+import { navigate } from '../history.js'
+import { namedRoutes as routes } from '../namedRoutes.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
 
 describe('Router scroll reset', () => {
   const Page1 = () => <div>Page 1</div>

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -23,10 +23,10 @@ import {
   Redirect,
   Route,
   Router,
-} from '../index'
-import { useParams } from '../params'
-import { Set } from '../Set'
-import type { GeneratedRoutesMap } from '../util'
+} from '../index.js'
+import { useParams } from '../params.js'
+import { Set } from '../Set.js'
+import type { GeneratedRoutesMap } from '../util.js'
 
 type UnknownAuthContextInterface = AuthContextInterface<
   unknown,

--- a/packages/router/src/__tests__/set.test.tsx
+++ b/packages/router/src/__tests__/set.test.tsx
@@ -4,10 +4,10 @@ import type { ReactNode } from 'react'
 import { act, render, waitFor } from '@testing-library/react'
 import { beforeEach, test, describe, vi, expect } from 'vitest'
 
-import { navigate } from '../history'
-import { Route } from '../Route'
-import { Router } from '../router'
-import { Set } from '../Set'
+import { navigate } from '../history.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
+import { Set } from '../Set.js'
 
 // SETUP
 interface LayoutProps {

--- a/packages/router/src/__tests__/setContextReuse.test.tsx
+++ b/packages/router/src/__tests__/setContextReuse.test.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 import { act, render, waitFor } from '@testing-library/react'
 import { test } from 'vitest'
 
-import { Route, Router, navigate } from '../'
-import { Set } from '../Set'
+import { Route, Router, navigate } from '../index.js'
+import { Set } from '../Set.js'
 
 const HomePage = () => {
   return <p>Home Page</p>

--- a/packages/router/src/__tests__/useBlocker.test.tsx
+++ b/packages/router/src/__tests__/useBlocker.test.tsx
@@ -1,8 +1,8 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 
-import { gHistory, navigate } from '../history'
-import { useBlocker } from '../useBlocker'
+import { gHistory, navigate } from '../history.js'
+import { useBlocker } from '../useBlocker.js'
 
 describe('useBlocker', () => {
   it('should initialize with IDLE state', () => {

--- a/packages/router/src/__tests__/useMatch.test.tsx
+++ b/packages/router/src/__tests__/useMatch.test.tsx
@@ -3,27 +3,13 @@ import React from 'react'
 import { render, renderHook as tlrRenderHook } from '@testing-library/react'
 import { describe, it, expect, afterEach } from 'vitest'
 
-import { Link } from '../link'
-import { LocationProvider } from '../location'
-import { useMatch } from '../useMatch'
-import { flattenSearchParams } from '../util'
+import { Link } from '../link.js'
+import { LocationProvider } from '../location.js'
+import { useMatch } from '../useMatch.js'
+import { flattenSearchParams } from '../util.js'
 
 function createDummyLocation(pathname: string, search = '') {
-  return {
-    pathname,
-    hash: '',
-    host: '',
-    hostname: '',
-    href: '',
-    ancestorOrigins: null,
-    assign: () => null,
-    reload: () => null,
-    replace: () => null,
-    origin: '',
-    port: '',
-    protocol: '',
-    search,
-  }
+  return new URL(pathname + search, 'http://localhost/')
 }
 
 describe('useMatch', () => {

--- a/packages/router/src/__tests__/useRoutePaths.test.tsx
+++ b/packages/router/src/__tests__/useRoutePaths.test.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { render, act } from '@testing-library/react'
 import { test } from 'vitest'
 
-import { navigate } from '../history'
-import { Route } from '../Route'
-import { Router } from '../router'
-import { Set } from '../Set'
-import { useRoutePaths, useRoutePath } from '../useRoutePaths'
+import { navigate } from '../history.js'
+import { Route } from '../Route.js'
+import { Router } from '../router.js'
+import { Set } from '../Set.js'
+import { useRoutePaths, useRoutePath } from '../useRoutePaths.js'
 
 test('useRoutePaths and useRoutePath', async () => {
   const HomePage = () => {

--- a/packages/router/src/__tests__/util.test.ts
+++ b/packages/router/src/__tests__/util.test.ts
@@ -7,7 +7,7 @@ import {
   validatePath,
   flattenSearchParams,
   replaceParams,
-} from '../util'
+} from '../util.js'
 
 describe('paramsForRoute', () => {
   it.each([

--- a/packages/router/tsconfig.build.json
+++ b/packages/router/tsconfig.build.json
@@ -6,13 +6,10 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext"
   },
-  "include": [
-    "src",
-    "./ambient.d.ts",
-    "./rsdw.modules.d.ts"
-  ],
+  "include": ["src", "./ambient.d.ts", "./rsdw.modules.d.ts"],
   "references": [
     { "path": "../auth/tsconfig.build.json" },
+    { "path": "../framework-tools" },
     { "path": "../server-store" }
   ]
 }

--- a/packages/router/tsconfig.build.json
+++ b/packages/router/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.compilerOption.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": [
+    "src",
+    "./ambient.d.ts",
+    "./rsdw.modules.d.ts"
+  ],
+  "references": [
+    { "path": "../auth/tsconfig.build.json" },
+    { "path": "../server-store" }
+  ]
+}

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,22 +1,22 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
+    "isolatedModules": true,
+    "moduleResolution": "NodeNext",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "outDir": "dist",
+    "typeRoots": [
+      "../../node_modules/@types",
+      "./node_modules/@types",
+      "../../node_modules/@testing-library"
+    ],
+    "types": ["jest", "jest-dom"]
   },
-  "include": [
-    "src",
-    "./ambient.d.ts",
-    "./rsdw.modules.d.ts"
-  ],
+  "include": ["."],
+  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],
   "references": [
-    {
-      "path": "../auth/tsconfig.build.json"
-    },
-    {
-      "path": "../server-store"
-    },
+    { "path": "../auth/tsconfig.build.json" },
+    { "path": "../framework-tools" },
+    { "path": "../server-store" }
   ]
 }

--- a/packages/router/tsconfig.types-cjs.json
+++ b/packages/router/tsconfig.types-cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
     "tsBuildInfoFile": "./tsconfig.types-cjs.tsbuildinfo"

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -6,7 +6,7 @@
   },
   "include": ["src"],
   "references": [
-    { "path": "../router" },
+    { "path": "../router/tsconfig.build.json" },
     { "path": "../babel-config" },
     { "path": "../project-config" },
     { "path": "../web/tsconfig.build.json" },

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -22,7 +22,7 @@
       "path": "../project-config"
     },
     {
-      "path": "../router"
+      "path": "../router/tsconfig.build.json"
     },
     {
       "path": "../server-store"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8519,6 +8519,7 @@ __metadata:
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.24.8"
     "@redwoodjs/auth": "workspace:*"
+    "@redwoodjs/framework-tools": "workspace:*"
     "@redwoodjs/server-store": "workspace:*"
     "@testing-library/jest-dom": "npm:6.4.6"
     "@types/react": "npm:^18.2.55"


### PR DESCRIPTION
Fixed some type errors in our router tests
 * Missing `@testing-library` types
 * Missing `.js` extensions on imports
 * Wrong type for `location` (This was updated in an older PR, but we forgot to update the tests)

There is still one error left (that shows up in a few different tests). But this is a legit bug in our (public) types, so didn't want to include that in this PR.

Someone should create a separate PR and then we can discuss if we want to mark it breaking or as a fix.