### PR TITLE
chore(crwrsca): Fix TS issue in error.ts

### DIFF
--- a/packages/create-redwood-rsc-app/src/error.ts
+++ b/packages/create-redwood-rsc-app/src/error.ts
@@ -33,7 +33,7 @@ export function handleError(e: unknown) {
     }
   } else {
     console.log()
-    if ('message' in e) {
+    if (typeof e === 'object' && e !== null && 'message' in e) {
       console.error('🚨 An error occurred:')
       console.error(e)
     } else {


### PR DESCRIPTION
TypeScript was saying `e` was of type `unknown`, so I couldn't use the `in` operator. Which is of course correct. This PR fixes that by making sure `e` is an object and that it's not `null`.