### PR TITLE
chore(babel-config): Fix incorrect internal type for tsconfig paths option

### DIFF
--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -124,7 +124,7 @@ export const parseTypeScriptConfigFiles = () => {
 }
 
 type CompilerOptionsForPaths = {
-  compilerOptions: { baseUrl: string; paths: string }
+  compilerOptions: { baseUrl: string; paths: Record<string, string[]> }
 }
 /**
  * Extracts and formats the paths from the [ts|js]config.json file


### PR DESCRIPTION
Spotted this the other day and thought it didn't quite look right. It's only an internal type used in that one file so this is just a tiny little chore.