### PR TITLE
linting: enable 'typescript-eslint/await-thenable' rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,7 +198,6 @@ module.exports = {
         camelcase: 'off',
 
         // TODO(jgmw): Work through these and either keep disabled or fix and re-enable
-        '@typescript-eslint/await-thenable': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',
         '@typescript-eslint/require-await': 'off',

--- a/packages/api-server/src/bothCLIConfigHandler.ts
+++ b/packages/api-server/src/bothCLIConfigHandler.ts
@@ -33,7 +33,7 @@ export async function handler(options: BothParsedOptions) {
     },
   })
 
-  const apiFastify = await await createApiServer({
+  const apiFastify = await createApiServer({
     apiRootPath: options.apiRootPath,
   })
 

--- a/packages/auth-providers/dbAuth/web/src/webAuthn.ts
+++ b/packages/auth-providers/dbAuth/web/src/webAuthn.ts
@@ -50,7 +50,7 @@ export default class WebAuthnClient {
 
   async isSupported() {
     const { browserSupportsWebAuthn } = await import('@simplewebauthn/browser')
-    return await browserSupportsWebAuthn()
+    return browserSupportsWebAuthn()
   }
 
   isEnabled() {

--- a/packages/auth-providers/netlify/web/src/netlify.ts
+++ b/packages/auth-providers/netlify/web/src/netlify.ts
@@ -73,7 +73,7 @@ function createAuthImplementation(netlifyIdentity: NetlifyIdentity) {
         // The client refresh function only actually refreshes token
         // when it's been expired. Don't panic
         await netlifyIdentity.refresh()
-        const user = await netlifyIdentity.currentUser()
+        const user = netlifyIdentity.currentUser()
         return user?.token?.access_token || null
       } catch {
         return null

--- a/packages/auth-providers/supabase/api/src/decoder.ts
+++ b/packages/auth-providers/supabase/api/src/decoder.ts
@@ -57,7 +57,7 @@ const getSupabaseAccessTokenFromCookie = async (
   if (!error) {
     const { session } = data
     if (session) {
-      return await session.access_token
+      return session.access_token
     }
     throw new Error('No Supabase session found')
   } else {

--- a/packages/cli/src/testUtils/matchFolderTransform.ts
+++ b/packages/cli/src/testUtils/matchFolderTransform.ts
@@ -123,7 +123,7 @@ export const matchFolderTransform: MatchFolderTransformFunction = async (
     const actualPath = path.join(tempDir, transformedFile)
     const expectedPath = path.join(fixtureOutputDir, transformedFile)
 
-    await expect(actualPath).toMatchFileContents(expectedPath, {
+    expect(actualPath).toMatchFileContents(expectedPath, {
       removeWhitespace,
     })
   }

--- a/packages/ogimage-gen/src/vite-plugin-ogimage-gen.test.ts
+++ b/packages/ogimage-gen/src/vite-plugin-ogimage-gen.test.ts
@@ -41,7 +41,7 @@ describe('vitePluginOgGen', () => {
   test('should generate rollup inputs for all OG components', async () => {
     // Type cast so TS doesn't complain calling config below
     // because config can be of many types!
-    const plugin = (await vitePluginOgGen()) as {
+    const plugin = vitePluginOgGen() as {
       config: (config: any, env: ConfigEnv) => any
     }
 
@@ -87,7 +87,7 @@ describe('vitePluginOgGen', () => {
       config: expect.any(Function),
     }
 
-    const plugin = await vitePluginOgGen()
+    const plugin = vitePluginOgGen()
 
     expect(plugin).toEqual(expectedPlugin)
   })

--- a/packages/router/src/__tests__/routeScrollReset.test.tsx
+++ b/packages/router/src/__tests__/routeScrollReset.test.tsx
@@ -24,7 +24,7 @@ describe('Router scroll reset', () => {
     render(<TestRouter />)
 
     // Make sure we're starting on the home route
-    await screen.getByText('Page 1')
+    screen.getByText('Page 1')
   })
 
   afterEach(async () => {
@@ -41,7 +41,7 @@ describe('Router scroll reset', () => {
       ),
     )
 
-    await screen.getByText('Page 2')
+    screen.getByText('Page 2')
 
     expect(globalThis.scrollTo).toHaveBeenCalledTimes(1)
   })
@@ -56,7 +56,7 @@ describe('Router scroll reset', () => {
       ),
     )
 
-    await screen.getByText('Page 2')
+    screen.getByText('Page 2')
 
     expect(globalThis.scrollTo).toHaveBeenCalledTimes(1)
   })
@@ -72,20 +72,20 @@ describe('Router scroll reset', () => {
       ),
     )
 
-    await screen.getByText('Page 1')
+    screen.getByText('Page 1')
 
     expect(globalThis.scrollTo).toHaveBeenCalledTimes(1)
   })
 
   it('does NOT reset on hash change', async () => {
-    await screen.getByText('Page 1')
+    screen.getByText('Page 1')
 
     act(() =>
       // Stay on page 1, but change the hash
       navigate(`#route=66`, { replace: true }),
     )
 
-    await screen.getByText('Page 1')
+    screen.getByText('Page 1')
 
     expect(globalThis.scrollTo).not.toHaveBeenCalled()
   })

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -163,7 +163,7 @@ async function createServer() {
 
   const port = getConfig().web.port
   console.log(`Started server on http://localhost:${port}`)
-  return await app.listen(port)
+  return app.listen(port)
 }
 
 let devApp = createServer()

--- a/packages/vite/src/rsc/rscRequestHandler.ts
+++ b/packages/vite/src/rsc/rscRequestHandler.ts
@@ -195,7 +195,7 @@ export function createRscRequestHandler(
         // In the component, getting location would otherwise be at the rw-rsc URL
         const fullUrl = getFullUrlForFlightRequest(req, props)
 
-        const pipeable = await renderRsc({
+        const pipeable = renderRsc({
           rscId,
           props,
           rsfId,

--- a/packages/vite/src/rsc/rscStudioHandlers.ts
+++ b/packages/vite/src/rsc/rscStudioHandlers.ts
@@ -141,7 +141,7 @@ export const sendRscFlightToStudio = async (input: StudioRenderInput) => {
     // becomes http://localhost:8910/about?foo=bar
     const fullUrl = getFullUrlForFlightRequest(req, props)
 
-    const pipeable = await renderRsc({
+    const pipeable = renderRsc({
       rscId,
       props,
       rsfId,

--- a/packages/web/src/server/MiddlewareResponse.test.ts
+++ b/packages/web/src/server/MiddlewareResponse.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'vitest'
 import {
   MiddlewareResponse,
   MiddlewareShortCircuit,
-} from './MiddlewareResponse'
+} from './MiddlewareResponse.js'
 
 describe('MiddlewareResponse', () => {
   test('constructor', () => {
@@ -119,7 +119,7 @@ describe('MiddlewareResponse', () => {
       ).toStrictEqual('Nope')
 
       expect(
-        await shortCircuitError.mwResponse.toResponse().statusText,
+        shortCircuitError.mwResponse.toResponse().statusText,
       ).toStrictEqual('Hold your horses!')
     }
 


### PR DESCRIPTION
Enables the `typescript-eslint/await-thenable` rule and addresses any of the issues that arisen. 