### PR TITLE
fix(tsconfig): set "module" to "ESNext" for web/tsconfig.json

### DIFF
--- a/__fixtures__/fragment-test-project/web/tsconfig.json
+++ b/__fixtures__/fragment-test-project/web/tsconfig.json
@@ -3,9 +3,9 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "esnext",
-    "module": "esnext",
-    "moduleResolution": "node",
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "baseUrl": "./",
     "skipLibCheck": false,
     "rootDirs": [

--- a/__fixtures__/test-project-rsa/web/tsconfig.json
+++ b/__fixtures__/test-project-rsa/web/tsconfig.json
@@ -3,9 +3,9 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "esnext",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",

--- a/__fixtures__/test-project-rsc-kitchen-sink/web/tsconfig.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/tsconfig.json
@@ -3,9 +3,9 @@
     "noEmit": true,
     "allowJs": true,
     "esModuleInterop": true,
-    "target": "esnext",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "skipLibCheck": false,
     "rootDirs": [
       "./src",

--- a/__fixtures__/test-project/web/tsconfig.json
+++ b/__fixtures__/test-project/web/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": false,
     "rootDirs": [

--- a/packages/create-redwood-app/templates/js/web/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/web/jsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": false,
     "rootDirs": [

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
     "skipLibCheck": false,
     "rootDirs": [


### PR DESCRIPTION
This is a followup on https://github.com/redwoodjs/redwood/pull/11170

As I noted there, from the TS docs:

> `--moduleResolution bundler` must be paired with `--module esnext` or `--module preserve`.

https://www.typescriptlang.org/docs/handbook/modules/reference.html#bundler

And since we all agreed that we want `moduleResolution: bundler` it sounds like we really should use `module: esnext`, which this PR changes to.

The thing #11170 has to say about using ESNext is that we want to be on a pinned version. But when paired with "Bundler" I wonder if that isn't a bit of a false sense of stability anyways. I think we're in the hands of the bundler (esbuild in our case) no matter what we specify for "module" as we're letting the bundler modify the code and figure module resolution out before node gets to actually run the code.

---

Skipping changeset for this PR. No need to have a separate note for this one. The changeset from #11170 still applies.