### PR TITLE
Updates SDL codegen to handle prettier 3 correctly

### DIFF
--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -96,7 +96,7 @@
     "@redwoodjs/graphql-server": "workspace:*",
     "@redwoodjs/project-config": "workspace:*",
     "@redwoodjs/router": "workspace:*",
-    "@sdl-codegen/node": "1.0.2",
+    "@sdl-codegen/node": "2.0.1",
     "chalk": "4.1.2",
     "core-js": "3.38.0",
     "deepmerge": "4.3.1",

--- a/packages/internal/src/generate/graphqlCodeGen.ts
+++ b/packages/internal/src/generate/graphqlCodeGen.ts
@@ -43,7 +43,7 @@ export const generateTypeDefGraphQLApi = async (): Promise<TypeDefResult> => {
     const dtsFiles: string[] = []
 
     try {
-      const output = sdlCodegen.runFullCodegen('redwood', { paths })
+      const output = await sdlCodegen.runFullCodegen('redwood', { paths })
       dtsFiles.concat(output.paths)
     } catch (e: unknown) {
       if (e instanceof Error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8304,7 +8304,7 @@ __metadata:
     "@redwoodjs/graphql-server": "workspace:*"
     "@redwoodjs/project-config": "workspace:*"
     "@redwoodjs/router": "workspace:*"
-    "@sdl-codegen/node": "npm:1.0.2"
+    "@sdl-codegen/node": "npm:2.0.1"
     "@types/fs-extra": "npm:11.0.4"
     chalk: "npm:4.1.2"
     concurrently: "npm:8.2.2"
@@ -9042,9 +9042,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sdl-codegen/node@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@sdl-codegen/node@npm:1.0.2"
+"@sdl-codegen/node@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@sdl-codegen/node@npm:2.0.1"
   dependencies:
     "@mrleebo/prisma-ast": "npm:^0.12.0"
     ts-morph: "npm:^22.0.0"
@@ -9055,7 +9055,7 @@ __metadata:
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 10c0/60df05c9d1d4b483343a07521a0e1796367ac2de0332fa9bd7b93044fd4a8d8fe703ceac0c80714def50ec0b4e04ea5bd378c0214750bb0cde6ec56abcb06ac8
+  checksum: 10c0/a99ae86cbc4f55939103716e7b7430e6cd60374cd86f8263cea69631996d386be4483763a32d4688279dfc95aaaa21b1d9fd6e154bb65623e76b1347aa4cbc2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates for https://github.com/puzzmo-com/sdl-codegen/blob/main/CHANGELOG.md#200 

- I had to change the API to be fully async to handle the prettier breaking change
- which includes prettier 3 support
- and some more tightening of the types