### PR TITLE
chore(rsc): Don't pass any props to the user's Routes

### DIFF
--- a/packages/router/src/rsc/ClientRouter.tsx
+++ b/packages/router/src/rsc/ClientRouter.tsx
@@ -48,8 +48,7 @@ const LocationAwareRouter = ({
     //   'No route found for the current URL. Make sure you have a route ' +
     //     'defined for the root of your React app.',
     // )
-    const routesProps = { location: { pathname, search } }
-    return <RscRoutes routesProps={routesProps} />
+    return <RscRoutes pathname={pathname} search={search} />
   }
 
   const requestedRoute = pathRouteMap[activeRoutePath]
@@ -70,8 +69,6 @@ const LocationAwareRouter = ({
       )
     }
 
-    const routesProps = { location: { pathname, search } }
-
     return (
       <RouterContextProvider
         useAuth={useAuth}
@@ -80,23 +77,15 @@ const LocationAwareRouter = ({
         activeRouteName={requestedRoute.name}
       >
         <AuthenticatedRoute unauthenticated={unauthenticated}>
-          <RscRoutes routesProps={routesProps} />
+          <RscRoutes pathname={pathname} search={search} />
         </AuthenticatedRoute>
       </RouterContextProvider>
     )
   }
 
-  const routesProps = { location: { pathname, search } }
   // TODO (RSC): I think that moving between private and public routes
-  // re-initializes RscFetcher. I wonder if there's an optimization to be made
-  // here. Maybe we can lift RscFetcher up so we can keep the same instance
+  // re-initializes RscRoutes. I wonder if there's an optimization to be made
+  // here. Maybe we can lift RscRoutes up so we can keep the same instance
   // around and reuse it everywhere
-  return <RscRoutes routesProps={routesProps} />
-}
-
-export interface RscFetchProps extends Record<string, unknown> {
-  location: {
-    pathname: string
-    search: string
-  }
+  return <RscRoutes pathname={pathname} search={search} />
 }

--- a/packages/router/src/rsc/RscRoutes.tsx
+++ b/packages/router/src/rsc/RscRoutes.tsx
@@ -78,7 +78,6 @@ function rscFetchRoutes(serializedLocation: SerializedLocation) {
 
       const searchParams = new URLSearchParams()
       searchParams.set('action_id', rsaId)
-      searchParams.set('props', serializedLocation)
       const rscId = '_'
 
       let body: Awaited<ReturnType<typeof encodeReply>> = ''
@@ -89,13 +88,16 @@ function rscFetchRoutes(serializedLocation: SerializedLocation) {
         console.error('Error encoding Server Action arguments', e)
       }
 
-      const responsePromise = fetch(BASE_PATH + rscId + '?' + searchParams, {
-        method: 'POST',
-        body,
-        headers: {
-          'rw-rsc': '1',
+      const responsePromise = fetch(
+        BASE_PATH + rscId + '?' + searchParams + '&' + serializedLocation,
+        {
+          method: 'POST',
+          body,
+          headers: {
+            'rw-rsc': '1',
+          },
         },
-      })
+      )
 
       onStreamFinished(responsePromise, () => {
         updateCurrentRscCacheKey(rscCacheKey)

--- a/packages/router/src/rsc/ServerRouter.tsx
+++ b/packages/router/src/rsc/ServerRouter.tsx
@@ -132,7 +132,7 @@ export const Router: React.FC<RouterProps> = ({ paramTypes, children }) => {
 }
 
 // TODO (RSC): We allow users to implement their own `hasRole` function in
-// `api/src/lib/auth.ts`. We should use that instead of implementing our
+// `api/src/lib/auth.ts`. We should use that instead of implementing our own
 // here. Should we just import it from there? Or should we allow users to
 // pass it to us instead somehow?
 function hasRole(requiredRoles: string | string[]): boolean {

--- a/packages/vite/src/__tests__/utils.test.ts
+++ b/packages/vite/src/__tests__/utils.test.ts
@@ -1,0 +1,45 @@
+import type { Request as ExpressRequest } from 'express'
+import { describe, it, expect } from 'vitest'
+
+import { getFullUrl } from '../utils.js'
+
+function mockExpressRequest(url: string) {
+  const req = {
+    originalUrl: url,
+    protocol: 'http',
+    headers: { host: 'localhost:8910' },
+    get: (header: 'host') => req.headers[header],
+    // Type casting here because a proper Request object has about 100 fields
+    // and I don't want to list them all here just for a test
+  } as ExpressRequest
+
+  return req
+}
+
+describe('getFullUrl', () => {
+  describe('rsc enabled', () => {
+    const rscEnabled = true
+
+    it("returns the original URL if the request's searchParams don't include rsc request props", () => {
+      const req = mockExpressRequest(
+        '/rw-rsc/__rwjs__Routes?props=' +
+          encodeURIComponent('__rwjs__pathname=/about&__rwjs__search='),
+      )
+
+      const result = getFullUrl(req, rscEnabled)
+
+      expect(result).toBe('http://localhost:8910/about')
+    })
+
+    it("reads pathname and search parameters from the request's searchParams if they're available", () => {
+      const req = mockExpressRequest(
+        '/rw-rsc/__rwjs__Routes?props=' +
+          encodeURIComponent('__rwjs__pathname=/about&__rwjs__search='),
+      )
+
+      const result = getFullUrl(req, rscEnabled)
+
+      expect(result).toBe('http://localhost:8910/about')
+    })
+  })
+})

--- a/packages/vite/src/__tests__/utils.test.ts
+++ b/packages/vite/src/__tests__/utils.test.ts
@@ -21,25 +21,24 @@ describe('getFullUrl', () => {
     const rscEnabled = true
 
     it("returns the original URL if the request's searchParams don't include rsc request props", () => {
-      const req = mockExpressRequest(
-        '/rw-rsc/__rwjs__Routes?props=' +
-          encodeURIComponent('__rwjs__pathname=/about&__rwjs__search='),
-      )
+      const req = mockExpressRequest('/foo/bar?extra=baz')
 
       const result = getFullUrl(req, rscEnabled)
 
-      expect(result).toBe('http://localhost:8910/about')
+      expect(result).toBe('http://localhost:8910/foo/bar?extra=baz')
     })
 
     it("reads pathname and search parameters from the request's searchParams if they're available", () => {
       const req = mockExpressRequest(
-        '/rw-rsc/__rwjs__Routes?props=' +
-          encodeURIComponent('__rwjs__pathname=/about&__rwjs__search='),
+        '/rw-rsc/__rwjs__Routes?__rwjs__pathname=' +
+          encodeURIComponent('/cux/cuux') +
+          '&__rwjs__search=' +
+          encodeURIComponent('extra=corge'),
       )
 
       const result = getFullUrl(req, rscEnabled)
 
-      expect(result).toBe('http://localhost:8910/about')
+      expect(result).toBe('http://localhost:8910/cux/cuux?extra=corge')
     })
   })
 })

--- a/packages/vite/src/devFeServer.ts
+++ b/packages/vite/src/devFeServer.ts
@@ -44,7 +44,7 @@ async function createServer() {
   const serverStorage = createServerStorage()
 
   app.use('*', (req, _res, next) => {
-    const fullUrl = getFullUrl(req)
+    const fullUrl = getFullUrl(req, rscEnabled)
 
     const perReqStore = createPerRequestMap({
       // Convert express headers to fetch header

--- a/packages/vite/src/rsc/rscRenderer.ts
+++ b/packages/vite/src/rsc/rscRenderer.ts
@@ -7,13 +7,11 @@ import { renderToReadableStream } from 'react-server-dom-webpack/server.edge'
 
 import { getPaths } from '@redwoodjs/project-config'
 
-import type { RscFetchProps } from '../../../router/src/rsc/ClientRouter.tsx'
 import { getEntriesFromDist } from '../lib/entries.js'
 import { StatusError } from '../lib/StatusError.js'
 
 export type RenderInput = {
   rscId?: string | undefined
-  props: RscFetchProps | Record<string, unknown>
   rsaId?: string | undefined
   args?: unknown[] | undefined
 }
@@ -121,7 +119,7 @@ async function renderRsc(input: RenderInput): Promise<ReadableStream> {
     )
   }
 
-  if (!input.rscId || !input.props) {
+  if (!input.rscId) {
     throw new Error('Unexpected input. Missing rscId or props.')
   }
 
@@ -129,10 +127,9 @@ async function renderRsc(input: RenderInput): Promise<ReadableStream> {
 
   const serverRoutes = await getRoutesComponent()
   const model: RscModel = {
-    __rwjs__Routes: createElement(serverRoutes, input.props),
+    __rwjs__Routes: createElement(serverRoutes),
   }
 
-  console.log('rscRenderer.ts renderRsc props', input.props)
   console.log('rscRenderer.ts renderRsc model', model)
 
   return renderToReadableStream(model, getBundlerConfig())
@@ -190,9 +187,7 @@ async function executeRsa(input: RenderInput): Promise<ReadableStream> {
   const serverRoutes = await getRoutesComponent()
   console.log('rscRenderer.ts executeRsa serverRoutes', serverRoutes)
   const model: RscModel = {
-    __rwjs__Routes: createElement(serverRoutes, {
-      location: { pathname: '/', search: '' },
-    }),
+    __rwjs__Routes: createElement(serverRoutes),
     __rwjs__rsa_data: data,
   }
   console.log('rscRenderer.ts executeRsa model', model)

--- a/packages/vite/src/rsc/rscRequestHandler.ts
+++ b/packages/vite/src/rsc/rscRequestHandler.ts
@@ -11,7 +11,6 @@ import type Router from 'find-my-way'
 import type { HTTPMethod } from 'find-my-way'
 import type { ViteDevServer } from 'vite'
 
-import type { RscFetchProps } from '@redwoodjs/router/RscRouter'
 import type { Middleware } from '@redwoodjs/web/dist/server/middleware'
 
 import {
@@ -90,11 +89,6 @@ export function createRscRequestHandler(
 
     const url = new URL(req.originalUrl || '', 'http://' + req.headers.host)
     let rscId: string | undefined
-    // "location":{"pathname":"/about","search":""}
-    // These values come from packages/vite/src/ClientRouter.tsx
-    const props: RscFetchProps = JSON.parse(
-      url.searchParams.get('props') || '{}',
-    )
     let rsaId: string | undefined
     let args: unknown[] = []
 
@@ -188,14 +182,13 @@ export function createRscRequestHandler(
       }
 
       try {
-        const readable = await renderRscToStream({ rscId, props, rsaId, args })
+        const readable = await renderRscToStream({ rscId, rsaId, args })
 
         Readable.fromWeb(readable).pipe(res)
 
         // TODO (RSC): Can we reuse `readable` here somehow?
         await sendRscFlightToStudio({
           rscId,
-          props,
           rsaId,
           args,
           basePath: BASE_PATH,

--- a/packages/vite/src/rsc/rscStudioHandlers.ts
+++ b/packages/vite/src/rsc/rscStudioHandlers.ts
@@ -123,19 +123,14 @@ export const sendRscFlightToStudio = async (input: StudioRenderInput) => {
     console.debug('Studio is not enabled')
     return
   }
-  const { rscId, props, rsaId, args, basePath, req, handleError } = input
+  const { rscId, rsaId, args, basePath, req, handleError } = input
 
   try {
     // surround renderRsc with performance metrics
     const startedAt = Date.now()
     const start = performance.now()
 
-    const readable = await renderRscToStream({
-      rscId,
-      props,
-      rsaId,
-      args,
-    })
+    const readable = await renderRscToStream({ rscId, rsaId, args })
     const endedAt = Date.now()
     const end = performance.now()
     const duration = end - start
@@ -145,7 +140,6 @@ export const sendRscFlightToStudio = async (input: StudioRenderInput) => {
       rsc: {
         rscId,
         rsaId,
-        props,
         args,
       },
       request: {

--- a/packages/vite/src/runFeServer.ts
+++ b/packages/vite/src/runFeServer.ts
@@ -141,7 +141,7 @@ export async function runFeServer() {
   )
 
   app.use('*', (req, _res, next) => {
-    const fullUrl = getFullUrl(req)
+    const fullUrl = getFullUrl(req, rscEnabled)
     const headers = convertExpressHeaders(req.headersDistinct)
     // Convert express headers to fetch headers
     const perReqStore = createPerRequestMap({ headers, fullUrl })

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -100,29 +100,17 @@ export const getFullUrl = (req: ExpressRequest, rscEnabled: boolean) => {
   // object and have it do the parsing for us.
   const url = new URL(req.originalUrl || '', baseUrl)
 
-  // `props` will be something like:
-  // "__rwjs__pathname=/about&__rwjs__search=
-  const props = url.searchParams.get('props') || ''
+  const pathname = url.searchParams.get('__rwjs__pathname')
+  const search = url.searchParams.get('__rwjs__search')
 
   console.log('getFullUrl url.href', url.href)
-  console.log('getFullUrl props', props)
+  console.log('getFullUrl pathname', pathname)
+  console.log('getFullUrl search', search)
 
   let pathnamePlusSearch = req.originalUrl
 
-  if (
-    rscEnabled &&
-    props.includes('__rwjs__pathname') &&
-    props.includes('__rwjs__search')
-  ) {
-    const matches = props.match(
-      /^__rwjs__pathname=(.*?)&__rwjs__search=(.*?)(?:::)?/,
-    )
-    const pathname = matches?.[1]
-    const search = matches?.[2]
-
-    if (pathname && (search === '' || search)) {
-      pathnamePlusSearch = pathname + search
-    }
+  if (rscEnabled && pathname !== null && search !== null) {
+    pathnamePlusSearch = pathname + '?' + search
   }
 
   return baseUrl + pathnamePlusSearch

--- a/packages/vite/src/utils.ts
+++ b/packages/vite/src/utils.ts
@@ -67,34 +67,7 @@ export function convertExpressHeaders(
 }
 
 export const getFullUrl = (req: ExpressRequest, rscEnabled: boolean) => {
-  // For a standard request:
-  //
-  // req.originalUrl /about
-  // req.protocol http
-  // req.headers.host localhost:8910
-  // req.get('host') localhost:8910
-  // baseUrl http://localhost:8910
-  // url.href http://localhost:8910/about
-  // props {}
-  //
-  // For an RSC request:
-  //
-  // req.originalUrl /rw-rsc/__rwjs__Routes?props=%7B%22location%22%3A%7B%22pathname%22%3A%22%2Fabout%22%2C%22search%22%3A%22%22%7D%7D
-  // req.protocol http
-  // req.headers.host localhost:8910
-  // req.get('host') localhost:8910
-  // baseUrl http://localhost:8910
-  // url.href http://localhost:8910/rw-rsc/__rwjs__Routes?props=%7B%22location%22%3A%7B%22pathname%22%3A%22%2Fabout%22%2C%22search%22%3A%22%22%7D%7D
-  // props { location: { pathname: '/about', search: '' } }
-
-  console.log('getFullUrl req.originalUrl', req.originalUrl)
-  console.log('getFullUrl req.protocol', req.protocol)
-  console.log('getFullUrl req.headers.host', req.headers.host)
-  console.log("getFullUrl req.get('host')", req.get('host'))
-
   const baseUrl = req.protocol + '://' + req.headers.host
-
-  console.log('getFullUrl baseUrl', baseUrl)
 
   // Properly parsing search params is difficult, so let's construct a URL
   // object and have it do the parsing for us.
@@ -102,10 +75,6 @@ export const getFullUrl = (req: ExpressRequest, rscEnabled: boolean) => {
 
   const pathname = url.searchParams.get('__rwjs__pathname')
   const search = url.searchParams.get('__rwjs__search')
-
-  console.log('getFullUrl url.href', url.href)
-  console.log('getFullUrl pathname', pathname)
-  console.log('getFullUrl search', search)
 
   let pathnamePlusSearch = req.originalUrl
 


### PR DESCRIPTION
There's no need to pass the location as props to the routes component anymore as we now store it in server-storage and can read it with `getLocation()`

This is the main part of this PR: 
![image](https://github.com/user-attachments/assets/bd51cd5f-d235-4d6a-86a7-96d1ae7865de)
https://github.com/redwoodjs/redwood/pull/11539/files#diff-13d61e6bc160d258f65d2b2e4d0e87d3b192b453d8e50e5e929dc7892e6706a1L132