### PR TITLE
feat(exec): Add --silent to silence all RW output

### DIFF
--- a/.changesets/11278.md
+++ b/.changesets/11278.md
@@ -1,0 +1,8 @@
+- feat(exec): Add --silent to silence all RW output (#11278) by @Tobbe
+
+Run with `--silent` (or `-s`) to not have the framework itself print anything to
+your console. Only console logs you have yourself in the script, or any files
+the script includes, will come through.
+
+If you're using Prisma you might want to tweak Prisma's logging (in
+`api/lib/db.ts`) and turn off "info" logging, depending on your goals.

--- a/packages/cli/src/commands/exec.js
+++ b/packages/cli/src/commands/exec.js
@@ -19,6 +19,12 @@ export const builder = (yargs) => {
       default: false,
       description: 'List available scripts',
     })
+    .option('silent', {
+      alias: 's',
+      type: 'boolean',
+      default: false,
+      description: "Silence Redwood's output, leaving only the script output",
+    })
     .strict(false)
     .epilogue(
       `Also see the ${terminalLink(

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -137,7 +137,7 @@ export const handler = async (args) => {
 
   const tasks = new Listr(scriptTasks, {
     rendererOptions: { collapseSubtasks: false },
-    renderer: 'verbose',
+    renderer: args.silent ? 'silent' : 'verbose',
   })
 
   // Prevent user project telemetry from within the script from being recorded


### PR DESCRIPTION
Run with `--silent` (or `-s`) to not have the framework itself print anything to your console. Only console logs you have yourself in the script, or any files the script includes, will come through. 

If you're using Prisma you might want to tweak Prisma's logging (in `api/lib/db.ts`) and turn off "info" logging, depending on your goals.

![image](https://github.com/user-attachments/assets/bc09edac-1ea9-4a41-84cc-fb71e09a530c)

Using `--silent`/`-s` is perfect for when you want to pipe the output to some other command or just to a file

---

Unfortunately it's not possible to unit test this code with vitest because of our reliance on babel and require