### PR TITLE
Revert "fix(rsc): Set a yarn resolution for rollup 4.21.3 (#11592)"

### DIFF
--- a/__fixtures__/fragment-test-project/package.json
+++ b/__fixtures__/fragment-test-project/package.json
@@ -20,8 +20,5 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.1.1",
-  "resolutions": {
-    "rollup": "4.21.3"
-  }
+  "packageManager": "yarn@4.1.1"
 }

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
-    "react-is": "19.0.0-rc-f2df5694-20240916",
-    "rollup": "4.21.3"
+    "react-is": "19.0.0-rc-f2df5694-20240916"
   }
 }

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "react-is": "19.0.0-rc-f2df5694-20240916",
-    "rollup": "4.21.3"
+    "react-is": "19.0.0-rc-f2df5694-20240916"
   }
 }

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "react-is": "19.0.0-rc-f2df5694-20240916",
-    "rollup": "4.21.3"
+    "react-is": "19.0.0-rc-f2df5694-20240916"
   }
 }

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -23,7 +23,6 @@
   "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
-    "react-is": "19.0.0-rc-f2df5694-20240916",
-    "rollup": "4.21.3"
+    "react-is": "19.0.0-rc-f2df5694-20240916"
   }
 }


### PR DESCRIPTION
This reverts commit 3fc9a4565253156e42c761a257e4f3b52fd0cb34.

Rollup has released v4.22.3 that fixes the issue we were seeing. 
https://github.com/rollup/rollup/issues/5659#issuecomment-2365003523

Getting rid of the resolution as it's not needed anymore