### PR TITLE
feat(rsc): Register top-level function-scoped RSAs

### DIFF
--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
@@ -1,14 +1,6 @@
 import { vol } from 'memfs'
 import type { TransformPluginContext } from 'rollup'
-import {
-  afterAll,
-  beforeAll,
-  describe,
-  it,
-  expect,
-  vi,
-  afterEach,
-} from 'vitest'
+import { afterAll, beforeAll, describe, it, expect, vi } from 'vitest'
 
 import { rscTransformUseServerPlugin } from '../vite-plugin-rsc-transform-server.js'
 
@@ -44,34 +36,564 @@ function getPluginTransform() {
 const pluginTransform = getPluginTransform()
 
 describe('rscTransformUseServerPlugin function scoped "use server"', () => {
-  it('should handle top-level exported named function', async () => {
-    const id = 'some/path/to/actions.ts'
-    const input = `
-      import fs from 'node:fs'
+  describe('top-level exports', () => {
+    it('should handle named function', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
 
-      export async function formAction(formData: FormData) {
-        'use server'
+        export async function formAction(formData: FormData) {
+          'use server'
 
-        await fs.promises.writeFile(
-          'settings.json',
-          \`{ "delay": \${formData.get('delay')} }\n\`
-        )
-      }`
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }`.trim()
 
-    const output = await pluginTransform(input, id)
+      const output = await pluginTransform(input, id)
 
-    if (typeof output !== 'string') {
-      throw new Error('Expected output to be a string')
-    }
+      if (typeof output !== 'string') {
+        throw new Error('Expected output to be a string')
+      }
 
-    expect(output).toContain(
-      'import {registerServerReference} from "react-server-dom-webpack/server";',
-    )
-    expect(output).toContain(
-      `registerServerReference(formAction,"${id}","formAction");`,
-    )
-    // One import and (exactly) one call to registerServerReference, so two
-    // matches
-    expect(output.match(/registerServerReference/g)).toHaveLength(2)
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              export async function formAction(formData: FormData) {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+        import {registerServerReference} from "react-server-dom-webpack/server";
+        registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+        "
+      `)
+    })
+
+    it('should handle arrow function', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
+
+        export const formAction = async (formData: FormData) => {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      if (typeof output !== 'string') {
+        throw new Error('Expected output to be a string')
+      }
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              export const formAction = async (formData: FormData) => {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+        import {registerServerReference} from "react-server-dom-webpack/server";
+        if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+        "
+      `)
+    })
+
+    it('should handle default exported named function', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
+
+        export default async function formAction(formData: FormData) {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      if (typeof output !== 'string') {
+        throw new Error('Expected output to be a string')
+      }
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              export default async function formAction(formData: FormData) {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+        import {registerServerReference} from "react-server-dom-webpack/server";
+        registerServerReference(formAction,"some/path/to/actions.ts","default");
+        "
+      `)
+    })
+
+    it('should handle exports with two consts', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
+
+        export const fortyTwo = () => { 'use server'; return 42 }, formAction = async (formData: FormData) => {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              export const fortyTwo = () => { 'use server'; return 42 }, formAction = async (formData: FormData) => {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+        import {registerServerReference} from "react-server-dom-webpack/server";
+        if (typeof fortyTwo === "function") registerServerReference(fortyTwo,"some/path/to/actions.ts","fortyTwo");
+        if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+        "
+      `)
+    })
+
+    it('should handle named function and arrow function with separate export', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
+
+        export { formAction, arrowAction }
+
+        async function formAction(formData: FormData) {
+          // A comment with 'use server' in it
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }
+
+        const arrowAction = async (formData: FormData) => {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              export { formAction, arrowAction }
+
+              async function formAction(formData: FormData) {
+                // A comment with 'use server' in it
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+              const arrowAction = async (formData: FormData) => {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+              import {registerServerReference} from "react-server-dom-webpack/server";
+              registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+              registerServerReference(arrowAction,"some/path/to/actions.ts","arrowAction");
+              "
+      `)
+    })
+
+    it('should handle separate renamed export', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
+
+        async function formAction(formData: FormData) {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }
+
+        const arrowAction = async (formData: FormData) => {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }
+
+        export { formAction as fA, arrowAction }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              async function formAction(formData: FormData) {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+              const arrowAction = async (formData: FormData) => {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+              export { formAction as fA, arrowAction }
+
+        import {registerServerReference} from "react-server-dom-webpack/server";
+        registerServerReference(formAction,"some/path/to/actions.ts","fA");
+        registerServerReference(arrowAction,"some/path/to/actions.ts","arrowAction");
+        "
+      `)
+    })
+
+    it.todo('should handle default exported arrow function', async () => {
+      const id = 'some/path/to/actions.ts'
+      const input = `
+        import fs from 'node:fs'
+
+        export default const formAction = async (formData: FormData) => {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      if (typeof output !== 'string') {
+        throw new Error('Expected output to be a string')
+      }
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs'
+
+              export const formAction = async (formData: FormData) => {
+                'use server'
+
+                await fs.promises.writeFile(
+                  'settings.json',
+                  \`{ "delay": \${formData.get('delay')} }\`
+                )
+              }
+
+        import {registerServerReference} from "react-server-dom-webpack/server";
+        if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+        "
+      `)
+    })
+
+    describe('without "use server"', () => {
+      it('should not register named function', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          // A comment with 'use server' in it
+          export async function formAction(formData: FormData) {
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        if (typeof output !== 'string') {
+          throw new Error('Expected output to be a string')
+        }
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                    // A comment with 'use server' in it
+                    export async function formAction(formData: FormData) {
+                      await fs.promises.writeFile(
+                        'settings.json',
+                        \`{ "delay": \${formData.get('delay')} }\`
+                      )
+                    }"
+        `)
+      })
+
+      it('should not register arrow function', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          // A comment with 'use server' in it
+          export const formAction = async (formData: FormData) => {
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        if (typeof output !== 'string') {
+          throw new Error('Expected output to be a string')
+        }
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                    // A comment with 'use server' in it
+                    export const formAction = async (formData: FormData) => {
+                      await fs.promises.writeFile(
+                        'settings.json',
+                        \`{ "delay": \${formData.get('delay')} }\`
+                      )
+                    }"
+        `)
+      })
+
+      it('should not register default exported named function', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          // A comment with 'use server' in it
+          export default async function formAction(formData: FormData) {
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        if (typeof output !== 'string') {
+          throw new Error('Expected output to be a string')
+        }
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                    // A comment with 'use server' in it
+                    export default async function formAction(formData: FormData) {
+                      await fs.promises.writeFile(
+                        'settings.json',
+                        \`{ "delay": \${formData.get('delay')} }\`
+                      )
+                    }"
+        `)
+      })
+
+      it('should not register exports with two consts', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          export const fortyTwo = () => 42, formAction = async (formData: FormData) => {
+            'use server'
+
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                export const fortyTwo = () => 42, formAction = async (formData: FormData) => {
+                  'use server'
+
+                  await fs.promises.writeFile(
+                    'settings.json',
+                    \`{ "delay": \${formData.get('delay')} }\`
+                  )
+                }
+
+          import {registerServerReference} from "react-server-dom-webpack/server";
+          if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+          "
+        `)
+      })
+
+      it('should not register named function and arrow function with separate export', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          export { formAction, arrowAction }
+
+          async function formAction(formData: FormData) {
+            // A comment with 'use server' in it
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }
+
+          const arrowAction = async (formData: FormData) => {
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                export { formAction, arrowAction }
+
+                async function formAction(formData: FormData) {
+                  // A comment with 'use server' in it
+                  await fs.promises.writeFile(
+                    'settings.json',
+                    \`{ "delay": \${formData.get('delay')} }\`
+                  )
+                }
+
+                const arrowAction = async (formData: FormData) => {
+                  await fs.promises.writeFile(
+                    'settings.json',
+                    \`{ "delay": \${formData.get('delay')} }\`
+                  )
+                }"
+        `)
+      })
+
+      it('should not register separate renamed export', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          async function formAction(formData: FormData) {
+            // A comment with 'use server' in it
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }
+
+          const arrowAction = async (formData: FormData) => {
+            // A comment with 'use server' in it
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }
+
+          export { formAction as fA, arrowAction }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                async function formAction(formData: FormData) {
+                  // A comment with 'use server' in it
+                  await fs.promises.writeFile(
+                    'settings.json',
+                    \`{ "delay": \${formData.get('delay')} }\`
+                  )
+                }
+
+                const arrowAction = async (formData: FormData) => {
+                  // A comment with 'use server' in it
+                  await fs.promises.writeFile(
+                    'settings.json',
+                    \`{ "delay": \${formData.get('delay')} }\`
+                  )
+                }
+
+                export { formAction as fA, arrowAction }"
+        `)
+      })
+
+      it('should not register default exported arrow function', async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+          import fs from 'node:fs'
+
+          export default async (formData: FormData) => {
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }`.trim()
+
+        const output = await pluginTransform(input, id)
+
+        if (typeof output !== 'string') {
+          throw new Error('Expected output to be a string')
+        }
+
+        expect(output).toMatchInlineSnapshot(`
+          "import fs from 'node:fs'
+
+                    export default async (formData: FormData) => {
+                      await fs.promises.writeFile(
+                        'settings.json',
+                        \`{ "delay": \${formData.get('delay')} }\`
+                      )
+                    }"
+        `)
+      })
+    })
   })
 })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
@@ -1,0 +1,77 @@
+import { vol } from 'memfs'
+import type { TransformPluginContext } from 'rollup'
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+} from 'vitest'
+
+import { rscTransformUseServerPlugin } from '../vite-plugin-rsc-transform-server.js'
+
+vi.mock('fs', async () => ({ default: (await import('memfs')).fs }))
+
+const RWJS_CWD = process.env.RWJS_CWD
+
+beforeAll(() => {
+  process.env.RWJS_CWD = '/Users/tobbe/rw-app/'
+
+  // Add a toml entry for getPaths et al.
+  vol.fromJSON({ 'redwood.toml': '' }, process.env.RWJS_CWD)
+})
+
+afterAll(() => {
+  process.env.RWJS_CWD = RWJS_CWD
+})
+
+function getPluginTransform() {
+  const plugin = rscTransformUseServerPlugin()
+
+  if (typeof plugin.transform !== 'function') {
+    throw new Error('Plugin does not have a transform function')
+  }
+
+  // Calling `bind` to please TS
+  // See https://stackoverflow.com/a/70463512/88106
+  // Typecasting because we're only going to call transform, and we don't need
+  // anything provided by the context.
+  return plugin.transform.bind({} as TransformPluginContext)
+}
+
+const pluginTransform = getPluginTransform()
+
+describe('rscTransformUseServerPlugin function scoped "use server"', () => {
+  it('should handle top-level exported named function', async () => {
+    const id = 'some/path/to/actions.ts'
+    const input = `
+      import fs from 'node:fs'
+
+      export async function formAction(formData: FormData) {
+        'use server'
+
+        await fs.promises.writeFile(
+          'settings.json',
+          \`{ "delay": \${formData.get('delay')} }\n\`
+        )
+      }`
+
+    const output = await pluginTransform(input, id)
+
+    if (typeof output !== 'string') {
+      throw new Error('Expected output to be a string')
+    }
+
+    expect(output).toContain(
+      'import {registerServerReference} from "react-server-dom-webpack/server";',
+    )
+    expect(output).toContain(
+      `registerServerReference(formAction,"${id}","formAction");`,
+    )
+    // One import and (exactly) one call to registerServerReference, so two
+    // matches
+    expect(output.match(/registerServerReference/g)).toHaveLength(2)
+  })
+})

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -181,12 +181,7 @@ function transformServerFunction(
           // Check if the body contains a "use server" directive as the first
           // statement.
           const firstStmt = node.declaration.body.stmts[0]
-          if (
-            firstStmt &&
-            firstStmt.type === 'ExpressionStatement' &&
-            firstStmt.expression.type === 'StringLiteral' &&
-            firstStmt.expression.value === 'use server'
-          ) {
+          if (isUseServerDirective(firstStmt)) {
             localNames.set(name, name)
             localTypes.set(name, 'function')
           }
@@ -201,12 +196,7 @@ function transformServerFunction(
             ) {
               const firstStmt = declaration.init.body.stmts[0]
 
-              if (
-                firstStmt &&
-                firstStmt.type === 'ExpressionStatement' &&
-                firstStmt.expression.type === 'StringLiteral' &&
-                firstStmt.expression.value === 'use server'
-              ) {
+              if (isUseServerDirective(firstStmt)) {
                 const name = declaration.id.value
                 localNames.set(name, name)
               }
@@ -225,12 +215,7 @@ function transformServerFunction(
         ) {
           const firstStmt = node.decl.body.stmts[0]
 
-          if (
-            firstStmt &&
-            firstStmt.type === 'ExpressionStatement' &&
-            firstStmt.expression.type === 'StringLiteral' &&
-            firstStmt.expression.value === 'use server'
-          ) {
+          if (isUseServerDirective(firstStmt)) {
             const identifier = node.decl.identifier
             if (identifier) {
               localNames.set(identifier.value, 'default')
@@ -271,12 +256,7 @@ function transformServerFunction(
         if (node.body?.type === 'BlockStatement') {
           const firstStmt = node.body.stmts[0]
 
-          if (
-            firstStmt &&
-            firstStmt.type === 'ExpressionStatement' &&
-            firstStmt.expression.type === 'StringLiteral' &&
-            firstStmt.expression.value === 'use server'
-          ) {
+          if (isUseServerDirective(firstStmt)) {
             serverActions.add(name)
           }
         }
@@ -295,12 +275,7 @@ function transformServerFunction(
           ) {
             const firstStmt = declaration.init.body.stmts[0]
 
-            if (
-              firstStmt &&
-              firstStmt.type === 'ExpressionStatement' &&
-              firstStmt.expression.type === 'StringLiteral' &&
-              firstStmt.expression.value === 'use server'
-            ) {
+            if (isUseServerDirective(firstStmt)) {
               serverActions.add(declaration.id.value)
             }
           }
@@ -338,4 +313,13 @@ function transformServerFunction(
   })
 
   return newSrc
+}
+
+function isUseServerDirective(stmt: swc.Statement | undefined): boolean {
+  return (
+    !!stmt &&
+    stmt.type === 'ExpressionStatement' &&
+    stmt.expression.type === 'StringLiteral' &&
+    stmt.expression.value === 'use server'
+  )
 }

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -65,6 +65,53 @@ export function rscTransformUseServerPlugin(): Plugin {
   }
 }
 
+function addLocalExportedNames(
+  names: Map<string, string>,
+  node: Pattern | AssignmentProperty | Expression,
+) {
+  switch (node.type) {
+    case 'Identifier':
+      names.set(node.name, node.name)
+      return
+
+    case 'ObjectPattern':
+      for (let i = 0; i < node.properties.length; i++) {
+        addLocalExportedNames(names, node.properties[i])
+      }
+
+      return
+
+    case 'ArrayPattern':
+      for (let i = 0; i < node.elements.length; i++) {
+        const element = node.elements[i]
+        if (element) {
+          addLocalExportedNames(names, element)
+        }
+      }
+
+      return
+
+    case 'Property':
+      addLocalExportedNames(names, node.value)
+      return
+
+    case 'AssignmentPattern':
+      addLocalExportedNames(names, node.left)
+      return
+
+    case 'RestElement':
+      addLocalExportedNames(names, node.argument)
+      return
+
+    case 'ParenthesizedExpression':
+      addLocalExportedNames(names, node.expression)
+      return
+
+    default:
+      throw new Error(`Unsupported node type: ${node.type}`)
+  }
+}
+
 function transformServerModule(
   mod: swc.Module,
   url: string,

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -182,6 +182,7 @@ function transformServerFunction(
           // statement.
           const firstStmt = node.declaration.body.stmts[0]
           if (
+            firstStmt &&
             firstStmt.type === 'ExpressionStatement' &&
             firstStmt.expression.type === 'StringLiteral' &&
             firstStmt.expression.value === 'use server'
@@ -201,6 +202,7 @@ function transformServerFunction(
               const firstStmt = declaration.init.body.stmts[0]
 
               if (
+                firstStmt &&
                 firstStmt.type === 'ExpressionStatement' &&
                 firstStmt.expression.type === 'StringLiteral' &&
                 firstStmt.expression.value === 'use server'
@@ -224,6 +226,7 @@ function transformServerFunction(
           const firstStmt = node.decl.body.stmts[0]
 
           if (
+            firstStmt &&
             firstStmt.type === 'ExpressionStatement' &&
             firstStmt.expression.type === 'StringLiteral' &&
             firstStmt.expression.value === 'use server'
@@ -269,6 +272,7 @@ function transformServerFunction(
           const firstStmt = node.body.stmts[0]
 
           if (
+            firstStmt &&
             firstStmt.type === 'ExpressionStatement' &&
             firstStmt.expression.type === 'StringLiteral' &&
             firstStmt.expression.value === 'use server'
@@ -292,6 +296,7 @@ function transformServerFunction(
             const firstStmt = declaration.init.body.stmts[0]
 
             if (
+              firstStmt &&
               firstStmt.type === 'ExpressionStatement' &&
               firstStmt.expression.type === 'StringLiteral' &&
               firstStmt.expression.value === 'use server'


### PR DESCRIPTION
This PR adds support for specifying `'use server'` inside top-level functions.

```ts
async function formAction(formData: FormData) {
  'use server'

  await fs.promises.writeFile(
    'settings.json',
    `{ "delay": ${formData.get('delay')} }\n`
  )
}
```

Still no support for inline functions