### PR TITLE
chore(lint): tell eslint to ignore crwrsca

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean:prisma": "rimraf node_modules/.prisma/client && node node_modules/@prisma/client/scripts/postinstall.js",
     "e2e": "node ./tasks/run-e2e",
     "generate-dependency-graph": "node ./tasks/generateDependencyGraph.mjs",
-    "lint": "RWJS_CWD=packages/create-redwood-app/templates/ts eslint --config .eslintrc.js --ignore-pattern Routes.jsx packages",
+    "lint": "RWJS_CWD=packages/create-redwood-app/templates/ts eslint --config .eslintrc.js --ignore-pattern Routes.jsx --ignore-pattern create-redwood-rsc-app packages",
     "lint:fix": "yarn lint --fix",
     "project:copy": "node ./tasks/framework-tools/frameworkFilesToProject.mjs",
     "project:deps": "node ./tasks/framework-tools/frameworkDepsToProject.mjs",


### PR DESCRIPTION
Eventually it'd be good to also include create-redwood-rsc-app in our main lint command. But for now we'll have to run it manually just for crwrsca when we need it. 