### PR TITLE
fix(jobs): Allow passing empty array when scheduling parameterless jobs

### DIFF
--- a/packages/jobs/src/core/JobManager.ts
+++ b/packages/jobs/src/core/JobManager.ts
@@ -2,12 +2,12 @@ import { AdapterNotFoundError } from '../errors.js'
 import type {
   Adapters,
   BasicLogger,
+  CreateSchedulerArgs,
   CreateSchedulerConfig,
   Job,
   JobDefinition,
   JobManagerConfig,
   QueueNames,
-  ScheduleJobOptions,
   WorkerConfig,
 } from '../types.js'
 
@@ -55,11 +55,15 @@ export class JobManager<
 
     return <TJob extends Job<TQueues, any[]>>(
       job: TJob,
-      ...argsAndOptions: Parameters<TJob['perform']> extends []
-        ? [undefined?, ScheduleJobOptions?]
-        : [Parameters<TJob['perform']>, ScheduleJobOptions?]
+      ...argsAndOptions: CreateSchedulerArgs<TJob>
     ) => {
-      return scheduler.schedule(job, ...argsAndOptions)
+      const [possibleArgs, possibleOptions] = argsAndOptions
+      const didPassArgs = Array.isArray(possibleArgs)
+
+      const args = didPassArgs ? possibleArgs : []
+      const options = didPassArgs ? possibleOptions : possibleArgs
+
+      return scheduler.schedule({ job, args, options })
     }
   }
 

--- a/packages/jobs/src/core/Scheduler.ts
+++ b/packages/jobs/src/core/Scheduler.ts
@@ -48,13 +48,15 @@ export class Scheduler<TAdapter extends BaseAdapter> {
     }
   }
 
-  buildPayload<TJob extends Job<QueueNames, unknown[]>>(
-    job: TJob,
-    ...argsAndOptions: Parameters<TJob['perform']> extends []
-      ? [undefined?, ScheduleJobOptions?]
-      : [Parameters<TJob['perform']>, ScheduleJobOptions?]
-  ): SchedulePayload {
-    const [args, options] = argsAndOptions
+  buildPayload<TJob extends Job<QueueNames, unknown[]>>({
+    job,
+    args,
+    options,
+  }: {
+    job: TJob
+    args: Parameters<TJob['perform']> | never[]
+    options?: ScheduleJobOptions
+  }): SchedulePayload {
     const queue = job.queue
     const priority = job.priority ?? DEFAULT_PRIORITY
     const wait = options?.wait ?? DEFAULT_WAIT
@@ -74,13 +76,20 @@ export class Scheduler<TAdapter extends BaseAdapter> {
     }
   }
 
-  async schedule<TJob extends Job<QueueNames, unknown[]>>(
-    job: TJob,
-    ...argsAndOptions: Parameters<TJob['perform']> extends []
-      ? [undefined?, ScheduleJobOptions?]
-      : [Parameters<TJob['perform']>, ScheduleJobOptions?]
-  ) {
-    const payload = this.buildPayload(job, ...argsAndOptions)
+  async schedule<TJob extends Job<QueueNames, unknown[]>>({
+    job,
+    args,
+    options,
+  }: {
+    job: TJob
+    args: Parameters<TJob['perform']> | never[]
+    options?: ScheduleJobOptions
+  }) {
+    const payload = this.buildPayload({
+      job,
+      args,
+      options,
+    })
 
     this.logger.info(payload, `[RedwoodJob] Scheduling ${job.name}`)
 

--- a/packages/jobs/src/core/__tests__/JobManager.test.ts
+++ b/packages/jobs/src/core/__tests__/JobManager.test.ts
@@ -125,11 +125,11 @@ describe('createScheduler()', () => {
 
     scheduler(mockJob, mockArgs, mockOptions)
 
-    expect(Scheduler.prototype.schedule).toHaveBeenCalledWith(
-      mockJob,
-      mockArgs,
-      mockOptions,
-    )
+    expect(Scheduler.prototype.schedule).toHaveBeenCalledWith({
+      job: mockJob,
+      args: mockArgs,
+      options: mockOptions,
+    })
   })
 
   it('returns a function that takes an array of arguments to pass to perform()', () => {
@@ -187,18 +187,13 @@ describe('createScheduler()', () => {
 
     const scheduler = manager.createScheduler({ adapter: 'mock' })
 
-    // Should be correct
-    scheduler(mockJob, undefined, { wait: 30 })
-    // Should be correct
+    // Should be correct, explicitly passing an empty array as job function arguments
+    scheduler(mockJob, [], { wait: 30 })
+    scheduler(mockJob, [])
+    // Should be correct, explicitly passing `undefined` as job options argument
     scheduler(mockJob, undefined)
-    // Should be correct
+    // Should be correct, not passing any arguments (allowed because the job doesn't require any)
     scheduler(mockJob)
-
-    // Uncomment the line below and you'll see an error right now. When the
-    // job's perform() method doesn't take any arguments you're not allowed to
-    // pass it an empty array. We could possibly allow this in the future if
-    // we want to, but for now it's an error.
-    // scheduler(mockJob, [], { wait: 30 })
   })
 
   it('returns a function with only optional arguments to pass to perform()', () => {

--- a/packages/jobs/src/core/__tests__/Scheduler.test.ts
+++ b/packages/jobs/src/core/__tests__/Scheduler.test.ts
@@ -94,7 +94,7 @@ describe('buildPayload()', () => {
       perform: vi.fn(),
     }
     const args = [{ foo: 'bar' }]
-    const payload = scheduler.buildPayload(job, args)
+    const payload = scheduler.buildPayload({ job, args })
 
     expect(payload.name).toEqual(job.name)
     expect(payload.path).toEqual(job.path)
@@ -117,7 +117,7 @@ describe('buildPayload()', () => {
 
       perform: vi.fn(),
     }
-    const payload = scheduler.buildPayload(job)
+    const payload = scheduler.buildPayload({ job, args: [] })
 
     expect(payload.priority).toEqual(DEFAULT_PRIORITY)
   })
@@ -137,7 +137,7 @@ describe('buildPayload()', () => {
       perform: vi.fn(),
     }
     const options = { wait: 10 }
-    const payload = scheduler.buildPayload(job, [], options)
+    const payload = scheduler.buildPayload({ job, args: [], options })
 
     expect(payload.runAt).toEqual(new Date(Date.now() + options.wait * 1000))
   })
@@ -157,7 +157,7 @@ describe('buildPayload()', () => {
       perform: vi.fn(),
     }
     const options = { waitUntil: new Date(2030, 0, 1, 12, 34, 56) }
-    const payload = scheduler.buildPayload(job, [], options)
+    const payload = scheduler.buildPayload({ job, args: [], options })
 
     expect(payload.runAt).toEqual(options.waitUntil)
   })
@@ -177,7 +177,7 @@ describe('buildPayload()', () => {
     }
 
     // @ts-expect-error testing error case
-    expect(() => scheduler.buildPayload(job)).toThrow(
+    expect(() => scheduler.buildPayload({ job, args: [] })).toThrow(
       errors.QueueNotDefinedError,
     )
   })
@@ -208,7 +208,7 @@ describe('schedule()', () => {
       wait: 10,
     }
 
-    await scheduler.schedule(job, args, options)
+    await scheduler.schedule({ job, args, options })
 
     expect(mockAdapter.schedule).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -240,7 +240,7 @@ describe('schedule()', () => {
       wait: 10,
     }
 
-    await expect(scheduler.schedule(job, args, options)).rejects.toThrow(
+    await expect(scheduler.schedule({ job, args, options })).rejects.toThrow(
       errors.SchedulingError,
     )
   })

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -205,4 +205,4 @@ export type ScheduleJobOptions =
       waitUntil: Date
     }
 
-type PriorityValue = IntRange<0, 101>
+type PriorityValue = IntRange<1, 101>

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -206,3 +206,8 @@ export type ScheduleJobOptions =
     }
 
 type PriorityValue = IntRange<1, 101>
+
+export type CreateSchedulerArgs<TJob extends Job<QueueNames>> =
+  Parameters<TJob['perform']> extends []
+    ? [ScheduleJobOptions?] | [[], ScheduleJobOptions?]
+    : [Parameters<TJob['perform']>, ScheduleJobOptions?]


### PR DESCRIPTION
You can now do:
```ts
await later(WithoutArgsJob, [])
```