### PR TITLE
chore(lint): fix prettier configs and ignores

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,9 +2,11 @@
 **/dist
 
 # Ignore fixture projects
-__fixtures__
+/__fixtures__
 
 # Ignore the certain files in /docs
+/docs/.docusaurus
+/docs/build
 /docs/versioned_docs
 /docs/versioned_sidebars
 
@@ -21,6 +23,7 @@ packages/create-redwood-rsc-app
 # Ignore test fixtures
 **/__testfixtures__
 **/__tests__/fixtures
+**/__tests__/__fixtures__
 
 # TODO(jgmw): Re-enable these in managable chunks
 packages/create-redwood-app/tests/e2e_prompts*

--- a/docs/prettier.config.js
+++ b/docs/prettier.config.js
@@ -1,4 +1,7 @@
-import rootConfig from '../prettier.config.mjs'
+/* eslint-env node */
+// @ts-check
+
+const rootConfig = require('../prettier.config')
 
 /**
  * @see https://prettier.io/docs/en/configuration.html
@@ -9,4 +12,4 @@ const config = {
   trailingComma: 'es5',
 }
 
-export default config
+module.exports = config

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,3 +1,6 @@
+/* eslint-env node */
+// @ts-check
+
 /**
  * @see https://prettier.io/docs/en/configuration.html
  * @type {import("prettier").Config}
@@ -14,4 +17,4 @@ const config = {
   ],
 }
 
-export default config
+module.exports = config


### PR DESCRIPTION
So tests started to fail because babel plugin tester uses prettier to format test output. It looks like it didn't play well with a `.mjs` config file. 