### PR TITLE
chore(formatting): Remove 'insert_final_newline' from editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,6 @@ root = true
 
 [*]
 end_of_line = lf
-insert_final_newline = true
 charset = utf-8
 
 [*.{js,jsx,ts,tsx,graphql,sql,md,html,mjml,json,jsonc,json5,yml,yaml,template,sh,Dockerfile}]


### PR DESCRIPTION
This setting isn't respected by prettier and I don't wish to end up in a situation where one setting is fighting another. 