### PR TITLE
chore(linting): Remove/fix references to non-existant files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -293,7 +293,7 @@ module.exports = {
     },
     // Entry.js rules
     {
-      files: ['packages/web/src/entry/index.js'],
+      files: ['packages/web/src/entry/index.jsx'],
       env: {
         browser: true,
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,6 @@ module.exports = {
     'packages/babel-config/src/__tests__/__fixtures__/**/*',
     'packages/codemods/**/__testfixtures__/**/*',
     'packages/cli/**/__testfixtures__/**/*',
-    'packages/studio/dist-*/**/*',
   ],
   plugins: [
     'unused-imports',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,10 +42,8 @@ module.exports = {
     'fixtures',
     'packages/babel-config/src/plugins/__tests__/__fixtures__/**/*',
     'packages/babel-config/src/__tests__/__fixtures__/**/*',
-    'packages/core/**/__fixtures__/**/*',
     'packages/codemods/**/__testfixtures__/**/*',
     'packages/cli/**/__testfixtures__/**/*',
-    'packages/core/config/storybook/**/*',
     'packages/studio/dist-*/**/*',
   ],
   plugins: [
@@ -317,7 +315,6 @@ module.exports = {
         'packages/api/src/**',
         'packages/api-server/src/**',
         'packages/cli/src/**',
-        'packages/core/config/**',
         'packages/create-redwood-app/src/*.js',
         'packages/internal/src/**',
         'packages/prerender/src/**',
@@ -371,11 +368,7 @@ module.exports = {
     },
     // Allow computed member access on process.env in NodeJS contexts and tests
     {
-      files: [
-        'packages/core/config/webpack.common.js',
-        'packages/testing/**',
-        'packages/vite/src/index.ts',
-      ],
+      files: ['packages/testing/**', 'packages/vite/src/index.ts'],
       rules: {
         '@redwoodjs/process-env-computed': 'off',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -207,13 +207,6 @@ module.exports = {
       },
     },
     {
-      files: [
-        'web/src/**/*.routeHooks.{js,ts}',
-        'web/src/entry.server.{jsx,tsx}',
-      ],
-      rules: { 'no-restricted-imports': 'off' },
-    },
-    {
       extends: ['plugin:@typescript-eslint/stylistic'],
       files: ['*.ts', '*.tsx'],
       rules: {


### PR DESCRIPTION
1. Removes references to files/folders which no longer exist
2. Fixes a reference to a file which has been renamed
3. Removed an override designed for users projects rather than the framework