### PR TITLE
chore(lint): enable 'typescript-eslint/prefer-find'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -225,7 +225,6 @@ module.exports = {
         '@typescript-eslint/no-base-to-string': 'off',
         '@typescript-eslint/no-duplicate-type-constituents': 'off',
         '@typescript-eslint/unbound-method': 'off',
-        '@typescript-eslint/prefer-find': 'off',
       },
     },
     {

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-routes-auto-loader.ts
@@ -77,9 +77,12 @@ export default function (
           importStatementPath(p.node.source?.value),
         )
 
-        const defaultSpecifier = p.node.specifiers.filter((specifiers) =>
+        const defaultSpecifier = p.node.specifiers.find((specifiers) =>
           t.isImportDefaultSpecifier(specifiers),
-        )[0]
+        )
+        if (!defaultSpecifier) {
+          return
+        }
 
         // Remove Page imports in prerender mode (see babel-preset)
         // The removed imports will be replaced further down in this file


### PR DESCRIPTION
Enables the `@typescript-eslint/prefer-find` rule and addresses any errors that resulted.