### PR TITLE
fix(cli): handle both single and double quotes during dbAuth setup

### DIFF
--- a/.changesets/11534.md
+++ b/.changesets/11534.md
@@ -1,0 +1,3 @@
+- fix(cli): handle both single and double quotes during dbAuth setup (#11534) by @Josh-Walker-GM
+
+If you had changed your prettier config to use double quotes instead of the default single quotes then the `yarn rw setup auth dbAuth` would fail. This change fixes that command to work regardless of quote flavour.

--- a/packages/cli-helpers/src/auth/authTasks.ts
+++ b/packages/cli-helpers/src/auth/authTasks.ts
@@ -109,14 +109,14 @@ export const addApiConfig = ({
   }
 
   const hasCurrentUserImport =
-    /(^import {.*?getCurrentUser(?!getCurrentUser).*?} from 'src\/lib\/auth')/s.test(
+    /(^import {.*?getCurrentUser(?!getCurrentUser).*?} from ['"]src\/lib\/auth['"])/s.test(
       newContent,
     )
 
   if (!hasCurrentUserImport) {
     // add import statement
     newContent = newContent.replace(
-      /^(import { db } from 'src\/lib\/db')$/m,
+      /^(import { db } from ['"]src\/lib\/db['"])$/m,
       `import { getCurrentUser } from 'src/lib/auth'\n$1`,
     )
 
@@ -140,7 +140,7 @@ const addAuthImportToApp = (content: string) => {
   const contentLines = content.split('\n')
   // Find the last import line that's not a .css or .scss import
   const importIndex = contentLines.findLastIndex((line: string) =>
-    /^\s*import (?!.*(?:.css'|.scss'))/.test(line),
+    /^\s*import (?!.*(?:.css['"]|.scss['"]))/.test(line),
   )
 
   // After the import found above, insert a blank line followed by the
@@ -154,7 +154,7 @@ const addAuthImportToRoutes = (content: string) => {
   const contentLines = content.split('\n')
   // Find the last import line that's not a .css or .scss import
   const importIndex = contentLines.findLastIndex((line: string) =>
-    /^\s*import (?!.*(?:.css'|.scss'))/.test(line),
+    /^\s*import (?!.*(?:.css['"]|.scss['"]))/.test(line),
   )
 
   // After the import found above, insert a blank line followed by the

--- a/packages/cli/src/lib/index.js
+++ b/packages/cli/src/lib/index.js
@@ -444,7 +444,7 @@ export const addScaffoldImport = () => {
   }
 
   appJsContents = appJsContents.replace(
-    "import './index.css'",
+    /import ['"]\.\/index\.css['"]/,
     "import './index.css'\nimport './scaffold.css'\n",
   )
   writeFile(appJsPath, appJsContents, { overwriteExisting: true })


### PR DESCRIPTION
Fixes #11526. 

We had a few find and replaces which don't work if you elect to have double quotes rather than single quotes.

By default we ship with a config that expects single quotes so I am not going to audit the entire cli/framework in this PR to ensure we support double quotes at all times. This addresses the issue and so I think is good enough for now. A lot of these functions are utilities so editing them here should have good coverage in other commands. 