### PR TITLE
RCS: Basic support for 'use server' inside components

### DIFF
--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
@@ -58,20 +58,14 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       }
 
       expect(output).toMatchInlineSnapshot(`
-        "import fs from 'node:fs'
+        "import fs from 'node:fs';
+        export async function formAction(formData) {
+          'use server';
 
-              export async function formAction(formData: FormData) {
-                'use server'
-
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-        import {registerServerReference} from "react-server-dom-webpack/server";
-        registerServerReference(formAction,"some/path/to/actions.ts","formAction");
-        "
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        }
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
       `)
     })
 
@@ -96,20 +90,14 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       }
 
       expect(output).toMatchInlineSnapshot(`
-        "import fs from 'node:fs'
+        "import fs from 'node:fs';
+        export const formAction = async formData => {
+          'use server';
 
-              export const formAction = async (formData: FormData) => {
-                'use server'
-
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-        import {registerServerReference} from "react-server-dom-webpack/server";
-        if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
-        "
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        };
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
       `)
     })
 
@@ -134,20 +122,14 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       }
 
       expect(output).toMatchInlineSnapshot(`
-        "import fs from 'node:fs'
+        "import fs from 'node:fs';
+        export default async function formAction(formData) {
+          'use server';
 
-              export default async function formAction(formData: FormData) {
-                'use server'
-
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-        import {registerServerReference} from "react-server-dom-webpack/server";
-        registerServerReference(formAction,"some/path/to/actions.ts","default");
-        "
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        }
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(formAction, "some/path/to/actions.ts", "default");"
       `)
     })
 
@@ -168,21 +150,20 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       const output = await pluginTransform(input, id)
 
       expect(output).toMatchInlineSnapshot(`
-        "import fs from 'node:fs'
+        "import fs from 'node:fs';
+        export const fortyTwo = () => {
+            'use server';
 
-              export const fortyTwo = () => { 'use server'; return 42 }, formAction = async (formData: FormData) => {
-                'use server'
+            return 42;
+          },
+          formAction = async formData => {
+            'use server';
 
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-        import {registerServerReference} from "react-server-dom-webpack/server";
-        if (typeof fortyTwo === "function") registerServerReference(fortyTwo,"some/path/to/actions.ts","fortyTwo");
-        if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
-        "
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          };
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(fortyTwo, "some/path/to/actions.ts", "fortyTwo");
+        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
       `)
     })
 
@@ -191,7 +172,9 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       const input = `
         import fs from 'node:fs'
 
-        export { formAction, arrowAction }
+        const variable = 'value'
+
+        export { formAction, arrowAction, variable }
 
         async function formAction(formData: FormData) {
           // A comment with 'use server' in it
@@ -215,35 +198,93 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       const output = await pluginTransform(input, id)
 
       expect(output).toMatchInlineSnapshot(`
-        "import fs from 'node:fs'
+        "import fs from 'node:fs';
+        const variable = 'value';
+        export { formAction, arrowAction, variable };
+        async function formAction(formData) {
+          // A comment with 'use server' in it
+          'use server';
 
-              export { formAction, arrowAction }
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        }
+        const arrowAction = async formData => {
+          'use server';
 
-              async function formAction(formData: FormData) {
-                // A comment with 'use server' in it
-                'use server'
-
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-              const arrowAction = async (formData: FormData) => {
-                'use server'
-
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-              import {registerServerReference} from "react-server-dom-webpack/server";
-              registerServerReference(formAction,"some/path/to/actions.ts","formAction");
-              registerServerReference(arrowAction,"some/path/to/actions.ts","arrowAction");
-              "
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        };
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");
+        registerServerReference(arrowAction, "some/path/to/actions.ts", "arrowAction");"
       `)
     })
+
+    it.todo(
+      "should handle named function and 'let' arrow function with separate export",
+      async () => {
+        const id = 'some/path/to/actions.ts'
+        const input = `
+        import fs from 'node:fs'
+
+        const variable = 'value'
+
+        export { formAction, letArrowAction, variable }
+
+        async function formAction(formData: FormData) {
+          // A comment with 'use server' in it
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }
+
+        // This one we don't know what'll happen to it. Had it been a const, we
+        // could have transformed it without doing typeof first
+        let letArrowAction = async (formData: FormData) => {
+          'use server'
+
+          await fs.promises.writeFile(
+            'settings.json',
+            \`{ "delay": \${formData.get('delay')} }\`
+          )
+        }
+
+        letArrowAction = async (formData: FormData) => {
+          // Not 'use server' anymore
+        }
+
+        `.trim()
+
+        const output = await pluginTransform(input, id)
+
+        expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs';
+        const variable = 'value';
+        export { formAction, letArrowAction, variable };
+        async function formAction(formData) {
+          // A comment with 'use server' in it
+          'use server';
+
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        }
+
+        // This one we don't know what'll happen to it. Had it been a const, we
+        // could have transformed it without doing typeof first
+        let letArrowAction = async formData => {
+          'use server';
+
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        };
+        letArrowAction = async formData => {
+          // Not 'use server' anymore
+        };
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");
+        if (typeof letArrowFunction === "function") registerServerReference(letArrowAction, "some/path/to/actions.ts", "letArrowAction");"
+      `)
+      },
+    )
 
     it('should handle separate renamed export', async () => {
       const id = 'some/path/to/actions.ts'
@@ -273,32 +314,21 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       const output = await pluginTransform(input, id)
 
       expect(output).toMatchInlineSnapshot(`
-        "import fs from 'node:fs'
+        "import fs from 'node:fs';
+        async function formAction(formData) {
+          'use server';
 
-              async function formAction(formData: FormData) {
-                'use server'
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        }
+        const arrowAction = async formData => {
+          'use server';
 
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-              const arrowAction = async (formData: FormData) => {
-                'use server'
-
-                await fs.promises.writeFile(
-                  'settings.json',
-                  \`{ "delay": \${formData.get('delay')} }\`
-                )
-              }
-
-              export { formAction as fA, arrowAction }
-
-        import {registerServerReference} from "react-server-dom-webpack/server";
-        registerServerReference(formAction,"some/path/to/actions.ts","fA");
-        registerServerReference(arrowAction,"some/path/to/actions.ts","arrowAction");
-        "
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        };
+        export { formAction as fA, arrowAction };
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        registerServerReference(formAction, "some/path/to/actions.ts", "fA");
+        registerServerReference(arrowAction, "some/path/to/actions.ts", "arrowAction");"
       `)
     })
 
@@ -361,15 +391,12 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         }
 
         expect(output).toMatchInlineSnapshot(`
-          "import fs from 'node:fs'
+          "import fs from 'node:fs';
 
-                    // A comment with 'use server' in it
-                    export async function formAction(formData: FormData) {
-                      await fs.promises.writeFile(
-                        'settings.json',
-                        \`{ "delay": \${formData.get('delay')} }\`
-                      )
-                    }"
+          // A comment with 'use server' in it
+          export async function formAction(formData) {
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          }"
         `)
       })
 
@@ -393,15 +420,12 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         }
 
         expect(output).toMatchInlineSnapshot(`
-          "import fs from 'node:fs'
+          "import fs from 'node:fs';
 
-                    // A comment with 'use server' in it
-                    export const formAction = async (formData: FormData) => {
-                      await fs.promises.writeFile(
-                        'settings.json',
-                        \`{ "delay": \${formData.get('delay')} }\`
-                      )
-                    }"
+          // A comment with 'use server' in it
+          export const formAction = async formData => {
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          };"
         `)
       })
 
@@ -425,15 +449,12 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         }
 
         expect(output).toMatchInlineSnapshot(`
-          "import fs from 'node:fs'
+          "import fs from 'node:fs';
 
-                    // A comment with 'use server' in it
-                    export default async function formAction(formData: FormData) {
-                      await fs.promises.writeFile(
-                        'settings.json',
-                        \`{ "delay": \${formData.get('delay')} }\`
-                      )
-                    }"
+          // A comment with 'use server' in it
+          export default async function formAction(formData) {
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          }"
         `)
       })
 
@@ -454,20 +475,15 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         const output = await pluginTransform(input, id)
 
         expect(output).toMatchInlineSnapshot(`
-          "import fs from 'node:fs'
+          "import fs from 'node:fs';
+          export const fortyTwo = () => 42,
+            formAction = async formData => {
+              'use server';
 
-                export const fortyTwo = () => 42, formAction = async (formData: FormData) => {
-                  'use server'
-
-                  await fs.promises.writeFile(
-                    'settings.json',
-                    \`{ "delay": \${formData.get('delay')} }\`
-                  )
-                }
-
-          import {registerServerReference} from "react-server-dom-webpack/server";
-          if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
-          "
+              await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+            };
+          import { registerServerReference } from "react-server-dom-webpack/server";
+          registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
         `)
       })
 
@@ -496,24 +512,15 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         const output = await pluginTransform(input, id)
 
         expect(output).toMatchInlineSnapshot(`
-          "import fs from 'node:fs'
-
-                export { formAction, arrowAction }
-
-                async function formAction(formData: FormData) {
-                  // A comment with 'use server' in it
-                  await fs.promises.writeFile(
-                    'settings.json',
-                    \`{ "delay": \${formData.get('delay')} }\`
-                  )
-                }
-
-                const arrowAction = async (formData: FormData) => {
-                  await fs.promises.writeFile(
-                    'settings.json',
-                    \`{ "delay": \${formData.get('delay')} }\`
-                  )
-                }"
+          "import fs from 'node:fs';
+          export { formAction, arrowAction };
+          async function formAction(formData) {
+            // A comment with 'use server' in it
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          }
+          const arrowAction = async formData => {
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          };"
         `)
       })
 
@@ -543,25 +550,16 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         const output = await pluginTransform(input, id)
 
         expect(output).toMatchInlineSnapshot(`
-          "import fs from 'node:fs'
-
-                async function formAction(formData: FormData) {
-                  // A comment with 'use server' in it
-                  await fs.promises.writeFile(
-                    'settings.json',
-                    \`{ "delay": \${formData.get('delay')} }\`
-                  )
-                }
-
-                const arrowAction = async (formData: FormData) => {
-                  // A comment with 'use server' in it
-                  await fs.promises.writeFile(
-                    'settings.json',
-                    \`{ "delay": \${formData.get('delay')} }\`
-                  )
-                }
-
-                export { formAction as fA, arrowAction }"
+          "import fs from 'node:fs';
+          async function formAction(formData) {
+            // A comment with 'use server' in it
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          }
+          const arrowAction = async formData => {
+            // A comment with 'use server' in it
+            await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+          };
+          export { formAction as fA, arrowAction };"
         `)
       })
 
@@ -595,5 +593,57 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         `)
       })
     })
+  })
+
+  describe('actions inside components', async () => {
+    it('should handle self-contained named function inside default exported component', async () => {
+      const id = 'some/path/to/Component.tsx'
+      const input = `
+        import fs from 'node:fs'
+
+        export default async function MyComponent() {
+          async function formAction(formData: FormData) {
+            'use server'
+
+            await fs.promises.writeFile(
+              'settings.json',
+              \`{ "delay": \${formData.get('delay')} }\`
+            )
+          }
+
+          return (
+            <form action={formAction}>
+              <input type="number" name="delay" />
+              <button type="submit">Submit</button>
+            </form>
+          )
+        }`.trim()
+
+      const output = await pluginTransform(input, id)
+
+      if (typeof output !== 'string') {
+        throw new Error('Expected output to be a string')
+      }
+
+      expect(output).toMatchInlineSnapshot(`
+        "import fs from 'node:fs';
+        export default async function MyComponent() {
+          const formAction = __rwjs__rsa0_formAction;
+          return <form action={formAction}>
+                      <input type="number" name="delay" />
+                      <button type="submit">Submit</button>
+                    </form>;
+        }
+        import { registerServerReference } from "react-server-dom-webpack/server";
+        export async function __rwjs__rsa0_formAction(formData: FormData) {
+          'use server';
+
+          await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
+        }
+        registerServerReference(__rwjs__rsa0_formAction, "some/path/to/Component.tsx", "__rwjs__rsa0_formAction");"
+      `)
+    })
+
+    it.skip('should handle self-contained named function inside function with separate export', async () => {})
   })
 })

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -196,8 +196,6 @@ function babelPluginTransformServerFunction({
   // If the same local name is exported more than once, we only need one of the names.
   const localNames = new Map<string, string>()
   const localTypes = new Map<string, string>()
-  // const serverActions = new Set<string>()
-  // const localExports = new Map<string, string>()
   const serverActionNodes: types.FunctionDeclaration[] = []
   const topLevelFunctions: string[] = []
 

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -1,3 +1,5 @@
+import * as babel from '@babel/core'
+import type { PluginObj, types } from '@babel/core'
 import * as swc from '@swc/core'
 import type { Plugin } from 'vite'
 
@@ -22,6 +24,8 @@ export function rscTransformUseServerPlugin(): Plugin {
         mod = swc.parseSync(code, {
           target: 'es2022',
           syntax: isTypescript ? 'typescript' : 'ecmascript',
+          tsx: id.endsWith('.tsx'),
+          jsx: id.endsWith('.jsx'),
         })
       } catch (e: any) {
         console.error('Error parsing', id, e.message)
@@ -61,7 +65,26 @@ export function rscTransformUseServerPlugin(): Plugin {
       if (moduleScopedUseServer) {
         transformedCode = transformServerModule(mod, id, code)
       } else {
-        transformedCode = transformServerFunction(mod, id, code)
+        // transformedCode = transformServerFunction(mod, id, code)
+
+        const result = babel.transformSync(code, {
+          filename: id,
+          // presets: ['@babel/preset-typescript', '@babel/preset-react'],
+          presets: ['@babel/preset-typescript'],
+          plugins: [[babelPluginTransformServerFunction, { url: id }]],
+        })
+
+        if (!result) {
+          console.error('Failed to transform code', id, code)
+          throw new Error('Failed to transform code')
+        }
+
+        if (!result.code) {
+          console.error('Failed to transform code', id, code)
+          throw new Error("Transform didn't return any code")
+        }
+
+        transformedCode = result.code
       }
 
       return transformedCode
@@ -154,172 +177,324 @@ function transformServerModule(
   return newSrc
 }
 
-function transformServerFunction(
-  mod: swc.Module,
-  url: string,
-  code: string,
-): string {
+interface PluginPass {
+  opts: {
+    url: string
+  }
+  file: {
+    opts: {
+      filename: string
+    }
+  }
+}
+
+function babelPluginTransformServerFunction({
+  types: t,
+}: {
+  types: typeof types
+}): PluginObj<PluginPass> {
   // If the same local name is exported more than once, we only need one of the names.
   const localNames = new Map<string, string>()
   const localTypes = new Map<string, string>()
-  const serverActions = new Set<string>()
-  const localExports = new Map<string, string>()
+  // const serverActions = new Set<string>()
+  // const localExports = new Map<string, string>()
+  const serverActionNodes: types.FunctionDeclaration[] = []
+  const topLevelFunctions: string[] = []
 
-  for (const node of mod.body) {
-    switch (node.type) {
-      // TODO (RSC): Add code comments with examples of each type of node
+  return {
+    name: 'babel-plugin-redwood-transform-server-function',
+    visitor: {
+      Program: {
+        enter(path) {
+          path.node.body.forEach((statement) => {
+            if (t.isFunctionDeclaration(statement)) {
+              if (hasUseServerDirective(statement)) {
+                const name = statement.id?.name
+                if (!name) {
+                  throw new Error('Function declaration must have a name')
+                }
 
-      // export async function formAction(formData: FormData) { /* ... */ }
-      // export const formAction = async (formData: FormData) => { /* ... */ }
-      case 'ExportDeclaration':
-        if (
-          node.declaration.type === 'FunctionDeclaration' &&
-          node.declaration.body
-        ) {
-          const name = node.declaration.identifier.value
+                topLevelFunctions.push(name)
+                localTypes.set(name, 'function')
+              }
+            }
+            if (t.isVariableDeclaration(statement)) {
+              statement.declarations.forEach((declarator) => {
+                if (t.isFunctionExpression(declarator.init)) {
+                  if (hasUseServerDirective(declarator.init)) {
+                    const name =
+                      declarator.id.type === 'Identifier'
+                        ? declarator.id.name
+                        : undefined
+                    if (!name) {
+                      throw new Error('Function declaration must have a name')
+                    }
 
-          // Check if the body contains a "use server" directive as the first
-          // statement.
-          const firstStmt = node.declaration.body.stmts[0]
-          if (isUseServerDirective(firstStmt)) {
-            localNames.set(name, name)
-            localTypes.set(name, 'function')
+                    topLevelFunctions.push(name)
+                    localTypes.set(name, 'function')
+                  }
+                } else if (t.isArrowFunctionExpression(declarator.init)) {
+                  if (hasUseServerDirective(declarator.init)) {
+                    const name =
+                      declarator.id.type === 'Identifier'
+                        ? declarator.id.name
+                        : undefined
+                    if (!name) {
+                      throw new Error('Function declaration must have a name')
+                    }
+
+                    topLevelFunctions.push(name)
+                    localTypes.set(name, 'function')
+                  }
+                }
+              })
+            }
+          })
+        },
+        exit(path, state) {
+          if (serverActionNodes.length === 0 && localTypes.size === 0) {
+            return
           }
-        } else if (node.declaration.type === 'VariableDeclaration') {
-          for (const declaration of node.declaration.declarations) {
-            if (
-              declaration.id.type === 'Identifier' &&
-              declaration.init?.type === 'ArrowFunctionExpression' &&
-              // The body has to be a block statement to have a "use server"
-              // directive
-              declaration.init.body.type === 'BlockStatement'
-            ) {
-              const firstStmt = declaration.init.body.stmts[0]
 
-              if (isUseServerDirective(firstStmt)) {
-                const name = declaration.id.value
-                localNames.set(name, name)
+          const importDeclaration = t.importDeclaration(
+            [
+              t.importSpecifier(
+                t.identifier('registerServerReference'),
+                t.identifier('registerServerReference'),
+              ),
+            ],
+            t.stringLiteral('react-server-dom-webpack/server'),
+          )
+
+          path.node.body.push(importDeclaration)
+
+          serverActionNodes.forEach((functionDeclaration) => {
+            path.node.body.push(t.exportNamedDeclaration(functionDeclaration))
+            const name = functionDeclaration.id?.name || ''
+
+            path.node.body.push(
+              t.expressionStatement(
+                t.callExpression(t.identifier('registerServerReference'), [
+                  t.identifier(name),
+                  t.stringLiteral(state.opts.url),
+                  t.stringLiteral(name),
+                ]),
+              ),
+            )
+          })
+
+          localNames.forEach((exportedName, localName) => {
+            if (!localTypes.get(localName)) {
+              return
+            }
+
+            const localType = localTypes.get(localName)
+            if (localType === 'function') {
+              path.node.body.push(
+                t.expressionStatement(
+                  t.callExpression(t.identifier('registerServerReference'), [
+                    t.identifier(localName),
+                    t.stringLiteral(state.opts.url),
+                    t.stringLiteral(exportedName),
+                  ]),
+                ),
+              )
+            } else {
+              path.node.body.push(
+                t.ifStatement(
+                  t.binaryExpression(
+                    '===',
+                    t.unaryExpression('typeof', t.identifier(localName)),
+                    t.stringLiteral('function'),
+                  ),
+                  t.expressionStatement(
+                    t.callExpression(t.identifier('registerServerReference'), [
+                      t.identifier(localName),
+                      t.stringLiteral(state.opts.url),
+                      t.stringLiteral(exportedName),
+                    ]),
+                  ),
+                ),
+              )
+            }
+          })
+        },
+      },
+      ExportNamedDeclaration(path) {
+        const declaration = path.node.declaration
+        const specifiers = path.node.specifiers
+
+        if (t.isFunctionDeclaration(declaration)) {
+          // export async function formAction(formData: FormData) {
+          if (hasUseServerDirective(declaration)) {
+            // exported named function with top-level "use server"
+            const identifier = declaration.id?.name
+
+            if (identifier) {
+              localNames.set(identifier, identifier)
+              localTypes.set(identifier, 'function')
+            }
+          } else {
+            // exported named function that might have a server action inside
+            const serverActionNodeIndex = indexOfServerActionNode(
+              t,
+              declaration.body,
+            )
+
+            if (serverActionNodeIndex >= 0) {
+              const serverActionNode =
+                declaration.body.body[serverActionNodeIndex]
+
+              if (
+                serverActionNode &&
+                t.isFunctionDeclaration(serverActionNode)
+              ) {
+                const name = serverActionNode.id?.name
+                if (!name) {
+                  // TODO (RSC): Write test for this scenario and add support
+                }
+
+                serverActionNodes.push(serverActionNode)
+              }
+            }
+          }
+        } else if (t.isVariableDeclaration(declaration)) {
+          // export const formAction = async (formData: FormData) => {
+          for (const declarator of declaration.declarations) {
+            const init = declarator.init
+
+            if (
+              !t.isArrowFunctionExpression(init) ||
+              !t.isBlockStatement(init.body)
+            ) {
+              continue
+            }
+
+            if (hasUseServerDirective(init)) {
+              // exported arrow function with top-level "use server"
+              if (declarator.id.type === 'Identifier') {
+                localNames.set(declarator.id.name, declarator.id.name)
+                localTypes.set(declarator.id.name, 'function')
+              }
+            } else {
+              // exported arrow function that might have a server action inside
+              const serverActionNodeIndex = indexOfServerActionNode(
+                t,
+                init.body,
+              )
+
+              if (serverActionNodeIndex >= 0) {
+                const serverActionNode = init.body.body[serverActionNodeIndex]
+
+                if (t.isFunctionDeclaration(serverActionNode)) {
+                  const name = serverActionNode.id?.name
+                  if (!name) {
+                    // TODO (RSC): For now at least...
+                    throw new Error('Server action must have a name')
+                  }
+
+                  const uniqueName = `__rwjs__rsa${serverActionNodes.length}_${name}`
+                  serverActionNode.id = t.identifier(uniqueName)
+                  serverActionNodes.push(serverActionNode)
+
+                  init.body.body[serverActionNodeIndex] = t.variableDeclaration(
+                    'const',
+                    [
+                      t.variableDeclarator(
+                        t.identifier(name),
+                        t.identifier(uniqueName),
+                      ),
+                    ],
+                  )
+                }
+              }
+            }
+          }
+        } else if (specifiers.length) {
+          specifiers.forEach((specifier) => {
+            if (t.isExportSpecifier(specifier)) {
+              const exportedName = t.isStringLiteral(specifier.exported)
+                ? specifier.exported.value
+                : specifier.exported.name
+              localNames.set(specifier.local.name, exportedName)
+            }
+          })
+        }
+      },
+      ExportDefaultDeclaration(path) {
+        const declaration = path.node.declaration
+
+        if (t.isFunctionDeclaration(declaration)) {
+          if (hasUseServerDirective(declaration)) {
+            // Default-exported function with top-level "use server"
+            const identifier = declaration.id?.name
+
+            if (identifier) {
+              localNames.set(identifier, 'default')
+              localTypes.set(identifier, 'function')
+            }
+          } else {
+            // Default-exported function that might have a server action inside
+            const serverActionNodeIndex = indexOfServerActionNode(
+              t,
+              declaration.body,
+            )
+
+            if (serverActionNodeIndex >= 0) {
+              const serverActionNode =
+                declaration.body.body[serverActionNodeIndex]
+
+              if (
+                serverActionNode &&
+                t.isFunctionDeclaration(serverActionNode)
+              ) {
+                const name = serverActionNode.id?.name
+                if (!name) {
+                  // TODO (RSC): For now at least...
+                  throw new Error('Server action must have a name')
+                }
+
+                const uniqueName = `__rwjs__rsa${serverActionNodes.length}_${name}`
+                serverActionNode.id = t.identifier(uniqueName)
+                serverActionNodes.push(serverActionNode)
+
+                declaration.body.body[serverActionNodeIndex] =
+                  t.variableDeclaration('const', [
+                    t.variableDeclarator(
+                      t.identifier(name),
+                      t.identifier(uniqueName),
+                    ),
+                  ])
               }
             }
           }
         }
-
-        break
-
-      case 'ExportDefaultDeclaration':
-        if (
-          node.decl.type === 'FunctionExpression' &&
-          // The body has to be a block statement to have a "use server"
-          // directive
-          node.decl.body?.type === 'BlockStatement'
-        ) {
-          const firstStmt = node.decl.body.stmts[0]
-
-          if (isUseServerDirective(firstStmt)) {
-            const identifier = node.decl.identifier
-            if (identifier) {
-              localNames.set(identifier.value, 'default')
-              localTypes.set(identifier.value, 'function')
-            }
-          }
-        }
-
-        break
-
-      // export { formAction, arrowAction }
-      case 'ExportNamedDeclaration':
-        for (const specifier of node.specifiers) {
-          if (specifier.type === 'ExportSpecifier') {
-            const name = specifier.orig.value
-
-            if (specifier.exported?.type === 'Identifier') {
-              const exportedName = specifier.exported.value
-              localExports.set(name, exportedName)
-            } else if (specifier.orig.type === 'Identifier') {
-              localExports.set(name, name)
-            }
-          }
-        }
-
-        break
-
-      case 'ExportDefaultExpression':
-        if (node.expression.type === 'Identifier') {
-          localNames.set(node.expression.value, 'default')
-        }
-
-        break
-
-      case 'FunctionDeclaration': {
-        const name = node.identifier.value
-
-        if (node.body?.type === 'BlockStatement') {
-          const firstStmt = node.body.stmts[0]
-
-          if (isUseServerDirective(firstStmt)) {
-            serverActions.add(name)
-          }
-        }
-
-        break
-      }
-
-      case 'VariableDeclaration':
-        for (const declaration of node.declarations) {
-          if (
-            declaration.id.type === 'Identifier' &&
-            declaration.init?.type === 'ArrowFunctionExpression' &&
-            // The body has to be a block statement to have a "use server"
-            // directive
-            declaration.init.body.type === 'BlockStatement'
-          ) {
-            const firstStmt = declaration.init.body.stmts[0]
-
-            if (isUseServerDirective(firstStmt)) {
-              serverActions.add(declaration.id.value)
-            }
-          }
-        }
-    }
+      },
+    },
   }
-
-  for (const [localName, exportName] of localExports) {
-    if (serverActions.has(localName)) {
-      localNames.set(localName, exportName)
-      localTypes.set(localName, 'function')
-    }
-  }
-
-  // No functions with "use server" directive found
-  if (localNames.size === 0) {
-    return code
-  }
-
-  let newSrc =
-    code +
-    '\n\n' +
-    'import {registerServerReference} from ' +
-    '"react-server-dom-webpack/server";\n'
-
-  localNames.forEach(function (exported, local) {
-    if (localTypes.get(local) !== 'function') {
-      // We first check if the export is a function and if so annotate it.
-      newSrc += 'if (typeof ' + local + ' === "function") '
-    }
-
-    const urlStr = JSON.stringify(url)
-    const exportedStr = JSON.stringify(exported)
-    newSrc += `registerServerReference(${local},${urlStr},${exportedStr});\n`
-  })
-
-  return newSrc
 }
 
-function isUseServerDirective(stmt: swc.Statement | undefined): boolean {
+function hasUseServerDirective(
+  statement:
+    | types.FunctionDeclaration
+    | types.ArrowFunctionExpression
+    | types.FunctionExpression,
+) {
   return (
-    !!stmt &&
-    stmt.type === 'ExpressionStatement' &&
-    stmt.expression.type === 'StringLiteral' &&
-    stmt.expression.value === 'use server'
+    'directives' in statement.body &&
+    statement.body.directives.some(
+      (directive) => directive.value.value === 'use server',
+    )
+  )
+}
+
+function indexOfServerActionNode(
+  t: typeof types,
+  blockStatement: types.BlockStatement,
+): number {
+  return blockStatement.body.findIndex(
+    (node): node is types.FunctionDeclaration => {
+      return t.isFunctionDeclaration(node) && hasUseServerDirective(node)
+    },
   )
 }


### PR DESCRIPTION
Support code like this

```tsx
import fs from 'node:fs'

export default async function MyComponent() {
  async function formAction(formData: FormData) {
     'use server'

    await fs.promises.writeFile(
      'settings.json',
      `{ "delay": \${formData.get('delay')} }`
    )
  }

  return (
    <form action={formAction}>
      <input type="number" name="delay" />
      <button type="submit">Submit</button>
    </form>
  )
}
```