### PR TITLE
Docs: update GitHub workflow file for running tests

### DIFF
--- a/docs/docs/how-to/test-in-github-actions.md
+++ b/docs/docs/how-to/test-in-github-actions.md
@@ -326,11 +326,12 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: corepack enable
       # install all the dependencies
       - run: yarn install
       # build the redwood app

--- a/docs/docs/how-to/test-in-github-actions.md
+++ b/docs/docs/how-to/test-in-github-actions.md
@@ -226,11 +226,12 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - run: corepack enable
       # install all the dependencies
       - run: yarn install
       # build the redwood app


### PR DESCRIPTION
I tried following the guide and added the workflow to my repo but then the action failed with the following error:
```
error This project's package.json defines "packageManager": "yarn@4.1.0". However the current global version of Yarn is 1.22.22.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
Error: Process completed with exit code 1.
```
I enabled Corepack and the workflow run correctly.

Added the extra step in the docs for the people that might incur in the same issue.
Also updated the `actions/checkout` and `actions/setup-node` to v4.