### PR TITLE
refactor(forms): Build with esbuild and add conditional exports

### DIFF
--- a/.changesets/11338.md
+++ b/.changesets/11338.md
@@ -1,0 +1,3 @@
+- refactor(forms): Build with esbuild and add conditional exports (#11338) by @Josh-Walker-GM
+
+This change introduces restrictions on what can be imported from the `@redwoodjs/forms` package. You can no longer import from `@redwoodjs/forms/dist/...`. All imports should be available simply from `@redwoodjs/forms`.

--- a/packages/forms/.babelrc.js
+++ b/packages/forms/.babelrc.js
@@ -1,1 +1,0 @@
-module.exports = { extends: '../../babel.config.js' }

--- a/packages/forms/build.mts
+++ b/packages/forms/build.mts
@@ -1,0 +1,3 @@
+import { build } from '@redwoodjs/framework-tools'
+
+await build()

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -7,31 +7,38 @@
     "directory": "packages/forms"
   },
   "license": "MIT",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "yarn build:js && yarn build:types",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\"",
+    "build": "tsx ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-forms.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.build.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
+    "check:attw": "yarn rw-fwtools-attw",
+    "check:package": "concurrently npm:check:attw yarn:publint",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/runtime-corejs3": "7.25.0",
-    "core-js": "3.38.0",
     "graphql": "16.9.0",
     "pascalcase": "1.0.0",
     "react-hook-form": "7.52.2"
   },
   "devDependencies": {
-    "@babel/cli": "7.24.8",
-    "@babel/core": "^7.22.20",
+    "@redwoodjs/framework-tools": "workspace:*",
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.4.8",
     "@testing-library/react": "14.3.1",
@@ -39,9 +46,12 @@
     "@types/pascalcase": "1.0.3",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
+    "concurrently": "8.2.2",
     "nodemon": "3.1.4",
+    "publint": "0.2.10",
     "react": "19.0.0-rc-8269d55d-20240802",
     "react-dom": "19.0.0-rc-8269d55d-20240802",
+    "tsx": "4.17.0",
     "typescript": "5.5.4",
     "vitest": "2.0.5"
   },

--- a/packages/forms/tsconfig.build.json
+++ b/packages/forms/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.compilerOption.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.compilerOption.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
+    "module": "Node16",
+    "moduleResolution": "Node16"
   },
-  "include": ["src"]
+  "include": ["."],
+  "exclude": ["dist", "node_modules", "**/__mocks__", "**/__tests__/fixtures"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8184,9 +8184,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/forms@workspace:packages/forms"
   dependencies:
-    "@babel/cli": "npm:7.24.8"
-    "@babel/core": "npm:^7.22.20"
-    "@babel/runtime-corejs3": "npm:7.25.0"
+    "@redwoodjs/framework-tools": "workspace:*"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:6.4.8"
     "@testing-library/react": "npm:14.3.1"
@@ -8194,13 +8192,15 @@ __metadata:
     "@types/pascalcase": "npm:1.0.3"
     "@types/react": "npm:^18.2.55"
     "@types/react-dom": "npm:^18.2.19"
-    core-js: "npm:3.38.0"
+    concurrently: "npm:8.2.2"
     graphql: "npm:16.9.0"
     nodemon: "npm:3.1.4"
     pascalcase: "npm:1.0.0"
+    publint: "npm:0.2.10"
     react: "npm:19.0.0-rc-8269d55d-20240802"
     react-dom: "npm:19.0.0-rc-8269d55d-20240802"
     react-hook-form: "npm:7.52.2"
+    tsx: "npm:4.17.0"
     typescript: "npm:5.5.4"
     vitest: "npm:2.0.5"
   peerDependencies:


### PR DESCRIPTION
This changes the build of the forms package to use esbuild instead of babel. It also introduces the conditional exports fields in the package.json.