### PR TITLE
chore(lint): enable 'typescript-eslint/no-unsafe-enum-comparison'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,7 +206,6 @@ module.exports = {
         '@typescript-eslint/prefer-nullish-coalescing': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
-        '@typescript-eslint/no-unsafe-enum-comparison': 'off',
         '@typescript-eslint/dot-notation': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/babel-config/src/plugins/babel-plugin-redwood-mock-cell-data.ts
+++ b/packages/babel-config/src/plugins/babel-plugin-redwood-mock-cell-data.ts
@@ -7,7 +7,7 @@ import { parse as babelParse } from '@babel/parser'
 import type { ParserPlugin } from '@babel/parser'
 import traverse from '@babel/traverse'
 import fg from 'fast-glob'
-import { parse as graphqlParse } from 'graphql'
+import { parse as graphqlParse, Kind } from 'graphql'
 
 export default function ({ types: t }: { types: typeof types }): PluginObj {
   let nodesToRemove: any[] = []
@@ -248,7 +248,10 @@ export const getCellMetadata = (p: string) => {
     const document = graphqlParse(operation)
 
     for (const definition of document.definitions) {
-      if (definition.kind === 'OperationDefinition' && definition.name?.value) {
+      if (
+        definition.kind === Kind.OPERATION_DEFINITION &&
+        definition.name?.value
+      ) {
         operationName = definition.name.value
       }
     }

--- a/packages/cli/src/testLib/cells.ts
+++ b/packages/cli/src/testLib/cells.ts
@@ -13,7 +13,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
-import { parse, visit } from 'graphql'
+import { Kind, parse, visit } from 'graphql'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -239,13 +239,13 @@ const getFields = (field: FieldNode): any => {
     const lookAtFieldNode = (node: FieldNode | InlineFragmentNode): void => {
       node.selectionSet?.selections.forEach((subField) => {
         switch (subField.kind) {
-          case 'Field':
+          case Kind.FIELD:
             obj[field.name.value].push(getFields(subField as FieldNode))
             break
-          case 'FragmentSpread':
+          case Kind.FRAGMENT_SPREAD:
             // TODO: Maybe this will also be needed, right now it's accounted for to not crash in the tests
             break
-          case 'InlineFragment':
+          case Kind.INLINE_FRAGMENT:
             lookAtFieldNode(subField)
         }
       })

--- a/packages/codemods/src/lib/cells.ts
+++ b/packages/codemods/src/lib/cells.ts
@@ -13,7 +13,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
-import { parse, visit } from 'graphql'
+import { Kind, parse, visit } from 'graphql'
 
 import { getPaths } from '@redwoodjs/project-config'
 
@@ -239,13 +239,13 @@ const getFields = (field: FieldNode): any => {
     const lookAtFieldNode = (node: FieldNode | InlineFragmentNode): void => {
       node.selectionSet?.selections.forEach((subField) => {
         switch (subField.kind) {
-          case 'Field':
+          case Kind.FIELD:
             obj[field.name.value].push(getFields(subField as FieldNode))
             break
-          case 'FragmentSpread':
+          case Kind.FRAGMENT_SPREAD:
             // TODO: Maybe this will also be needed, right now it's accounted for to not crash in the tests
             break
-          case 'InlineFragment':
+          case Kind.INLINE_FRAGMENT:
             lookAtFieldNode(subField)
         }
       })

--- a/packages/eslint-plugin/src/service-type-annotations.ts
+++ b/packages/eslint-plugin/src/service-type-annotations.ts
@@ -48,7 +48,10 @@ export const serviceTypeAnnotations = createRule({
 
         node.declaration.declarations.forEach((vd) => {
           // VariableDeclarator means an `export const abcThing =`
-          if (vd.type === 'VariableDeclarator' && vd.id.type === 'Identifier') {
+          if (
+            vd.type === AST_NODE_TYPES.VariableDeclarator &&
+            vd.id.type === AST_NODE_TYPES.Identifier
+          ) {
             // Don't add types to functions that start with _
             if (vd.id.name.startsWith('_')) {
               return
@@ -65,7 +68,7 @@ export const serviceTypeAnnotations = createRule({
             // Only run for lowercase arrow funcs ATM
             if (
               isGlobalOrMutationResolver &&
-              vd.init?.type !== 'ArrowFunctionExpression'
+              vd.init?.type !== AST_NODE_TYPES.ArrowFunctionExpression
             ) {
               return
             }
@@ -117,7 +120,7 @@ export const serviceTypeAnnotations = createRule({
               }
 
               const isCorrectType =
-                type.typeName?.type === 'Identifier' &&
+                type.typeName?.type === AST_NODE_TYPES.Identifier &&
                 type.typeName?.name === typeName
 
               if (isCorrectType) {

--- a/packages/eslint-plugin/src/unsupported-route-components.ts
+++ b/packages/eslint-plugin/src/unsupported-route-components.ts
@@ -1,5 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/utils'
-import { ESLintUtils } from '@typescript-eslint/utils'
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils'
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 
 const createRule = ESLintUtils.RuleCreator.withoutDocs
@@ -13,9 +13,9 @@ function checkNodes(
   nodesToCheck: TSESTree.JSXElement | TSESTree.JSXChild,
   context: RuleContext<'unexpected', []>,
 ) {
-  if (nodesToCheck.type === 'JSXElement') {
+  if (nodesToCheck.type === AST_NODE_TYPES.JSXElement) {
     const name =
-      nodesToCheck.openingElement.name.type === 'JSXIdentifier'
+      nodesToCheck.openingElement.name.type === AST_NODE_TYPES.JSXIdentifier
         ? nodesToCheck.openingElement.name.name
         : null
     if (name && !isAllowedElement(name)) {
@@ -51,15 +51,21 @@ export const unsupportedRouteComponents = createRule({
         if (isRoutesRenderBlock(node.declarations[0])) {
           const routesDeclaration = node.declarations[0].init
 
-          if (routesDeclaration?.type === 'ArrowFunctionExpression') {
-            if (routesDeclaration.body.type === 'JSXElement') {
+          if (
+            routesDeclaration?.type === AST_NODE_TYPES.ArrowFunctionExpression
+          ) {
+            if (routesDeclaration.body.type === AST_NODE_TYPES.JSXElement) {
               // Routes = () => <Router>...</Router>
               checkNodes(routesDeclaration.body, context)
-            } else if (routesDeclaration.body.type === 'BlockStatement') {
+            } else if (
+              routesDeclaration.body.type === AST_NODE_TYPES.BlockStatement
+            ) {
               // For when  Routes = () => { return (<Router>...</Router>) }
               if (
-                routesDeclaration.body.body[0].type === 'ReturnStatement' &&
-                routesDeclaration.body.body[0].argument?.type === 'JSXElement'
+                routesDeclaration.body.body[0].type ===
+                  AST_NODE_TYPES.ReturnStatement &&
+                routesDeclaration.body.body[0].argument?.type ===
+                  AST_NODE_TYPES.JSXElement
               ) {
                 const routesReturnStatement =
                   routesDeclaration.body.body[0].argument
@@ -76,8 +82,8 @@ export const unsupportedRouteComponents = createRule({
 
 function isRoutesRenderBlock(node?: TSESTree.VariableDeclarator) {
   return (
-    node?.type === 'VariableDeclarator' &&
-    node?.id.type === 'Identifier' &&
+    node?.type === AST_NODE_TYPES.VariableDeclarator &&
+    node?.id.type === AST_NODE_TYPES.Identifier &&
     node?.id.name === 'Routes'
   )
 }

--- a/packages/graphql-server/src/directives/makeDirectives.ts
+++ b/packages/graphql-server/src/directives/makeDirectives.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode } from 'graphql'
+import { Kind, type DocumentNode } from 'graphql'
 
 import type {
   RedwoodDirective,
@@ -49,7 +49,7 @@ export const makeDirectivesForPlugin = (
 
 export const getDirectiveName = (schema: DocumentNode) => {
   const definition = schema.definitions.find(
-    (definition) => definition.kind === 'DirectiveDefinition',
+    (definition) => definition.kind === Kind.DIRECTIVE_DEFINITION,
   )
 
   return definition?.name?.value

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -15,7 +15,7 @@ import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader'
 import { loadDocuments, loadSchemaSync } from '@graphql-tools/load'
 import type { LoadTypedefsOptions } from '@graphql-tools/load'
 import execa from 'execa'
-import type { DocumentNode } from 'graphql'
+import { Kind, type DocumentNode } from 'graphql'
 
 import { getPaths, getConfig } from '@redwoodjs/project-config'
 
@@ -346,7 +346,7 @@ const printMappedModelsPlugin: CodegenPlugin = {
     // this way we can make sure relation types are not required
     const sdlTypesWhichAreMapped = Object.values(schema.getTypeMap())
       .filter((type) => {
-        return type.astNode?.kind === 'ObjectTypeDefinition'
+        return type.astNode?.kind === Kind.OBJECT_TYPE_DEFINITION
       })
       .filter((objectDefType) => {
         const modelName = objectDefType.astNode?.name.value

--- a/packages/internal/src/gql.ts
+++ b/packages/internal/src/gql.ts
@@ -7,7 +7,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeNode,
 } from 'graphql'
-import { parse, print, visit } from 'graphql'
+import { Kind, parse, print, visit } from 'graphql'
 
 import { rootSchema } from '@redwoodjs/graphql-server'
 import { getPaths } from '@redwoodjs/project-config'
@@ -61,13 +61,13 @@ const getFields = (field: FieldNode): any => {
     const lookAtFieldNode = (node: FieldNode | InlineFragmentNode): void => {
       node.selectionSet?.selections.forEach((subField) => {
         switch (subField.kind) {
-          case 'Field':
+          case Kind.FIELD:
             obj[field.name.value].push(getFields(subField as FieldNode))
             break
-          case 'FragmentSpread':
+          case Kind.FRAGMENT_SPREAD:
             // TODO: Maybe this will also be needed, right now it's accounted for to not crash in the tests
             break
-          case 'InlineFragment':
+          case Kind.INLINE_FRAGMENT:
             lookAtFieldNode(subField)
         }
       })

--- a/packages/structure/src/model/RWCell.ts
+++ b/packages/structure/src/model/RWCell.ts
@@ -1,4 +1,4 @@
-import { parse as parseGraphQL } from 'graphql'
+import { Kind, parse as parseGraphQL } from 'graphql'
 import * as tsm from 'ts-morph'
 import { DiagnosticSeverity } from 'vscode-languageserver-types'
 
@@ -60,7 +60,7 @@ export class RWCell extends RWComponent {
       return undefined
     }
     for (const def of ast.definitions) {
-      if (def.kind == 'OperationDefinition') {
+      if (def.kind == Kind.OPERATION_DEFINITION) {
         return def?.name?.value
       }
     }

--- a/packages/structure/src/model/RWSDL.ts
+++ b/packages/structure/src/model/RWSDL.ts
@@ -1,5 +1,6 @@
 import { basename } from 'path'
 
+import { Kind } from 'graphql'
 import { parse as parseGraphQL } from 'graphql/language/parser'
 import * as tsm from 'ts-morph'
 
@@ -59,7 +60,7 @@ export class RWSDL extends FileNode {
       } //?
       const ast = parseGraphQL(self.schemaString)
       for (const def of ast.definitions) {
-        if (def.kind === 'ObjectTypeDefinition') {
+        if (def.kind === Kind.OBJECT_TYPE_DEFINITION) {
           if (def.name.value === 'Query' || def.name.value === 'Mutation') {
             for (const field of def.fields ?? []) {
               yield new RWSDLField(def, field, self)

--- a/packages/web/src/apollo/index.tsx
+++ b/packages/web/src/apollo/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '@apollo/client/react/hooks/hooks.cjs'
 import { getMainDefinition } from '@apollo/client/utilities/utilities.cjs'
 import { fetch as crossFetch } from '@whatwg-node/fetch'
+import { Kind, OperationTypeNode } from 'graphql'
 import { print } from 'graphql/language/printer.js'
 
 import type { UseAuth } from '@redwoodjs/auth'
@@ -48,6 +49,7 @@ import {
 } from './fragmentRegistry.js'
 import * as SSELinkExports from './sseLink.js'
 import { useCache } from './useCache.js'
+
 // Not sure why we need to import it this way for legacy builds to work
 const { SSELink } = SSELinkExports
 
@@ -236,8 +238,8 @@ const ApolloProviderWithFetchConfig: React.FunctionComponent<{
             const definition = getMainDefinition(query)
 
             return (
-              definition.kind === 'OperationDefinition' &&
-              definition.operation === 'subscription'
+              definition.kind === Kind.OPERATION_DEFINITION &&
+              definition.operation === OperationTypeNode.SUBSCRIPTION
             )
           },
           new SSELink({

--- a/packages/web/src/graphql.ts
+++ b/packages/web/src/graphql.ts
@@ -1,4 +1,4 @@
-import type { DocumentNode } from 'graphql'
+import { Kind, type DocumentNode } from 'graphql'
 
 /**
  * Given a query like the one below this function will return
@@ -23,7 +23,10 @@ import type { DocumentNode } from 'graphql'
  */
 export function getOperationName(document: DocumentNode) {
   for (const definition of document.definitions) {
-    if (definition.kind === 'OperationDefinition' && definition.name?.value) {
+    if (
+      definition.kind === Kind.OPERATION_DEFINITION &&
+      definition.name?.value
+    ) {
       return definition.name.value
     }
   }


### PR DESCRIPTION
Enables the `typescript-eslint/no-unsafe-enum-comparison` rule and addresses the points it raised.