### PR TITLE
RSC: Reduce risk of false positives when detecting server actions

### DIFF
--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -8,7 +8,7 @@ export function rscTransformUseServerPlugin(): Plugin {
     transform: async function (code, id) {
       // Do a quick check for the exact string. If it doesn't exist, don't
       // bother parsing.
-      if (!code.includes('use server')) {
+      if (!code.includes("'use server'") && !code.includes('"use server"')) {
         return code
       }
 


### PR DESCRIPTION
The previous implementation would get a false positive for code like this:
```
const str = 'This is a random string that mentions use server'
```
It's still not perfect. But it doesn't have to be. It's just a quick first check before parsing the entire file to an AST