### PR TITLE
fix(rsc): Remove unused Set in vite plugin

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-analyze.ts
@@ -7,8 +7,6 @@ export function rscAnalyzePlugin(
   clientEntryCallback: (id: string) => void,
   serverEntryCallback: (id: string) => void,
 ): Plugin {
-  const clientEntryIdSet = new Set<string>()
-
   return {
     name: 'redwood-rsc-analyze-plugin',
     transform(code, id) {
@@ -27,7 +25,6 @@ export function rscAnalyzePlugin(
           ) {
             if (item.expression.value === 'use client') {
               clientEntryCallback(id)
-              clientEntryIdSet.add(id)
             } else if (item.expression.value === 'use server') {
               serverEntryCallback(id)
             }


### PR DESCRIPTION
We had a `Set` we were adding file ids to, but we never actually used it for anything. This PR removes that Set.