### PR TITLE
chore(publishing): Fix canary publishing for next branch

### DIFF
--- a/.github/scripts/publish_canary.sh
+++ b/.github/scripts/publish_canary.sh
@@ -35,7 +35,7 @@ echo 'n' \
   | yarn lerna publish "${args[@]}" 2>&1 \
     > publish_output
 cat publish_output \
-  | grep '\-canary\.' \
+  | grep -E '\-canary\.|\-next\.' \
   | tail -n 1 \
   | sed 's/.*=> //' \
   | sed 's/\+.*//' \


### PR DESCRIPTION
You'll see that the canary publishing for the next branch is broken. Example action log: https://github.com/redwoodjs/redwood/actions/runs/10706015686/job/29682729719

The problem as I see it is that we're grep'ing for `-canary.` but in this case we're looking to publish with the `-next.` prefix which is clearly the one output by lerna. This PR updates the grep to use a regex for either the next or canary match.