### PR TITLE
feat(baremetal): Check available disk space

### DIFF
--- a/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
+++ b/packages/cli/src/commands/deploy/__tests__/baremetal.test.js
@@ -553,6 +553,17 @@ describe('deployTasks', () => {
     expect(tasks[8].skip()).toEqual(false)
   })
 
+  it('skips the available space check if --no-df is passed', () => {
+    const tasks = baremetal.deployTasks(
+      { ...defaultYargs, df: false },
+      {}, // ssh
+      defaultServerConfig,
+      {}, // lifecycle
+    )
+
+    expect(tasks[0].skip()).toBeTruthy()
+  })
+
   it('throws an error if there is not enough available space on the server', () => {
     const ssh = {
       exec: () => ({ stdout: 'df:1875' }),


### PR DESCRIPTION
Adds an early step to the `yarn rw deploy baremetal` command that checks to make sure there is enough free disk space on the server before continuing. 

I ran into an issue over the weekend where I was getting the weirdest errors when trying to deploy. It would just fail at random steps during the deploy process. Clearing up some space on the server fixed it. I had a little bit over 1.5GB free when it happened. A typical deploy seems to take up about 720MB for me right now. So it seems I needed more than twice that size for a successful deploy. 

For now I decided to check for at least 2 GB free space. Less than that and the deploy will error out with a more helpful error message than the errors I was getting 😅

If the user wants to bypass the check they can just pass `--no-df`