### PR TITLE
chore(rwjs/vite): Rename build script and format source

### DIFF
--- a/packages/vite/build.ts
+++ b/packages/vite/build.ts
@@ -1,13 +1,13 @@
+import { writeFileSync } from 'node:fs'
+
+import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
+import * as esbuild from 'esbuild'
+
 import {
   build,
   defaultBuildOptions,
   defaultIgnorePatterns,
 } from '@redwoodjs/framework-tools'
-
-import { writeFileSync } from 'node:fs'
-import { commonjs } from '@hyrious/esbuild-plugin-commonjs'
-
-import * as esbuild from 'esbuild'
 
 // CJS Build
 await build({
@@ -43,28 +43,43 @@ await esbuild.build({
   conditions: ['react-server'],
   platform: 'node',
   target: ['node20'],
-  // ⭐ Without this plugin, we get "Error: Dynamic require of "util" is not supported"
-  // when trying to run the built files. This plugin will
-  //  "just rewrite that file to replace "require(node-module)" to a toplevel static import statement." (see issue)
+  // Without this plugin, we get "Error: Dynamic require of "util" is not
+  // supported" when trying to run the built files. This plugin will "just
+  // rewrite that file to replace "require(node-module)" to a toplevel static
+  // import statement." (see issue)
   // https://github.com/evanw/esbuild/issues/2113
   // https://github.com/evanw/esbuild/pull/2067
   plugins: [commonjs()],
   logLevel: 'info',
 })
 
-// Place a package.json file with `type: commonjs` in the dist/cjs folder so that
-// all .js files are treated as CommonJS files.
+// Place a package.json file with `type: commonjs` in the dist/cjs folder so
+// that all .js files are treated as CommonJS files.
 writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
 
 // Place a package.json file with `type: module` in the dist folder so that
 // all .js files are treated as ES Module files.
 writeFileSync('dist/package.json', JSON.stringify({ type: 'module' }))
 
-// Add CommonJS types by creating common JS types. Using a .d.ts file, because .d.cts files don't auto resolve
-// Notice I haven't specified thee types in package.json for these - it's following the naming conversion TSC wants.
+// Add CommonJS types by creating common JS types. Using a .d.ts file, because
+// .d.cts files don't auto resolve
+// Notice I haven't specified the types in package.json for these - it's
+// following the naming conversion TSC wants.
 writeFileSync('dist/cjs/index.d.ts', 'export type * from "../index.d.ts"')
-writeFileSync('dist/cjs/buildFeServer.d.ts', 'export type * from "../buildFeServer.d.ts"')
+writeFileSync(
+  'dist/cjs/buildFeServer.d.ts',
+  'export type * from "../buildFeServer.d.ts"',
+)
 writeFileSync('dist/cjs/client.d.ts', 'export type * from "../client.d.ts"')
-writeFileSync('dist/cjs/clientSsr.d.ts', 'export type * from "../clientSsr.d.ts"')
-writeFileSync('dist/cjs/ClientRouter.d.ts', 'export type * from "../ClientRouter.d.ts"')
-writeFileSync('dist/cjs/build/build.d.ts', 'export type * from "../../build/build.d.ts"')
+writeFileSync(
+  'dist/cjs/clientSsr.d.ts',
+  'export type * from "../clientSsr.d.ts"',
+)
+writeFileSync(
+  'dist/cjs/ClientRouter.d.ts',
+  'export type * from "../ClientRouter.d.ts"',
+)
+writeFileSync(
+  'dist/cjs/build/build.d.ts',
+  'export type * from "../../build/build.d.ts"',
+)

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -51,7 +51,7 @@
     "inject"
   ],
   "scripts": {
-    "build": "tsx build.mts && yarn build:types",
+    "build": "tsx build.ts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-vite.tgz",
     "build:types": "tsc --build --verbose ./tsconfig.json",
     "check:attw": "tsx ./attw.ts",


### PR DESCRIPTION
Rename `build.mts` to `build.ts` because that's what we use in other packages that already specify `"type": "module"`

Also format the source of `build.ts` to match our eslint and TSC rules