### PR TITLE
fix(template): Format tsconfig and jsconfig

### DIFF
--- a/__fixtures__/test-project/api/tsconfig.json
+++ b/__fixtures__/test-project/api/tsconfig.json
@@ -7,22 +7,13 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "skipLibCheck": false,
-    "rootDirs": [
-      "./src",
-      "../.redwood/types/mirror/api/src"
-    ],
+    "rootDirs": ["./src", "../.redwood/types/mirror/api/src"],
     "paths": {
-      "src/*": [
-        "./src/*",
-        "../.redwood/types/mirror/api/src/*"
-      ],
+      "src/*": ["./src/*", "../.redwood/types/mirror/api/src/*"],
       "types/*": ["./types/*", "../types/*"],
       "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/api"]
     },
-    "typeRoots": [
-      "../node_modules/@types",
-      "./node_modules/@types"
-    ],
+    "typeRoots": ["../node_modules/@types", "./node_modules/@types"],
     "types": ["jest"],
     "jsx": "react-jsx"
   },

--- a/__fixtures__/test-project/scripts/tsconfig.json
+++ b/__fixtures__/test-project/scripts/tsconfig.json
@@ -7,26 +7,12 @@
     "module": "esnext",
     "moduleResolution": "node",
     "paths": {
-      "$api/*": [
-        "../api/*"
-      ],
-      "api/*": [
-        "../api/*"
-      ],
-      "$web/*": [
-        "../web/*"
-      ],
-      "web/*": [
-        "../web/*"
-      ],
-      "$web/src/*": [
-        "../web/src/*",
-        "../.redwood/types/mirror/web/src/*"
-      ],
-      "web/src/*": [
-        "../web/src/*",
-        "../.redwood/types/mirror/web/src/*"
-      ],
+      "$api/*": ["../api/*"],
+      "api/*": ["../api/*"],
+      "$web/*": ["../web/*"],
+      "web/*": ["../web/*"],
+      "$web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],
+      "web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],
       "types/*": ["../types/*", "../web/types/*", "../api/types/*"]
     },
     "typeRoots": ["../node_modules/@types"],

--- a/__fixtures__/test-project/web/tsconfig.json
+++ b/__fixtures__/test-project/web/tsconfig.json
@@ -20,26 +20,16 @@
         "../api/src/*",
         "../.redwood/types/mirror/api/src/*"
       ],
-      "$api/*": [
-        "../api/*"
-      ],
-      "types/*": [
-        "./types/*",
-        "../types/*"
-      ],
-      "@redwoodjs/testing": [
-        "../node_modules/@redwoodjs/testing/web"
-      ]
+      "$api/*": ["../api/*"],
+      "types/*": ["./types/*", "../types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]
     },
     "typeRoots": [
       "../node_modules/@types",
       "./node_modules/@types",
       "../node_modules/@testing-library"
     ],
-    "types": [
-      "jest",
-      "jest-dom"
-    ],
+    "types": ["jest", "jest-dom"],
     "jsx": "preserve"
   },
   "include": [

--- a/packages/create-redwood-app/templates/js/api/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/api/jsconfig.json
@@ -6,30 +6,14 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "skipLibCheck": false,
-    "rootDirs": [
-      "./src",
-      "../.redwood/types/mirror/api/src"
-    ],
+    "rootDirs": ["./src", "../.redwood/types/mirror/api/src"],
     "paths": {
-      "src/*": [
-        "./src/*",
-        "../.redwood/types/mirror/api/src/*"
-      ],
-      "types/*": [
-        "./types/*",
-        "../types/*"
-      ],
-      "@redwoodjs/testing": [
-        "../node_modules/@redwoodjs/testing/api"
-      ]
+      "src/*": ["./src/*", "../.redwood/types/mirror/api/src/*"],
+      "types/*": ["./types/*", "../types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/api"]
     },
-    "typeRoots": [
-      "../node_modules/@types",
-      "./node_modules/@types"
-    ],
-    "types": [
-      "jest"
-    ],
+    "typeRoots": ["../node_modules/@types", "./node_modules/@types"],
+    "types": ["jest"],
     "jsx": "react-jsx"
   },
   "include": [

--- a/packages/create-redwood-app/templates/js/scripts/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/scripts/jsconfig.json
@@ -6,35 +6,15 @@
     "module": "esnext",
     "moduleResolution": "node",
     "paths": {
-      "$api/*": [
-        "../api/*"
-      ],
-      "api/*": [
-        "../api/*"
-      ],
-      "$web/*": [
-        "../web/*"
-      ],
-      "web/*": [
-        "../web/*"
-      ],
-      "$web/src/*": [
-        "../web/src/*",
-        "../.redwood/types/mirror/web/src/*"
-      ],
-      "web/src/*": [
-        "../web/src/*",
-        "../.redwood/types/mirror/web/src/*"
-      ],
-      "types/*": [
-        "../types/*",
-        "../web/types/*",
-        "../api/types/*"
-      ]
+      "$api/*": ["../api/*"],
+      "api/*": ["../api/*"],
+      "$web/*": ["../web/*"],
+      "web/*": ["../web/*"],
+      "$web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],
+      "web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],
+      "types/*": ["../types/*", "../web/types/*", "../api/types/*"]
     },
-    "typeRoots": [
-      "../node_modules/@types"
-    ],
+    "typeRoots": ["../node_modules/@types"],
     "jsx": "preserve"
   },
   "include": [

--- a/packages/create-redwood-app/templates/js/web/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/web/jsconfig.json
@@ -19,26 +19,16 @@
         "../api/src/*",
         "../.redwood/types/mirror/api/src/*"
       ],
-      "$api/*": [
-        "../api/*"
-      ],
-      "types/*": [
-        "./types/*",
-        "../types/*"
-      ],
-      "@redwoodjs/testing": [
-        "../node_modules/@redwoodjs/testing/web"
-      ]
+      "$api/*": ["../api/*"],
+      "types/*": ["./types/*", "../types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]
     },
     "typeRoots": [
       "../node_modules/@types",
       "./node_modules/@types",
       "../node_modules/@testing-library"
     ],
-    "types": [
-      "jest",
-      "jest-dom"
-    ],
+    "types": ["jest", "jest-dom"],
     "jsx": "preserve"
   },
   "include": [

--- a/packages/create-redwood-app/templates/ts/api/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/api/tsconfig.json
@@ -7,22 +7,13 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "skipLibCheck": false,
-    "rootDirs": [
-      "./src",
-      "../.redwood/types/mirror/api/src"
-    ],
+    "rootDirs": ["./src", "../.redwood/types/mirror/api/src"],
     "paths": {
-      "src/*": [
-        "./src/*",
-        "../.redwood/types/mirror/api/src/*"
-      ],
+      "src/*": ["./src/*", "../.redwood/types/mirror/api/src/*"],
       "types/*": ["./types/*", "../types/*"],
       "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/api"]
     },
-    "typeRoots": [
-      "../node_modules/@types",
-      "./node_modules/@types"
-    ],
+    "typeRoots": ["../node_modules/@types", "./node_modules/@types"],
     "types": ["jest"],
     "jsx": "react-jsx"
   },

--- a/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
@@ -9,8 +9,6 @@
     "paths": {
       "$api/*": ["../api/*"],
       "api/*": ["../api/*"],
-      "$api/src/*": ["../api/src/*", "../.redwood/types/mirror/api/src/*"],
-      "api/src/*": ["../api/src/*", "../.redwood/types/mirror/api/src/*"],
       "$web/*": ["../web/*"],
       "web/*": ["../web/*"],
       "$web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],

--- a/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
@@ -7,26 +7,14 @@
     "module": "esnext",
     "moduleResolution": "node",
     "paths": {
-      "$api/*": [
-        "../api/*"
-      ],
-      "api/*": [
-        "../api/*"
-      ],
-      "$web/*": [
-        "../web/*"
-      ],
-      "web/*": [
-        "../web/*"
-      ],
-      "$web/src/*": [
-        "../web/src/*",
-        "../.redwood/types/mirror/web/src/*"
-      ],
-      "web/src/*": [
-        "../web/src/*",
-        "../.redwood/types/mirror/web/src/*"
-      ],
+      "$api/*": ["../api/*"],
+      "api/*": ["../api/*"],
+      "$api/src/*": ["../api/src/*", "../.redwood/types/mirror/api/src/*"],
+      "api/src/*": ["../api/src/*", "../.redwood/types/mirror/api/src/*"],
+      "$web/*": ["../web/*"],
+      "web/*": ["../web/*"],
+      "$web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],
+      "web/src/*": ["../web/src/*", "../.redwood/types/mirror/web/src/*"],
       "types/*": ["../types/*", "../web/types/*", "../api/types/*"]
     },
     "typeRoots": ["../node_modules/@types"],

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -20,26 +20,16 @@
         "../api/src/*",
         "../.redwood/types/mirror/api/src/*"
       ],
-      "$api/*": [
-        "../api/*"
-      ],
-      "types/*": [
-        "./types/*",
-        "../types/*"
-      ],
-      "@redwoodjs/testing": [
-        "../node_modules/@redwoodjs/testing/web"
-      ]
+      "$api/*": ["../api/*"],
+      "types/*": ["./types/*", "../types/*"],
+      "@redwoodjs/testing": ["../node_modules/@redwoodjs/testing/web"]
     },
     "typeRoots": [
       "../node_modules/@types",
       "./node_modules/@types",
       "../node_modules/@testing-library"
     ],
-    "types": [
-      "jest",
-      "jest-dom"
-    ],
+    "types": ["jest", "jest-dom"],
     "jsx": "preserve"
   },
   "include": [


### PR DESCRIPTION
My editor (Zed) insisted on reformatting these files whenever I saved them. I also checked with VSCode, and it doesn't seem to care one way or the other, so I'm reformatting like this to make both editors happy.

To be clear: I don't care exactly what the files look like. But I don't want to have to undo my editor's autosave formatting all the time 😅 