### PR TITLE
feat(crwrsca): Add support for --template

### DIFF
--- a/packages/create-redwood-rsc-app/src/config.ts
+++ b/packages/create-redwood-rsc-app/src/config.ts
@@ -2,22 +2,22 @@ import { ExitCodeError } from './error.js'
 
 export interface Config {
   installationDir: string
-  verbose: boolean
   template: string
+  verbose: boolean
 }
 
 export function initConfig() {
   const config: Config = {
     installationDir: '',
-    verbose: false,
     template: '',
+    verbose: false,
   }
 
   const args = {
-    verbose: false,
     help: false,
-    version: false,
     template: '',
+    verbose: false,
+    version: false,
   }
 
   // Skipping the first two arguments, which are the path to the node executable

--- a/packages/create-redwood-rsc-app/src/config.ts
+++ b/packages/create-redwood-rsc-app/src/config.ts
@@ -1,18 +1,23 @@
+import { ExitCodeError } from './error.js'
+
 export interface Config {
   installationDir: string
   verbose: boolean
+  template: string
 }
 
 export function initConfig() {
   const config: Config = {
     installationDir: '',
     verbose: false,
+    template: '',
   }
 
   const args = {
     verbose: false,
     help: false,
     version: false,
+    template: '',
   }
 
   // Skipping the first two arguments, which are the path to the node executable
@@ -34,6 +39,25 @@ export function initConfig() {
     args.version = true
   }
 
+  const templateIndex = process.argv.findIndex(
+    (arg) => arg.startsWith('--template') || arg.startsWith('-t'),
+  )
+  if (templateIndex >= 0) {
+    if (process.argv[templateIndex].includes('=')) {
+      args.template = process.argv[templateIndex].split('=')[1]
+    } else if (
+      process.argv[templateIndex + 1] &&
+      !process.argv[templateIndex + 1].startsWith('-')
+    ) {
+      args.template = process.argv[templateIndex + 1]
+    } else {
+      throw new ExitCodeError(
+        1,
+        'Error: No template provided after --template flag',
+      )
+    }
+  }
+
   if (args.verbose) {
     console.log('Parsed command line arguments:')
     console.log('    arguments:', args)
@@ -42,6 +66,7 @@ export function initConfig() {
 
   config.verbose = !!args.verbose
   config.installationDir = installationDir ?? ''
+  config.template = args.template || 'test-project-rsc-kitchen-sink'
 
   return config
 }

--- a/packages/create-redwood-rsc-app/src/index.ts
+++ b/packages/create-redwood-rsc-app/src/index.ts
@@ -12,7 +12,13 @@ import { checkNodeVersion, checkYarnInstallation } from './prerequisites.js'
 import { upgradeToLatestCanary } from './upgradeToLatestCanary.js'
 import { unzip } from './zip.js'
 
-const config = initConfig()
+let config: Config | null = null
+
+try {
+  config = initConfig()
+} catch (e) {
+  handleError(e)
+}
 
 if (shouldRelaunch(config)) {
   await relaunchOnLatest(config)

--- a/packages/create-redwood-rsc-app/src/index.ts
+++ b/packages/create-redwood-rsc-app/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import type { Config } from './config.js'
+
 import { initConfig } from './config.js'
 import { downloadTemplate } from './download.js'
 import { handleError } from './error.js'

--- a/packages/create-redwood-rsc-app/src/zip.ts
+++ b/packages/create-redwood-rsc-app/src/zip.ts
@@ -21,7 +21,11 @@ export async function unzip(config: Config, zipFilePath: string) {
 
   try {
     for await (const entry of zip) {
-      const baseDir = 'redwood-main/__fixtures__/test-project-rsc-kitchen-sink/'
+      const baseDir = `redwood-main/__fixtures__/${config.template}/`
+
+      if (config.verbose) {
+        console.log('baseDir:', baseDir)
+      }
 
       const isDir = entry.filename.endsWith('/')
 


### PR DESCRIPTION
To be able to quick-start an RSC project with an initial set of features already enabled or provided for the user I wanted the option to pass in a template to use.

I also personally want to use this so I can show off a specific demo. To not distract the viewer with everything that's going on in the kitchen-sink application

Currently all the templates have to live inside the __fixtures__ folder in the main redwood repo. But in the future I want to be able to support external templates too. But that's for a future PR