### PR TITLE
chore(ci): Split formatting check into separate job 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,22 @@ jobs:
     steps:
       - run: echo "Skipped"
 
+  formatting-check:
+    name: 📝 Check formatting (prettier)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+        with:
+          set-up-yarn-cache: false
+          yarn-install-directory: .
+          build: false
+
+      - name: 📝 Check formatting (prettier)
+        run: yarn format:check
+
   build-lint-test:
     needs: check
 
@@ -89,9 +105,6 @@ jobs:
 
       - name: 🔎 Lint
         run: yarn lint
-
-      - name: 📝 Check formatting (prettier)
-        run: yarn format:check
 
       - name: 🥡 Check packaging and attw
         run: yarn check:package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - run: echo "Skipped"
 
   build-lint-test:
-    needs: detect-changes
+    needs: check
 
     strategy:
       matrix:
@@ -95,20 +95,31 @@ jobs:
 
       - name: 🥡 Check packaging and attw
         run: yarn check:package
-        if: needs.detect-changes.outputs.code == 'true'
 
       - name: 🌡 Test Types
         run: yarn test:types
-        if: needs.detect-changes.outputs.code == 'true'
 
       - name: Get number of CPU cores
-        if: needs.detect-changes.outputs.code == 'true'
+        if: always()
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v2
 
       - name: 🧪 Test
         run: yarn test-ci --minWorkers=1 --maxWorkers=${{ steps.cpu-cores.outputs.count }}
-        if: needs.detect-changes.outputs.code == 'true'
+
+  build-lint-test-skip:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'false'
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    name: 🏗 Build, lint, test / ${{ matrix.os }} / node 20 latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - run: echo "Skipped"
 
   tutorial-e2e:
     needs: check


### PR DESCRIPTION
This reverts #11324 and adds a dedicated job for checking the formatting. We need to check formatting on all PRs so having a standalone job like this makes sense to me.