### PR TITLE
chore(deps): Add missing semver dep to cli-helpers

### DIFF
--- a/packages/cli-helpers/package.json
+++ b/packages/cli-helpers/package.json
@@ -52,6 +52,7 @@
     "pascalcase": "1.0.0",
     "prettier": "3.3.3",
     "prompts": "2.4.2",
+    "semver": "7.6.3",
     "smol-toml": "1.3.0",
     "terminal-link": "2.1.1"
   },
@@ -60,6 +61,7 @@
     "@types/dotenv-defaults": "^2.0.4",
     "@types/lodash": "4.17.7",
     "@types/pascalcase": "1.0.3",
+    "@types/semver": "^7",
     "@types/yargs": "17.0.32",
     "tsx": "4.16.2",
     "typescript": "5.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7890,6 +7890,7 @@ __metadata:
     "@types/dotenv-defaults": "npm:^2.0.4"
     "@types/lodash": "npm:4.17.7"
     "@types/pascalcase": "npm:1.0.3"
+    "@types/semver": "npm:^7"
     "@types/yargs": "npm:17.0.32"
     chalk: "npm:4.1.2"
     dotenv: "npm:16.4.5"
@@ -7900,6 +7901,7 @@ __metadata:
     pascalcase: "npm:1.0.0"
     prettier: "npm:3.3.3"
     prompts: "npm:2.4.2"
+    semver: "npm:7.6.3"
     smol-toml: "npm:1.3.0"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.16.2"
@@ -11157,7 +11159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.4, @types/semver@npm:^7.5.0":
+"@types/semver@npm:^7, @types/semver@npm:^7.3.4, @types/semver@npm:^7.5.0":
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
   checksum: 10c0/8663ff927234d1c5fcc04b33062cb2b9fcfbe0f5f351ed26c4d1e1581657deebd506b41ff7fdf89e787e3d33ce05854bc01686379b89e9c49b564c4cfa988efa


### PR DESCRIPTION
I was seeing this error in my console
![image](https://github.com/user-attachments/assets/599c144f-c7bc-44fc-866d-2601e611c78a)

Fixing by adding semver as a dependency to cli-helpers (it's used in `packages/cli-helpers/src/lib/version.ts`)