### PR TITLE
chore(lint): enable 'typescript-eslint/prefer-includes'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -221,7 +221,6 @@ module.exports = {
         '@typescript-eslint/restrict-template-expressions': 'off',
         '@typescript-eslint/non-nullable-type-assertion-style': 'off',
         '@typescript-eslint/no-implied-eval': 'off',
-        '@typescript-eslint/prefer-includes': 'off',
         '@typescript-eslint/no-base-to-string': 'off',
         '@typescript-eslint/no-duplicate-type-constituents': 'off',
         '@typescript-eslint/unbound-method': 'off',

--- a/packages/api-server/src/plugins/lambdaLoader.ts
+++ b/packages/api-server/src/plugins/lambdaLoader.ts
@@ -66,7 +66,7 @@ export const loadFunctionsFromDist = async (
   )
 
   // Place `GraphQL` serverless function at the start.
-  const i = serverFunctions.findIndex((x) => x.indexOf('graphql') !== -1)
+  const i = serverFunctions.findIndex((x) => x.includes('graphql'))
   if (i >= 0) {
     const graphQLFn = serverFunctions.splice(i, 1)[0]
     serverFunctions.unshift(graphQLFn)

--- a/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
+++ b/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
@@ -70,7 +70,7 @@ export const handler = async ({ force }: Args) => {
         )
 
         const pluginsIndex = contentLines.findLastIndex((line) =>
-          /extraPlugins:/.test(line),
+          line.includes('extraPlugins:'),
         )
 
         if (handlerIndex === -1 || pluginsIndex !== -1) {
@@ -119,7 +119,7 @@ export const handler = async ({ force }: Args) => {
         )
 
         const boundaryOpenIndex = contentLines.findLastIndex((line) =>
-          /<FatalErrorBoundary page={FatalErrorPage}>/.test(line),
+          line.includes('<FatalErrorBoundary page={FatalErrorPage}>'),
         )
         contentLines.splice(
           boundaryOpenIndex,
@@ -128,7 +128,7 @@ export const handler = async ({ force }: Args) => {
         )
 
         const boundaryCloseIndex = contentLines.findLastIndex((line) =>
-          /<\/FatalErrorBoundary>/.test(line),
+          line.includes('</FatalErrorBoundary>'),
         )
         contentLines.splice(boundaryCloseIndex, 1, '</Sentry.ErrorBoundary>')
 

--- a/packages/graphql-server/src/makeMergedSchema.ts
+++ b/packages/graphql-server/src/makeMergedSchema.ts
@@ -164,10 +164,7 @@ const resolveUnionType = (types: readonly GraphQLObjectType[]) => ({
 
     // If the maxIntersection fields is not unique, we are unable to determine type
     if (
-      fieldIntersections.indexOf(
-        maxIntersectionFields,
-        maxIntersectionIdx + 1,
-      ) !== -1
+      fieldIntersections.includes(maxIntersectionFields, maxIntersectionIdx + 1)
     ) {
       throw Error(
         'Unable to resolve correct type for union. Try adding unique fields to each type or __typename to each resolver',

--- a/packages/internal/src/generate/watch.ts
+++ b/packages/internal/src/generate/watch.ts
@@ -101,7 +101,7 @@ watcher
         chalk.dim.italic(Date.now() - start + ' ms'),
       )
 
-    if (absPath.indexOf('Cell') !== -1 && isCellFile(absPath)) {
+    if (absPath.includes('Cell') && isCellFile(absPath)) {
       await generateTypeDefGraphQLWeb()
       await generateClientPreset()
       if (eventName === 'unlink') {
@@ -114,7 +114,7 @@ watcher
       generateTypeDefRouterRoutes()
       routesWarningMessage = warningForDuplicateRoutes()
       finished('Routes')
-    } else if (absPath.indexOf('Page') !== -1 && isPageFile(absPath)) {
+    } else if (absPath.includes('Page') && isPageFile(absPath)) {
       generateTypeDefRouterPages()
       finished('Page')
     } else if (isDirectoryNamedModuleFile(absPath)) {

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -259,7 +259,7 @@ export function validatePath(path: string, routeName: string) {
     )
   }
 
-  if (path.indexOf(' ') >= 0) {
+  if (path.includes(' ')) {
     throw new Error(`Route path for ${routeName} contains spaces: "${path}"`)
   }
 

--- a/packages/structure/src/util.ts
+++ b/packages/structure/src/util.ts
@@ -5,7 +5,7 @@ export function validateRoutePath(path: string) {
     throw new Error(`Route path does not begin with a slash: "${path}"`)
   }
 
-  if (path.indexOf(' ') >= 0) {
+  if (path.includes(' ')) {
     throw new Error(`Route path contains spaces: "${path}"`)
   }
 

--- a/packages/telemetry/src/sendTelemetry.ts
+++ b/packages/telemetry/src/sendTelemetry.ts
@@ -138,7 +138,7 @@ export const sanitizeArgv = (
     if (sensitiveCommand.positions) {
       sensitiveCommand.positions.forEach((pos: number, index: number) => {
         // only redact if the text in the given position is not a --flag
-        if (args[pos] && !/--/.test(args[pos])) {
+        if (args[pos] && !args[pos].includes('--')) {
           args[pos] = sensitiveCommand.redactWith[index]
         }
       })


### PR DESCRIPTION
Enables the `@typescript-eslint/prefer-includes` rule and addresses and errors which result. 