### PR TITLE
chore(kitchen-sink): Fix css for page width

### DIFF
--- a/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.css
+++ b/__fixtures__/test-project-rsc-kitchen-sink/web/src/layouts/NavigationLayout/NavigationLayout.css
@@ -51,5 +51,9 @@
   & > main {
     display: flex;
     flex-grow: 1;
+
+    & > div {
+      width: 100%;
+    }
   }
 }


### PR DESCRIPTION
Back when I added the RSC blog to kitchen-sink I messed up the CSS for other pages. This should fix that so that they are full-screen wide again.