### PR TITLE
fix(crwrsca): push to upstream in last step

### DIFF
--- a/packages/create-redwood-rsc-app/publish.ts
+++ b/packages/create-redwood-rsc-app/publish.ts
@@ -57,7 +57,7 @@ async function main() {
   await $`git commit -am "create-redwood-rsc-app v${packageJson.version}"`
   await $`git tag "create-redwood-rsc-app/v${packageJson.version}"`
   await $`yarn npm publish --otp ${otp}`
-  await $`git push --follow-tags`
+  await $`git push upstream --follow-tags`
 }
 
 main().catch((error: unknown) => {


### PR DESCRIPTION
`git push` only pushes to your own fork. We want to push to upstream, so that everyone gets the new commit and tag