### PR TITLE
chore(ci): fix type tests running in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "nx run-many -t test -- --minWorkers=1 --maxWorkers=4",
     "test-ci": "nx run-many -t test",
     "test:k6": "tsx ./tasks/k6-test/run-k6-tests.mts",
-    "test:types": "tstyche"
+    "test:types": "nx run-many -t test:types"
   },
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",


### PR DESCRIPTION
We expect the root package json to run tests via nx run-many. If we just use tstyche then it won't pick up any custom behaviour that the individual test:types scripts define.