### PR TITLE
fix(crwrsca): Fix handling of positional args

### DIFF
--- a/packages/create-redwood-rsc-app/src/zip.ts
+++ b/packages/create-redwood-rsc-app/src/zip.ts
@@ -19,14 +19,14 @@ export async function unzip(config: Config, zipFilePath: string) {
     console.log(zip.entryCount, 'entries in zip file')
   }
 
+  const baseDir = `redwood-main/__fixtures__/${config.template}/`
+
+  if (config.verbose) {
+    console.log('baseDir:', baseDir)
+  }
+
   try {
     for await (const entry of zip) {
-      const baseDir = `redwood-main/__fixtures__/${config.template}/`
-
-      if (config.verbose) {
-        console.log('baseDir:', baseDir)
-      }
-
       const isDir = entry.filename.endsWith('/')
 
       if (isDir || !entry.filename.includes(baseDir)) {


### PR DESCRIPTION
If the user does `crwrsca --template template-name ~/tmp/rw-crwrsca-app` we'd find "template-name" as the first positional argument. But obviously that's connected to `--template` and shouldn't be used as the installation dir. The correct installation dir is `~/tmp/rw-crwrsca-app`.
This PR fixes this cli args parsing bug