### PR TITLE
chore(lint): enable '@typescript-eslint/only-throw-error'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -208,7 +208,6 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         '@typescript-eslint/no-unsafe-enum-comparison': 'off',
         '@typescript-eslint/dot-notation': 'off',
-        '@typescript-eslint/only-throw-error': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/prefer-optional-chain': 'off',

--- a/packages/auth/src/__tests__/AuthProvider.test.tsx
+++ b/packages/auth/src/__tests__/AuthProvider.test.tsx
@@ -649,7 +649,7 @@ describe('Custom auth provider', () => {
 
   test("getToken doesn't fail if client throws an error", async () => {
     mockedTestAuthClient.getToken.mockImplementation(() => {
-      throw 'Login Required'
+      throw new Error('Login Required')
     })
     const auth = await getCustomTestAuth()
 

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodError.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodError.test.ts
@@ -1,7 +1,10 @@
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 import { CurrencyDefinition, CurrencyResolver } from 'graphql-scalars'
 
-import { RedwoodError, EmailValidationError } from '@redwoodjs/api'
+import type {
+  RedwoodError as RedwoodErrorType,
+  EmailValidationError as EmailValidationErrorType,
+} from '@redwoodjs/api'
 import { createLogger } from '@redwoodjs/api/logger'
 
 import { createGraphQLHandler } from '../../functions/graphql'
@@ -15,6 +18,10 @@ jest.mock('../../makeMergedSchema', () => {
   } = require('@redwoodjs/graphql-server/dist/errors')
 
   const { CurrencyResolver } = require('graphql-scalars')
+  const { RedwoodError, EmailValidationError } = require('@redwoodjs/api') as {
+    RedwoodError: typeof RedwoodErrorType
+    EmailValidationError: typeof EmailValidationErrorType
+  }
 
   class WeatherError extends RedwoodError {
     constructor(message: string, extensions?: Record<string, any>) {

--- a/packages/graphql-server/src/plugins/__tests__/useRedwoodError.test.ts
+++ b/packages/graphql-server/src/plugins/__tests__/useRedwoodError.test.ts
@@ -1,6 +1,7 @@
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 import { CurrencyDefinition, CurrencyResolver } from 'graphql-scalars'
 
+import { RedwoodError, EmailValidationError } from '@redwoodjs/api'
 import { createLogger } from '@redwoodjs/api/logger'
 
 import { createGraphQLHandler } from '../../functions/graphql'
@@ -12,7 +13,6 @@ jest.mock('../../makeMergedSchema', () => {
     ForbiddenError,
     RedwoodGraphQLError,
   } = require('@redwoodjs/graphql-server/dist/errors')
-  const { EmailValidationError, RedwoodError } = require('@redwoodjs/api')
 
   const { CurrencyResolver } = require('graphql-scalars')
 

--- a/packages/prerender/src/errors.tsx
+++ b/packages/prerender/src/errors.tsx
@@ -1,11 +1,12 @@
 import type { DocumentNode } from 'graphql'
 import { print } from 'graphql'
 
-export class PrerenderGqlError {
+export class PrerenderGqlError extends Error {
   message: string
   stack: string
 
   constructor(message: string) {
+    super('GQL error: ' + message)
     this.message = 'GQL error: ' + message
     // The stacktrace would just point to this file, which isn't helpful,
     // because that's not where the error is. So we're just putting the
@@ -14,11 +15,12 @@ export class PrerenderGqlError {
   }
 }
 
-export class GqlHandlerImportError {
+export class GqlHandlerImportError extends Error {
   message: string
   stack: string
 
   constructor(message: string) {
+    super('Gql Handler Import Error:  ' + message)
     this.message = 'Gql Handler Import Error:  ' + message
     // The stacktrace would just point to this file, which isn't helpful,
     // because that's not where the error is. So we're just putting the

--- a/packages/prerender/src/errors.tsx
+++ b/packages/prerender/src/errors.tsx
@@ -2,12 +2,10 @@ import type { DocumentNode } from 'graphql'
 import { print } from 'graphql'
 
 export class PrerenderGqlError extends Error {
-  message: string
   stack: string
 
   constructor(message: string) {
     super('GQL error: ' + message)
-    this.message = 'GQL error: ' + message
     // The stacktrace would just point to this file, which isn't helpful,
     // because that's not where the error is. So we're just putting the
     // message there as well
@@ -16,12 +14,10 @@ export class PrerenderGqlError extends Error {
 }
 
 export class GqlHandlerImportError extends Error {
-  message: string
   stack: string
 
   constructor(message: string) {
     super('Gql Handler Import Error:  ' + message)
-    this.message = 'Gql Handler Import Error:  ' + message
     // The stacktrace would just point to this file, which isn't helpful,
     // because that's not where the error is. So we're just putting the
     // message there as well

--- a/packages/web/src/components/cell/createSuspendingCell.tsx
+++ b/packages/web/src/components/cell/createSuspendingCell.tsx
@@ -107,7 +107,10 @@ export function createSuspendingCell<
     const FailureComponent = ({ error, resetErrorBoundary }: FallbackProps) => {
       if (!Failure) {
         // So that it bubbles up to the nearest error boundary
-        throw error
+        if (error) {
+          throw error
+        }
+        throw new Error('Unreachable code: FailureComponent without a Failure')
       }
 
       const queryResultWithErrorReset = {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.compilerOption.json",
-  "exclude": ["dist", "node_modules", "**/__mocks__"]
+  "exclude": ["dist", "node_modules", "**/__mocks__"],
+  "include": ["**/*"]
 }


### PR DESCRIPTION
Enables `@typescript-eslint/only-throw-error` rule and addresses the resulting errors. 

Also updates the eslint tsconfig to handle test files.