### PR TITLE
Add note to error message about running `yarn rw dev` or `yarn rw build` before the workers can be started

### DIFF
--- a/packages/jobs/src/errors.ts
+++ b/packages/jobs/src/errors.ts
@@ -1,4 +1,4 @@
-const JOBS_CONFIG_FILENAME = 'jobs.ts/js'
+const JOBS_CONFIG_FILENAME = 'jobs.{ts,js}'
 
 /**
  * Parent class for any RedwoodJob-related error
@@ -71,7 +71,7 @@ export class JobExportNotFoundError extends RedwoodJobError {
 export class JobsLibNotFoundError extends RedwoodJobError {
   constructor() {
     super(
-      `api/src/lib/${JOBS_CONFIG_FILENAME} not found. Run \`yarn rw setup jobs\` to create this file and configure background jobs`,
+      `api/src/lib/${JOBS_CONFIG_FILENAME} not found. Run \`yarn rw setup jobs\` to create this file and configure background jobs. Already did that? You'll need to run \`yarn rw dev\` or \`yarn rw build\` before you can start the job workers!`,
     )
   }
 }


### PR DESCRIPTION
Since job config is loaded from `api/dist` you need to build the site (either with the dev server, or an explicit `yarn rw build`) before that directory will exist. This updates the error message you see if `api/src/lib/jobs.js` can't be found to tell you that info.