### PR TITLE
fix(crwrsca): Set env when re-spawning crwrsca

### DIFF
--- a/packages/create-redwood-rsc-app/src/latest.ts
+++ b/packages/create-redwood-rsc-app/src/latest.ts
@@ -106,6 +106,10 @@ export function relaunchOnLatest(config: Config) {
     )
   }
 
+  if (config.verbose) {
+    console.log('spawnSync result', result)
+  }
+
   if (result.error) {
     console.error(
       'There was an error launching the latest version of create-redwood-rsc-app.',


### PR DESCRIPTION
When not including `process.env` in `spawnOpts` I'd get an `ENOENT` error when relaunching crwrsca with `@latest`