### PR TITLE
fix(babel-plugins): Handle additional syntax when extracting graphql options

### DIFF
--- a/.changesets/11189.md
+++ b/.changesets/11189.md
@@ -1,0 +1,11 @@
+- fix(babel-plugins): Handle additional syntax when extracting graphql options (#11189) by @Josh-Walker-GM
+
+This fixes an issue with the automatic extraction of options from the `createGraphQLHandler` function when you were wrapping that function within a custom handler function. For example the following would have failed before this fix:
+```ts
+const graphQLHandler = createGraphQLHandler({
+  // ...options
+})
+export const handler = (event, context) => {
+  return graphQLHandler(event, context)
+}
+```

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/aliased-import/code.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/aliased-import/code.js
@@ -1,0 +1,36 @@
+import scuid from 'scuid'
+
+import { createGraphQLHandler as someOtherFunctionName } from '@redwoodjs/graphql-server'
+
+import directives from 'src/directives/**/*.{js,ts}'
+import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
+
+import { db } from 'src/lib/db'
+import { executionContext } from 'src/lib/executionContext'
+import { logger } from 'src/lib/logger'
+
+const graphQLHandler = someOtherFunctionName({
+  loggerConfig: { logger, options: {} },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+})
+
+export const handler = async (event, context) => {
+  const requestIdHeader = 'x-request-id'
+  const requestId = event.headers[requestIdHeader] ?? scuid()
+  const store = new Map([['requestId', requestId]])
+
+  const response = await executionContext.run(store, () =>
+    graphQLHandler(event, context)
+  )
+  return {
+    ...response,
+    headers: { ...(response.headers ?? {}), [requestIdHeader]: requestId },
+  }
+}

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/aliased-import/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/aliased-import/output.js
@@ -1,0 +1,37 @@
+import scuid from 'scuid'
+import { createGraphQLHandler as someOtherFunctionName } from '@redwoodjs/graphql-server'
+import directives from 'src/directives/**/*.{js,ts}'
+import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
+import { db } from 'src/lib/db'
+import { executionContext } from 'src/lib/executionContext'
+import { logger } from 'src/lib/logger'
+export const __rw_graphqlOptions = {
+  loggerConfig: {
+    logger,
+    options: {},
+  },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+}
+const graphQLHandler = someOtherFunctionName(__rw_graphqlOptions)
+export const handler = async (event, context) => {
+  const requestIdHeader = 'x-request-id'
+  const requestId = event.headers[requestIdHeader] ?? scuid()
+  const store = new Map([['requestId', requestId]])
+  const response = await executionContext.run(store, () =>
+    graphQLHandler(event, context)
+  )
+  return {
+    ...response,
+    headers: {
+      ...(response.headers ?? {}),
+      [requestIdHeader]: requestId,
+    },
+  }
+}

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/wrapper-function/code.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/wrapper-function/code.js
@@ -1,0 +1,36 @@
+import scuid from 'scuid'
+
+import { createGraphQLHandler } from '@redwoodjs/graphql-server'
+
+import directives from 'src/directives/**/*.{js,ts}'
+import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
+
+import { db } from 'src/lib/db'
+import { executionContext } from 'src/lib/executionContext'
+import { logger } from 'src/lib/logger'
+
+const graphQLHandler = createGraphQLHandler({
+  loggerConfig: { logger, options: {} },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+})
+
+export const handler = async (event, context) => {
+  const requestIdHeader = 'x-request-id'
+  const requestId = event.headers[requestIdHeader] ?? scuid()
+  const store = new Map([['requestId', requestId]])
+
+  const response = await executionContext.run(store, () =>
+    graphQLHandler(event, context)
+  )
+  return {
+    ...response,
+    headers: { ...(response.headers ?? {}), [requestIdHeader]: requestId },
+  }
+}

--- a/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/wrapper-function/output.js
+++ b/packages/babel-config/src/plugins/__tests__/__fixtures__/graphql-options-extract/wrapper-function/output.js
@@ -1,0 +1,37 @@
+import scuid from 'scuid'
+import { createGraphQLHandler } from '@redwoodjs/graphql-server'
+import directives from 'src/directives/**/*.{js,ts}'
+import sdls from 'src/graphql/**/*.sdl.{js,ts}'
+import services from 'src/services/**/*.{js,ts}'
+import { db } from 'src/lib/db'
+import { executionContext } from 'src/lib/executionContext'
+import { logger } from 'src/lib/logger'
+export const __rw_graphqlOptions = {
+  loggerConfig: {
+    logger,
+    options: {},
+  },
+  directives,
+  sdls,
+  services,
+  onException: () => {
+    // Disconnect from your database with an unhandled exception.
+    db.$disconnect()
+  },
+}
+const graphQLHandler = createGraphQLHandler(__rw_graphqlOptions)
+export const handler = async (event, context) => {
+  const requestIdHeader = 'x-request-id'
+  const requestId = event.headers[requestIdHeader] ?? scuid()
+  const store = new Map([['requestId', requestId]])
+  const response = await executionContext.run(store, () =>
+    graphQLHandler(event, context)
+  )
+  return {
+    ...response,
+    headers: {
+      ...(response.headers ?? {}),
+      [requestIdHeader]: requestId,
+    },
+  }
+}

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-graphql-options-extract.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-graphql-options-extract.ts
@@ -1,6 +1,6 @@
-import type { PluginObj, PluginPass, types } from '@babel/core'
+import type { NodePath, PluginObj, PluginPass, types} from '@babel/core'
 
-// This extracts the options passed to the graphql function and stores them in a file so they can be imported elsewhere.
+// This extracts the options passed to the graphql function and stores them in an exported variable so they can be imported elsewhere.
 
 const exportVariableName = '__rw_graphqlOptions' as const
 
@@ -32,36 +32,59 @@ function optionsConstNode(
 }
 
 export default function ({ types: t }: { types: typeof types }): PluginObj {
+
   return {
     name: 'babel-plugin-redwood-graphql-options-extract',
     visitor: {
-      ExportNamedDeclaration(path, state) {
-        const declaration = path.node.declaration
-        if (declaration?.type !== 'VariableDeclaration') {
+      Program(path, state) {
+        // Find all imports of the 'createGraphQLHandler' function from '@redwoodjs/graphql-server'
+        const importNames = new Set<string>()
+        path.traverse({
+          ImportDeclaration(p) {
+            if (t.isStringLiteral(p.node.source, { value: '@redwoodjs/graphql-server' })) {
+              for (const specifier of p.node.specifiers) {
+                if (t.isImportSpecifier(specifier) && t.isIdentifier(specifier.imported) && specifier.imported.name === 'createGraphQLHandler') {
+                  importNames.add(specifier.local.name)
+                }
+              }
+            }
+          },
+        })
+
+        // Find all calls to the 'createGraphQLHandler' function
+        const callExpressionPaths: NodePath<types.CallExpression>[] = []
+        path.traverse({
+          CallExpression(p) {
+            if (t.isIdentifier(p.node.callee) && importNames.has(p.node.callee.name)) {
+              callExpressionPaths.push(p)
+            }
+          },
+        })
+        if (callExpressionPaths.length > 1) {
+          console.log(`There are ${callExpressionPaths.length} calls to 'createGraphQLHandler' in '${state.file.opts.filename}'. The automatic extraction of graphql options will fallback to the first usage.`)
+          return
+        }
+        const callExpressionPath = callExpressionPaths[0]
+        if (!callExpressionPath) {
           return
         }
 
-        const declarator = declaration.declarations[0]
-        if (declarator?.type !== 'VariableDeclarator') {
-          return
-        }
+        // Extract the options into a new exported variable
+        const options = callExpressionPath.node.arguments[0]
 
-        const identifier = declarator.id
-        if (identifier?.type !== 'Identifier') {
-          return
+        // Insert the new variable declaration
+        const optionsConst = optionsConstNode(t, options, state)
+        const statementParent =
+          callExpressionPath.getStatementParent()
+        if (!statementParent) {
+          throw new Error(
+            `Unable to find statement parent for graphql function in '${state.file.opts.filename}'`,
+          )
         }
-        if (identifier.name !== 'handler') {
-          return
-        }
+        statementParent.insertBefore(optionsConst)
 
-        const init = declarator.init
-        if (init?.type !== 'CallExpression') {
-          return
-        }
-
-        const options = init.arguments[0]
-        path.insertBefore(optionsConstNode(t, options, state))
-        init.arguments[0] = t.identifier(exportVariableName)
+        // Replace the first argument with the new variable identifier
+        callExpressionPath.node.arguments[0] = t.identifier(exportVariableName)
       },
     },
   }

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-graphql-options-extract.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-graphql-options-extract.ts
@@ -1,4 +1,4 @@
-import type { NodePath, PluginObj, PluginPass, types} from '@babel/core'
+import type { NodePath, PluginObj, PluginPass, types } from '@babel/core'
 
 // This extracts the options passed to the graphql function and stores them in an exported variable so they can be imported elsewhere.
 
@@ -32,7 +32,6 @@ function optionsConstNode(
 }
 
 export default function ({ types: t }: { types: typeof types }): PluginObj {
-
   return {
     name: 'babel-plugin-redwood-graphql-options-extract',
     visitor: {
@@ -41,9 +40,17 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         const importNames = new Set<string>()
         path.traverse({
           ImportDeclaration(p) {
-            if (t.isStringLiteral(p.node.source, { value: '@redwoodjs/graphql-server' })) {
+            if (
+              t.isStringLiteral(p.node.source, {
+                value: '@redwoodjs/graphql-server',
+              })
+            ) {
               for (const specifier of p.node.specifiers) {
-                if (t.isImportSpecifier(specifier) && t.isIdentifier(specifier.imported) && specifier.imported.name === 'createGraphQLHandler') {
+                if (
+                  t.isImportSpecifier(specifier) &&
+                  t.isIdentifier(specifier.imported) &&
+                  specifier.imported.name === 'createGraphQLHandler'
+                ) {
                   importNames.add(specifier.local.name)
                 }
               }
@@ -55,13 +62,18 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
         const callExpressionPaths: NodePath<types.CallExpression>[] = []
         path.traverse({
           CallExpression(p) {
-            if (t.isIdentifier(p.node.callee) && importNames.has(p.node.callee.name)) {
+            if (
+              t.isIdentifier(p.node.callee) &&
+              importNames.has(p.node.callee.name)
+            ) {
               callExpressionPaths.push(p)
             }
           },
         })
         if (callExpressionPaths.length > 1) {
-          console.log(`There are ${callExpressionPaths.length} calls to 'createGraphQLHandler' in '${state.file.opts.filename}'. The automatic extraction of graphql options will fallback to the first usage.`)
+          console.log(
+            `There are ${callExpressionPaths.length} calls to 'createGraphQLHandler' in '${state.file.opts.filename}'. The automatic extraction of graphql options will fallback to the first usage.`,
+          )
           return
         }
         const callExpressionPath = callExpressionPaths[0]
@@ -74,8 +86,7 @@ export default function ({ types: t }: { types: typeof types }): PluginObj {
 
         // Insert the new variable declaration
         const optionsConst = optionsConstNode(t, options, state)
-        const statementParent =
-          callExpressionPath.getStatementParent()
+        const statementParent = callExpressionPath.getStatementParent()
         if (!statementParent) {
           throw new Error(
             `Unable to find statement parent for graphql function in '${state.file.opts.filename}'`,


### PR DESCRIPTION
Fixes #11153. See that issue for additional information.