### PR TITLE
fix(crwrsca): Remove execa to loosen up node version requirements

### DIFF
--- a/packages/create-redwood-rsc-app/package.json
+++ b/packages/create-redwood-rsc-app/package.json
@@ -28,7 +28,6 @@
     "chalk": "5.3.0",
     "ci-info": "4.0.0",
     "enquirer": "2.4.1",
-    "execa": "9.3.0",
     "node-fetch": "3.3.2",
     "semver": "7.6.3",
     "untildify": "5.0.0",

--- a/packages/create-redwood-rsc-app/src/git.ts
+++ b/packages/create-redwood-rsc-app/src/git.ts
@@ -6,12 +6,12 @@ export function initialCommit(config: Config) {
   if (config.verbose) {
     console.log('Running `git init .`')
   }
-  spawnSync('git init .', { cwd: config.installationDir })
+  spawnSync('git', ['init', '.'], { cwd: config.installationDir })
 
   if (config.verbose) {
     console.log('Running `git add .`')
   }
-  spawnSync('git add .', { cwd: config.installationDir })
+  spawnSync('git', ['add', '.'], { cwd: config.installationDir })
 
   if (config.verbose) {
     console.log('Running `git commit`')

--- a/packages/create-redwood-rsc-app/src/git.ts
+++ b/packages/create-redwood-rsc-app/src/git.ts
@@ -1,22 +1,22 @@
-import { execa } from 'execa'
+import { spawnSync } from 'node:child_process'
 
 import type { Config } from './config.js'
 
-export async function initialCommit(config: Config) {
+export function initialCommit(config: Config) {
   if (config.verbose) {
     console.log('Running `git init .`')
   }
-  await execa({ cwd: config.installationDir })`git init .`
+  spawnSync('git init .', { cwd: config.installationDir })
 
   if (config.verbose) {
     console.log('Running `git add .`')
   }
-  await execa({ cwd: config.installationDir })`git add .`
+  spawnSync('git add .', { cwd: config.installationDir })
 
   if (config.verbose) {
     console.log('Running `git commit`')
   }
-  await execa({
+  spawnSync('git', ['commit', '-m', 'Initial commit'], {
     cwd: config.installationDir,
-  })`git commit -m ${'Initial commit'}`
+  })
 }

--- a/packages/create-redwood-rsc-app/src/index.ts
+++ b/packages/create-redwood-rsc-app/src/index.ts
@@ -23,18 +23,18 @@ try {
   telemetryInfo.template = config.template
 
   if (shouldRelaunch(config)) {
-    await relaunchOnLatest(config)
+    relaunchOnLatest(config)
   } else {
     printWelcome()
 
-    await checkNodeVersion(config)
+    checkNodeVersion(config)
     checkYarnInstallation(config)
     await setInstallationDir(config)
     const templateZipPath = await downloadTemplate(config)
     await unzip(config, templateZipPath)
     await upgradeToLatestCanary(config)
-    await install(config)
-    await initialCommit(config)
+    install(config)
+    initialCommit(config)
 
     printDone(config)
   }

--- a/packages/create-redwood-rsc-app/src/install.ts
+++ b/packages/create-redwood-rsc-app/src/install.ts
@@ -1,10 +1,10 @@
-import { execa } from 'execa'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 
 import type { Config } from './config.js'
 
-export async function install(config: Config) {
+export function install(config: Config) {
   console.log('🐈 Running `yarn install`')
   console.log('    ⏳ This might take a while...')
 
@@ -13,5 +13,5 @@ export async function install(config: Config) {
   // this project)
   fs.writeFileSync(path.join(config.installationDir, 'yarn.lock'), '')
 
-  await execa({ cwd: config.installationDir })`yarn install`
+  spawnSync('yarn install', { cwd: config.installationDir })
 }

--- a/packages/create-redwood-rsc-app/src/install.ts
+++ b/packages/create-redwood-rsc-app/src/install.ts
@@ -13,5 +13,5 @@ export function install(config: Config) {
   // this project)
   fs.writeFileSync(path.join(config.installationDir, 'yarn.lock'), '')
 
-  spawnSync('yarn install', { cwd: config.installationDir })
+  spawnSync('yarn', ['install'], { cwd: config.installationDir })
 }

--- a/packages/create-redwood-rsc-app/src/latest.ts
+++ b/packages/create-redwood-rsc-app/src/latest.ts
@@ -1,4 +1,4 @@
-import { execa } from 'execa'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 
 import type { Config } from './config.js'
@@ -65,7 +65,7 @@ export function shouldRelaunch(config: Config) {
   return true
 }
 
-export async function relaunchOnLatest(config: Config) {
+export function relaunchOnLatest(config: Config) {
   if (config.verbose) {
     console.log('relaunchOnLatest process.argv', process.argv)
   }
@@ -83,7 +83,7 @@ export async function relaunchOnLatest(config: Config) {
     }
   }
 
-  const execaOpts = {
+  const spawnOpts = {
     stdio: 'inherit',
     env: {
       npm_config_yes: 'true',
@@ -93,8 +93,12 @@ export async function relaunchOnLatest(config: Config) {
   // the execa template string tag is used to escape arguments. It handles
   // arrays, like `args` correctly
   if (process.argv.includes('--npx')) {
-    await execa(execaOpts)`yarn dev ${args}`
+    spawnSync('yarn', ['dev', ...args], spawnOpts)
   } else {
-    await execa(execaOpts)`npx @tobbe.dev/create-redwood-rsc-app@latest ${args}`
+    spawnSync(
+      'npx',
+      ['@tobbe.dev/create-redwood-rsc-app@latest', ...args],
+      spawnOpts,
+    )
   }
 }

--- a/packages/create-redwood-rsc-app/src/prerequisites.ts
+++ b/packages/create-redwood-rsc-app/src/prerequisites.ts
@@ -12,13 +12,22 @@ export function checkNodeVersion(config: Config) {
     console.log('Running `node --version`')
   }
 
-  const { stdout: version } = spawnSync('node --version')
+  // const { stdout: version } = spawnSync('node --version')
+  const result = spawnSync('node', ['--version'])
+
+  if (result.error) {
+    console.error('❌ Could not run `node --version`')
+
+    throw new ExitCodeError(1, result.error.message)
+  }
+
+  const version = result.stdout.toString()
 
   if (config.verbose) {
     console.log('Node version:', version)
   }
 
-  if (!semver.satisfies(version.toString(), '>=20')) {
+  if (!semver.satisfies(version, '>=20')) {
     console.error('❌Your Node.js version must be >=20')
     console.error('Plesae install or switch to a newer version of Node')
     console.error(

--- a/packages/create-redwood-rsc-app/src/prerequisites.ts
+++ b/packages/create-redwood-rsc-app/src/prerequisites.ts
@@ -1,4 +1,4 @@
-import { execa } from 'execa'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import semver from 'semver'
 import which from 'which'
@@ -7,18 +7,18 @@ import type { Config } from './config.js'
 
 import { ExitCodeError } from './error.js'
 
-export async function checkNodeVersion(config: Config) {
+export function checkNodeVersion(config: Config) {
   if (config.verbose) {
     console.log('Running `node --version`')
   }
 
-  const { stdout: version } = await execa`node --version`
+  const { stdout: version } = spawnSync('node --version')
 
   if (config.verbose) {
     console.log('Node version:', version)
   }
 
-  if (!semver.satisfies(version, '>=20')) {
+  if (!semver.satisfies(version.toString(), '>=20')) {
     console.error('❌Your Node.js version must be >=20')
     console.error('Plesae install or switch to a newer version of Node')
     console.error(
@@ -90,7 +90,7 @@ export function checkYarnInstallation(config: Config) {
       console.log('')
       console.log(
         'You have more than one active yarn installation. One is installed ' +
-        "by corepack,\nbut it's not the first one in $PATH.",
+          "by corepack,\nbut it's not the first one in $PATH.",
       )
       console.log("Perhaps you've manually installed it using Homebrew or npm.")
       console.log(

--- a/packages/create-redwood-rsc-app/yarn.lock
+++ b/packages/create-redwood-rsc-app/yarn.lock
@@ -883,20 +883,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sec-ant/readable-stream@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "@sec-ant/readable-stream@npm:0.4.1"
-  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
-  languageName: node
-  linkType: hard
-
-"@sindresorhus/merge-streams@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
-  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
-  languageName: node
-  linkType: hard
-
 "@snyk/github-codeowners@npm:1.1.0":
   version: 1.1.0
   resolution: "@snyk/github-codeowners@npm:1.1.0"
@@ -1552,7 +1538,6 @@ __metadata:
     eslint-plugin-perfectionist: "npm:^3.0.0"
     eslint-plugin-regexp: "npm:^2.6.0"
     eslint-plugin-yml: "npm:^1.14.0"
-    execa: "npm:9.3.0"
     fast-glob: "npm:3.3.2"
     fs-extra: "npm:11.2.0"
     jsonc-eslint-parser: "npm:^2.4.0"
@@ -1577,7 +1562,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2264,26 +2249,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:9.3.0":
-  version: 9.3.0
-  resolution: "execa@npm:9.3.0"
-  dependencies:
-    "@sindresorhus/merge-streams": "npm:^4.0.0"
-    cross-spawn: "npm:^7.0.3"
-    figures: "npm:^6.1.0"
-    get-stream: "npm:^9.0.0"
-    human-signals: "npm:^7.0.0"
-    is-plain-obj: "npm:^4.1.0"
-    is-stream: "npm:^4.0.1"
-    npm-run-path: "npm:^5.2.0"
-    pretty-ms: "npm:^9.0.0"
-    signal-exit: "npm:^4.1.0"
-    strip-final-newline: "npm:^4.0.0"
-    yoctocolors: "npm:^2.0.0"
-  checksum: 10c0/99ae08e7fb9172d25c453c2a9c414b54c7689e72f68263f6da7bc94c7011720dc8129cc64c2e3be44fb0c6ae8e37a08d346a61dbcfe9f1e79ad24364da2c48ce
-  languageName: node
-  linkType: hard
-
 "exponential-backoff@npm:^3.1.1":
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
@@ -2341,15 +2306,6 @@ __metadata:
     node-domexception: "npm:^1.0.0"
     web-streams-polyfill: "npm:^3.0.3"
   checksum: 10c0/60054bf47bfa10fb0ba6cb7742acec2f37c1f56344f79a70bb8b1c48d77675927c720ff3191fa546410a0442c998d27ab05e9144c32d530d8a52fbe68f843b69
-  languageName: node
-  linkType: hard
-
-"figures@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "figures@npm:6.1.0"
-  dependencies:
-    is-unicode-supported: "npm:^2.0.0"
-  checksum: 10c0/9159df4264d62ef447a3931537de92f5012210cf5135c35c010df50a2169377581378149abfe1eb238bd6acbba1c0d547b1f18e0af6eee49e30363cedaffcfe4
   languageName: node
   linkType: hard
 
@@ -2503,16 +2459,6 @@ __metadata:
   version: 9.0.0
   resolution: "get-stdin@npm:9.0.0"
   checksum: 10c0/7ef2edc0c81a0644ca9f051aad8a96ae9373d901485abafaabe59fd347a1c378689d8a3d8825fb3067415d1d09dfcaa43cb9b9516ecac6b74b3138b65a8ccc6b
-  languageName: node
-  linkType: hard
-
-"get-stream@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "get-stream@npm:9.0.1"
-  dependencies:
-    "@sec-ant/readable-stream": "npm:^0.4.1"
-    is-stream: "npm:^4.0.1"
-  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
   languageName: node
   linkType: hard
 
@@ -2786,13 +2732,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"human-signals@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "human-signals@npm:7.0.0"
-  checksum: 10c0/ce0c6d62d2e9bfe529d48f7c7fdf4b8c70fce950eef7850719b4e3f5bc71795ae7d61a3699ce13262bed7847705822601cc81f1921ea6a2906852e16228a94ab
-  languageName: node
-  linkType: hard
-
 "iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -2974,20 +2913,6 @@ __metadata:
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "is-stream@npm:4.0.1"
-  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
-  languageName: node
-  linkType: hard
-
-"is-unicode-supported@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-unicode-supported@npm:2.0.0"
-  checksum: 10c0/3013dfb8265fe9f9a0d1e9433fc4e766595631a8d85d60876c457b4bedc066768dab1477c553d02e2f626d88a4e019162706e04263c94d74994ef636a33b5f94
   languageName: node
   linkType: hard
 
@@ -3544,15 +3469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^5.2.0":
-  version: 5.3.0
-  resolution: "npm-run-path@npm:5.3.0"
-  dependencies:
-    path-key: "npm:^4.0.0"
-  checksum: 10c0/124df74820c40c2eb9a8612a254ea1d557ddfab1581c3e751f825e3e366d9f00b0d76a3c94ecd8398e7f3eee193018622677e95816e8491f0797b21e30b2deba
-  languageName: node
-  linkType: hard
-
 "object-keys@npm:^1.1.1":
   version: 1.1.1
   resolution: "object-keys@npm:1.1.1"
@@ -3696,13 +3612,6 @@ __metadata:
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 10c0/748c43efd5a569c039d7a00a03b58eecd1d75f3999f5a28303d75f521288df4823bc057d8784eb72358b2895a05f29a070bc9f1f17d28226cc4e62494cc58c4c
-  languageName: node
-  linkType: hard
-
-"path-key@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "path-key@npm:4.0.0"
-  checksum: 10c0/794efeef32863a65ac312f3c0b0a99f921f3e827ff63afa5cb09a377e202c262b671f7b3832a4e64731003fa94af0263713962d317b9887bd1e0c48a342efba3
   languageName: node
   linkType: hard
 
@@ -4055,7 +3964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
+"signal-exit@npm:^4.0.1":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -4250,13 +4159,6 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
-  languageName: node
-  linkType: hard
-
-"strip-final-newline@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "strip-final-newline@npm:4.0.0"
-  checksum: 10c0/b0cf2b62d597a1b0e3ebc42b88767f0a0d45601f89fd379a928a1812c8779440c81abba708082c946445af1d6b62d5f16e2a7cf4f30d9d6587b89425fae801ff
   languageName: node
   linkType: hard
 
@@ -4687,13 +4589,6 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
-  languageName: node
-  linkType: hard
-
-"yoctocolors@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "yoctocolors@npm:2.1.1"
-  checksum: 10c0/85903f7fa96f1c70badee94789fade709f9d83dab2ec92753d612d84fcea6d34c772337a9f8914c6bed2f5fc03a428ac5d893e76fab636da5f1236ab725486d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From execa's `package.json`
```
"engines": {
  "node": "^18.19.0 || >=20.5.0"
},
```

I want to be able to support node >= 16