### PR TITLE
fix(cli): explicitly set the version so `--version` works

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -227,6 +227,10 @@ async function runYargs() {
   // Load any CLI plugins
   await loadPlugins(yarg)
 
+  // We explicitly set the version here so that it's always available
+  const pkgJson = require('../package.json')
+  yarg.version(pkgJson['version'])
+
   // Run
   await yarg.parse(process.argv.slice(2), {}, (err, _argv, output) => {
     // Configuring yargs with `strict` makes it error on unknown args;


### PR DESCRIPTION
For whatever reason the `--version` flag broke in v8. The code to explicitly set the version for yargs is 2 lines so we may as well be explicit and in doing so we fix the problem. 