### PR TITLE
feat(uploads): Increase default fastify body limit to 100MB

### DIFF
--- a/.changesets/11412.md
+++ b/.changesets/11412.md
@@ -1,0 +1,15 @@
+- feat(uploads): Increase default fastify body limit to 100MB (#11412) by @dac09
+
+Increases the default limit for receiving requests to 100MB (instead of 15MB). This number is arbitary really, but it is the TOTAL size of the request, not of each file being uploaded. 
+
+The user can override this in their server file. 
+
+```jsx
+// api/server.js
+  const server = await createServer({
+    logger,
+    fastifyServerOptions: {
+      bodyLimit: 1048576 * 2, // 2 MiB
+    },
+  })
+```

--- a/.changesets/11412.md
+++ b/.changesets/11412.md
@@ -1,15 +1,15 @@
 - feat(uploads): Increase default fastify body limit to 100MB (#11412) by @dac09
 
-Increases the default limit for receiving requests to 100MB (instead of 15MB). This number is arbitary really, but it is the TOTAL size of the request, not of each file being uploaded. 
+Increases the default limit for receiving requests to 100MB (instead of 15MB). This number is arbitrary really, but it is the TOTAL size of the request, not of each file being uploaded.
 
-The user can override this in their server file. 
+The user can override this in their server file.
 
 ```jsx
 // api/server.js
-  const server = await createServer({
-    logger,
-    fastifyServerOptions: {
-      bodyLimit: 1048576 * 2, // 2 MiB
-    },
-  })
+const server = await createServer({
+  logger,
+  fastifyServerOptions: {
+    bodyLimit: 1048576 * 2, // 2 MiB
+  },
+})
 ```

--- a/packages/api-server/src/createServerHelpers.ts
+++ b/packages/api-server/src/createServerHelpers.ts
@@ -59,7 +59,7 @@ export const DEFAULT_CREATE_SERVER_OPTIONS: DefaultCreateServerOptions = {
   },
   fastifyServerOptions: {
     requestTimeout: 15_000,
-    bodyLimit: 1024 * 1024 * 15, // 15MB
+    bodyLimit: 1024 * 1024 * 100, // 100MB
   },
   configureApiServer: () => {},
   parseArgs: true,


### PR DESCRIPTION
Increases the default limit for receiving requests to 100MB (instead of 15MB). This number is arbitrary really, but it is the TOTAL size of the request, not of each file being uploaded. 

The user can override this in their server file. 

```jsx
// api/server.js
  const server = await createServer({
    logger,
    fastifyServerOptions: {
      bodyLimit: 1048576 * 2, // 2 MiB
    },
  })
```