### PR TITLE
Default NODE_ENV to "development" if it's `undefined` when starting jobs worker

### DIFF
--- a/.changesets/11572.md
+++ b/.changesets/11572.md
@@ -1,0 +1,3 @@
+- Default NODE_ENV to "development" if it's `undefined` when starting jobs worker (#11572) by @cannikin
+
+This mimics the behavior of `yarn rw dev` where `NODE_ENV` will equal `development` if you don't set it explicitly.

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -701,7 +701,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may simply be able to rely on the job runner to start your job workers, which will run forever:
+For many use cases you may be able to rely on the job runner to start and deatch your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start
@@ -722,6 +722,20 @@ For maximum reliability you should take a look at the [Advanced Job Workers](#ad
 Of course if you have a process monitor system watching your workers you'll want to use the process monitor's version of the `restart` command each time you deploy!
 
 :::
+
+### NODE_ENV
+
+You'll need to explicitly set your `NODE_ENV` when in environments other than development or test. We like having a `.env` file in a serverfull production environment, and you just include:
+
+```bash
+NODE_ENV=production
+```
+
+If you're using Docker, make sure you have an `ENV` declaration for it:
+
+```docker
+ENV NODE_ENV="production"
+```
 
 ## Advanced Job Workers
 

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -701,7 +701,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may be able to rely on the job runner to start and deatch your job workers, which will then run forever:
+For many use cases you may be able to rely on the job runner to start and detatch your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start

--- a/docs/docs/background-jobs.md
+++ b/docs/docs/background-jobs.md
@@ -701,7 +701,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may be able to rely on the job runner to start and detatch your job workers, which will then run forever:
+For many use cases you may be able to rely on the job runner to start and detach your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start

--- a/docs/versioned_docs/version-8.0/background-jobs.md
+++ b/docs/versioned_docs/version-8.0/background-jobs.md
@@ -705,7 +705,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may simply be able to rely on the job runner to start your job workers, which will run forever:
+For many use cases you may be able to rely on the job runner to start and detatch your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start

--- a/docs/versioned_docs/version-8.0/background-jobs.md
+++ b/docs/versioned_docs/version-8.0/background-jobs.md
@@ -727,6 +727,20 @@ Of course if you have a process monitor system watching your workers you'll want
 
 :::
 
+### NODE_ENV
+
+You'll need to explicitly set your `NODE_ENV` when in environments other than development or test. We like having a `.env` file in a serverfull production environment, and you just include:
+
+```bash
+NODE_ENV=production
+```
+
+If you're using Docker, make sure you have an `ENV` declaration for it:
+
+```docker
+ENV NODE_ENV="production"
+```
+
 ## Advanced Job Workers
 
 As noted above, although the workers are started and detached using the `yarn rw jobs start` command, there is nothing to monitor those workers to make sure they keep running. To do that, you'll want to start the workers yourself (or have your process monitor start them) using command line flags.

--- a/docs/versioned_docs/version-8.0/background-jobs.md
+++ b/docs/versioned_docs/version-8.0/background-jobs.md
@@ -705,7 +705,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may be able to rely on the job runner to start and detatch your job workers, which will then run forever:
+For many use cases you may be able to rely on the job runner to start and detach your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start

--- a/docs/versioned_docs/version-8.1/background-jobs.md
+++ b/docs/versioned_docs/version-8.1/background-jobs.md
@@ -701,7 +701,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may simply be able to rely on the job runner to start your job workers, which will run forever:
+For many use cases you may be able to rely on the job runner to start and detatch your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start

--- a/docs/versioned_docs/version-8.1/background-jobs.md
+++ b/docs/versioned_docs/version-8.1/background-jobs.md
@@ -723,6 +723,20 @@ Of course if you have a process monitor system watching your workers you'll want
 
 :::
 
+### NODE_ENV
+
+You'll need to explicitly set your `NODE_ENV` when in environments other than development or test. We like having a `.env` file in a serverfull production environment, and you just include:
+
+```bash
+NODE_ENV=production
+```
+
+If you're using Docker, make sure you have an `ENV` declaration for it:
+
+```docker
+ENV NODE_ENV=production
+```
+
 ## Advanced Job Workers
 
 As noted above, although the workers are started and detached using the `yarn rw jobs start` command, there is nothing to monitor those workers to make sure they keep running. To do that, you'll want to start the workers yourself (or have your process monitor start them) using command line flags.

--- a/docs/versioned_docs/version-8.1/background-jobs.md
+++ b/docs/versioned_docs/version-8.1/background-jobs.md
@@ -701,7 +701,7 @@ By checking the `lastError` field in the database you can see what the last erro
 
 ## Deployment
 
-For many use cases you may be able to rely on the job runner to start and detatch your job workers, which will then run forever:
+For many use cases you may be able to rely on the job runner to start and detach your job workers, which will then run forever:
 
 ```bash
 yarn rw jobs start

--- a/packages/jobs/src/__tests__/setupEnv.test.ts
+++ b/packages/jobs/src/__tests__/setupEnv.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { setupEnv } from '../setupEnv'
+
+vi.mock('@redwoodjs/cli-helpers/loadEnvFiles', () => {
+  return {
+    loadEnvFiles: () => {},
+  }
+})
+
+const ORIGNAL_NODE_ENV = process.env.NODE_ENV
+
+describe('setupEnv', () => {
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGNAL_NODE_ENV
+  })
+
+  it('if not called, NODE_ENV is not overridden in any way', () => {
+    expect(process.env.NODE_ENV).toEqual(ORIGNAL_NODE_ENV)
+  })
+
+  it.skip('sets NODE_ENV to development if it starts undefined', () => {
+    process.env.NODE_ENV = undefined
+
+    setupEnv()
+
+    expect(process.env.NODE_ENV).toEqual('development')
+  })
+})

--- a/packages/jobs/src/__tests__/setupEnv.test.ts
+++ b/packages/jobs/src/__tests__/setupEnv.test.ts
@@ -19,8 +19,8 @@ describe('setupEnv', () => {
     expect(process.env.NODE_ENV).toEqual(ORIGNAL_NODE_ENV)
   })
 
-  it.skip('sets NODE_ENV to development if it starts undefined', () => {
-    process.env.NODE_ENV = undefined
+  it('sets NODE_ENV to development if it starts undefined', () => {
+    delete process.env.NODE_ENV
 
     setupEnv()
 

--- a/packages/jobs/src/bins/rw-jobs-worker.ts
+++ b/packages/jobs/src/bins/rw-jobs-worker.ts
@@ -16,12 +16,6 @@ import { setupEnv } from '../setupEnv.js'
 
 setupEnv()
 
-// If even after loading `.env` we find that `NODE_ENV` is `undefined` default
-// to `development` to mimic what the other CLI tools to
-if (!process.env.NODE_ENV) {
-  process.env.NODE_ENV = 'development'
-}
-
 const parseArgs = (argv: string[]) => {
   return yargs(hideBin(argv))
     .usage(

--- a/packages/jobs/src/bins/rw-jobs-worker.ts
+++ b/packages/jobs/src/bins/rw-jobs-worker.ts
@@ -8,14 +8,19 @@ import process from 'node:process'
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 
-import { loadEnvFiles } from '@redwoodjs/cli-helpers/loadEnvFiles'
-
 import { PROCESS_TITLE_PREFIX } from '../consts.js'
 import type { Worker } from '../core/Worker.js'
 import { WorkerConfigIndexNotFoundError } from '../errors.js'
 import { loadJobsManager } from '../loaders.js'
+import { setupEnv } from '../setupEnv.js'
 
-loadEnvFiles()
+setupEnv()
+
+// If even after loading `.env` we find that `NODE_ENV` is `undefined` default
+// to `development` to mimic what the other CLI tools to
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = 'development'
+}
 
 const parseArgs = (argv: string[]) => {
   return yargs(hideBin(argv))

--- a/packages/jobs/src/bins/rw-jobs.ts
+++ b/packages/jobs/src/bins/rw-jobs.ts
@@ -13,10 +13,9 @@ import { setTimeout } from 'node:timers'
 import { hideBin } from 'yargs/helpers'
 import yargs from 'yargs/yargs'
 
-import { loadEnvFiles } from '@redwoodjs/cli-helpers/loadEnvFiles'
-
 import { DEFAULT_LOGGER, PROCESS_TITLE_PREFIX } from '../consts.js'
 import { loadJobsManager } from '../loaders.js'
+import { setupEnv } from '../setupEnv.js'
 import type {
   Adapters,
   BasicLogger,
@@ -26,7 +25,7 @@ import type {
 
 export type NumWorkersConfig = [number, number][]
 
-loadEnvFiles()
+setupEnv()
 
 process.title = 'rw-jobs'
 

--- a/packages/jobs/src/setupEnv.ts
+++ b/packages/jobs/src/setupEnv.ts
@@ -1,0 +1,11 @@
+import { loadEnvFiles } from '@redwoodjs/cli-helpers/loadEnvFiles'
+
+export const setupEnv = () => {
+  loadEnvFiles()
+
+  // If even after loading `.env` we find that `NODE_ENV` is `undefined` default
+  // to `development` to mimic what the other CLI tools to
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'development'
+  }
+}

--- a/packages/jobs/src/setupEnv.ts
+++ b/packages/jobs/src/setupEnv.ts
@@ -5,7 +5,7 @@ export const setupEnv = () => {
 
   // If even after loading `.env` we find that `NODE_ENV` is `undefined` default
   // to `development` to mimic what the other CLI tools to
-  if (!process.env.NODE_ENV) {
+  if (process.env.NODE_ENV === undefined) {
     process.env.NODE_ENV = 'development'
   }
 }


### PR DESCRIPTION
This mimics the behavior of `yarn rw dev` where `NODE_ENV` will equal `development` if you don't set it explicitly.

Because of this, you need to make sure you explicitly set it in other environments. You should set `NODE_ENV=production` in your `.env` file/Dockerfile on your production server, for example. The docs have been updated to note this.

Closes #11569 