### PR TITLE
chore(build): Move more repetitive code into framework-tools

### DIFF
--- a/packages/auth-providers/dbAuth/middleware/build.mts
+++ b/packages/auth-providers/dbAuth/middleware/build.mts
@@ -1,29 +1,16 @@
-import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+import { buildExternalCjs, buildExternalEsm } from '@redwoodjs/framework-tools'
 import {
   generateTypesCjs,
   generateTypesEsm,
   insertCommonJsPackageJson,
 } from '@redwoodjs/framework-tools/generateTypes'
 
-// ESM build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    format: 'esm',
-    packages: 'external',
-  },
-})
+await buildExternalEsm()
 await generateTypesEsm()
 
-// CJS build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    outdir: 'dist/cjs',
-    packages: 'external',
-  },
-})
+await buildExternalCjs()
 await generateTypesCjs()
+
 await insertCommonJsPackageJson({
   buildFileUrl: import.meta.url,
   cjsDir: 'dist/cjs',

--- a/packages/auth-providers/dbAuth/middleware/build.mts
+++ b/packages/auth-providers/dbAuth/middleware/build.mts
@@ -11,7 +11,4 @@ await generateTypesEsm()
 await buildExternalCjs()
 await generateTypesCjs()
 
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-  cjsDir: 'dist/cjs',
-})
+await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/auth-providers/dbAuth/middleware/package.json
+++ b/packages/auth-providers/dbAuth/middleware/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsx ./build.mts",
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-middleware.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose tsconfig.cjs.json",
     "check:attw": "yarn attw -P",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/defaultGetRoles.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/defaultGetRoles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { defaultGetRoles } from '../defaultGetRoles'
+import { defaultGetRoles } from '../defaultGetRoles.js'
 
 describe('dbAuth: defaultGetRoles', () => {
   it('returns an empty array if no roles are present', () => {

--- a/packages/auth-providers/dbAuth/middleware/src/__tests__/initDbAuthMiddleware.test.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/__tests__/initDbAuthMiddleware.test.ts
@@ -8,9 +8,10 @@ import {
   MiddlewareResponse,
 } from '@redwoodjs/web/middleware'
 
-import { middlewareDefaultAuthProviderState } from '../../../../../auth/dist/AuthProvider/AuthProviderState'
-import type { DbAuthMiddlewareOptions } from '../index'
-import { initDbAuthMiddleware } from '../index'
+import { middlewareDefaultAuthProviderState } from '../../../../../auth/dist/AuthProvider/AuthProviderState.js'
+import type { DbAuthMiddlewareOptions } from '../index.js'
+import { initDbAuthMiddleware } from '../index.js'
+
 const FIXTURE_PATH = path.resolve(
   __dirname,
   '../../../../../../__fixtures__/example-todo-main',
@@ -39,6 +40,8 @@ beforeAll(() => {
               mockedSession: 'this_is_the_only_correct_session',
             }
           }
+
+          return undefined
         }),
       },
     }

--- a/packages/auth-providers/dbAuth/middleware/src/defaultGetRoles.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/defaultGetRoles.ts
@@ -1,4 +1,6 @@
-export const defaultGetRoles = (decoded: Record<string, any>): string[] => {
+export const defaultGetRoles = (
+  decoded: Record<string, any> | undefined | null,
+): string[] => {
   try {
     const roles = decoded?.currentUser?.roles
 

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.build.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.build.json
@@ -2,12 +2,13 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
+    "rootDir": "src",
     "outDir": "dist",
     "module": "Node16",
-    "moduleResolution": "Node16"
+    "moduleResolution": "Node16",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
-  "include": ["."],
-  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],
+  "include": ["src/**/*"],
   "references": [
     { "path": "../../../auth/tsconfig.build.json" },
     { "path": "../../../vite/tsconfig.build.json" }

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.build.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.build.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/auth-providers/dbAuth/middleware/tsconfig.cjs.json
+++ b/packages/auth-providers/dbAuth/middleware/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
     "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"

--- a/packages/auth-providers/supabase/middleware/build.mts
+++ b/packages/auth-providers/supabase/middleware/build.mts
@@ -1,29 +1,16 @@
-import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+import { buildExternalCjs, buildExternalEsm } from '@redwoodjs/framework-tools'
 import {
   generateTypesCjs,
   generateTypesEsm,
   insertCommonJsPackageJson,
 } from '@redwoodjs/framework-tools/generateTypes'
 
-// ESM build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    format: 'esm',
-    packages: 'external',
-  },
-})
+await buildExternalEsm()
 await generateTypesEsm()
 
-// CJS build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    outdir: 'dist/cjs',
-    packages: 'external',
-  },
-})
+await buildExternalCjs()
 await generateTypesCjs()
+
 await insertCommonJsPackageJson({
   buildFileUrl: import.meta.url,
   cjsDir: 'dist/cjs',

--- a/packages/auth-providers/supabase/middleware/build.mts
+++ b/packages/auth-providers/supabase/middleware/build.mts
@@ -11,7 +11,4 @@ await generateTypesEsm()
 await buildExternalCjs()
 await generateTypesCjs()
 
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-  cjsDir: 'dist/cjs',
-})
+await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/auth-providers/supabase/middleware/package.json
+++ b/packages/auth-providers/supabase/middleware/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsx ./build.mts",
     "build:pack": "yarn pack -o redwoodjs-auth-supabase-middleware.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "check:attw": "yarn attw -P",
     "check:package": "concurrently npm:check:attw yarn:publint",

--- a/packages/auth-providers/supabase/middleware/src/__tests__/defaultGetRoles.test.ts
+++ b/packages/auth-providers/supabase/middleware/src/__tests__/defaultGetRoles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { defaultGetRoles } from '../defaultGetRoles'
+import { defaultGetRoles } from '../defaultGetRoles.js'
 
 describe('dbAuth: defaultGetRoles', () => {
   it('returns an empty array if no roles are present', () => {

--- a/packages/auth-providers/supabase/middleware/src/__tests__/initSupabaseAuthMiddleware.test.ts
+++ b/packages/auth-providers/supabase/middleware/src/__tests__/initSupabaseAuthMiddleware.test.ts
@@ -10,8 +10,9 @@ import {
   MiddlewareResponse,
 } from '@redwoodjs/web/middleware'
 
-import initSupabaseAuthMiddleware from '../index'
-import type { SupabaseAuthMiddlewareOptions } from '../index'
+import initSupabaseAuthMiddleware from '../index.js'
+import type { SupabaseAuthMiddlewareOptions } from '../index.js'
+
 const FIXTURE_PATH = path.resolve(
   __dirname,
   '../../../../../../__fixtures__/example-todo-main',

--- a/packages/auth-providers/supabase/middleware/src/defaultGetRoles.ts
+++ b/packages/auth-providers/supabase/middleware/src/defaultGetRoles.ts
@@ -33,7 +33,8 @@
 
 interface PartialSupabaseDecoded {
   app_metadata: {
-    roles?: string
+    [key: string]: unknown
+    roles?: string | undefined
   }
 }
 

--- a/packages/auth-providers/supabase/middleware/tsconfig.build.json
+++ b/packages/auth-providers/supabase/middleware/tsconfig.build.json
@@ -2,12 +2,13 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
+    "rootDir": "src",
     "outDir": "dist",
     "module": "Node16",
-    "moduleResolution": "Node16"
+    "moduleResolution": "Node16",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
-  "include": ["."],
-  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],
+  "include": ["src/**/*"],
   "references": [
     { "path": "../../../auth/tsconfig.build.json" },
     { "path": "../../../vite/tsconfig.build.json" }

--- a/packages/auth-providers/supabase/middleware/tsconfig.build.json
+++ b/packages/auth-providers/supabase/middleware/tsconfig.build.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/auth-providers/supabase/middleware/tsconfig.cjs.json
+++ b/packages/auth-providers/supabase/middleware/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
     "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"

--- a/packages/auth-providers/supabase/middleware/tsconfig.json
+++ b/packages/auth-providers/supabase/middleware/tsconfig.json
@@ -2,13 +2,12 @@
   "extends": "../../../../tsconfig.compilerOption.json",
   "compilerOptions": {
     "strict": true,
-    "rootDir": "src",
     "outDir": "dist",
     "module": "Node16",
-    "moduleResolution": "Node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "moduleResolution": "Node16"
   },
-  "include": ["src/**/*"],
+  "include": ["."],
+  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],
   "references": [
     { "path": "../../../auth/tsconfig.build.json" },
     { "path": "../../../vite/tsconfig.build.json" }

--- a/packages/context/build.mts
+++ b/packages/context/build.mts
@@ -1,27 +1,16 @@
-import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+import { buildCjs, buildEsm } from '@redwoodjs/framework-tools'
 import {
   generateTypesCjs,
   generateTypesEsm,
   insertCommonJsPackageJson,
 } from '@redwoodjs/framework-tools/generateTypes'
 
-// ESM build and type generation
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    format: 'esm',
-  },
-})
+await buildEsm()
 await generateTypesEsm()
 
-// CJS build, type generation, and package.json insert
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    outdir: 'dist/cjs',
-  },
-})
+await buildCjs()
 await generateTypesCjs()
+
 await insertCommonJsPackageJson({
   buildFileUrl: import.meta.url,
   cjsDir: 'dist/cjs',

--- a/packages/context/build.mts
+++ b/packages/context/build.mts
@@ -11,7 +11,4 @@ await generateTypesEsm()
 await buildCjs()
 await generateTypesCjs()
 
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-  cjsDir: 'dist/cjs',
-})
+await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsx ./build.mts",
     "build:pack": "yarn pack -o redwoodjs-context.tgz",
-    "build:types": "tsc --build --verbose ./tsconfig.json",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:types-cjs": "tsc --build --verbose ./tsconfig.cjs.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "check:attw": "yarn attw -P",

--- a/packages/context/tsconfig.build.json
+++ b/packages/context/tsconfig.build.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/packages/context/tsconfig.build.json
+++ b/packages/context/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.compilerOption.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/context/tsconfig.cjs.json
+++ b/packages/context/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
     "tsBuildInfoFile": "./tsconfig.cjs.tsbuildinfo"

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "rootDir": "src",
     "outDir": "dist",
     "module": "Node16",
-    "moduleResolution": "Node16",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "moduleResolution": "Node16"
   },
-  "include": ["src"]
+  "include": ["."],
+  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__fixtures__"],
+  "references": [{ "path": "../framework-tools" }]
 }

--- a/packages/framework-tools/src/buildDefaults.ts
+++ b/packages/framework-tools/src/buildDefaults.ts
@@ -85,6 +85,48 @@ export async function build({
   }
 }
 
+export function buildCjs() {
+  return build({
+    buildOptions: {
+      ...defaultBuildOptions,
+      tsconfig: 'tsconfig.cjs.json',
+      outdir: 'dist/cjs',
+    },
+  })
+}
+
+export function buildEsm() {
+  return build({
+    buildOptions: {
+      ...defaultBuildOptions,
+      tsconfig: 'tsconfig.build.json',
+      format: 'esm',
+    },
+  })
+}
+
+export function buildExternalCjs() {
+  return build({
+    buildOptions: {
+      ...defaultBuildOptions,
+      tsconfig: 'tsconfig.cjs.json',
+      outdir: 'dist/cjs',
+      packages: 'external',
+    },
+  })
+}
+
+export function buildExternalEsm() {
+  return build({
+    buildOptions: {
+      ...defaultBuildOptions,
+      tsconfig: 'tsconfig.build.json',
+      format: 'esm',
+      packages: 'external',
+    },
+  })
+}
+
 interface CopyAssetsOptions {
   buildFileUrl: string
   patterns: string[]

--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -57,10 +57,10 @@ export async function generateTypesEsm() {
  */
 export async function insertCommonJsPackageJson({
   buildFileUrl,
-  cjsDir,
+  cjsDir = 'dist/cjs',
 }: {
   buildFileUrl: string
-  cjsDir: string
+  cjsDir?: string
 }) {
   const packageDir = path.dirname(fileURLToPath(buildFileUrl))
   const packageJsonPath = path.join(packageDir, cjsDir, 'package.json')

--- a/packages/framework-tools/src/generateTypes.ts
+++ b/packages/framework-tools/src/generateTypes.ts
@@ -6,11 +6,15 @@ import type { PackageJson } from 'type-fest'
 import { $ } from 'zx'
 
 /**
- * This function will run `yarn build:types-cjs` to generate the CJS type definitions.
+ * This function will run `yarn build:types-cjs` to generate the CJS type
+ * definitions.
  *
- * It will also temporarily change the package.json file to have "type": "commonjs". This
- * is the most reliable way to generate CJS type definitions. It will revert the package.json
- * file back to its original state after the types have been generated - even if an error occurs.
+ * It will also temporarily change the package.json file to have
+ *`"type": "commonjs"`. This is the most reliable way to generate CJS type
+ * definitions[1]. It will revert the package.json file back to its original
+ * state after the types have been generated - even if an error occurs.
+ *
+ * [1]: https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/21#issuecomment-1494618930
  */
 export async function generateTypesCjs() {
   await $`cp package.json package.json.bak`
@@ -33,7 +37,8 @@ export async function generateTypesCjs() {
 }
 
 /**
- * This function will run `yarn build:types` to generate the ESM type definitions.
+ * This function will run `yarn build:types` to generate the ESM type
+ * definitions.
  */
 export async function generateTypesEsm() {
   try {
@@ -46,9 +51,9 @@ export async function generateTypesEsm() {
 }
 
 /**
- * This function will insert a package.json file with "type": "commonjs" in the CJS build directory.
- * This is necessary for the CJS build to be recognized as CommonJS modules when the root package.json
- * file has "type": "module".
+ * This function will insert a package.json file with "type": "commonjs" in the
+ * CJS build directory. This is necessary for the CJS build to be recognized as
+ * CommonJS modules when the root package.json file has `"type": "module"`.
  */
 export async function insertCommonJsPackageJson({
   buildFileUrl,

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -7,5 +7,8 @@
     "moduleResolution": "Node16"
   },
   "include": ["ambient.d.ts", "src/**/*"],
-  "references": [{ "path": "../api" }, { "path": "../context" }]
+  "references": [
+    { "path": "../api" },
+    { "path": "../context/tsconfig.build.json" }
+  ]
 }

--- a/packages/router/build.ts
+++ b/packages/router/build.ts
@@ -1,31 +1,16 @@
-import { build, defaultBuildOptions } from '@redwoodjs/framework-tools'
+import { buildExternalCjs, buildExternalEsm } from '@redwoodjs/framework-tools'
 import {
   generateTypesCjs,
   generateTypesEsm,
   insertCommonJsPackageJson,
 } from '@redwoodjs/framework-tools/generateTypes'
 
-// ESM build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    tsconfig: 'tsconfig.build.json',
-    format: 'esm',
-    packages: 'external',
-  },
-})
+await buildExternalEsm()
 await generateTypesEsm()
 
-// CJS build
-await build({
-  buildOptions: {
-    ...defaultBuildOptions,
-    tsconfig: 'tsconfig.cjs.json',
-    outdir: 'dist/cjs',
-    packages: 'external',
-  },
-})
+await buildExternalCjs()
 await generateTypesCjs()
+
 await insertCommonJsPackageJson({
   buildFileUrl: import.meta.url,
   cjsDir: 'dist/cjs',

--- a/packages/router/build.ts
+++ b/packages/router/build.ts
@@ -11,7 +11,4 @@ await generateTypesEsm()
 await buildExternalCjs()
 await generateTypesCjs()
 
-await insertCommonJsPackageJson({
-  buildFileUrl: import.meta.url,
-  cjsDir: 'dist/cjs',
-})
+await insertCommonJsPackageJson({ buildFileUrl: import.meta.url })


### PR DESCRIPTION
Try to streamline building dual packages even more, and make things even more uniform