### PR TITLE
chore(ci): Add permissions to some workflows/jobs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: 🔬 Analyze

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# No top level permissions are required for this workflows
+permissions: {}
+
 jobs:
   require-milestone:
     name: 🚩 Require milestone

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -10,7 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# No top level permissions are required for this workflows
+# No top level permissions are required for this workflow
 permissions: {}
 
 jobs:

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -10,10 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# No top level permissions are required for this workflows
+permissions: {}
+
 jobs:
   require-release-label:
     name: 🏷 Require release label
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
     steps:
       - uses: mheap/github-action-required-labels@v5
         with:

--- a/.github/workflows/require-release-label.yml
+++ b/.github/workflows/require-release-label.yml
@@ -10,7 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# No top level permissions are required for this workflows
+# No top level permissions are required for this workflow
 permissions: {}
 
 jobs:


### PR DESCRIPTION
We should work towards ensuring we have the minimum permissions running for the workflows we execute.

It is difficult to find good documentation on exactly what permissions are required.