### PR TITLE
chore(test-fixture): correct rebuild script string suffix substitution 

### DIFF
--- a/tasks/test-project/codemods/scenarioValueSuffix.js
+++ b/tasks/test-project/codemods/scenarioValueSuffix.js
@@ -1,16 +1,15 @@
+const stringWithSuffixRegex = /String\d+$/
+
 export default (file, api) => {
   const j = api.jscodeshift
   const root = j(file.source)
 
-  const endsWith6DigitsRE = /String.*\d{6,}$/
-
-  // Replaces the randomly generated value with consistent ones
-
+  // Replaces the randomly generated value with a consistent one
   return root
     .find(j.Literal, { type: 'StringLiteral' })
     .forEach((obj) => {
       const stringValue = obj.value.value
-      if (endsWith6DigitsRE.test(stringValue)) {
+      if (stringWithSuffixRegex.test(stringValue)) {
         obj.value.value = `String${obj.value.loc.start.line}`
       }
     })


### PR DESCRIPTION
We replace the randomly generated suffix in scenarios when we rebuild the test fixture to prevent git conflicts. The regex wasn't quite right. The number is randomly generated between 0 and 10 million but the regex required at least 6 digits. There was therefore cases where the generated number was less than 6 digits and did not get replaced.