### PR TITLE
fix(auth0): avoid use of undefined global in browser environment

### DIFF
--- a/.changesets/11531.md
+++ b/.changesets/11531.md
@@ -1,0 +1,3 @@
+- fix(auth0): avoid use of undefined global in browser environment (#11531) by @Josh-Walker-GM
+
+The Auth0 auth provider was failing in the browser due to trying to access `global`. This change corrects this and fixes Auth0 usage in the browser.

--- a/__fixtures__/test-project/web/package.json
+++ b/__fixtures__/test-project/web/package.json
@@ -27,6 +27,6 @@
     "postcss": "^8.4.45",
     "postcss-loader": "^8.1.1",
     "prettier-plugin-tailwindcss": "^0.5.12",
-    "tailwindcss": "^3.4.10"
+    "tailwindcss": "^3.4.11"
   }
 }

--- a/packages/auth-providers/auth0/web/src/auth0.ts
+++ b/packages/auth-providers/auth0/web/src/auth0.ts
@@ -31,14 +31,14 @@ function createAuthImplementation(auth0Client: Auth0Client) {
     client: auth0Client,
     restoreAuthState: async () => {
       if (
-        global?.location?.search?.includes('code=') &&
-        global?.location?.search?.includes('state=')
+        globalThis?.location?.search?.includes('code=') &&
+        globalThis?.location?.search?.includes('state=')
       ) {
         const { appState } = await auth0Client.handleRedirectCallback()
         const url = appState?.targetUrl
           ? appState.targetUrl
           : window.location.pathname
-        global?.location?.assign(url)
+        globalThis?.location?.assign(url)
       }
     },
     login: async (options?: RedirectLoginOptions) =>


### PR DESCRIPTION
As part of migrating the build tool we likely removed some transpiliation that was allowing `global` in the browser. Switching to `globalThis` is a small change which fixes the issue. 

I have tested this locally and confirmed the bug before and the fix after. 

We could also directly use `window` instead but I don't really think there's anything more or less correct about that vs `globalThis`. I didn't really want to go down the road to adding configuration to esbuild to start adding back build time changes to support this.