### PR TITLE
[storybook-vite] Ignore auto-generated `auto-imports.d.ts`

### DIFF
--- a/packages/create-redwood-app/templates/ts/gitignore.template
+++ b/packages/create-redwood-app/templates/ts/gitignore.template
@@ -12,6 +12,7 @@ dist-babel
 node_modules
 yarn-error.log
 web/public/mockServiceWorker.js
+web/src/auto-imports.d.ts
 web/types/graphql.d.ts
 api/types/graphql.d.ts
 api/src/lib/generateGraphiQLHeader.*


### PR DESCRIPTION
After having upgraded to RW 7.7.4 and migration storybook to vite, i noticed the unintentionally checked-in file `web/src/auto-imports.d.ts`.

So this should be part of the storybook → vite migration.