### PR TITLE
chore(deps): Add missing dev dep (memfs) to our vite package

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -108,6 +108,7 @@
     "@types/yargs-parser": "21.0.3",
     "concurrently": "8.2.2",
     "glob": "11.0.0",
+    "memfs": "4.11.1",
     "publint": "0.2.10",
     "rollup": "4.20.0",
     "tsx": "4.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8754,6 +8754,7 @@ __metadata:
     glob: "npm:11.0.0"
     http-proxy-middleware: "npm:3.0.0"
     isbot: "npm:5.1.16"
+    memfs: "npm:4.11.1"
     publint: "npm:0.2.10"
     react: "npm:19.0.0-rc-8269d55d-20240802"
     react-server-dom-webpack: "npm:19.0.0-rc-8269d55d-20240802"


### PR DESCRIPTION
Our tests are using `memfs` but it wasn't listed as a devDependency in the package's package.json