### PR TITLE
RSC: Improve type safety in RSC transform plugins

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-client.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-client.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import type { Statement, ModuleDeclaration, AssignmentExpression } from 'acorn'
+import type { AssignmentExpression, Program } from 'acorn'
 import * as acorn from 'acorn-loose'
 import { normalizePath, type Plugin } from 'vite'
 
@@ -27,7 +27,7 @@ export function rscTransformUseClientPlugin(
         return code
       }
 
-      let body: (Statement | ModuleDeclaration)[]
+      let body: Program['body']
 
       try {
         body = acorn.parse(code, {
@@ -126,7 +126,7 @@ function addExportNames(names: Array<string>, node: any) {
  */
 async function parseExportNamesIntoNames(
   code: string,
-  body: (Statement | ModuleDeclaration)[],
+  body: Program['body'],
   names: Array<string>,
 ): Promise<void> {
   for (let i = 0; i < body.length; i++) {
@@ -246,7 +246,7 @@ async function parseExportNamesIntoNames(
 
 async function transformClientModule(
   code: string,
-  body: (Statement | ModuleDeclaration)[],
+  body: Program['body'],
   url: string,
   clientEntryFiles: Record<string, string>,
 ): Promise<string> {


### PR DESCRIPTION
Don't use `any` for the acorn types.

I've also added a couple of `throw new Error` for unexpected input. Those are a bit more risky as I don't know if the code actually just expected to silently ignore those cases. I'm trusting our CI tests to tell me if this works or not.