### PR TITLE
chore(playwright): Make RSC tests less flakey

### DIFF
--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -16,6 +16,8 @@ test.beforeAll(async ({ browser }) => {
   await page.getByLabel('Username').fill(testUser.email)
   await page.getByLabel('Password').fill(testUser.password)
 
+  await page.waitForTimeout(300)
+
   await page.getByRole('button', { name: 'Sign Up' }).click()
 
   // Wait for either...
@@ -172,9 +174,24 @@ test("'use client' cell navigation", async ({ page }) => {
 })
 
 test('Server Cell', async ({ page }) => {
-  await page.goto('/user-examples/1')
+  await page.goto('/user-examples')
 
-  const h1 = await page.locator('h1').innerHTML()
+  let h1 = await page.locator('h1').innerHTML()
+  expect(h1).toMatch(/UserExamples - userExamples/)
+
+  await expect(page.getByText('Email')).toBeVisible()
+  await expect(page.getByText('jackie@example.com')).toBeVisible()
+
+  const row = page
+    .locator('tr')
+    .filter({ hasText: 'jackie@example.com' })
+    .first()
+  const showLink = row.locator('a').filter({ hasText: 'SHOW' }).first()
+  await showLink.click()
+
+  page.waitForURL(/\/user-examples\/\d/)
+
+  h1 = await page.locator('h1').innerHTML()
   expect(h1).toMatch(/UserExamples - userExamples/)
 
   await expect(page.getByText('Email')).toBeVisible()

--- a/tasks/smoke-tests/shared/common.ts
+++ b/tasks/smoke-tests/shared/common.ts
@@ -95,6 +95,8 @@ export const loginAsTestUser = async ({
   await page.getByLabel('Username').fill(email)
   await page.getByLabel('Password').fill(password)
 
+  await page.waitForTimeout(300)
+
   await page.getByRole('button', { name: 'Login' }).click()
 
   await page.waitForURL(redirectUrl)


### PR DESCRIPTION
When I was running the tests locally with `--headed` I noticed that the tests would sometimes try to click the "Login" button before the page had updated with the password filled in. A short 300ms wait seems to have fixed that.

Also noticed that after resetting the DB to run the tests with a clean slate users weren't seeded with the same IDs as the tests expected. So now the tests rely less on the ("random") ID assignment, and more on just the deterministic emails we have for the users