### PR TITLE
Make WebAuthn work when authModelAccessor is set to a custom value

### DIFF
--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -907,11 +907,11 @@ export class DbAuthHandler<
     let user
 
     if (credentialId) {
-      user = await this.dbCredentialAccessor
-        .findFirst({
-          where: { [webAuthnOptions.credentialFields.id]: credentialId },
-        })
-        .user()
+      const credential = await this.dbCredentialAccessor.findUnique({
+        where: { [webAuthnOptions.credentialFields.id]: credentialId },
+        include: { [this.options.authModelAccessor]: true },
+      })
+      user = credential[this.options.authModelAccessor]
     } else {
       // webauthn session not present, fallback to getting user from regular
       // session cookie


### PR DESCRIPTION
- Instead of directly accessing auth model with hardcoded `user()` name, use `authModelAccessor` from DbAuthHandler options.
- Also replaces `findFirst()` with `findUnique()` - we are querying data by the primary key. Feels semantically more correct, though may have no practical difference, I would expect Postgres to optimize query anyway if the only provided "where" criteria is PK.