### PR TITLE
fix: concurrent api builds

### DIFF
--- a/.changesets/11109.md
+++ b/.changesets/11109.md
@@ -1,0 +1,13 @@
+(Delete this help paragraph when you're done.) Thanks for writing a changeset! Here's a place to start.
+Don't edit the title, but in editing the body, try to explain what this PR means for Redwood users.
+The more detail the better. E.g., is it a new feature? How do they use it? Code examples go a long way!
+
+- fix: concurrent api builds (#11109) by @callingmedic911
+
+A few users [reported](https://community.redwoodjs.com/t/redwood-v7-0-0-upgrade-guide/5713/90?u=callingmedic911) that the API server crashes with the error `EADDRINUSE` when switching between branches. This issue happens on the API side when:
+1. New files are added or existing files are removed.
+2. Immediately after, an existing file is changed.
+
+This scenario is common when doing git operations like switching branches or using git stash, where these changes occur simultaneously. When this happens, step 1 triggers a full build (without esbuild's rebuild), and step 2, without canceling the build from step 1, triggers a separate `rebuild`. This results in concurrent builds and two instances of the API server trying to start.
+
+This PR provides a quick fix for the issue. A follow-up PR will be created to refactor the process, aiming to avoid separate build processes altogether, ensure a cleaner separation between the build and the server, and improve overall readability.

--- a/packages/api-server/src/watch.ts
+++ b/packages/api-server/src/watch.ts
@@ -243,6 +243,7 @@ chokidar
       debouncedBuild()
     } else {
       // If files have just changed, then rebuild
+      debouncedBuild.cancel()
       debouncedRebuild.cancel()
       debouncedRebuild()
     }


### PR DESCRIPTION
A few users [reported](https://community.redwoodjs.com/t/redwood-v7-0-0-upgrade-guide/5713/90?u=callingmedic911) that the API server crashes with the error `EADDRINUSE` when switching between branches. This issue happens on the API side when:
1. New files are added or existing files are removed.
2. Immediately after, an existing file is changed.

This scenario is common when doing git operations like switching branches or using git stash, where these changes occur simultaneously. When this happens, step 1 triggers a full build (without esbuild's rebuild), and step 2, without canceling the build from step 1, triggers a separate `rebuild`. This results in concurrent builds and two instances of the API server trying to start.

This PR provides a quick fix for the issue. It's not ideal to cancel a full build (without a rebuild flag) with a rebuild. I created a [follow-up PR](https://github.com/redwoodjs/redwood/pull/11110) to address this + refactor the process a bit.