### PR TITLE
fix(jobs): Fix the `deleteSuccessfulJobs` type showing up 

### DIFF
--- a/packages/jobs/src/core/Worker.ts
+++ b/packages/jobs/src/core/Worker.ts
@@ -12,11 +12,11 @@ import {
   DEFAULT_SLEEP_DELAY,
 } from '../consts.js'
 import { AdapterRequiredError, QueuesRequiredError } from '../errors.js'
-import type { BasicLogger } from '../types.js'
+import type { BasicLogger, WorkerSharedOptions } from '../types.js'
 
 import { Executor } from './Executor.js'
 
-export interface WorkerOptions {
+export interface WorkerOptions extends WorkerSharedOptions {
   // required
 
   adapter: BaseAdapter
@@ -30,22 +30,7 @@ export interface WorkerOptions {
   logger?: BasicLogger
   /** If true, will clear the queue of all jobs and then exit */
   clear?: boolean
-  /** The maximum number of times to retry a failed job */
-  maxAttempts?: number
-  /** The maximum amount of time to let a job run in seconds */
-  maxRuntime?: number
-  /** Whether to keep succeeded jobs in the database */
-  deleteSuccessfulJobs?: boolean
-  /** Whether to keep failed jobs in the database after reaching maxAttempts */
-  deleteFailedJobs?: boolean
-  /**
-   * The amount of time to wait in milliseconds between checking for jobs.
-   * The time it took to run a job is subtracted from this time, so this is a
-   * maximum wait time.
-   *
-   * @default 5 seconds
-   */
-  sleepDelay?: number
+
   /**
    * Set to `false` and the work loop will quit when the current job is done
    * running (regardless of how many outstanding jobs there are to be worked
@@ -54,11 +39,11 @@ export interface WorkerOptions {
    */
   workoff?: boolean
 
-  // For testing
-
   /**
-   * Mainly used to make testing much easier: we can set to false to NOT run in
-   * an infinite loop by default during tests
+   * If set to `true` will run the worker forever looking for new jobs. Otherwise
+   * will only look for jobs one time and then exit.
+   *
+   * Useful for testing to avoid infinite loops!
    */
   forever?: boolean
 }

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -34,7 +34,7 @@ export type QueueNames = readonly [string, ...string[]]
 export interface WorkerConfig<
   TAdapters extends Adapters,
   TQueues extends QueueNames,
-> {
+> extends WorkerSharedOptions {
   /**
    * The name of the adapter to use for this worker. This must be one of the keys
    * in the `adapters` object when you created the `JobManager`.
@@ -48,6 +48,21 @@ export interface WorkerConfig<
    */
   queue: '*' | TQueues[number] | TQueues[number][]
 
+  /**
+   * The number of workers to spawn for this worker configuration.
+   *
+   * @default 1
+   */
+  count?: number
+
+  /**
+   * The logger to use for this worker. If not provided, the logger from the
+   * `JobManager` will be used.
+   */
+  logger?: BasicLogger
+}
+
+export interface WorkerSharedOptions {
   /**
    * The maximum number of retries to attempt for a job before giving up.
    *
@@ -73,6 +88,15 @@ export interface WorkerConfig<
   deleteFailedJobs?: boolean
 
   /**
+   * Whether to keep succeeded jobs in the database after they have completed
+   * successfully.
+   *
+   * @default true
+   *
+   */
+  deleteSuccessfulJobs?: boolean
+
+  /**
    * The amount of time in seconds to wait between polling the queue for new
    * jobs. Some adapters may not need this if they do not poll the queue and
    * instead rely on a subscription model.
@@ -80,19 +104,6 @@ export interface WorkerConfig<
    * @default 5
    */
   sleepDelay?: number
-
-  /**
-   * The number of workers to spawn for this worker configuration.
-   *
-   * @default 1
-   */
-  count?: number
-
-  /**
-   * The logger to use for this worker. If not provided, the logger from the
-   * `JobManager` will be used.
-   */
-  logger?: BasicLogger
 }
 
 export interface JobManagerConfig<


### PR DESCRIPTION
The type wasn't showing up. We had the types for config in two places so this moves them into one place that can then be referenced. 