### PR TITLE
fix(linting): Re-enable babel presets during linting of javascript projects

### DIFF
--- a/.changesets/11458.md
+++ b/.changesets/11458.md
@@ -1,0 +1,3 @@
+- fix(linting): Re-enable babel presets during linting of javascript projects (#11458) by @Josh-Walker-GM
+
+The `yarn rw lint` command was failing for JavaScript projects. This change re-enables certain babel plugins to correct this issue and allow this command to succeed again.

--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -20,6 +20,7 @@ export interface Flags {
   forJest?: boolean // will change the alias for module-resolver plugin
   forPrerender?: boolean // changes what babel-plugin-redwood-routes-auto-loader does
   forRsc?: boolean
+  forJavaScriptLinting?: boolean // will enable presets to supporting linting in the absence of typescript related presets/plugins/parsers
 }
 
 export const getWebSideBabelPlugins = (
@@ -166,7 +167,7 @@ export const getWebSideOverrides = (
 export const getWebSideBabelPresets = (options: Flags) => {
   // When we perform prerendering we don't use vite, so we need to add the
   // appropriate presets for react, env, and typescript, etc.
-  if (options.forPrerender || options.forJest) {
+  if (options.forPrerender || options.forJest || options.forJavaScriptLinting) {
     let reactPresetConfig: babel.PluginItem = { runtime: 'automatic' }
 
     // This is a special case, where @babel/preset-react needs config

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -7,7 +7,7 @@ const {
   getApiSideDefaultBabelConfig,
   getWebSideDefaultBabelConfig,
 } = require('@redwoodjs/babel-config')
-const { getConfig } = require('@redwoodjs/project-config')
+const { getConfig, isTypeScriptProject } = require('@redwoodjs/project-config')
 
 const config = getConfig()
 
@@ -16,7 +16,10 @@ const getProjectBabelOptions = () => {
   // So we just take it out and put it as a separate item
   // Ignoring overrides, as I don't think it has any impact on linting
   const { overrides: _webOverrides, ...otherWebConfig } =
-    getWebSideDefaultBabelConfig()
+    getWebSideDefaultBabelConfig({
+      // We have to enable certain presets like `@babel/preset-react` for JavaScript projects
+      forJavaScriptLinting: !isTypeScriptProject(),
+    })
 
   const { overrides: _apiOverrides, ...otherApiConfig } =
     getApiSideDefaultBabelConfig()

--- a/packages/project-config/src/paths.ts
+++ b/packages/project-config/src/paths.ts
@@ -440,3 +440,11 @@ export function projectIsEsm() {
 
   return true
 }
+
+export const isTypeScriptProject = () => {
+  const paths = getPaths()
+  return (
+    fs.existsSync(path.join(paths.web.base, 'tsconfig.json')) ||
+    fs.existsSync(path.join(paths.api.base, 'tsconfig.json'))
+  )
+}


### PR DESCRIPTION
Fixes #11457 

In #10867 I removed the presets by default and they are only included in specific cases - for jest, for prerender. It looks like I forgot to consider the case of linting javascript projects. I therefore re-enable these presets in that specific case. 

It's already on my medium term wish list to simplify and rip out as much of our babel config/reliance as we can. It would be better if this was all just simpler and didn't have as many branches.

I also introduced a copy of `isTypeScriptProject` into `@redwoodjs/project-config`. It doesn't add any dependencies to that package and it relies on the functionality already provided in it. I will make a note to refactor our existing usage to use this one. I think that would be better.