### PR TITLE
fix(scaffold): Use plain strings in NamesCell template

### DIFF
--- a/__fixtures__/test-project/web/src/components/Contact/ContactsCell/ContactsCell.tsx
+++ b/__fixtures__/test-project/web/src/components/Contact/ContactsCell/ContactsCell.tsx
@@ -27,9 +27,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No contacts yet. '}
+      No contacts yet.{' '}
       <Link to={routes.newContact()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )

--- a/__fixtures__/test-project/web/src/components/Post/PostsCell/PostsCell.tsx
+++ b/__fixtures__/test-project/web/src/components/Post/PostsCell/PostsCell.tsx
@@ -26,9 +26,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No posts yet. '}
+      No posts yet.{' '}
       <Link to={routes.newPost()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffold.test.js.snap
@@ -207,9 +207,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No posts yet. '}
+      No posts yet.{' '}
       <Link to={routes.newPost()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )
@@ -1586,9 +1586,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No posts yet. '}
+      No posts yet.{' '}
       <Link to={routes.newPost()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )
@@ -3428,9 +3428,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No posts yet. '}
+      No posts yet.{' '}
       <Link to={routes.newPost()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )

--- a/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
+++ b/packages/cli/src/commands/generate/scaffold/__tests__/__snapshots__/scaffoldNoNest.test.js.snap
@@ -1058,9 +1058,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No posts yet. '}
+      No posts yet.{' '}
       <Link to={routes.newPost()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )
@@ -2434,9 +2434,9 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No posts yet. '}
+      No posts yet.{' '}
       <Link to={routes.newPost()} className="rw-link">
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )

--- a/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.tsx.template
+++ b/packages/cli/src/commands/generate/scaffold/templates/components/NamesCell.tsx.template
@@ -25,12 +25,12 @@ export const Loading = () => <div>Loading...</div>
 export const Empty = () => {
   return (
     <div className="rw-text-center">
-      {'No ${pluralCamelName} yet. '}
+      No ${pluralCamelName} yet.{' '}
       <Link
         to={routes.${newRouteName}()}
         className="rw-link"
       >
-        {'Create one?'}
+        Create one?
       </Link>
     </div>
   )


### PR DESCRIPTION
No need to use interpreted values here since we're just outputting plain strings