### PR TITLE
fix(record): Update dependencies and build dual esm/cjs

### DIFF
--- a/packages/record/.babelrc.js
+++ b/packages/record/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/record/build.mts
+++ b/packages/record/build.mts
@@ -1,0 +1,23 @@
+import { writeFileSync } from 'node:fs'
+
+import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+
+// ESM build
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    format: 'esm',
+  },
+})
+
+// CJS build
+await build({
+  buildOptions: {
+    ...defaultBuildOptions,
+    outdir: 'dist/cjs',
+  },
+})
+
+// Place a package.json file with `type: commonjs` in the 'dist/cjs' folder so that
+// all files are considered CommonJS modules.
+writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))

--- a/packages/record/build.mts
+++ b/packages/record/build.mts
@@ -1,6 +1,5 @@
-import { writeFileSync } from 'node:fs'
-
 import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+import { insertCommonJsPackageJson } from '@redwoodjs/framework-tools/generateTypes'
 
 // ESM build
 await build({
@@ -17,7 +16,6 @@ await build({
     outdir: 'dist/cjs',
   },
 })
-
-// Place a package.json file with `type: commonjs` in the 'dist/cjs' folder so that
-// all files are considered CommonJS modules.
-writeFileSync('dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))
+await insertCommonJsPackageJson({
+  buildFileUrl: import.meta.url,
+})

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -7,32 +7,39 @@
     "directory": "packages/record"
   },
   "license": "MIT",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/index.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "yarn build:js",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\"",
+    "build": "tsx ./build.mts",
     "build:pack": "yarn pack -o redwoodjs-record.tgz",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
-    "datamodel:parse": "node src/scripts/parse.js",
+    "check:package": "yarn publint",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "7.25.0",
     "@prisma/client": "5.18.0",
+    "@redwoodjs/api": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",
-    "core-js": "3.38.0"
+    "camelcase": "6.3.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.24.8",
-    "@babel/core": "^7.22.20",
     "@prisma/internals": "5.18.0",
+    "@redwoodjs/framework-tools": "workspace:*",
     "esbuild": "0.23.0",
+    "publint": "0.2.10",
+    "tsx": "4.17.0",
     "vitest": "2.0.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8516,14 +8516,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/record@workspace:packages/record"
   dependencies:
-    "@babel/cli": "npm:7.24.8"
-    "@babel/core": "npm:^7.22.20"
-    "@babel/runtime-corejs3": "npm:7.25.0"
     "@prisma/client": "npm:5.18.0"
     "@prisma/internals": "npm:5.18.0"
+    "@redwoodjs/api": "workspace:*"
+    "@redwoodjs/framework-tools": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"
-    core-js: "npm:3.38.0"
+    camelcase: "npm:6.3.0"
     esbuild: "npm:0.23.0"
+    publint: "npm:0.2.10"
+    tsx: "npm:4.17.0"
     vitest: "npm:2.0.5"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
The main motivation here was to switch the build off of babel to esbuild. In doing so I've made it dual esm/cjs.

I also noticed that some of the dependencies/scripts didn't look quite right. I have limited understanding of the details of this package so I'll work with @cannikin to confirm.