### PR TITLE
chore(router): Make React a normal dependency

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -93,7 +93,9 @@
     "@babel/runtime-corejs3": "7.25.0",
     "@redwoodjs/auth": "workspace:*",
     "@redwoodjs/server-store": "workspace:*",
-    "core-js": "3.38.0"
+    "core-js": "3.38.0",
+    "react": "19.0.0-rc-8269d55d-20240802",
+    "react-dom": "19.0.0-rc-8269d55d-20240802"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.15.4",
@@ -105,8 +107,6 @@
     "@types/react-dom": "^18.2.19",
     "concurrently": "8.2.2",
     "publint": "0.2.10",
-    "react": "19.0.0-rc-8269d55d-20240802",
-    "react-dom": "19.0.0-rc-8269d55d-20240802",
     "tstyche": "2.1.1",
     "tsx": "4.17.0",
     "typescript": "5.5.4",


### PR DESCRIPTION
The router clearly uses React, so it should definitely be a normal dependency and not just a development dependency 😄