### PR TITLE
chore(studio): Make studioHandler install Studio v12

### DIFF
--- a/packages/cli/src/commands/studioHandler.js
+++ b/packages/cli/src/commands/studioHandler.js
@@ -17,7 +17,7 @@ export const handler = async (options) => {
       console.log(
         'The studio package is not installed, installing it for you, this may take a moment...',
       )
-      await installModule('@redwoodjs/studio', '11')
+      await installModule('@redwoodjs/studio', '12')
       console.log('Studio package installed successfully.')
 
       const installedRealtime = await installModule('@redwoodjs/realtime')


### PR DESCRIPTION
I just released Redwood Studio v12. This PR makes that the version that's installed when you run `yarn rw studio`