### PR TITLE
fix(rsa): Use dist filenames when registering server references

### DIFF
--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
@@ -33,7 +33,7 @@ function getPluginTransform(serverEntryFiles: Record<string, string>) {
   return plugin.transform.bind({} as TransformPluginContext)
 }
 
-const id = 'some/path/to/actions.ts'
+const id = 'rw-app/web/src/some/path/to/actions.ts'
 const pluginTransform = getPluginTransform({
   'some/dist/path/to/rsa-actions.ts-0.mjs': id,
 })
@@ -585,7 +585,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
 
   describe('actions inside components', async () => {
     it('should handle self-contained named function inside default exported component', async () => {
-      const id = 'some/path/to/Component.tsx'
+      const id = 'rw-app/web/src/some/path/to/Component.tsx'
       const pluginTransform = getPluginTransform({
         'some/dist/path/to/rsa-Component.tsx-0.mjs': id,
       })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
@@ -19,8 +19,8 @@ afterAll(() => {
   process.env.RWJS_CWD = RWJS_CWD
 })
 
-function getPluginTransform() {
-  const plugin = rscTransformUseServerPlugin()
+function getPluginTransform(serverEntryFiles: Record<string, string>) {
+  const plugin = rscTransformUseServerPlugin(serverEntryFiles)
 
   if (typeof plugin.transform !== 'function') {
     throw new Error('Plugin does not have a transform function')
@@ -33,12 +33,14 @@ function getPluginTransform() {
   return plugin.transform.bind({} as TransformPluginContext)
 }
 
-const pluginTransform = getPluginTransform()
+const id = 'some/path/to/actions.ts'
+const pluginTransform = getPluginTransform({
+  'some/dist/path/to/rsa-actions.ts-0.mjs': id,
+})
 
 describe('rscTransformUseServerPlugin function scoped "use server"', () => {
   describe('top-level exports', () => {
     it('should handle named function', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -65,12 +67,11 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         }
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
       `)
     })
 
     it('should handle arrow function', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -97,12 +98,11 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
       `)
     })
 
     it('should handle default exported named function', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -129,12 +129,11 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         }
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/path/to/actions.ts", "default");"
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "default");"
       `)
     })
 
     it('should handle exports with two consts', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -162,13 +161,12 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
             await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
           };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(fortyTwo, "some/path/to/actions.ts", "fortyTwo");
-        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
+        registerServerReference(fortyTwo, "some/dist/path/to/rsa-actions.ts-0.mjs", "fortyTwo");
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
       `)
     })
 
     it('should handle named function and arrow function with separate export', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -213,15 +211,14 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");
-        registerServerReference(arrowAction, "some/path/to/actions.ts", "arrowAction");"
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");
+        registerServerReference(arrowAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "arrowAction");"
       `)
     })
 
     it.todo(
       "should handle named function and 'let' arrow function with separate export",
       async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
         import fs from 'node:fs'
 
@@ -280,14 +277,13 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           // Not 'use server' anymore
         };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/path/to/actions.ts", "formAction");
-        if (typeof letArrowFunction === "function") registerServerReference(letArrowAction, "some/path/to/actions.ts", "letArrowAction");"
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");
+        if (typeof letArrowFunction === "function") registerServerReference(letArrowAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "letArrowAction");"
       `)
       },
     )
 
     it('should handle separate renamed export', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -327,13 +323,12 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         };
         export { formAction as fA, arrowAction };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/path/to/actions.ts", "fA");
-        registerServerReference(arrowAction, "some/path/to/actions.ts", "arrowAction");"
+        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "fA");
+        registerServerReference(arrowAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "arrowAction");"
       `)
     })
 
     it.todo('should handle default exported arrow function', async () => {
-      const id = 'some/path/to/actions.ts'
       const input = `
         import fs from 'node:fs'
 
@@ -365,14 +360,13 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
               }
 
         import {registerServerReference} from "react-server-dom-webpack/server";
-        if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+        if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
         "
       `)
     })
 
     describe('without "use server"', () => {
       it('should not register named function', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -401,7 +395,6 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       })
 
       it('should not register arrow function', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -430,7 +423,6 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       })
 
       it('should not register default exported named function', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -459,7 +451,6 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       })
 
       it('should not register exports with two consts', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -483,12 +474,11 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
               await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
             };
           import { registerServerReference } from "react-server-dom-webpack/server";
-          registerServerReference(formAction, "some/path/to/actions.ts", "formAction");"
+          registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
         `)
       })
 
       it('should not register named function and arrow function with separate export', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -525,7 +515,6 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       })
 
       it('should not register separate renamed export', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -564,7 +553,6 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
       })
 
       it('should not register default exported arrow function', async () => {
-        const id = 'some/path/to/actions.ts'
         const input = `
           import fs from 'node:fs'
 
@@ -598,6 +586,10 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
   describe('actions inside components', async () => {
     it('should handle self-contained named function inside default exported component', async () => {
       const id = 'some/path/to/Component.tsx'
+      const pluginTransform = getPluginTransform({
+        'some/dist/path/to/rsa-Component.tsx-0.mjs': id,
+      })
+
       const input = `
         import fs from 'node:fs'
 
@@ -640,7 +632,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
 
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         }
-        registerServerReference(__rwjs__rsa0_formAction, "some/path/to/Component.tsx", "__rwjs__rsa0_formAction");"
+        registerServerReference(__rwjs__rsa0_formAction, "some/dist/path/to/rsa-Component.tsx-0.mjs", "__rwjs__rsa0_formAction");"
       `)
     })
 

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.function-scope.test.ts
@@ -20,7 +20,7 @@ afterAll(() => {
 })
 
 function getPluginTransform(serverEntryFiles: Record<string, string>) {
-  const plugin = rscTransformUseServerPlugin(serverEntryFiles)
+  const plugin = rscTransformUseServerPlugin('some/dist/path', serverEntryFiles)
 
   if (typeof plugin.transform !== 'function') {
     throw new Error('Plugin does not have a transform function')
@@ -35,7 +35,7 @@ function getPluginTransform(serverEntryFiles: Record<string, string>) {
 
 const id = 'rw-app/web/src/some/path/to/actions.ts'
 const pluginTransform = getPluginTransform({
-  'some/dist/path/to/rsa-actions.ts-0.mjs': id,
+  'rsa-actions.ts-0': id,
 })
 
 describe('rscTransformUseServerPlugin function scoped "use server"', () => {
@@ -67,7 +67,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         }
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "formAction");"
       `)
     })
 
@@ -98,7 +98,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "formAction");"
       `)
     })
 
@@ -129,7 +129,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         }
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "default");"
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "default");"
       `)
     })
 
@@ -161,8 +161,8 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
             await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
           };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(fortyTwo, "some/dist/path/to/rsa-actions.ts-0.mjs", "fortyTwo");
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
+        registerServerReference(fortyTwo, "some/dist/path/assets/rsa-actions.ts-0.mjs", "fortyTwo");
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "formAction");"
       `)
     })
 
@@ -211,8 +211,8 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");
-        registerServerReference(arrowAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "arrowAction");"
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "formAction");
+        registerServerReference(arrowAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "arrowAction");"
       `)
     })
 
@@ -277,8 +277,8 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
           // Not 'use server' anymore
         };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");
-        if (typeof letArrowFunction === "function") registerServerReference(letArrowAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "letArrowAction");"
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "formAction");
+        if (typeof letArrowFunction === "function") registerServerReference(letArrowAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "letArrowAction");"
       `)
       },
     )
@@ -323,8 +323,8 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
         };
         export { formAction as fA, arrowAction };
         import { registerServerReference } from "react-server-dom-webpack/server";
-        registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "fA");
-        registerServerReference(arrowAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "arrowAction");"
+        registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "fA");
+        registerServerReference(arrowAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "arrowAction");"
       `)
     })
 
@@ -360,7 +360,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
               }
 
         import {registerServerReference} from "react-server-dom-webpack/server";
-        if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
+        if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction");
         "
       `)
     })
@@ -474,7 +474,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
               await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
             };
           import { registerServerReference } from "react-server-dom-webpack/server";
-          registerServerReference(formAction, "some/dist/path/to/rsa-actions.ts-0.mjs", "formAction");"
+          registerServerReference(formAction, "some/dist/path/assets/rsa-actions.ts-0.mjs", "formAction");"
         `)
       })
 
@@ -587,7 +587,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
     it('should handle self-contained named function inside default exported component', async () => {
       const id = 'rw-app/web/src/some/path/to/Component.tsx'
       const pluginTransform = getPluginTransform({
-        'some/dist/path/to/rsa-Component.tsx-0.mjs': id,
+        'rsa-Component.tsx-0': id,
       })
 
       const input = `
@@ -632,7 +632,7 @@ describe('rscTransformUseServerPlugin function scoped "use server"', () => {
 
           await fs.promises.writeFile('settings.json', \`{ "delay": \${formData.get('delay')} }\`);
         }
-        registerServerReference(__rwjs__rsa0_formAction, "some/dist/path/to/rsa-Component.tsx-0.mjs", "__rwjs__rsa0_formAction");"
+        registerServerReference(__rwjs__rsa0_formAction, "some/dist/path/assets/rsa-Component.tsx-0.mjs", "__rwjs__rsa0_formAction");"
       `)
     })
 

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.test.ts
@@ -27,10 +27,8 @@ afterAll(() => {
   process.env.RWJS_CWD = RWJS_CWD
 })
 
-function getPluginTransform() {
-  const plugin = rscTransformUseServerPlugin({
-    'some/dist/path/to/rsa-actions.ts-0.mjs': 'some/path/to/actions.ts',
-  })
+function getPluginTransform(serverEntryFiles: Record<string, string>) {
+  const plugin = rscTransformUseServerPlugin(serverEntryFiles)
 
   if (typeof plugin.transform !== 'function') {
     throw new Error('Plugin does not have a transform function')
@@ -43,7 +41,10 @@ function getPluginTransform() {
   return plugin.transform.bind({} as TransformPluginContext)
 }
 
-const pluginTransform = getPluginTransform()
+const id = 'rw-app/web/src/some/path/to/actions.ts'
+const pluginTransform = getPluginTransform({
+  'some/dist/path/to/rsa-actions.ts-0.mjs': id,
+})
 
 describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   afterEach(() => {
@@ -51,7 +52,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle one function', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -85,7 +85,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle two functions', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -134,7 +133,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle arrow function', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -168,7 +166,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle exports with two consts', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -203,7 +200,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle named function and arrow function with separate export', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -256,7 +252,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle separate renamed export', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -309,7 +304,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it.todo('should handle default exported arrow function', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 
@@ -343,7 +337,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle default exported named function', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       "use server"
 
@@ -381,7 +374,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it('should handle default exported inline-named function', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
         "use server"
 
@@ -415,7 +407,6 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
   })
 
   it.todo('should handle default exported anonymous function', async () => {
-    const id = 'some/path/to/actions.ts'
     const input = `
       'use server'
 

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.test.ts
@@ -28,7 +28,7 @@ afterAll(() => {
 })
 
 function getPluginTransform(serverEntryFiles: Record<string, string>) {
-  const plugin = rscTransformUseServerPlugin(serverEntryFiles)
+  const plugin = rscTransformUseServerPlugin('some/dist/path', serverEntryFiles)
 
   if (typeof plugin.transform !== 'function') {
     throw new Error('Plugin does not have a transform function')
@@ -43,7 +43,7 @@ function getPluginTransform(serverEntryFiles: Record<string, string>) {
 
 const id = 'rw-app/web/src/some/path/to/actions.ts'
 const pluginTransform = getPluginTransform({
-  'some/dist/path/to/rsa-actions.ts-0.mjs': id,
+  'rsa-actions.ts-0': id,
 })
 
 describe('rscTransformUseServerPlugin module scoped "use server"', () => {
@@ -79,7 +79,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
+      registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })
@@ -126,8 +126,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(formAction1,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction1");
-      registerServerReference(formAction2,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction2");
+      registerServerReference(formAction1,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction1");
+      registerServerReference(formAction2,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction2");
       "
     `)
   })
@@ -160,7 +160,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })
@@ -193,8 +193,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof fortyTwo === "function") registerServerReference(fortyTwo,"some/dist/path/to/rsa-actions.ts-0.mjs","fortyTwo");
-      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
+      if (typeof fortyTwo === "function") registerServerReference(fortyTwo,"some/dist/path/assets/rsa-actions.ts-0.mjs","fortyTwo");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })
@@ -245,8 +245,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             export { formAction, arrowAction }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
-      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/dist/path/to/rsa-actions.ts-0.mjs","arrowAction");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction");
+      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","arrowAction");
       "
     `)
   })
@@ -297,8 +297,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             export { formAction as fA, arrowAction }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","fA");
-      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/dist/path/to/rsa-actions.ts-0.mjs","arrowAction");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","fA");
+      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","arrowAction");
       "
     `)
   })
@@ -331,7 +331,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(default,"some/dist/path/to/rsa-actions.ts-0.mjs","default");
+      registerServerReference(default,"some/dist/path/assets/rsa-actions.ts-0.mjs","default");
       "
     `)
   })
@@ -368,7 +368,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             export default formAction
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","default");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","default");
       "
     `)
   })
@@ -401,7 +401,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
               }
 
         import {registerServerReference} from "react-server-dom-webpack/server";
-        registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","default");
+        registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","default");
         "
       `)
   })
@@ -434,7 +434,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
+      registerServerReference(formAction,"some/dist/path/assets/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })

--- a/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.test.ts
+++ b/packages/vite/src/plugins/__tests__/vite-plugin-rsc-transform-server.test.ts
@@ -28,7 +28,9 @@ afterAll(() => {
 })
 
 function getPluginTransform() {
-  const plugin = rscTransformUseServerPlugin()
+  const plugin = rscTransformUseServerPlugin({
+    'some/dist/path/to/rsa-actions.ts-0.mjs': 'some/path/to/actions.ts',
+  })
 
   if (typeof plugin.transform !== 'function') {
     throw new Error('Plugin does not have a transform function')
@@ -77,7 +79,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+      registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })
@@ -125,8 +127,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(formAction1,"some/path/to/actions.ts","formAction1");
-      registerServerReference(formAction2,"some/path/to/actions.ts","formAction2");
+      registerServerReference(formAction1,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction1");
+      registerServerReference(formAction2,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction2");
       "
     `)
   })
@@ -160,7 +162,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })
@@ -194,8 +196,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof fortyTwo === "function") registerServerReference(fortyTwo,"some/path/to/actions.ts","fortyTwo");
-      if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+      if (typeof fortyTwo === "function") registerServerReference(fortyTwo,"some/dist/path/to/rsa-actions.ts-0.mjs","fortyTwo");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })
@@ -247,8 +249,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             export { formAction, arrowAction }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","formAction");
-      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/path/to/actions.ts","arrowAction");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
+      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/dist/path/to/rsa-actions.ts-0.mjs","arrowAction");
       "
     `)
   })
@@ -300,8 +302,8 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             export { formAction as fA, arrowAction }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","fA");
-      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/path/to/actions.ts","arrowAction");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","fA");
+      if (typeof arrowAction === "function") registerServerReference(arrowAction,"some/dist/path/to/rsa-actions.ts-0.mjs","arrowAction");
       "
     `)
   })
@@ -335,7 +337,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(default,"some/path/to/actions.ts","default");
+      registerServerReference(default,"some/dist/path/to/rsa-actions.ts-0.mjs","default");
       "
     `)
   })
@@ -373,7 +375,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             export default formAction
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      if (typeof formAction === "function") registerServerReference(formAction,"some/path/to/actions.ts","default");
+      if (typeof formAction === "function") registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","default");
       "
     `)
   })
@@ -407,7 +409,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
               }
 
         import {registerServerReference} from "react-server-dom-webpack/server";
-        registerServerReference(formAction,"some/path/to/actions.ts","default");
+        registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","default");
         "
       `)
   })
@@ -441,7 +443,7 @@ describe('rscTransformUseServerPlugin module scoped "use server"', () => {
             }
 
       import {registerServerReference} from "react-server-dom-webpack/server";
-      registerServerReference(formAction,"some/path/to/actions.ts","formAction");
+      registerServerReference(formAction,"some/dist/path/to/rsa-actions.ts-0.mjs","formAction");
       "
     `)
   })

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -80,6 +80,13 @@ export function rscTransformUseServerPlugin(
         builtFileName = path.join(outDir, 'assets', serverEntryKey + '.mjs')
       }
 
+      console.log('windows paths')
+      console.log('windows paths, outDir:', outDir)
+      console.log('windows paths, severEntryFiles:', serverEntryFiles)
+      console.log('windows paths, severEntryKey:', serverEntryKey)
+      console.log('windows paths, builtFileName:', builtFileName)
+      console.log('windows paths')
+
       if (!builtFileName) {
         throw new Error(
           `Could not find ${id} in serverEntryFiles: ` +

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -62,9 +62,14 @@ export function rscTransformUseServerPlugin(
         )
       }
 
-      const builtFileName = Object.entries(serverEntryFiles).find(
-        ([_key, value]) => value === id,
-      )?.[0]
+      // TODO (RSC): We need a more robust check here. Or maybe we can just
+      // always check, and fall back to passing `id` through if we can't find
+      // it in `serverEntryFiles`.
+      const builtFileName = id.includes('/web/src/')
+        ? Object.entries(serverEntryFiles).find(
+            ([_key, value]) => value === id,
+          )?.[0]
+        : id
 
       if (!builtFileName) {
         throw new Error(

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -3,7 +3,9 @@ import type { PluginObj, types } from '@babel/core'
 import * as swc from '@swc/core'
 import type { Plugin } from 'vite'
 
-export function rscTransformUseServerPlugin(): Plugin {
+export function rscTransformUseServerPlugin(
+  serverEntryFiles: Record<string, string>,
+): Plugin {
   return {
     name: 'rsc-transform-use-server-plugin',
     transform: async function (code, id) {
@@ -60,18 +62,26 @@ export function rscTransformUseServerPlugin(): Plugin {
         )
       }
 
+      const builtFileName = Object.entries(serverEntryFiles).find(
+        ([_key, value]) => value === id,
+      )?.[0]
+
+      if (!builtFileName) {
+        throw new Error(
+          `Could not find ${id} in serverEntryFiles: ` +
+            JSON.stringify(serverEntryFiles),
+        )
+      }
+
       let transformedCode = code
 
       if (moduleScopedUseServer) {
-        transformedCode = transformServerModule(mod, id, code)
+        transformedCode = transformServerModule(mod, builtFileName, code)
       } else {
-        // transformedCode = transformServerFunction(mod, id, code)
-
         const result = babel.transformSync(code, {
           filename: id,
-          // presets: ['@babel/preset-typescript', '@babel/preset-react'],
           presets: ['@babel/preset-typescript'],
-          plugins: [[babelPluginTransformServerAction, { url: id }]],
+          plugins: [[babelPluginTransformServerAction, { url: builtFileName }]],
         })
 
         if (!result) {

--- a/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
+++ b/packages/vite/src/plugins/vite-plugin-rsc-transform-server.ts
@@ -78,6 +78,10 @@ export function rscTransformUseServerPlugin(
         // We output server actions in the `assets` subdirectory, and add a .mjs
         // extension to the file name
         builtFileName = path.join(outDir, 'assets', serverEntryKey + '.mjs')
+
+        if (process.platform === 'win32') {
+          builtFileName = builtFileName.replaceAll('\\', '/')
+        }
       }
 
       console.log('windows paths')

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -84,7 +84,7 @@ export async function rscBuildForServer(
       // That's why it needs the `clientEntryFiles` data
       // (It does other things as well, but that's why it needs clientEntryFiles)
       rscTransformUseClientPlugin(clientEntryFiles),
-      rscTransformUseServerPlugin(),
+      rscTransformUseServerPlugin(serverEntryFiles),
       rscRoutesImports(),
     ],
     build: {

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -31,6 +31,9 @@ export async function rscBuildForServer(
     throw new Error('Server Entry file not found')
   }
 
+  /** Base path for where to place built artifacts */
+  const outDir = rwPaths.web.dist
+
   // TODO (RSC): No redwood-vite plugin, add it in here
   const rscServerBuildOutput = await viteBuild({
     envFile: false,
@@ -84,7 +87,7 @@ export async function rscBuildForServer(
       // That's why it needs the `clientEntryFiles` data
       // (It does other things as well, but that's why it needs clientEntryFiles)
       rscTransformUseClientPlugin(clientEntryFiles),
-      rscTransformUseServerPlugin(serverEntryFiles),
+      rscTransformUseServerPlugin(outDir, serverEntryFiles),
       rscRoutesImports(),
     ],
     build: {
@@ -92,7 +95,7 @@ export async function rscBuildForServer(
       minify: false,
       ssr: true,
       ssrEmitAssets: true,
-      outDir: rwPaths.web.distRsc,
+      outDir,
       emptyOutDir: true, // Needed because `outDir` is not inside `root`
       manifest: 'server-build-manifest.json',
       rollupOptions: {

--- a/packages/vite/src/rsc/rscBuildForServer.ts
+++ b/packages/vite/src/rsc/rscBuildForServer.ts
@@ -32,7 +32,7 @@ export async function rscBuildForServer(
   }
 
   /** Base path for where to place built artifacts */
-  const outDir = rwPaths.web.dist
+  const outDir = rwPaths.web.distRsc
 
   // TODO (RSC): No redwood-vite plugin, add it in here
   const rscServerBuildOutput = await viteBuild({

--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -182,6 +182,10 @@ const shutdown = async () => {
   parentPort.close()
 }
 
+async function loadServerFile(filePath: string) {
+  return import(`file://${filePath}`)
+}
+
 if (!parentPort) {
   throw new Error('parentPort is undefined')
 }
@@ -241,7 +245,7 @@ const getRoutesComponent: any = async () => {
     throw new StatusError('No entry found for __rwjs__Routes', 404)
   }
 
-  const routes = await import(`file://${routesPath}`)
+  const routes = await loadServerFile(routesPath)
 
   return routes.default
 }
@@ -298,7 +302,7 @@ async function setClientEntries(): Promise<void> {
 
   const entriesFile = getPaths().web.distRscEntries
   console.log('setClientEntries :: entriesFile', entriesFile)
-  const { clientEntries } = await import(entriesFile)
+  const { clientEntries } = await loadServerFile(entriesFile)
   console.log('setClientEntries :: clientEntries', clientEntries)
   if (!clientEntries) {
     throw new Error('Failed to load clientEntries')
@@ -424,7 +428,7 @@ async function handleRsa(input: RenderInput): Promise<PipeableStream> {
 
   const [fileName, actionName] = input.rsaId.split('#')
   console.log('Server Action fileName', fileName, 'actionName', actionName)
-  const module = await import(fileName)
+  const module = await loadServerFile(fileName)
 
   if (isSerializedFormData(input.args[0])) {
     const formData = new FormData()

--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -154,7 +154,7 @@ const vitePromise = createServer({
       parentPort.postMessage(message)
     }),
     rscTransformUseClientPlugin({}),
-    rscTransformUseServerPlugin({}),
+    rscTransformUseServerPlugin('', {}),
     rscRoutesAutoLoader(),
   ],
   ssr: {

--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -182,13 +182,6 @@ const shutdown = async () => {
   parentPort.close()
 }
 
-const loadServerFile = async (fname: string) => {
-  const vite = await vitePromise
-  // TODO (RSC): In prod we shouldn't need this. We should be able to just
-  // import the built files
-  return vite.ssrLoadModule(fname)
-}
-
 if (!parentPort) {
   throw new Error('parentPort is undefined')
 }
@@ -248,7 +241,7 @@ const getRoutesComponent: any = async () => {
     throw new StatusError('No entry found for __rwjs__Routes', 404)
   }
 
-  const routes = await loadServerFile(routesPath)
+  const routes = await import(routesPath)
 
   return routes.default
 }
@@ -305,7 +298,7 @@ async function setClientEntries(): Promise<void> {
 
   const entriesFile = getPaths().web.distRscEntries
   console.log('setClientEntries :: entriesFile', entriesFile)
-  const { clientEntries } = await loadServerFile(entriesFile)
+  const { clientEntries } = await import(entriesFile)
   console.log('setClientEntries :: clientEntries', clientEntries)
   if (!clientEntries) {
     throw new Error('Failed to load clientEntries')
@@ -431,7 +424,7 @@ async function handleRsa(input: RenderInput): Promise<PipeableStream> {
 
   const [fileName, actionName] = input.rsaId.split('#')
   console.log('Server Action fileName', fileName, 'actionName', actionName)
-  const module = await loadServerFile(fileName)
+  const module = await import(fileName)
 
   if (isSerializedFormData(input.args[0])) {
     const formData = new FormData()

--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -154,7 +154,7 @@ const vitePromise = createServer({
       parentPort.postMessage(message)
     }),
     rscTransformUseClientPlugin({}),
-    rscTransformUseServerPlugin(),
+    rscTransformUseServerPlugin({}),
     rscRoutesAutoLoader(),
   ],
   ssr: {

--- a/packages/vite/src/rsc/rscWorker.ts
+++ b/packages/vite/src/rsc/rscWorker.ts
@@ -241,7 +241,7 @@ const getRoutesComponent: any = async () => {
     throw new StatusError('No entry found for __rwjs__Routes', 404)
   }
 
-  const routes = await import(routesPath)
+  const routes = await import(`file://${routesPath}`)
 
   return routes.default
 }


### PR DESCRIPTION
Server actions in `web/src/...` will be built and placed in `web/dist/rsc/...`. When registering them with React we need to point to the path in `dist` for prod. In dev, when we can use Vite's `ssrLoadModule` the rewrite should happen on the fly. But for now we don't support dev, so for now the correct thing to do is to always rewrite