### PR TITLE
fix(isCellEmpty): Fix doc comment

### DIFF
--- a/packages/web/src/components/cell/isCellEmpty.ts
+++ b/packages/web/src/components/cell/isCellEmpty.ts
@@ -1,7 +1,8 @@
 import type { DataObject } from './cellTypes.js'
 
 /**
- * The default `isEmpty` implementation. Checks if any of the field is `null` or an empty array.
+ * The default `isEmpty` implementation checks if any of the fields are `null`
+ * or an empty array.
  *
  * Consider the following queries. The former returns an object, the latter a list:
  *
@@ -36,12 +37,7 @@ import type { DataObject } from './cellTypes.js'
  * ```
  *
  * Note that the latter can return `null` as well depending on the SDL (`posts: [Post!]`).
- * ```
  */
-function isFieldEmptyArray(field: unknown) {
-  return Array.isArray(field) && field.length === 0
-}
-
 export function isDataEmpty(data?: DataObject) {
   return (
     !data ||
@@ -49,4 +45,8 @@ export function isDataEmpty(data?: DataObject) {
       return fieldValue === null || isFieldEmptyArray(fieldValue)
     })
   )
+}
+
+function isFieldEmptyArray(field: unknown) {
+  return Array.isArray(field) && field.length === 0
 }


### PR DESCRIPTION
Fix formatting and grammar in the `isCellEmpty` doc comment. And also associate it with the correct function

I have not included a changeset because I don't think this is anything we need to highlight in any release notes