### PR TITLE
fix(rsc): Set a yarn resolution for rollup 4.21.3

### DIFF
--- a/__fixtures__/fragment-test-project/package.json
+++ b/__fixtures__/fragment-test-project/package.json
@@ -20,5 +20,8 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.1.1"
+  "packageManager": "yarn@4.1.1",
+  "resolutions": {
+    "rollup": "4.21.3"
+  }
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "react-is": "19.0.0-rc-f2df5694-20240916"
+    "react-is": "19.0.0-rc-f2df5694-20240916",
+    "rollup": "4.21.3"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "react-is": "19.0.0-rc-f2df5694-20240916"
+    "react-is": "19.0.0-rc-f2df5694-20240916",
+    "rollup": "4.21.3"
   }
 }

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "react-is": "19.0.0-rc-f2df5694-20240916"
+    "react-is": "19.0.0-rc-f2df5694-20240916",
+    "rollup": "4.21.3"
   }
 }

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -23,6 +23,7 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "react-is": "19.0.0-rc-f2df5694-20240916"
+    "react-is": "19.0.0-rc-f2df5694-20240916",
+    "rollup": "4.21.3"
   }
 }


### PR DESCRIPTION
Setting the resolution works around an issue we were seeing when trying to serve an RSC project

```
file:///Users/tobbe/tmp/rw-rollup/web/dist/ssr/assets/rsc-auth.ts-12-VjYFUfRl.mjs:820
if (Object$1.defineProperty.sham) defineProperty$5.sham = true;
             ^

TypeError: Cannot read properties of undefined (reading 'defineProperty')
    at file:///Users/tobbe/tmp/rw-rollup/web/dist/ssr/assets/rsc-auth.ts-12-VjYFUfRl.mjs:820:14
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async createMiddlewareRouter (file:///Users/tobbe/tmp/rw-rollup/node_modules/@redwoodjs/vite/dist/middleware/register.js:57:69)
    at async runFeServer (file:///Users/tobbe/tmp/rw-rollup/node_modules/@redwoodjs/vite/dist/runFeServer.js:56:28)
```

Possibly related to https://github.com/rollup/rollup/issues/5659