### PR TITLE
chore(ci): refactor to make conditional checks more robust

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,0 +1,55 @@
+name: 🏗 Build, lint, test
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: The target to run on.
+        type: string
+        required: true
+      skip:
+        description: Whether to skip all jobs.
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  build-lint-test:
+    name: node 20 latest
+    runs-on: ${{ inputs.target }}
+    if: ${{ !inputs.skip }}
+
+    steps:
+      - name: Remove the tsc problem matcher if not ubuntu-latest
+        if: inputs.target != 'ubuntu-latest'
+        run: echo "echo "::remove-matcher owner=tsc::""
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: Set up job
+        uses: ./.github/actions/set-up-job
+
+      - name: 🔎 Lint
+        run: yarn lint
+
+      # TODO(jgmw): Re-enable when it doesn't hang
+      # - name: 🥡 Check packaging and attw
+      #   run: yarn check:package
+
+      - name: 🌡 Test Types
+        run: yarn test:types
+
+      - name: Get number of CPU cores
+        if: always()
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2
+
+      - name: 🧪 Test
+        run: yarn test-ci --minWorkers=1 --maxWorkers=${{ steps.cpu-cores.outputs.count }}
+
+  skipped:
+    name: node 20 latest
+    runs-on: ${{ inputs.target }}
+    if: ${{ inputs.skip }}
+    steps:
+      - name: Skip
+        run: echo "Skipping as requested from caller"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,55 +87,18 @@ jobs:
         run: yarn format:check
 
   build-lint-test:
-    needs: check
+    needs: [check, detect-changes]
 
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
 
-    name: 🏗 Build, lint, test / ${{ matrix.os }} / node 20 latest
-    runs-on: ${{ matrix.os }}
+    name: 🏗 Build, lint, test / ${{ matrix.os }}
 
-    steps:
-      - name: Remove the tsc problem matcher if not ubuntu-latest
-        if: matrix.os != 'ubuntu-latest'
-        run: echo "echo "::remove-matcher owner=tsc::""
-
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      - name: Set up job
-        uses: ./.github/actions/set-up-job
-
-      - name: 🔎 Lint
-        run: yarn lint
-
-      # TODO(jgmw): Re-enable when it doesn't hang
-      # - name: 🥡 Check packaging and attw
-      #   run: yarn check:package
-
-      - name: 🌡 Test Types
-        run: yarn test:types
-
-      - name: Get number of CPU cores
-        if: always()
-        id: cpu-cores
-        uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2
-
-      - name: 🧪 Test
-        run: yarn test-ci --minWorkers=1 --maxWorkers=${{ steps.cpu-cores.outputs.count }}
-
-  build-lint-test-skip:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.code == 'false'
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-
-    name: 🏗 Build, lint, test / ${{ matrix.os }} / node 20 latest
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - run: echo "Skipped"
+    uses: ./.github/workflows/build-lint-test.yml
+    with:
+      target: ${{ matrix.os }}
+      skip: ${{ needs.detect-changes.outputs.code == 'false' }}
 
   tutorial-e2e:
     needs: check


### PR DESCRIPTION
This is a bit of an experiment so expect a couple follow ups and some general churn on this area of code or indeed for this to all just get binned.

The issue we have is that we have required checks for PRs. GitHub requires these checks to run and pass before allowing you to merge (members with permission can of course override but yuck). The issue is that we want to only run a subset of CI based on what changes - e.g. we don't care about code testing if it's just a docs update. However, to meet the GitHub requirement we need a job with that name to run. 

Currently we follow some now removed GitHub advice to have a duplicate job with the same name and conditionally either run the job that actually does the tests or the job that simply passes.

It's not possible to have a step within a job short circuit and pass the full job early. 

This is still WIP but not marked as draft so I can see what GitHub thinks about merging with the required checks.
