### PR TITLE
feat(uploads): Add File scalar to rootSchema

### DIFF
--- a/.changesets/11378.md
+++ b/.changesets/11378.md
@@ -1,0 +1,6 @@
+- feat(uploads): Add File scalar to rootSchema (#11378) by @dac09
+
+Adds `File` scalar to rootSchema, to enable parsing fields set to File as a https://developer.mozilla.org/en-US/docs/Web/API/File
+
+The parsing and scalar is actually built in to GraphQL Yoga, this change just enables it by default instead of having to add `scalar File` to one or more of your SDLs.
+

--- a/.changesets/11378.md
+++ b/.changesets/11378.md
@@ -3,4 +3,3 @@
 Adds `File` scalar to rootSchema, to enable parsing fields set to File as a https://developer.mozilla.org/en-US/docs/Web/API/File
 
 The parsing and scalar is actually built in to GraphQL Yoga, this change just enables it by default instead of having to add `scalar File` to one or more of your SDLs.
-

--- a/__fixtures__/example-todo-main/web/src/graphql/graphql.ts
+++ b/__fixtures__/example-todo-main/web/src/graphql/graphql.ts
@@ -18,6 +18,7 @@ export type Scalars = {
   Byte: { input: any; output: any; }
   Date: { input: any; output: any; }
   DateTime: { input: any; output: any; }
+  File: { input: any; output: any; }
   JSON: { input: any; output: any; }
   JSONObject: { input: any; output: any; }
   Time: { input: any; output: any; }

--- a/packages/graphql-server/src/rootSchema.ts
+++ b/packages/graphql-server/src/rootSchema.ts
@@ -27,6 +27,7 @@ export const schema = gql`
   scalar JSON
   scalar JSONObject
   scalar Byte
+  scalar File
 
   """
   The RedwoodJS Root Schema

--- a/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlCodeGen.test.ts.snap
@@ -36,6 +36,7 @@ export type Scalars = {
   Byte: Buffer;
   Date: Date | string;
   DateTime: Date | string;
+  File: File;
   JSON: Prisma.JsonValue;
   JSONObject: Prisma.JsonObject;
   Time: Date | string;
@@ -164,6 +165,7 @@ export type ResolversTypes = {
   Byte: ResolverTypeWrapper<Scalars['Byte']>;
   Date: ResolverTypeWrapper<Scalars['Date']>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
+  File: ResolverTypeWrapper<Scalars['File']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   JSON: ResolverTypeWrapper<Scalars['JSON']>;
   JSONObject: ResolverTypeWrapper<Scalars['JSONObject']>;
@@ -182,6 +184,7 @@ export type ResolversParentTypes = {
   Byte: Scalars['Byte'];
   Date: Scalars['Date'];
   DateTime: Scalars['DateTime'];
+  File: Scalars['File'];
   Int: Scalars['Int'];
   JSON: Scalars['JSON'];
   JSONObject: Scalars['JSONObject'];
@@ -217,6 +220,10 @@ export interface DateScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 
 export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
+}
+
+export interface FileScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['File'], any> {
+  name: 'File';
 }
 
 export interface JSONScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
@@ -290,6 +297,7 @@ export type Resolvers<ContextType = RedwoodGraphQLContext> = {
   Byte: GraphQLScalarType;
   Date: GraphQLScalarType;
   DateTime: GraphQLScalarType;
+  File: GraphQLScalarType;
   JSON: GraphQLScalarType;
   JSONObject: GraphQLScalarType;
   Mutation: MutationResolvers<ContextType>;
@@ -324,6 +332,7 @@ export type Scalars = {
   Byte: Buffer;
   Date: string;
   DateTime: string;
+  File: File;
   JSON: Prisma.JsonValue;
   JSONObject: Prisma.JsonObject;
   Time: string;

--- a/packages/internal/src/__tests__/__snapshots__/graphqlSchema.test.ts.snap
+++ b/packages/internal/src/__tests__/__snapshots__/graphqlSchema.test.ts.snap
@@ -13,6 +13,8 @@ scalar Date
 
 scalar DateTime
 
+scalar File
+
 scalar JSON
 
 scalar JSONObject
@@ -83,6 +85,8 @@ scalar Byte
 scalar Date
 
 scalar DateTime
+
+scalar File
 
 scalar JSON
 


### PR DESCRIPTION
As discussed in CTM - we were wondering if it's possible to make the File scalar available by default for uploads.

It is! We just have to add it to the rootSchema. 

