### PR TITLE
fix: Comment out unused import line in seed script template

### DIFF
--- a/__fixtures__/test-project/scripts/seed.ts
+++ b/__fixtures__/test-project/scripts/seed.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { db } from 'api/src/lib/db'
 
 // Manually apply seeds via the `yarn rw prisma db seed` command.

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -27,6 +27,6 @@
     "postcss": "^8.4.41",
     "postcss-loader": "^8.1.1",
     "prettier-plugin-tailwindcss": "^0.5.12",
-    "tailwindcss": "^3.4.7"
+    "tailwindcss": "^3.4.9"
   }
 }

--- a/packages/create-redwood-app/templates/js/scripts/seed.js
+++ b/packages/create-redwood-app/templates/js/scripts/seed.js
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-unused-vars
-import { db } from 'api/src/lib/db'
+// import { db } from 'api/src/lib/db'
 
 // Manually apply seeds via the `yarn rw prisma db seed` command.
 //

--- a/packages/create-redwood-app/templates/ts/scripts/seed.ts
+++ b/packages/create-redwood-app/templates/ts/scripts/seed.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { db } from 'api/src/lib/db'
+// import { db } from 'api/src/lib/db'
 
 // Manually apply seeds via the `yarn rw prisma db seed` command.
 //

--- a/tasks/test-project/codemods/seed.js
+++ b/tasks/test-project/codemods/seed.js
@@ -65,5 +65,13 @@ export default (file, api) => {
   const j = api.jscodeshift
   const root = j(file.source)
 
-  return root.find(j.TryStatement).insertBefore(createPosts).toSource()
+  let newSource = root.find(j.TryStatement).insertBefore(createPosts).toSource()
+
+  // Uncomment the db import line
+  newSource = newSource.replace(
+    "// import { db } from 'api/src/lib/db'",
+    "import { db } from 'api/src/lib/db'",
+  )
+
+  return newSource
 }


### PR DESCRIPTION
We changed the seed script to no include a bunch of actual database steps but still kept it in as comments to show the user an example of how to do it.

I think instead of adding a skip about the unused import we could just comment it out too. Thoughts @cannikin? 