### PR TITLE
chore(rebuild-test-project-fixture): Make addDbAuth resumable

### DIFF
--- a/tasks/test-project/tui-tasks.js
+++ b/tasks/test-project/tui-tasks.js
@@ -529,7 +529,7 @@ async function apiTasks(outputPath, { linkWithLatestFwBuild }) {
         `createContact(input: CreateContactInput!): Contact @skipAuth`,
       )
       .replace(
-        'deleteContact(id: Int!): Contact! @requireAuth',
+        /deleteContact\(id: Int!\): Contact! @requireAuth(?=\s)/,
         'deleteContact(id: Int!): Contact! @requireAuth(roles:["ADMIN"])',
       ) // make deleting contacts admin only
     fs.writeFileSync(pathContactsSdl, resultsContactsSdl)


### PR DESCRIPTION
Resuming on step 8.5 would produce an invalid `api/src/graphql/contacts.sdl.ts` file.

First time you run it, it'd change 
`deleteContact(id: Int!): Contact! @requireAuth`
into
`deleteContact(id: Int!): Contact! @requireAuth(roles:["ADMIN"])`
as expected

On resuming/retrying though, it'd find the
`deleteContact(id: Int!): Contact! @requireAuth`
part of
`deleteContact(id: Int!): Contact! @requireAuth(roles:["ADMIN"])` 
and replace only that first part with 
`deleteContact(id: Int!): Contact! @requireAuth(roles:["ADMIN"])`
ultimately leaving the file with 
`deleteContact(id: Int!): Contact! @requireAuth(roles:["ADMIN"])(roles:["ADMIN"])`
which isn't valid.

I've now made the search pattern more robust by including a lookahead for a whitespace character (like newline) after the "h" in "requireAuth". So if the file has already been updated it won't match again and just leave it like it should be.