### PR TITLE
chore(lint): enable 'typescript-eslint/prefer-string-starts-ends-with'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,7 +198,6 @@ module.exports = {
         camelcase: 'off',
 
         // TODO(jgmw): Work through these and either keep disabled or fix and re-enable
-        '@typescript-eslint/prefer-string-starts-ends-with': 'off',
         '@typescript-eslint/await-thenable': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',

--- a/packages/adapters/fastify/web/src/helpers.ts
+++ b/packages/adapters/fastify/web/src/helpers.ts
@@ -1,7 +1,7 @@
 /** Ensures that `path` starts and ends with a slash ('/') */
 export function coerceRootPath(path: string) {
-  const prefix = path.charAt(0) !== '/' ? '/' : ''
-  const suffix = path.charAt(path.length - 1) !== '/' ? '/' : ''
+  const prefix = !path.startsWith('/') ? '/' : ''
+  const suffix = !path.endsWith('/') ? '/' : ''
 
   return `${prefix}${path}${suffix}`
 }

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-src-alias.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-src-alias.ts
@@ -34,7 +34,7 @@ export default function (
         if (process.platform === 'win32') {
           newImport = newImport.replaceAll('\\', '/')
         }
-        if (newImport.indexOf('.') !== 0) {
+        if (!newImport.startsWith('.')) {
           newImport = './' + newImport
         }
         const newSource = t.stringLiteral(newImport)

--- a/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
+++ b/packages/cli/src/commands/setup/monitoring/sentry/sentryHandler.ts
@@ -66,7 +66,7 @@ export const handler = async ({ force }: Args) => {
           .split('\n')
 
         const handlerIndex = contentLines.findLastIndex((line) =>
-          /^export const handler = createGraphQLHandler\({/.test(line),
+          line.startsWith('export const handler = createGraphQLHandler({'),
         )
 
         const pluginsIndex = contentLines.findLastIndex((line) =>

--- a/packages/forms/src/coercion.ts
+++ b/packages/forms/src/coercion.ts
@@ -261,6 +261,6 @@ export const setCoercion = (
     valueAs, // type
     emptyAs, // emptyAs
     validation.required !== undefined && validation.required !== false, // required
-    /Id$/.test(name || ''), // isId
+    (name || '').endsWith('Id'), // isId
   )
 }

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -139,7 +139,7 @@ const LocationAwareRouter: React.FC<RouterProps> = ({
   let redirectPath: string | undefined = undefined
 
   if (redirect) {
-    if (redirect[0] === '/') {
+    if (redirect.startsWith('/')) {
       redirectPath = replaceParams(redirect, allParams)
     } else {
       const redirectRouteObject = Object.values(pathRouteMap).find(

--- a/packages/router/src/rsc/ServerRouter.tsx
+++ b/packages/router/src/rsc/ServerRouter.tsx
@@ -93,7 +93,7 @@ export const Router: React.FC<RouterProps> = ({ paramTypes, children }) => {
   let redirectPath: string | undefined = undefined
 
   if (redirect) {
-    if (redirect[0] === '/') {
+    if (redirect.startsWith('/')) {
       redirectPath = replaceParams(redirect, allParams)
     } else {
       const redirectRouteObject = Object.values(pathRouteMap).find(

--- a/packages/router/src/util.ts
+++ b/packages/router/src/util.ts
@@ -38,7 +38,7 @@ export function paramsForRoute(route: string) {
 
       // Normalize the name
       let name = parts[0]
-      if (name.slice(-3) === '...') {
+      if (name.endsWith('...')) {
         // Globs have their ellipsis removed
         name = name.slice(0, -3)
       }
@@ -47,7 +47,7 @@ export function paramsForRoute(route: string) {
       let type = parts[1]
       if (!type) {
         // Strings and Globs are implicit in the syntax
-        type = match.slice(-3) === '...' ? 'Glob' : 'String'
+        type = match.endsWith('...') ? 'Glob' : 'String'
       }
 
       return [name, type, `{${match}}`]

--- a/packages/structure/src/x/URL.ts
+++ b/packages/structure/src/x/URL.ts
@@ -51,7 +51,7 @@ function fileUriToPath(uri: string, sep = path_sep): string {
   if (
     typeof uri !== 'string' ||
     uri.length <= 7 ||
-    uri.substring(0, 7) !== FILE_SCHEME
+    !uri.startsWith(FILE_SCHEME)
   ) {
     throw new TypeError('must pass in a file:// URI to convert to a file path')
   }


### PR DESCRIPTION
Enables the `typescript-eslint/prefer-string-starts-ends-with` rule and fixes issues that resulted. 