### PR TITLE
Disable RSC live reload in production.

### DIFF
--- a/packages/vite/src/streaming/streamHelpers.ts
+++ b/packages/vite/src/streaming/streamHelpers.ts
@@ -193,7 +193,7 @@ export async function reactRenderToStreamResponse(
     bootstrapScriptContent:
       // Only insert assetMap if client side JS will be loaded
       jsBundles.length > 0
-        ? `window.__REDWOOD__ASSET_MAP = ${assetMap}; ${rscWebpackShims}; ${rscLiveReload};`
+        ? `window.__REDWOOD__ASSET_MAP = ${assetMap}; ${rscWebpackShims}; ${isProd ? '' : rscLiveReload}`
         : undefined,
     bootstrapModules: jsBundles,
   }


### PR DESCRIPTION
Disabling live reload in production should have been the default case.