### PR TITLE
chore(clean): Don't clean inside nested node_modules

### DIFF
--- a/tasks/clean.mjs
+++ b/tasks/clean.mjs
@@ -8,7 +8,7 @@ await $`yarn clean:prisma`
 
 await rimraf('packages/**/dist', {
   glob: {
-    ignore: 'packages/**/{fixtures,__fixtures__}/**/dist',
+    ignore: 'packages/**/{fixtures,__fixtures__,node_modules}/**/dist',
   },
 })
 


### PR DESCRIPTION
With the new create-redwood-rsc-app project we now have a node_modules folder nested inside projects/
Our `build:clean` script was a little too eager in cleaning files and nuked the dist file for packages in that node_modules folder :D This PR tells rimraf to ignore nested node_modules