### PR TITLE
chore(kitchen-sink): Disable test and stories generation

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/redwood.toml
+++ b/__fixtures__/test-project-rsc-kitchen-sink/redwood.toml
@@ -20,6 +20,10 @@
 [notifications]
   versionUpdates = ["latest"]
 
+[generate]
+  tests = false
+  stories = false
+
 [experimental.streamingSsr]
   enabled = true
 


### PR DESCRIPTION
Disable test and stories generation for new pages, layouts etc in the kitchen-sink test project.
This mainly affects the projects that get generated by the create-redwood-rsc-app tool as it (currently) uses the kitchen-sink test project as its template

We haven't spent any time focusing on unit testing or storybook support for RSCs yet, so we don't want to include these files by default. 
We've also been considering not generating them by default simply to limit the files we spit out during generation to make it less overwhelming for new users