### PR TITLE
chore(formatting): Add prettier check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: 🔎 Lint
         run: yarn lint
 
-      - name: 📝 Formatting
+      - name: 📝 Check formatting (prettier)
         run: yarn format:check
 
       - name: 🥡 Check packaging and attw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: 🔎 Lint
         run: yarn lint
 
+      - name: 📝 Formatting
+        run: yarn format:check
+
       - name: 🥡 Check packaging and attw
         run: yarn check:package
 


### PR DESCRIPTION
Runs `yarn format:check` into CI to prevent merging unformatted code. 