### PR TITLE
feat(jobs): Expose types

### DIFF
--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -6,3 +6,5 @@ export { Worker } from './core/Worker.js'
 
 export { BaseAdapter } from './adapters/BaseAdapter/BaseAdapter.js'
 export { PrismaAdapter } from './adapters/PrismaAdapter/PrismaAdapter.js'
+
+export type * from './types.js'


### PR DESCRIPTION
Exposing the types used by Background Jobs is helpful for example if I want to create an options object separately and then use it for scheduling several jobs with the same options

```ts
import type { ScheduleJobOptions } from '@redwoodjs/jobs'

// ...

const options: ScheduleJobOptions = {
  wait: 30,
}
```