### PR TITLE
feat(context): Build and publish package as dual esm/cjs

### DIFF
--- a/packages/context/build.mts
+++ b/packages/context/build.mts
@@ -15,9 +15,6 @@ await build({
   buildOptions: {
     ...defaultBuildOptions,
     outdir: 'dist/cjs',
-    outExtension: {
-      '.js': '.cjs',
-    },
   },
 })
 

--- a/packages/context/build.mts
+++ b/packages/context/build.mts
@@ -1,3 +1,26 @@
-import { build } from '@redwoodjs/framework-tools'
+import { writeFileSync } from 'node:fs'
 
-await build()
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+
+// ESM build
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    format: 'esm',
+  },
+})
+
+// CJS build
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    outdir: 'dist/cjs',
+    outExtension: {
+      '.js': '.cjs',
+    },
+  },
+})
+
+// Place a package.json file with `type: commonjs` in the 'dist/cjs' folder so that
+// all files are considered CommonJS modules.
+writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -16,7 +16,17 @@
       },
       "default": {
         "types": "./dist/cjs/index.d.ts",
-        "default": "./dist/cjs/index.cjs"
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./dist/store": {
+      "import": {
+        "types": "./dist/store.d.ts",
+        "default": "./dist/store.js"
+      },
+      "default": {
+        "types": "./dist/cjs/store.d.ts",
+        "default": "./dist/cjs/store.js"
       }
     }
   },

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -7,7 +7,21 @@
     "directory": "packages/context"
   },
   "license": "MIT",
-  "main": "./dist/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "default": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -15,12 +29,17 @@
   "scripts": {
     "build": "tsx ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-context.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.json ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
+    "check:attw": "yarn attw -P",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "0.15.4",
     "@redwoodjs/framework-tools": "workspace:*",
+    "concurrently": "8.2.2",
+    "publint": "0.2.10",
     "tsx": "4.17.0",
     "typescript": "5.5.4"
   },

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -30,7 +30,7 @@
       }
     }
   },
-  "main": "./dist/cjs/index.cjs",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/context/src/context.ts
+++ b/packages/context/src/context.ts
@@ -1,4 +1,4 @@
-import { getAsyncStoreInstance } from './store'
+import { getAsyncStoreInstance } from './store.js'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface GlobalContext extends Record<string, unknown> {}

--- a/packages/context/src/global.api-auto-imports.ts
+++ b/packages/context/src/global.api-auto-imports.ts
@@ -1,4 +1,4 @@
-import type { GlobalContext } from './context'
+import type { GlobalContext } from './context.js'
 
 declare global {
   const context: GlobalContext

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,5 +1,5 @@
-export * from './context'
+export * from './context.js'
 // Note: store is not exported here to discourage direct usage.
 
-import './global.api-auto-imports'
-export * from './global.api-auto-imports'
+import './global.api-auto-imports.js'
+export * from './global.api-auto-imports.js'

--- a/packages/context/src/store.ts
+++ b/packages/context/src/store.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'async_hooks'
 
-import type { GlobalContext } from './context'
+import type { GlobalContext } from './context.js'
 
 let CONTEXT_STORAGE: AsyncLocalStorage<Map<string, GlobalContext>>
 

--- a/packages/context/tsconfig.cjs.json
+++ b/packages/context/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"
+  }
+}

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "rootDir": "src",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7983,7 +7983,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/context@workspace:packages/context"
   dependencies:
+    "@arethetypeswrong/cli": "npm:0.15.4"
     "@redwoodjs/framework-tools": "workspace:*"
+    concurrently: "npm:8.2.2"
+    publint: "npm:0.2.10"
     tsx: "npm:4.17.0"
     typescript: "npm:5.5.4"
   languageName: unknown


### PR DESCRIPTION
Followed the general pattern we've established around our approach to dual publishing. I only wrote one additional package.json file in the dist because it felt a little redundant to repeat the one we have at the root. 

We've spoke before about perhaps not wanting to ship two sets of type definitions - one for cjs and one for esm. I know that they're essentially the same and for a package like this it almost doubles the published size. For now let's just ship types for both. In the future we'll stop publishing cjs anyway.

Since I was just following our established pattern I'm going to go ahead and merge this in. If we discover something we'd rather change we can always revert or follow up.