### PR TITLE
chore(lint): enable 'typescript-eslint/no-duplicate-type-constituents'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -221,7 +221,6 @@ module.exports = {
         '@typescript-eslint/non-nullable-type-assertion-style': 'off',
         '@typescript-eslint/no-implied-eval': 'off',
         '@typescript-eslint/no-base-to-string': 'off',
-        '@typescript-eslint/no-duplicate-type-constituents': 'off',
         '@typescript-eslint/unbound-method': 'off',
       },
     },

--- a/packages/api/src/auth/verifiers/common.ts
+++ b/packages/api/src/auth/verifiers/common.ts
@@ -33,7 +33,6 @@ export type SupportedVerifiers =
   | Sha256Verifier
   | Base64Sha1Verifier
   | Base64Sha256Verifier
-  | Sha1Verifier
   | TimestampSchemeVerifier
   | JwtVerifier
 

--- a/packages/forms/src/coercion.ts
+++ b/packages/forms/src/coercion.ts
@@ -110,8 +110,7 @@ const SET_VALUE_AS_FUNCTIONS: Record<
       isValueEmpty(val) ? null : +val,
     emptyAsUndefined: (val: string): number | undefined =>
       isValueEmpty(val) ? undefined : +val,
-    emptyAsNaN: (val: string): number | typeof NaN =>
-      isValueEmpty(val) ? NaN : +val,
+    emptyAsNaN: (val: string): number => (isValueEmpty(val) ? NaN : +val),
     emptyAsString: (val: string): number | '' =>
       isValueEmpty(val) ? '' : +val,
     emptyAsZero: (val: string): number => (isValueEmpty(val) ? 0 : +val),


### PR DESCRIPTION
Enabled `typescript-eslint/no-duplicate-type-constituents` and addresses points raised.