### PR TITLE
chore(router): Switch to experimental types

### DIFF
--- a/packages/router/ambient.d.ts
+++ b/packages/router/ambient.d.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-var */
+/* eslint-disable no-var */
+/// <reference types="react/experimental" />
 
 declare global {
   var __REDWOOD__PRERENDERING: boolean


### PR DESCRIPTION
Use `react/experimental` to get access to `use()` and other new APIs