### PR TITLE
chore(rsc): Rename rscFetch to rscFetchRoutes and hardcode the rscId

### DIFF
--- a/packages/router/src/rsc/ClientRouter.tsx
+++ b/packages/router/src/rsc/ClientRouter.tsx
@@ -49,7 +49,7 @@ const LocationAwareRouter = ({
     //     'defined for the root of your React app.',
     // )
     const rscProps = { location: { pathname, search } }
-    return <RscFetcher rscId="__rwjs__Routes" rscProps={rscProps} />
+    return <RscFetcher rscProps={rscProps} />
   }
 
   const requestedRoute = pathRouteMap[activeRoutePath]
@@ -80,7 +80,7 @@ const LocationAwareRouter = ({
         activeRouteName={requestedRoute.name}
       >
         <AuthenticatedRoute unauthenticated={unauthenticated}>
-          <RscFetcher rscId="__rwjs__Routes" rscProps={rscProps} />
+          <RscFetcher rscProps={rscProps} />
         </AuthenticatedRoute>
       </RouterContextProvider>
     )
@@ -91,7 +91,7 @@ const LocationAwareRouter = ({
   // re-initializes RscFetcher. I wonder if there's an optimization to be made
   // here. Maybe we can lift RscFetcher up so we can keep the same instance
   // around and reuse it everywhere
-  return <RscFetcher rscId="__rwjs__Routes" rscProps={rscProps} />
+  return <RscFetcher rscProps={rscProps} />
 }
 
 export interface RscFetchProps extends Record<string, unknown> {


### PR DESCRIPTION
We were always just fetching the same component (which means we were always using the same `rscId`). So I renamed the function to be more explicit in what it does, and then got rid of the `rscId` argument as it was always just the same string anyway. So now the id is hardcoded inside the function