### PR TITLE
fix(crwa): silence telemetry errors

### DIFF
--- a/packages/create-redwood-app/src/telemetry.js
+++ b/packages/create-redwood-app/src/telemetry.js
@@ -109,9 +109,8 @@ export async function shutdownTelemetry() {
     await traceProvider?.shutdown()
     await traceProcessor?.shutdown()
     await traceExporter?.shutdown()
-  } catch (error) {
-    console.error('Telemetry error')
-    console.error(error)
+  } catch {
+    // We silence this error for user experience
   }
 }
 


### PR DESCRIPTION
Recently there has been an increasing amount of telemetry errors. I will replace our current telemetry based on otel back to the classic telemetry we had before. Until then we wish to disable logging this error to improve the user experience. 