### PR TITLE
fix(crwrsca): Check for Node >= 20.10.0

### DIFF
--- a/packages/create-redwood-rsc-app/src/prerequisites.ts
+++ b/packages/create-redwood-rsc-app/src/prerequisites.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
-
 import semver from 'semver'
 import which from 'which'
 
 import type { Config } from './config.js'
+
 import { ExitCodeError } from './error.js'
 
 export function checkNodeVersion(config: Config) {

--- a/packages/create-redwood-rsc-app/src/prerequisites.ts
+++ b/packages/create-redwood-rsc-app/src/prerequisites.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
+
 import semver from 'semver'
 import which from 'which'
 
 import type { Config } from './config.js'
-
 import { ExitCodeError } from './error.js'
 
 export function checkNodeVersion(config: Config) {
@@ -12,7 +12,6 @@ export function checkNodeVersion(config: Config) {
     console.log('Running `node --version`')
   }
 
-  // const { stdout: version } = spawnSync('node --version')
   const result = spawnSync('node', ['--version'])
 
   if (result.error) {
@@ -27,8 +26,11 @@ export function checkNodeVersion(config: Config) {
     console.log('Node version:', version)
   }
 
-  if (!semver.satisfies(version, '>=20')) {
-    console.error('❌Your Node.js version must be >=20')
+  // https://github.com/redwoodjs/redwood/issues/10492#issuecomment-2076063552
+  // The comment above and the one after explains why we check specifically
+  // for >= 20.10.0
+  if (!semver.satisfies(version, '>=20.10')) {
+    console.error('❌Your Node.js version must be >=20.10.0')
     console.error('Please install or switch to a newer version of Node')
     console.error(
       'We recommend using a Node version manager like `fnm`, `nvm` or `n`',


### PR DESCRIPTION
Updating the minimum version of Node because they decided to introduce a breaking change between 20.9 and 20.10

See this link for further details: https://github.com/redwoodjs/redwood/issues/10492#issuecomment-2076063552

This is what you'll see if you're on node 20.3.0

![image](https://github.com/user-attachments/assets/eeebaa01-aac4-4d11-b361-80cc1ec84bee)
