### PR TITLE
chore(ci): Temporarily disable 'check:package' step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,9 @@ jobs:
       - name: 🔎 Lint
         run: yarn lint
 
-      - name: 🥡 Check packaging and attw
-        run: yarn check:package
+      # TODO(jgmw): Re-enable when it doesn't hang
+      # - name: 🥡 Check packaging and attw
+      #   run: yarn check:package
 
       - name: 🌡 Test Types
         run: yarn test:types


### PR DESCRIPTION
This appears to be hanging and running at 100% cpu forever after recent updates. I wish to continue to a release so will disable for the moment and circle back with a fix.