### PR TITLE
feat(testing): Configure jest to ignore sidecar files in __tests__ folder

### DIFF
--- a/.changesets/11108.md
+++ b/.changesets/11108.md
@@ -1,0 +1,29 @@
+- feat(testing): Configure jest to ignore sidecar files in __tests__ folder (#11108) by @V1shvesh
+
+Solves for #10870
+
+### Description:
+`./api` directory structure:
+<img width="438" alt="image" src="https://github.com/user-attachments/assets/932e78a8-e105-4a98-a67e-3e71e292f325">
+`./web` directory structure:
+<img width="594" alt="image" src="https://github.com/user-attachments/assets/00a12bde-c7dd-4ef5-a6c5-bb403cbde2e0">
+
+
+
+Before: 
+
+`yarn rw test api`:
+<img width="772" alt="image" src="https://github.com/user-attachments/assets/1ccbe49a-7702-4134-b07b-cc4a0ad1cce9">
+
+`yarn rw test web`:
+<img width="1170" alt="image" src="https://github.com/user-attachments/assets/814c987b-f562-43cd-a3e2-08ab2ddf0b15">
+
+
+
+After:
+`yarn rw test api`:
+<img width="778" alt="image" src="https://github.com/user-attachments/assets/55c6b352-1c3c-487c-b7a0-df64b56eda60">
+
+`yarn rw test web`:
+<img width="1168" alt="image" src="https://github.com/user-attachments/assets/e96d7423-826c-4987-8d81-de12f376ff31">
+

--- a/packages/testing/config/jest/api/jest-preset.js
+++ b/packages/testing/config/jest/api/jest-preset.js
@@ -66,4 +66,5 @@ module.exports = {
       },
     ],
   },
+  testPathIgnorePatterns: ['.scenarios.[jt]s$'],
 }

--- a/packages/testing/config/jest/web/jest-preset.js
+++ b/packages/testing/config/jest/web/jest-preset.js
@@ -88,4 +88,5 @@ module.exports = {
     ],
   },
   resolver: path.resolve(__dirname, './resolver.js'),
+  testPathIgnorePatterns: ['.(stories|mock).[jt]sx?$'],
 }


### PR DESCRIPTION
Solves for #10870

### Description:
`./api` directory structure:
<img width="438" alt="image" src="https://github.com/user-attachments/assets/932e78a8-e105-4a98-a67e-3e71e292f325">
`./web` directory structure:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/00a12bde-c7dd-4ef5-a6c5-bb403cbde2e0">



Before: 

`yarn rw test api`:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/1ccbe49a-7702-4134-b07b-cc4a0ad1cce9">

`yarn rw test web`:
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/814c987b-f562-43cd-a3e2-08ab2ddf0b15">



After:
`yarn rw test api`:
<img width="778" alt="image" src="https://github.com/user-attachments/assets/55c6b352-1c3c-487c-b7a0-df64b56eda60">

`yarn rw test web`:
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/e96d7423-826c-4987-8d81-de12f376ff31">

