### PR TITLE
feat(cli): Make scaffolded layout routing type-safe

### DIFF
--- a/.changesets/11542.md
+++ b/.changesets/11542.md
@@ -1,0 +1,5 @@
+- feat(cli): Make scaffolded layout routing type-safe (#11542) by @Tobbe
+
+With this feature we now make sure only valid route names are passed as `titleTo` and `buttonTo` props to the scaffolded layout.
+
+This also means you get helpful code completion when typing out the prop values

--- a/__fixtures__/test-project/web/src/layouts/ScaffoldLayout/ScaffoldLayout.tsx
+++ b/__fixtures__/test-project/web/src/layouts/ScaffoldLayout/ScaffoldLayout.tsx
@@ -3,9 +3,9 @@ import { Toaster } from '@redwoodjs/web/toast'
 
 type LayoutProps = {
   title: string
-  titleTo: string
+  titleTo: keyof typeof routes
   buttonLabel: string
-  buttonTo: string
+  buttonTo: keyof typeof routes
   children: React.ReactNode
 }
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -2440,9 +2440,9 @@ import { Toaster } from '@redwoodjs/web/toast'
 
 type LayoutProps = {
   title: string
-  titleTo: string
+  titleTo: keyof typeof routes
   buttonLabel: string
-  buttonTo: string
+  buttonTo: keyof typeof routes
   children: React.ReactNode
 }
 

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
@@ -1500,9 +1500,9 @@ import { Toaster } from '@redwoodjs/web/toast'
 
 type LayoutProps = {
   title: string
-  titleTo: string
+  titleTo: keyof typeof routes
   buttonLabel: string
-  buttonTo: string
+  buttonTo: keyof typeof routes
   children: React.ReactNode
 }
 

--- a/packages/cli/src/commands/generate/scaffold/templates/layouts/ScaffoldLayout.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/layouts/ScaffoldLayout.tsx.template
@@ -3,9 +3,9 @@ import { Toaster } from '@redwoodjs/web/toast'
 
 type LayoutProps = {
   title: string
-  titleTo: string
+  titleTo: keyof typeof routes
   buttonLabel: string
-  buttonTo: string
+  buttonTo: keyof typeof routes
   children: React.ReactNode
 }
 


### PR DESCRIPTION
With this feature we now make sure only valid route names are passed as `titleTo` and `buttonTo` props to the scaffolded layout.

This also means you get helpful code completion when typing out the prop values

![image](https://github.com/user-attachments/assets/f2cd5bf1-af4f-41fc-8983-543036f6c305)

Note that this only affects newly generated scaffolds. All existing scaffold layouts will have to be manually updated by the user (or regenerated) if they wish to have the extra type safety