### PR TITLE
fix(template): Set scripts/ module resolution to match api/

### DIFF
--- a/.changesets/11366.md
+++ b/.changesets/11366.md
@@ -1,0 +1,5 @@
+- fix(template): Set scripts/ module resolution to match api/ (#11366) by @Tobbe
+
+Make the module resolution for `scripts/` be more predictable/stable, and match that of `api/`
+
+See also https://github.com/redwoodjs/redwood/pull/11170

--- a/__fixtures__/test-project/scripts/tsconfig.json
+++ b/__fixtures__/test-project/scripts/tsconfig.json
@@ -3,9 +3,9 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "paths": {
       "$api/*": ["../api/*"],
       "api/*": ["../api/*"],

--- a/packages/create-redwood-app/templates/js/scripts/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/scripts/jsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "noEmit": true,
     "esModuleInterop": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "paths": {
       "$api/*": [
         "../api/*"

--- a/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/scripts/tsconfig.json
@@ -3,9 +3,9 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2023",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "paths": {
       "$api/*": [
         "../api/*"


### PR DESCRIPTION
Make the module resolution for `scripts/` be more predictable/stable, and match that of `api/`

See also https://github.com/redwoodjs/redwood/pull/11170