### PR TITLE
fix(cli-helpers): Don't add spaces around `=` for env vars

### DIFF
--- a/.changesets/11414.md
+++ b/.changesets/11414.md
@@ -1,0 +1,3 @@
+- fix(cli-helpers): Don't add spaces around `=` for env vars (#11414) by @Tobbe
+
+The `addEnvVar` helper function in `packages/cli-helpers` no longer adds spaces around `=` when setting environment variables.

--- a/packages/cli-helpers/src/lib/__tests__/__snapshots__/project.test.ts.snap
+++ b/packages/cli-helpers/src/lib/__tests__/__snapshots__/project.test.ts.snap
@@ -6,7 +6,7 @@ exports[`addEnvVar > addEnvVar adds environment variables as part of a setup tas
 
 # Note: The existing environment variable EXISTING_VAR was not overwritten. Uncomment to use its new value.
 # Updated existing variable Comment
-# EXISTING_VAR = new_value
+# EXISTING_VAR=new_value
 "
 `;
 
@@ -15,7 +15,7 @@ exports[`addEnvVar > addEnvVar adds environment variables as part of a setup tas
 # CommentedVar = 123
 
 # New Variable Comment
-NEW_VAR = new_value
+NEW_VAR=new_value
 "
 `;
 
@@ -24,7 +24,7 @@ exports[`addEnvVar > addEnvVar adds environment variables as part of a setup tas
 # CommentedVar = 123
 
 # New Variable Comment
-NEW_VAR = new_value
+NEW_VAR=new_value
 "
 `;
 
@@ -34,7 +34,7 @@ exports[`addEnvVar > addEnvVar adds environment variables as part of a setup tas
 
 # Note: The existing environment variable EXISTING_VAR was not overwritten. Uncomment to use its new value.
 # New Variable Comment
-# EXISTING_VAR = new_value
+# EXISTING_VAR=new_value
 "
 `;
 

--- a/packages/cli-helpers/src/lib/project.ts
+++ b/packages/cli-helpers/src/lib/project.ts
@@ -126,7 +126,7 @@ export const addEnvVar = (name: string, value: string, comment: string) => {
   let envFile = ''
   const newEnvironmentVariable = [
     comment && `# ${comment}`,
-    `${name} = ${value}`,
+    `${name}=${value}`,
     '',
   ]
     .flat()
@@ -144,7 +144,7 @@ export const addEnvVar = (name: string, value: string, comment: string) => {
       const p = [
         `# Note: The existing environment variable ${name} was not overwritten. Uncomment to use its new value.`,
         comment && `# ${comment}`,
-        `# ${name} = ${value}`,
+        `# ${name}=${value}`,
         '',
       ]
         .flat()


### PR DESCRIPTION
We ship `.env.defaults` and `.env.example` as part of a new RW app (see [here (.env.defaults)](https://github.com/redwoodjs/redwood/blob/04a005049ff590b9dfecbfab10fa0843fa4f70d3/packages/create-redwood-app/templates/ts/.env.defaults) for an example). 
They don't have spaces around `=` when setting environment variables.
For example, this is how we set the default `DATABASE_URL` environment variable
`DATABASE_URL=file:./dev.db`

This PR updates our `addEnvVar` helper function to match that pattern of not using spaces