### PR TITLE
fix: update community discussion link in output from cli - yarn rw upgrade

### DIFF
--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -150,7 +150,7 @@ export const handler = async ({ dryRun, tag, verbose, dedupe }) => {
             messageSections.push(
               `   Please review the release notes for any manual steps: \n   ❖ ${terminalLink(
                 `Redwood community discussion`,
-                `https://community.redwoodjs.com/search?q=${version}%23announcements`,
+                `https://community.redwoodjs.com/c/announcements/releases-and-upgrade-guides/`,
               )}\n   ❖ ${terminalLink(
                 `GitHub Release notes`,
                 `https://github.com/redwoodjs/redwood/releases`, // intentionally not linking to specific version


### PR DESCRIPTION
This is a fix for [(#11463)](https://github.com/redwoodjs/redwood/issues/11463) . This PR simply updates the dynamic url generated via the 'yarn rw upgrade' to a static url. The dynamic link yieled no results in a search. The updated url (https://community.redwoodjs.com/c/announcements/releases-and-upgrade-guides/) makes it easy to find the upgrade guide. 

This is a quick fix. A better long term solution should link directly to the url for the specific version that was upgraded to, but that likely requires a lot more thinking about generating/standardizing the routes of the community docs themselves. 

Test Plan: 

Before the fix - run 'yarn rw upgrade' in any project and navigate to the link output by the cli (https://community.redwoodjs.com/search?q=8.0.0%23announcements). Observe a page with no results 
![Screenshot 2024-09-09 at 4 41 56 AM](https://github.com/user-attachments/assets/506ecbbc-bbfd-4df8-bdc7-99ea79e713bf)

After the fix - follow the [steps to test the cli](https://github.com/redwoodjs/redwood/blob/main/CONTRIBUTING.md#testing-the-cli-in-your-project) and navigate to the cli link where release notes are immediately found. 
![Screenshot 2024-09-09 at 4 42 24 AM](https://github.com/user-attachments/assets/3f0a6ec9-4d86-4ad8-91d0-6ef392143eff)
