### PR TITLE
chore(test): Update tests to make them compatible with Vite's ecosystem CI

### DIFF
--- a/packages/cli/src/commands/__tests__/dev.test.js
+++ b/packages/cli/src/commands/__tests__/dev.test.js
@@ -114,7 +114,13 @@ describe('yarn rw dev', () => {
       'yarn cross-env NODE_ENV=development rw-vite-dev',
     )
 
-    expect(apiCommand.command.replace(/\s+/g, ' ')).toEqual(
+    expect(
+      apiCommand.command
+        .replace(/\s+/g, ' ')
+        // Remove the --max-old-space-size flag, as it's not consistent across
+        // test environments (vite sets this in their vite-ecosystem-ci tests)
+        .replace(/--max-old-space-size=\d+\s/, ''),
+    ).toEqual(
       'yarn cross-env NODE_ENV=development NODE_OPTIONS="--enable-source-maps" yarn nodemon --quiet --watch "/mocked/project/redwood.toml" --exec "yarn rw-api-server-watch --port 8911 --debug-port 18911 | rw-log-formatter"',
     )
 
@@ -153,7 +159,13 @@ describe('yarn rw dev', () => {
       'yarn cross-env NODE_ENV=development rw-dev-fe',
     )
 
-    expect(apiCommand.command.replace(/\s+/g, ' ')).toEqual(
+    expect(
+      apiCommand.command
+        .replace(/\s+/g, ' ')
+        // Remove the --max-old-space-size flag, as it's not consistent across
+        // test environments (vite sets this in their vite-ecosystem-ci tests)
+        .replace(/--max-old-space-size=\d+\s/, ''),
+    ).toEqual(
       'yarn cross-env NODE_ENV=development NODE_OPTIONS="--enable-source-maps" yarn nodemon --quiet --watch "/mocked/project/redwood.toml" --exec "yarn rw-api-server-watch --port 8911 --debug-port 18911 | rw-log-formatter"',
     )
 

--- a/packages/cli/src/lib/__tests__/getDevNodeOptions.test.js
+++ b/packages/cli/src/lib/__tests__/getDevNodeOptions.test.js
@@ -1,9 +1,19 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 import { getDevNodeOptions } from '../../commands/devHandler'
 
 describe('getNodeOptions', () => {
   const enableSourceMapsOption = '--enable-source-maps'
+  let oldNodeOptions = ''
+
+  beforeEach(() => {
+    oldNodeOptions = process.env.NODE_OPTIONS
+    process.env.NODE_OPTIONS = ''
+  })
+
+  afterEach(() => {
+    process.env.NODE_OPTIONS = oldNodeOptions
+  })
 
   it('defaults to enable-source-maps', () => {
     const nodeOptions = getDevNodeOptions()


### PR DESCRIPTION
Updating our tests to be compatible with Vite's [vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci) test runner/test environment
They were failing like this: https://cloud.nx.app/runs/6Uy2nBXabb