### PR TITLE
Docs: Use Redwood's hashPassword() for loginToken hashing in the password-less dbAuth flow

### DIFF
--- a/docs/docs/how-to/dbauth-passwordless.md
+++ b/docs/docs/how-to/dbauth-passwordless.md
@@ -59,7 +59,8 @@ Now that you have the file, let's add the `generateToken` function.
 
 ```javascript {21} title="/api/src/services/users/users.js"
 // add this import to the top of the file
-import { hashPassword } from "@redwoodjs/auth-dbauth-api"
+import CryptoJS from 'crypto-js'
+import { hashPassword } from '@redwoodjs/auth-dbauth-api'
 // add this to the bottom of the file
 export const generateLoginToken = async ({ email }) => {
   try {

--- a/docs/docs/how-to/dbauth-passwordless.md
+++ b/docs/docs/how-to/dbauth-passwordless.md
@@ -59,7 +59,7 @@ Now that you have the file, let's add the `generateToken` function.
 
 ```javascript {21} title="/api/src/services/users/users.js"
 // add this import to the top of the file
-import CryptoJS from 'crypto-js'
+import { hashPassword } from "@redwoodjs/auth-dbauth-api"
 // add this to the bottom of the file
 export const generateLoginToken = async ({ email }) => {
   try {
@@ -84,10 +84,7 @@ export const generateLoginToken = async ({ email }) => {
       return sixDigitNumber.toString()
     })()
     console.log({ randomNumber }) // email the user this number
-    let salt = CryptoJS.lib.WordArray.random(30)
-    let loginToken = CryptoJS.PBKDF2(randomNumber, salt, {
-      keySize: 256 / 32,
-    }).toString()
+    const [loginToken, salt] = hashPassword(randomNumber)
     // now we'll update the user with the new salt and loginToken
     let loginTokenExpiresAt = new Date()
     loginTokenExpiresAt.setMinutes(loginTokenExpiresAt.getMinutes() + 15)

--- a/docs/docs/how-to/dbauth-passwordless.md
+++ b/docs/docs/how-to/dbauth-passwordless.md
@@ -84,7 +84,7 @@ export const generateLoginToken = async ({ email }) => {
       return sixDigitNumber.toString()
     })()
     console.log({ randomNumber }) // email the user this number
-    const [loginToken, salt] = hashPassword(randomNumber)
+    let [loginToken, salt] = hashPassword(randomNumber)
     // now we'll update the user with the new salt and loginToken
     let loginTokenExpiresAt = new Date()
     loginTokenExpiresAt.setMinutes(loginTokenExpiresAt.getMinutes() + 15)


### PR DESCRIPTION
The hashing algorithm used in the current version of the guide doesn't match the algorithm that Redwood uses to find user by username/password before passing control to the custom login handler. This breaks login flow, users can never sign in even with a correct valid token.

Introduced changes replace 3rd-party crypto-js library with the `hashPassword()` function imported from the Redwood itself.