### PR TITLE
chore(lint): enable 'typescript-eslint/no-implied-eval'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -219,7 +219,6 @@ module.exports = {
         '@typescript-eslint/prefer-regexp-exec': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
         '@typescript-eslint/non-nullable-type-assertion-style': 'off',
-        '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/no-base-to-string': 'off',
         '@typescript-eslint/no-duplicate-type-constituents': 'off',
         '@typescript-eslint/unbound-method': 'off',

--- a/packages/internal/src/generate/templates.ts
+++ b/packages/internal/src/generate/templates.ts
@@ -23,6 +23,7 @@ export const writeTemplate = (
 }
 
 const templatized = (template: string, vars = {}) => {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
   const handler = new Function(
     'vars',
     [


### PR DESCRIPTION
Enables `typescript-eslint/no-implied-eval` and addresses points raised.