### PR TITLE
fix(cli): Update react versions during RSC setup command

### DIFF
--- a/packages/cli/src/commands/experimental/setupRscHandler.js
+++ b/packages/cli/src/commands/experimental/setupRscHandler.js
@@ -359,7 +359,7 @@ export const handler = async ({ force, verbose }) => {
         },
       },
       {
-        title: 'Updating react version...',
+        title: 'Updating React version...',
         task: async () => {
           // Fetch the web package.json from the main branch
           const canaryWebPackageJsonUrl =


### PR DESCRIPTION
This PR updates the `yarn rw exp setup-rsc` command to update the versions of `react` and `react-dom` to match those currently used in the main branch (canary release).