### PR TITLE
fix(cli-cache): Remove RW CLI cache on upgrade

### DIFF
--- a/.changesets/11135.md
+++ b/.changesets/11135.md
@@ -1,0 +1,11 @@
+- fix(cli-cache): Remove RW CLI cache on upgrade (#11135) by @dac09
+
+This change removes the redwood cli plugin cache in `.redwood/commandCache.json` on running `rw upgrade`. 
+
+This prevents the redwood CLI from using outdated versions of CLI plugins, and is particularly important when they same alias.
+
+**Before**
+running `yarn rw sb` -> would use the outdated storybook-cli package, and error out.
+
+**After**
+with no commandCache, it'll create a new command cache, and attempt to install the new vite CLI

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -12,6 +12,7 @@ import { getConfig } from '@redwoodjs/project-config'
 import { getPaths } from '../lib'
 import c from '../lib/colors'
 import { generatePrismaClient } from '../lib/generatePrismaClient'
+import { PLUGIN_CACHE_FILENAME } from '../lib/plugin'
 
 export const command = 'upgrade'
 export const description = 'Upgrade all @redwoodjs packages via interactive CLI'
@@ -117,6 +118,10 @@ export const handler = async ({ dryRun, tag, verbose, dedupe }) => {
         enabled: (ctx) => ctx.versionToUpgradeTo?.includes('canary'),
       },
       {
+        title: 'Removing CLI cache',
+        task: (ctx) => removeCliCache(ctx, { dryRun, verbose }),
+      },
+      {
         title: 'Running yarn install',
         task: (ctx) => yarnInstall(ctx, { dryRun, verbose }),
         skip: () => dryRun,
@@ -203,6 +208,25 @@ async function yarnInstall({ verbose }) {
     throw new Error(
       'Could not finish installation. Please run `yarn install` and then `yarn dedupe`, before continuing',
     )
+  }
+}
+
+/**
+ * Removes the CLI plugin cache. This prevents the CLI from using outdated versions of the plugin,
+ * when the plugins share the same alias. e.g. `rw sb` used to point to `@redwoodjs/cli-storybook` but now points to `@redwoodjs/cli-storybook-vite`
+ */
+async function removeCliCache(ctx, { dryRun, verbose }) {
+  const cliCacheDir = path.join(
+    getPaths().generated.base,
+    PLUGIN_CACHE_FILENAME,
+  )
+
+  if (verbose) {
+    console.log('Removing CLI cache at: ', cliCacheDir)
+  }
+
+  if (!dryRun) {
+    fs.removeSync(cliCacheDir)
   }
 }
 

--- a/packages/cli/src/lib/plugin.js
+++ b/packages/cli/src/lib/plugin.js
@@ -14,7 +14,7 @@ const { Select } = require('enquirer')
 /**
  * The file inside .redwood which will contain cached plugin command mappings
  */
-const PLUGIN_CACHE_FILENAME = 'commandCache.json'
+export const PLUGIN_CACHE_FILENAME = 'commandCache.json'
 
 /**
  * A cache of yargs information for redwood commands that are available from plugins.


### PR DESCRIPTION
This change removes the redwood cli plugin cache in `.redwood/commandCache.json` on running `rw upgrade`. 

This prevents the redwood CLI from using outdated versions of CLI plugins, and is particularly important when they same alias.

**Before**
running `yarn rw sb` -> would use the outdated storybook-cli package, and error out.

**After**
with no commandCache, it'll create a new command cache, and attempt to install the new vite CLI