### PR TITLE
chore(crwrsca): log process.argv when --verbose

### DIFF
--- a/packages/create-redwood-rsc-app/src/config.ts
+++ b/packages/create-redwood-rsc-app/src/config.ts
@@ -59,6 +59,7 @@ export function initConfig() {
   }
 
   if (args.verbose) {
+    console.log('process.argv', process.argv)
     console.log('Parsed command line arguments:')
     console.log('    arguments:', args)
     console.log('    installationDir:', installationDir)


### PR DESCRIPTION
I'm trying to debug an issue where the template (`-t rsc-caching`) is used as the installation directory if crwrsca decides it needs to relaunch with `@latest`