### PR TITLE
chore(ci): Add label to force all CI checks to run

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -9,6 +9,10 @@ outputs:
   ssr:
     description: If SSR-related changes have been made
 
+inputs:
+  labels:
+    required: true
+
 runs:
   using: node20
   main: detectChanges.mjs

--- a/.github/actions/detect-changes/detectChanges.mjs
+++ b/.github/actions/detect-changes/detectChanges.mjs
@@ -232,6 +232,17 @@ async function main() {
     return
   }
 
+  // If the PR has the "force-ci" label, set all to true.
+  const { labels } = JSON.parse(core.getInput('labels'))
+  const hasForceCiLabel = labels.some((label) => label.name === 'force-ci')
+  if (hasForceCiLabel) {
+    console.log('Skipping check because of the "force-ci" label')
+    core.setOutput('code', true)
+    core.setOutput('rsc', true)
+    core.setOutput('ssr', true)
+    return
+  }
+
   const branchName = await getPrBranchName()
   const workflowRun = await getLatestCompletedWorkflowRun(branchName)
   const prCommits = await getCommitsNewerThan(workflowRun?.updated_at)

--- a/.github/workflows/check-test-project-fixture.yml
+++ b/.github/workflows/check-test-project-fixture.yml
@@ -33,6 +33,8 @@ jobs:
       - name: 🔍 Detect changes
         id: detect-changes
         uses: ./.github/actions/detect-changes
+        with:
+          labels: '{ "labels": ${{ toJSON(github.event.pull_request.labels) }} }'
 
   check-test-project-fixture:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - name: 🔍 Detect changes
         id: detect-changes
         uses: ./.github/actions/detect-changes
+        with:
+          labels: '{ "labels": ${{ toJSON(github.event.pull_request.labels) }} }'
 
   check:
     needs: detect-changes


### PR DESCRIPTION
We have logic which narrows down the CI checks that are run based on what code has changed. I have encountered a case where I want more CI to run than is currently being triggered. Rather than change any of the detection logic - which could face resistance - I'll add a label which forces all CI to run.

We can always revert this. 