### PR TITLE
chore(ci): Print full diff when check-test-project-fixture fails

### DIFF
--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -69,6 +69,9 @@ jobs:
             echo 'Untracked files:'
             git status --porcelain | grep '^?? ' | awk '{print "        " $2}'
             echo
+            echo
+            echo 'Full diff:'
+            git diff
             exit 1;
           fi
 


### PR DESCRIPTION
The `check-test-project-fixture` CI job sometimes fails with false positives. It's not super often, but it's still annoying when it happens. 

Seeing the full diff hopefully makes it easier to debug exactly why this is happening.

---

Funnily it actually failed with one of those false positives in this PR 😄

![image](https://github.com/user-attachments/assets/2bad118e-1a3a-49aa-9853-e34cfe91f893)

The package.json diff was expected. But the other one is exactly the error I want to track down and fix