### PR TITLE
chore(ci): Temporary fix for format checking on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - run: echo "Skipped"
 
   build-lint-test:
-    needs: check
+    needs: detect-changes
 
     strategy:
       matrix:
@@ -95,31 +95,20 @@ jobs:
 
       - name: 🥡 Check packaging and attw
         run: yarn check:package
+        if: needs.detect-changes.outputs.code == 'true'
 
       - name: 🌡 Test Types
         run: yarn test:types
+        if: needs.detect-changes.outputs.code == 'true'
 
       - name: Get number of CPU cores
-        if: always()
+        if: needs.detect-changes.outputs.code == 'true'
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v2
 
       - name: 🧪 Test
         run: yarn test-ci --minWorkers=1 --maxWorkers=${{ steps.cpu-cores.outputs.count }}
-
-  build-lint-test-skip:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.code == 'false'
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-
-    name: 🏗 Build, lint, test / ${{ matrix.os }} / node 20 latest
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - run: echo "Skipped"
+        if: needs.detect-changes.outputs.code == 'true'
 
   tutorial-e2e:
     needs: check


### PR DESCRIPTION
We currently only run `build-lint-test` if it's a code change but I have updated the repo so that non-code content - like docs - have to be formatted correctly too.

This is a temporary fix to allow work to continue and prevent unformatted content from merging in. I will follow up with a proper fix that decouples formatting/linting from the building and testing checks.