### PR TITLE
Remove erronerous console.log("In decorators") in Storybook package

### DIFF
--- a/packages/storybook/src/preview.tsx
+++ b/packages/storybook/src/preview.tsx
@@ -6,7 +6,6 @@ import { MockingLoader, StorybookProvider } from './mocks/StorybookProvider'
 
 const decorators: Addon_DecoratorFunction<any>[] = [
   (storyFn, { id }) => {
-    console.log('In decorators')
     return React.createElement(StorybookProvider, { storyFn, id })
   },
 ]


### PR DESCRIPTION
Just upgraded Storybook to Vite and loving it.

Only got a little confused while migrating and developing stories about a re-occurring `"In decorators"` message appearing in my console.

As i assume this is not a mission critical line of code i'd hereby propose to remove it :wink: 