### PR TITLE
fix(exec): Include nested scripts in --list

### DIFF
--- a/.changesets/11262.md
+++ b/.changesets/11262.md
@@ -1,0 +1,4 @@
+- fix(exec): Include nested scripts in --list (#11262) by @Tobbe
+
+Now also nested scripts, like `scripts/nested/script.ts`, are included in the
+output of `yarn rw exec --list`

--- a/__fixtures__/test-project/scripts/one/two/myNestedScript.ts
+++ b/__fixtures__/test-project/scripts/one/two/myNestedScript.ts
@@ -1,0 +1,3 @@
+export default async () => {
+  console.log('Hello from myNestedScript.ts')
+}

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -41,7 +41,10 @@ afterEach(() => {
 describe('yarn rw exec --list', () => {
   it('includes nested scripts', async () => {
     await handler({ list: true })
-    const scriptPath = 'one' + path.sep + 'two' + path.sep + 'myNestedScript'
+    const scriptPath = path
+      .join('one', 'two', 'myNestedScript')
+      // Handle Windows path separators
+      .replaceAll('\\', '\\\\')
     expect(vi.mocked(console).log).toHaveBeenCalledWith(
       expect.stringMatching(new RegExp('\\b' + scriptPath + '\\b')),
     )

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -1,0 +1,47 @@
+import path from 'node:path'
+
+import '../../lib/mockTelemetry'
+
+import { vi, afterEach, beforeEach, describe, it, expect } from 'vitest'
+
+import { handler } from '../execHandler'
+
+vi.mock('envinfo', () => ({ default: { run: () => '' } }))
+vi.mock('@redwoodjs/project-config', () => ({
+  getPaths: () => ({
+    scripts: path.join(__dirname, '../../../../../__fixtures__/test-project/scripts'),
+  }),
+  resolveFile: (path: string) => path
+}))
+
+const mockRedwoodToml = {
+  fileContents: '',
+}
+
+// Before rw tests run, api/ and web/ `jest.config.js` is confirmed via existsSync()
+vi.mock('node:fs', async () => ({
+  default: {
+    readFileSync: () => {
+      return mockRedwoodToml.fileContents
+    },
+  },
+}))
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.mocked(console).log.mockRestore()
+})
+
+describe('yarn rw exec --list', () => {
+  it('includes nested scripts', async () => {
+    await handler({ list: true })
+    expect(vi.mocked(console).log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'one' + path.sep + 'two' + path.sep + 'myNestedScript'
+      )
+    )
+  })
+})

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -9,9 +9,12 @@ import { handler } from '../execHandler'
 vi.mock('envinfo', () => ({ default: { run: () => '' } }))
 vi.mock('@redwoodjs/project-config', () => ({
   getPaths: () => ({
-    scripts: path.join(__dirname, '../../../../../__fixtures__/test-project/scripts'),
+    scripts: path.join(
+      __dirname,
+      '../../../../../__fixtures__/test-project/scripts',
+    ),
   }),
-  resolveFile: (path: string) => path
+  resolveFile: (path: string) => path,
 }))
 
 const mockRedwoodToml = {
@@ -40,7 +43,7 @@ describe('yarn rw exec --list', () => {
     await handler({ list: true })
     const scriptPath = 'one' + path.sep + 'two' + path.sep + 'myNestedScript'
     expect(vi.mocked(console).log).toHaveBeenCalledWith(
-      expect.stringMatching(new RegExp('\\b' + scriptPath + '\\b'))
+      expect.stringMatching(new RegExp('\\b' + scriptPath + '\\b')),
     )
   })
 })

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -38,10 +38,9 @@ afterEach(() => {
 describe('yarn rw exec --list', () => {
   it('includes nested scripts', async () => {
     await handler({ list: true })
+    const scriptPath = 'one' + path.sep + 'two' + path.sep + 'myNestedScript'
     expect(vi.mocked(console).log).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'one' + path.sep + 'two' + path.sep + 'myNestedScript'
-      )
+      expect.stringMatching(new RegExp('\\b' + scriptPath + '\\b'))
     )
   })
 })

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -21,10 +21,7 @@ const printAvailableScriptsToConsole = () => {
   findScripts(getPaths().scripts).forEach((scriptPath) => {
     const relativePath = path.relative(getPaths().scripts, scriptPath)
     const { ext } = path.parse(relativePath)
-    const relativePathWithoutExt =
-      // Using \\ to escape the . in the file extension
-      // Ending with $ to match the end of the string
-      relativePath.replace(new RegExp(`\\${ext}$`), '')
+    const relativePathWithoutExt = relativePath.slice(0, -ext.length)
     console.log(c.info(`- ${relativePathWithoutExt}`))
   })
   console.log()

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -19,8 +19,13 @@ import { generatePrismaClient } from '../lib/generatePrismaClient'
 const printAvailableScriptsToConsole = () => {
   console.log('Available scripts:')
   findScripts().forEach((scriptPath) => {
-    const { name } = path.parse(scriptPath)
-    console.log(c.info(`- ${name}`))
+    const relativePath = path.relative(getPaths().scripts, scriptPath)
+    const { ext } = path.parse(relativePath)
+    const relativePathWithoutExt =
+      // Using \\ to escape the . in the file extension
+      // Ending with $ to match the end of the string
+      relativePath.replace(new RegExp(`\\${ext}$`), '')
+    console.log(c.info(`- ${relativePathWithoutExt}`))
   })
   console.log()
 }

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -18,7 +18,7 @@ import { generatePrismaClient } from '../lib/generatePrismaClient'
 
 const printAvailableScriptsToConsole = () => {
   console.log('Available scripts:')
-  findScripts().forEach((scriptPath) => {
+  findScripts(getPaths().scripts).forEach((scriptPath) => {
     const relativePath = path.relative(getPaths().scripts, scriptPath)
     const { ext } = path.parse(relativePath)
     const relativePathWithoutExt =

--- a/packages/internal/src/files.ts
+++ b/packages/internal/src/files.ts
@@ -146,7 +146,7 @@ export const isCellFile = (p: string) => {
 }
 
 export const findScripts = (cwd: string = getPaths().scripts) => {
-  return fg.sync('*.{js,jsx,ts,tsx}', {
+  return fg.sync('./**/*.{js,jsx,ts,tsx}', {
     cwd,
     absolute: true,
     ignore: ['node_modules'],

--- a/tasks/test-project/rebuild-test-project-fixture.ts
+++ b/tasks/test-project/rebuild-test-project-fixture.ts
@@ -386,8 +386,29 @@ async function runCommand() {
     },
   })
 
+    await tuiTask({
+      step: 9,
+      title: 'Add scripts',
+      task: () => {
+        const nestedPath = path.join(
+          OUTPUT_PROJECT_PATH,
+          'scripts',
+          'one',
+          'two'
+        )
+
+        fs.mkdirSync(nestedPath, { recursive: true })
+        fs.writeFileSync(
+          path.join(nestedPath, 'myNestedScript.ts'),
+          'export default async () => {\n' +
+            "  console.log('Hello from myNestedScript.ts')\n" +
+            '}\n\n'
+        )
+      },
+    })
+
   await tuiTask({
-    step: 9,
+    step: 10,
     title: 'Running prisma migrate reset',
     task: () => {
       return exec(
@@ -399,7 +420,7 @@ async function runCommand() {
   })
 
   await tuiTask({
-    step: 10,
+    step: 11,
     title: 'Lint --fix all the things',
     task: async () => {
       try {
@@ -431,7 +452,7 @@ async function runCommand() {
   })
 
   await tuiTask({
-    step: 11,
+    step: 12,
     title: 'Replace and Cleanup Fixture',
     task: async () => {
       // @TODO: This only works on UNIX, we should use path.join everywhere
@@ -469,7 +490,7 @@ async function runCommand() {
   })
 
   await tuiTask({
-    step: 12,
+    step: 13,
     title: 'All done!',
     task: () => {
       console.log('-'.repeat(30))


### PR DESCRIPTION
If you have a script in `scripts/nested/script.ts` you can already execute it by running `yarn rw exec nested/script`.
But it wasn't included in the output of `yarn rw exec --list`. This PR adds also nested scripts to the list of scripts that it finds and lists