### PR TITLE
chore(test-project): Update autoprefier

### DIFF
--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -23,7 +23,7 @@
     "@redwoodjs/vite": "7.0.0",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
-    "autoprefixer": "^10.4.19",
+    "autoprefixer": "^10.4.20",
     "postcss": "^8.4.40",
     "postcss-loader": "^8.1.1",
     "prettier-plugin-tailwindcss": "^0.5.12",


### PR DESCRIPTION
The "Check test project fixture" action was failing because the test-project package.json wasn't updated