### PR TITLE
crwrsca: publish.ts script

### DIFF
--- a/packages/create-redwood-rsc-app/README.md
+++ b/packages/create-redwood-rsc-app/README.md
@@ -12,3 +12,17 @@ please use our standard RedwoodJS installer.
 ```shell
 npx -y create-redwood-rsc-app <desired-installation-directory>
 ```
+
+## Publishing
+
+First make sure you have an NPM token with publish rights configured in your
+`~/.yarnrc.yml` file.
+
+Then just run the following command when you're on the `main` branch:
+`yarn tsx publish.ts <version> <otp>` where `<version>` is
+"patch", "minor", or "major" and `<otp>` is your two-factor authentication
+token.
+
+It will updata the version in `package.json`, create a new commit and tag it.
+After that it'll publish a new version to NPM and finally it'll push the new
+commit and tag to the upstream `main` branch.

--- a/packages/create-redwood-rsc-app/package.json
+++ b/packages/create-redwood-rsc-app/package.json
@@ -63,9 +63,11 @@
     "prettier-plugin-packagejson": "^2.5.1",
     "prettier-plugin-sh": "^0.14.0",
     "publint": "^0.2.9",
+    "rimraf": "^6.0.1",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3",
-    "typescript-eslint": "^7.16.1"
+    "typescript-eslint": "^7.16.1",
+    "zx": "^8.1.4"
   },
   "engines": {
     "node": ">=16"

--- a/packages/create-redwood-rsc-app/publish.ts
+++ b/packages/create-redwood-rsc-app/publish.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { rimrafSync } from 'rimraf'
+import { $ } from 'zx'
+
+async function main() {
+  if (process.argv.length !== 4) {
+    throw new Error('Usage: publish.ts <patch|minor|major> <otp>')
+  }
+
+  const version = process.argv[2]
+
+  if (version !== 'patch' && version !== 'minor' && version !== 'major') {
+    console.error(
+      'The specified version needs to be one of patch, minor, or major',
+    )
+
+    throw new Error('Usage: yarn tsx publish.ts <patch|minor|major> <otp>')
+  }
+
+  const otp = process.argv[3]
+
+  if (typeof otp !== 'string' || !/^\d{6}$/.test(otp)) {
+    console.error('The OTP needs to be a string of 6 digits')
+
+    throw new Error('Usage: yarn tsx publish.ts <patch|minor|major> <otp>')
+  }
+
+  const yarnrcPath = path.join(os.homedir(), '.yarnrc.yml')
+
+  if (!fs.existsSync(yarnrcPath)) {
+    throw new Error(
+      'You need a .yarn.yml file in your home directory to run this script.',
+    )
+  }
+
+  const yarnrc = fs.readFileSync(yarnrcPath, 'utf-8')
+
+  if (!/^npmAuthToken:/m.test(yarnrc)) {
+    console.error('This script needs an NPM auth token to run.')
+    console.error('You set it in your ~/.yarnrc.yml file like this:')
+    console.error('npmAuthToken: your-auth-token')
+    console.error(
+      'Generate a token on your https://www.npmjs.com/ account settings page',
+    )
+
+    throw new Error(
+      'Could not detect an `npmAuthToken` config option in your ~/.yarnrc.yml file',
+    )
+  }
+
+  rimrafSync('dist')
+  await $`yarn build`
+  await $`npm version ${version}`
+  const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'))
+  await $`git commit -am "create-redwood-rsc-app v${packageJson.version}"`
+  await $`git tag "create-redwood-rsc-app/v${packageJson.version}"`
+  await $`yarn npm publish --otp ${otp}`
+  await $`git push --follow-tags`
+}
+
+main().catch((error: unknown) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/create-redwood-rsc-app/yarn.lock
+++ b/packages/create-redwood-rsc-app/yarn.lock
@@ -955,7 +955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/fs-extra@npm:^11":
+"@types/fs-extra@npm:>=11, @types/fs-extra@npm:^11":
   version: 11.0.4
   resolution: "@types/fs-extra@npm:11.0.4"
   dependencies:
@@ -1013,6 +1013,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10c0/59bc5fa11fdd23fd517f859063118f54a1ab53d3399ef63c926f8902429d7453abc0db22ef4b0a6110026b6ab81b6472fee894e1d235c24b01a0b3e10cfae0bb
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=20":
+  version: 22.0.0
+  resolution: "@types/node@npm:22.0.0"
+  dependencies:
+    undici-types: "npm:~6.11.1"
+  checksum: 10c0/af26a8ec7266c857b0ced75dc3a93c6b65280d1fa40d1b4488c814d30831c5c752489c99ecb5698daec1376145b1a9ddd08350882dc2e07769917a5f22a460bc
   languageName: node
   linkType: hard
 
@@ -1546,6 +1555,7 @@ __metadata:
     prettier-plugin-packagejson: "npm:^2.5.1"
     prettier-plugin-sh: "npm:^0.14.0"
     publint: "npm:^0.2.9"
+    rimraf: "npm:^6.0.1"
     semver: "npm:7.6.3"
     tsx: "npm:^4.16.2"
     typescript: "npm:^5.5.3"
@@ -1553,6 +1563,7 @@ __metadata:
     untildify: "npm:5.0.0"
     which: "npm:4.0.0"
     yauzl-promise: "npm:4.0.0"
+    zx: "npm:^8.1.4"
   bin:
     create-redwood-rsc-app: dist/index.js
   languageName: unknown
@@ -2554,6 +2565,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^4.0.1"
+    minimatch: "npm:^10.0.0"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/419866015d8795258a8ac51de5b9d1a99c72634fc3ead93338e4da388e89773ab21681e494eac0fbc4250b003451ca3110bb4f1c9393d15d14466270094fdb4e
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -2983,6 +3010,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jackspeak@npm:4.0.1"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10c0/c87997d9c9c5b7366259b1f2a444ef148692f8eedad5307caca939babbb60af2b47d306e5c63bf9d5fefbab2ab48d4da275188c3de525d0e716cc21b784bbccb
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^1.21.6":
   version: 1.21.6
   resolution: "jiti@npm:1.21.6"
@@ -3158,6 +3198,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "lru-cache@npm:11.0.0"
+  checksum: 10c0/827ff0e0739f9b0f30f92f5a5fc97c6a2bd3ae32c0452bc58cb7411d6c589d49536073027293f2d1f02d0c2e72b63b162f238df7e9ff6f4cc0345f92afec4d1d
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^13.0.0":
   version: 13.0.1
   resolution: "make-fetch-happen@npm:13.0.1"
@@ -3225,7 +3272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.0.1":
+"minimatch@npm:^10.0.0, minimatch@npm:^10.0.1":
   version: 10.0.1
   resolution: "minimatch@npm:10.0.1"
   dependencies:
@@ -3668,6 +3715,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -3889,6 +3946,18 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: 10c0/c19ef26e4e188f408922c46f7ff480d38e8dfc55d448310dfb518736b23ed2c4f547fb64a6ed5bdba92cd7e7ddc889d36ff78f794816d5e71498d645ef476107
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: "npm:^11.0.0"
+    package-json-from-dist: "npm:^1.0.0"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 10c0/b30b6b072771f0d1e73b4ca5f37bb2944ee09375be9db5f558fcd3310000d29dfcfa93cf7734d75295ad5a7486dc8e40f63089ced1722a664539ffc0c3ece8c6
   languageName: node
   linkType: hard
 
@@ -4394,6 +4463,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~6.11.1":
+  version: 6.11.1
+  resolution: "undici-types@npm:6.11.1"
+  checksum: 10c0/d8f5739a8e6c779d72336c82deb49c56d5ac9f9f6e0eb2e8dd4d3f6929ae9db7cde370d2e46516fe6cad04ea53e790c5e16c4c75eed7cd0f9bd31b0763bb2fa3
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^3.0.0":
   version: 3.0.0
   resolution: "unique-filename@npm:3.0.0"
@@ -4626,5 +4702,22 @@ __metadata:
   version: 3.23.8
   resolution: "zod@npm:3.23.8"
   checksum: 10c0/8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69
+  languageName: node
+  linkType: hard
+
+"zx@npm:^8.1.4":
+  version: 8.1.4
+  resolution: "zx@npm:8.1.4"
+  dependencies:
+    "@types/fs-extra": "npm:>=11"
+    "@types/node": "npm:>=20"
+  dependenciesMeta:
+    "@types/fs-extra":
+      optional: true
+    "@types/node":
+      optional: true
+  bin:
+    zx: build/cli.js
+  checksum: 10c0/ced255787ecb5e8d4ea6931c8d9a4f0662c2e6048c0727675c221cfdf4bdb8df9f9fbc860bd0abb93135409a33f667c33d79b900e51030ca6872efee2a886ef0
   languageName: node
   linkType: hard


### PR DESCRIPTION
create-redwood-rsc-app is not released together with our other packages because we want more flexibility in how we handle the releases and release schedule for crwrsca. This is a small little script to 
1. Make releasing faster and easier for me
2. Make it so that anyone can release
3. Explain how releasing works (you just have to look at what steps the script performs and you'll see how releases are made)