### PR TITLE
fix(crwrsca): Spawn in shell on Windows

### DIFF
--- a/packages/create-redwood-rsc-app/src/install.ts
+++ b/packages/create-redwood-rsc-app/src/install.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 
 import type { Config } from './config.js'
 
@@ -13,5 +14,10 @@ export function install(config: Config) {
   // this project)
   fs.writeFileSync(path.join(config.installationDir, 'yarn.lock'), '')
 
-  spawnSync('yarn', ['install'], { cwd: config.installationDir })
+  spawnSync('yarn', ['install'], {
+    cwd: config.installationDir,
+    // On Windows `yarn` isn't an executable. It can't be run as a system
+    // process. So it needs to be run in a shell process.
+    shell: process.platform === 'win32',
+  })
 }

--- a/packages/create-redwood-rsc-app/src/latest.ts
+++ b/packages/create-redwood-rsc-app/src/latest.ts
@@ -1,5 +1,6 @@
-import { spawnSync } from 'node:child_process'
 import type { SpawnSyncOptions } from 'node:child_process'
+
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import process from 'node:process'
 

--- a/packages/create-redwood-rsc-app/src/latest.ts
+++ b/packages/create-redwood-rsc-app/src/latest.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from 'node:child_process'
+import type { SpawnSyncOptions } from 'node:child_process'
 import fs from 'node:fs'
+import process from 'node:process'
 
 import type { Config } from './config.js'
 
@@ -86,13 +88,16 @@ export function relaunchOnLatest(config: Config) {
     }
   }
 
-  const spawnOpts = {
+  const spawnOpts: SpawnSyncOptions = {
     stdio: 'inherit',
+    // On Windows, `npx` isn't an executable, so we need to run it in a shell
+    shell: process.platform === 'win32',
     env: {
       ...process.env,
+      // Install without asking for confirmation
       npm_config_yes: 'true',
     },
-  } as const
+  }
 
   let result: ReturnType<typeof spawnSync>
 


### PR DESCRIPTION
On Windows yarn, npm, npx and other unix-y cli programs aren't proper executables, so they can't be run as a standalone system process. So when using `child_process.spawnSync()` we need to pass `shell: true` to launch those programs inside a shell process.

(Node on the other hand is a full `.exe` and can be run standalone) 