### PR TITLE
docs(how-to): replace crypto-js with node's crypto module for random number generation in passwordless auth

### DIFF
--- a/docs/docs/how-to/dbauth-passwordless.md
+++ b/docs/docs/how-to/dbauth-passwordless.md
@@ -59,7 +59,7 @@ Now that you have the file, let's add the `generateToken` function.
 
 ```javascript title="/api/src/services/users/users.js"
 // add the following two imports to the top of the file
-import crypto from "node:crypto"
+import crypto from 'node:crypto'
 import { hashPassword } from '@redwoodjs/auth-dbauth-api'
 
 // add this to the bottom of the file
@@ -73,7 +73,10 @@ export const generateLoginToken = async ({ email }) => {
     }
 
     // here we're going to generate a random password of 6 numbers
-    const randomNumber = crypto.randomInt(0, 1_000_000).toString().padStart(6, "0")
+    const randomNumber = crypto
+      .randomInt(0, 1_000_000)
+      .toString()
+      .padStart(6, '0')
     console.log({ randomNumber }) // email the user this number
 
     const [loginToken, salt] = hashPassword(randomNumber)

--- a/docs/docs/how-to/dbauth-passwordless.md
+++ b/docs/docs/how-to/dbauth-passwordless.md
@@ -73,7 +73,7 @@ export const generateLoginToken = async ({ email }) => {
     }
 
     // here we're going to generate a random password of 6 numbers
-    const randomNumber = crypto.randomInt(0, 1_000_000).toString().padStart(length, "0")
+    const randomNumber = crypto.randomInt(0, 1_000_000).toString().padStart(6, "0")
     console.log({ randomNumber }) // email the user this number
 
     const [loginToken, salt] = hashPassword(randomNumber)

--- a/docs/docs/how-to/dbauth-passwordless.md
+++ b/docs/docs/how-to/dbauth-passwordless.md
@@ -59,7 +59,7 @@ Now that you have the file, let's add the `generateToken` function.
 
 ```javascript title="/api/src/services/users/users.js"
 // add the following two imports to the top of the file
-import CryptoJS from 'crypto-js'
+import crypto from "node:crypto"
 import { hashPassword } from '@redwoodjs/auth-dbauth-api'
 
 // add this to the bottom of the file
@@ -73,19 +73,9 @@ export const generateLoginToken = async ({ email }) => {
     }
 
     // here we're going to generate a random password of 6 numbers
-    const randomNumber = (() => {
-      const random = CryptoJS.lib.WordArray.random(6)
-      const randomString = random.toString()
-      let sixDigitNumber = randomString.replace(/\D/g, '')
-      if (sixDigitNumber.length < 6) {
-        sixDigitNumber = sixDigitNumber.padStart(6, '0')
-      }
-      if (sixDigitNumber.length > 6) {
-        sixDigitNumber = sixDigitNumber.slice(0, 6)
-      }
-      return sixDigitNumber.toString()
-    })()
+    const randomNumber = crypto.randomInt(0, 1_000_000).toString().padStart(length, "0")
     console.log({ randomNumber }) // email the user this number
+
     const [loginToken, salt] = hashPassword(randomNumber)
     // now we'll update the user with the new salt and loginToken
     const loginTokenExpiresAt = new Date()


### PR DESCRIPTION
This is the last remaining place in the guide where 3rd-party crypto-js package is used. Replaced crypto-js with node's crypto module to simplify the code and get rid of external dependency.

One thing I'm not certain about is how proposed changes compare with the existing solution from the security point of view.  `crypto.randomInt()` should be secure, but after generating a number I padStart the value with "0" which may reduce randomness I guess. However the same is done for crypto-js generated values as well, so I would assume it shouldn't be less secure.