### PR TITLE
fix(resolutions): Remove rehackt resolution

### DIFF
--- a/.changesets/11447.md
+++ b/.changesets/11447.md
@@ -1,0 +1,5 @@
+- fix(resolutions): Remove rehackt resolution (#11447) by @Tobbe
+
+The rehackt resolution isn't needed anymore. Apollo Client has updated to rehackt 0.1.0. See https://github.com/apollographql/apollo-client/blob/HEAD/CHANGELOG.md#3101
+
+Unfortunately this requires our users to manually go and update their resolutions

--- a/__fixtures__/rsc-caching/package.json
+++ b/__fixtures__/rsc-caching/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "@apollo/client/rehackt": "0.1.0",
     "react-is": "19.0.0-rc-8269d55d-20240802"
   }
 }

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -22,7 +22,6 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "@apollo/client/rehackt": "0.1.0",
     "react-is": "19.0.0-rc-8269d55d-20240802"
   }
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "@apollo/client/rehackt": "0.1.0",
     "react-is": "19.0.0-rc-8269d55d-20240802"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "@apollo/client/rehackt": "0.1.0",
     "react-is": "19.0.0-rc-8269d55d-20240802"
   }
 }

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "@apollo/client/rehackt": "0.1.0",
     "react-is": "19.0.0-rc-8269d55d-20240802"
   }
 }

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "@apollo/client/rehackt": "0.1.0",
     "react-is": "19.0.0-rc-8269d55d-20240802"
   }
 }


### PR DESCRIPTION
The rehackt resolution isn't needed anymore. Apollo Client has updated to rehackt 0.1.0. See https://github.com/apollographql/apollo-client/blob/HEAD/CHANGELOG.md#3101

Unfortunately this requires our users to manually go and update their resolutions