### PR TITLE
chore(rsc): Add ServerDelayForm to rsc-caching fixture

### DIFF
--- a/__fixtures__/rsc-caching/web/src/components/CachingBoxes/CachingBoxes.tsx
+++ b/__fixtures__/rsc-caching/web/src/components/CachingBoxes/CachingBoxes.tsx
@@ -1,3 +1,5 @@
+import fs from 'node:fs'
+
 import './CachingBoxes.css'
 
 const colors = [
@@ -28,7 +30,16 @@ const colors = [
   'violet',
 ]
 
-const CachingBoxes = () => {
+const CachingBoxes = async () => {
+  let delay = 0
+
+  if (fs.existsSync('settings.json')) {
+    delay = JSON.parse(fs.readFileSync('settings.json', 'utf8')).delay || 0
+  }
+
+  console.log('delaying execution', delay, 'ms')
+  await new Promise((resolve) => setTimeout(resolve, delay))
+
   const shuffledColors = colors
     .map((value) => ({ value, sort: Math.random() }))
     .sort((a, b) => a.sort - b.sort)

--- a/__fixtures__/rsc-caching/web/src/layouts/MainLayout/MainLayout.css
+++ b/__fixtures__/rsc-caching/web/src/layouts/MainLayout/MainLayout.css
@@ -1,4 +1,10 @@
 .main-layout {
+  .demo-wrapper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   nav {
     display: flex;
     justify-content: center;

--- a/__fixtures__/rsc-caching/web/src/layouts/MainLayout/MainLayout.tsx
+++ b/__fixtures__/rsc-caching/web/src/layouts/MainLayout/MainLayout.tsx
@@ -2,6 +2,7 @@ import { namedRoutes } from '@redwoodjs/router/namedRoutes'
 import { NavLink } from '@redwoodjs/router/NavLink'
 
 import CachingBoxes from 'src/components/CachingBoxes/CachingBoxes'
+import ServerDelayForm from 'src/components/ServerDelayForm'
 
 import './MainLayout.css'
 
@@ -12,7 +13,10 @@ interface Props {
 const MainLayout = ({ children }: Props) => {
   return (
     <div className="main-layout">
-      <CachingBoxes />
+      <div className="demo-wrapper">
+        <CachingBoxes />
+        <ServerDelayForm />
+      </div>
 
       <nav>
         <ul>


### PR DESCRIPTION
Adds an input to control how long recomputing the random colors should take on the server
<img width="649" alt="image" src="https://github.com/user-attachments/assets/049e7e76-cecc-4269-aaa7-525f5f594044">
