### PR TITLE
chore(ci): update release label list

### DIFF
--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "release:docs, release:chore, release:experiment, release:fix, release:feature, release:breaking"
+          labels: "release:docs, release:chore, release:experimental-breaking, release:fix, release:feature, release:breaking, release:dependency"


### PR DESCRIPTION
We have added the `release:experimental-breaking` and `release:dependency` labels. I updated the list to match the current labels.