### PR TITLE
fix(router): Add check for excessively long path 

### DIFF
--- a/.changesets/11062.md
+++ b/.changesets/11062.md
@@ -1,0 +1,3 @@
+- fix(router): Add check for excessively long path  (#11062) by @Josh-Walker-GM
+
+This change adds an additional internal check to protect against route paths which are excessively long.

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -273,6 +273,13 @@ export function validatePath(path: string, routeName: string) {
     )
   }
 
+  // Guard the following regex matching
+  if (path.length > 2000) {
+    throw new Error(
+      `Route path for ${routeName} is too long to process at ${path.length} characters, limit is 2000 characters.`,
+    )
+  }
+
   // Check for duplicate named params.
   const matches = path.matchAll(/\{([^}]+)\}/g)
   const memo: Record<string, boolean> = {}


### PR DESCRIPTION
**Problem**
Code scanning is alerting to the "Polynomial regular expression used on uncontrolled data" issue associated with the route path processing.

**Changes**
1. Check that the route path is not excessively long. 2000 characters seems like a reasonable limit. 