### PR TITLE
Highlight output commands

### DIFF
--- a/packages/cli/src/commands/setup/jobs/jobsHandler.js
+++ b/packages/cli/src/commands/setup/jobs/jobsHandler.js
@@ -108,8 +108,8 @@ const tasks = async ({ force }) => {
           ${!modelExists ? 'Migrate your database to finish setting up jobs:\n' : ''}
           ${!modelExists ? c.important('\n\u00A0\u00A0yarn rw prisma migrate dev\n') : ''}
 
-          Generate jobs with: ${c.info('yarn rw g job <name>')}
-          Execute jobs with:  ${c.info('yarn rw jobs work\n')}
+          Generate jobs with: ${c.warning('yarn rw g job <name>')}
+          Execute jobs with:  ${c.warning('yarn rw jobs work\n')}
 
           Check out the docs for more info:
           ${c.link('https://docs.redwoodjs.com/docs/background-jobs')}


### PR DESCRIPTION
@Tobbe I want these to be orange, I want the user to see them. Whether we call that a "warning" internally with the color palette is another discussion, but this is what I want the message to look like when someone creates a job. 

We can/should be consistent with other generators, but I think it should start here: the other commands that are now enabled as a result of running this one are the most important part of this output, and if you don't read any other documentation at least you are now are aware of these.

If we're going to insist on tying specific meanings to colors this is always going to feel like a friction point, which may be why the `colors` package itself doesn't do that. If I want to write something in red to really draw the user's attention to it I want to be able to that, without the code implying that I'm outputting an error message because I used `c.error`. This is purely decorative for the console output, it shouldn't have any more weight than that.