### PR TITLE
chore(lint): Remove override for 'unused-imports/no-unused-imports'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -399,11 +399,7 @@ module.exports = {
       },
     },
     {
-      files: [
-        'packages/create-redwood-app/templates/js/scripts/seed.js',
-        'packages/create-redwood-app/templates/ts/scripts/seed.ts',
-        'packages/testing/src/web/global.ts',
-      ],
+      files: ['packages/testing/src/web/global.ts'],
       rules: {
         'unused-imports/no-unused-imports': 'off',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -398,11 +398,5 @@ module.exports = {
         ],
       },
     },
-    {
-      files: ['packages/testing/src/web/global.ts'],
-      rules: {
-        'unused-imports/no-unused-imports': 'off',
-      },
-    },
   ],
 }

--- a/packages/testing/src/web/global.ts
+++ b/packages/testing/src/web/global.ts
@@ -1,7 +1,6 @@
 import type {
   mockGraphQLQuery as _mockGraphQLQuery,
   mockGraphQLMutation as _mockGraphQLMutation,
-  mockCurrentUser as _mockCurrentUser,
 } from './mockRequests'
 
 declare global {


### PR DESCRIPTION
As title. It's best to reduce the amount of config if we don't strictly need it. I have checked that the removal of the unused import that was highlighted after this change doesn't cause any issues. 