### PR TITLE
fix(api-server): Fix issue with clean builds

### DIFF
--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -33,6 +33,7 @@
     "@fastify/url-data": "5.4.0",
     "@redwoodjs/context": "workspace:*",
     "@redwoodjs/fastify-web": "workspace:*",
+    "@redwoodjs/internal": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",
     "@redwoodjs/web-server": "workspace:*",
     "chalk": "4.1.2",

--- a/packages/api-server/tsconfig.build.json
+++ b/packages/api-server/tsconfig.build.json
@@ -8,6 +8,7 @@
   "references": [
     { "path": "../internal" },
     { "path": "../project-config" },
+    { "path": "../context/tsconfig.build.json" },
     { "path": "../adapters/fastify/web" },
     { "path": "../web-server" }
   ]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,7 @@
     { "path": "../api-server/tsconfig.build.json" },
     { "path": "../cli-helpers" },
     { "path": "../internal" },
-    { "path": "../prerender" },
+    { "path": "../prerender/tsconfig.build.json" },
     { "path": "../project-config" },
     { "path": "../structure" },
     { "path": "../telemetry" }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@babel/cli": "7.24.8",
+    "@redwoodjs/api-server": "workspace:*",
     "@redwoodjs/cli": "workspace:*",
     "@redwoodjs/eslint-config": "workspace:*",
     "@redwoodjs/internal": "workspace:*",

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsx ./build.mts && yarn build:types",
     "build:pack": "yarn pack -o redwoodjs-graphql-server.tgz",
-    "build:types": "tsc --build --verbose",
+    "build:types": "tsc --build --verbose ./tsconfig.json",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "jest src",
@@ -49,6 +49,7 @@
     "@babel/core": "^7.22.20",
     "@envelop/testing": "7.0.0",
     "@envelop/types": "5.0.0",
+    "@redwoodjs/framework-tools": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",
     "@redwoodjs/realtime": "workspace:*",
     "@types/aws-lambda": "8.10.143",

--- a/packages/graphql-server/tsconfig.json
+++ b/packages/graphql-server/tsconfig.json
@@ -9,6 +9,7 @@
   "include": ["ambient.d.ts", "src/**/*"],
   "references": [
     { "path": "../api" },
-    { "path": "../context/tsconfig.build.json" }
+    { "path": "../context/tsconfig.build.json" },
+    { "path": "../realtime" }
   ]
 }

--- a/packages/jobs/tsconfig.build.json
+++ b/packages/jobs/tsconfig.build.json
@@ -8,5 +8,8 @@
     "tsBuildInfoFile": "./tsconfig.build.tsbuildinfo"
   },
   "include": ["src"],
-  "references": [{ "path": "../cli-helpers" }, { "path": "../project-config" }]
+  "references": [
+    { "path": "../cli-helpers/tsconfig.build.json" },
+    { "path": "../project-config" }
+  ]
 }

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     { "path": "../router/tsconfig.build.json" },
     { "path": "../babel-config" },
+    { "path": "../context/tsconfig.build.json" },
     { "path": "../project-config" },
     { "path": "../web/tsconfig.build.json" },
     { "path": "../auth/tsconfig.build.json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7227,6 +7227,7 @@ __metadata:
     "@redwoodjs/context": "workspace:*"
     "@redwoodjs/fastify-web": "workspace:*"
     "@redwoodjs/framework-tools": "workspace:*"
+    "@redwoodjs/internal": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/web-server": "workspace:*"
     "@types/aws-lambda": "npm:8.10.143"
@@ -8083,6 +8084,7 @@ __metadata:
   resolution: "@redwoodjs/core@workspace:packages/core"
   dependencies:
     "@babel/cli": "npm:7.24.8"
+    "@redwoodjs/api-server": "workspace:*"
     "@redwoodjs/cli": "workspace:*"
     "@redwoodjs/eslint-config": "workspace:*"
     "@redwoodjs/framework-tools": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8248,6 +8248,7 @@ __metadata:
     "@opentelemetry/api": "npm:1.8.0"
     "@redwoodjs/api": "workspace:*"
     "@redwoodjs/context": "workspace:*"
+    "@redwoodjs/framework-tools": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/realtime": "workspace:*"
     "@types/aws-lambda": "npm:8.10.143"


### PR DESCRIPTION
This address an issue where building from a clean state (no existing dist) would fail. The api-server including internal as a dependency is the fix here. There are other changes included which feel okay to add here too. They're left over from when I was just fixing things to try work out what was wrong. 

My findings whilst trying to debug why clean builds were failing:

Recently during the refactoring we now build two sets of types as part of the build command for packages which are hybrid cjs/esm. We first build esm types and then we build the cjs ones. This has had an unintended side effect. It has made it more important that our packages are built in the right order. If a package doesn't list another package as a dependency nx won't build the right graph and won't build them in the right order (so that packages have their dependencies built first before they themselves are).
Why does this matter more now? Well if we list the package in the references in a tsconfig then tsc itself will start walking through that references based dependency graph. Tsc will just run against the tsconfig file and won't run our build script which builds both sets of types. This can result in a package not having both cjs/esm types generated when a package which depends on that one goes to build.
The example here:
api-server does not list internal as a dependency in the package.json but it is in the references. This means nx didn't ensure internal (and all it's dependencies) were built before api-server was. Tsc however did know that internal and all it's dependencies needed types generated before api-server. The result was that the context package wasn't built before tsc checked if it had types. When it noticed context was lacking types it went ahead and generated them - but only for esm not cjs too. This appears to have been the reason for the issue as a commonjs package would then not have any types resolved for context.