### PR TITLE
chore(docs): Fix links in Storybook docs; add link to dbAuth OAuth plugin

### DIFF
--- a/docs/docs/how-to/oauth.md
+++ b/docs/docs/how-to/oauth.md
@@ -2,6 +2,10 @@
 
 If you're using an auth provider like [Auth0](/docs/auth/auth0), OAuth login to third party services (GitHub, Google, Facebook) is usually just a setting you can toggle on in your provider's dashboard. But if you're using [dbAuth](/docs/auth/dbauth) you'll only have username/password login to start. But, adding one or more OAuth clients isn't hard. This recipe will walk you through it from scratch, adding OAuth login via GitHub.
 
+Alternatively, consider using the [redwoodjs-dbauth-oauth](https://github.com/spoonjoy/redwoodjs-dbauth-oauth) community package. This package streamlines the setup, includes support for multiple providers, and even includes UI components that you can use for making setup even easier.
+
+If you do prefer to set this up manually or are just curious how OAuth and dbAuth can work together, read on!
+
 ## Prerequisites
 
 This article assumes you have an app set up and are using dbAuth. We're going to make use of the dbAuth system to validate that you're who you say you are. If you just want to try this code out in a sandbox app, you can create a test blog app from scratch by checking out the [Redwood codebase](https://github.com/redwoodjs/redwood) itself and then running a couple of commands:

--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -13,7 +13,7 @@ You don't have to start the dev server, login as a user, tab through dropdowns, 
 And say goodbye to rendering a whole page and make six GraphQL calls just to change the color of a modal!
 You can set up every component as a story and tweak it within Storybook. And for any [cells](./cells.md), [mocking GraphQL could not be easier!](./how-to/mocking-graphql-in-storybook.md)
 
-RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/configure/integration/frameworks),
+RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/7/configure/integration/frameworks),
 using Vite as its bundler to align with your production project.
 
 An older version of our Storybook integration used Webpack as its bundler — For more information on the differences, see [this forum post](https://community.redwoodjs.com/t/storybook-in-redwood-is-moving-to-vite/7212).
@@ -32,7 +32,7 @@ If this is your first time running Storybook:
 - The Redwood CLI will install Storybook, the framework package, and all related dependencies.
 - The Redwood CLI will create the following config files for you:
   - `web/.storybook/main.ts`
-    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
+    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/7/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
   - `web/.storybook/preview-body.html`
     - This is required to change the `id` of the root div to `redwood-app`, which is what the entry file used by Vite requires.
 
@@ -40,7 +40,7 @@ Once Storybook is all set up, it'll spin up on localhost port `7910` and open yo
 
 ## Configuring Storybook
 
-To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/configure).
+To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/7/configure).
 
 ## Migrating from Storybook Webpack to Storybook Vite
 
@@ -48,6 +48,6 @@ An older version of our Storybook integration relied on Webpack. If you're just 
 
 If you've been using Storybook for a while, you might need to take some manual steps in upgrading to the new version.
 
-If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/storybook#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
+If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/7.x/storybook/#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
 If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators


### PR DESCRIPTION
This PR:
- Adds a link to the dbAuth OAuth plugin
- Fixes some links in the Storybook docs