### PR TITLE
chore(types): Fix/improve types config for the router package

### DIFF
--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -7,10 +7,8 @@
     "outDir": "dist",
     "typeRoots": [
       "../../node_modules/@types",
-      "./node_modules/@types",
       "../../node_modules/@testing-library"
-    ],
-    "types": ["jest", "jest-dom"]
+    ]
   },
   "include": ["."],
   "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],


### PR DESCRIPTION
Shouldn't limit our types to just jest. (Especially since we aren't even using jest anymore 😆)
Also no need to look for types inside `./node_modules` because it won't exist. Packages (and thus types) are installed to `../../node_modules`