### PR TITLE
breaking(baremetal): Throw an error if there is not enough available space

### DIFF
--- a/.changesets/11638.md
+++ b/.changesets/11638.md
@@ -1,0 +1,1 @@
+- breaking(baremetal): Throw an error if there is not enough available space (#11638) by @Tobbe

--- a/packages/cli/src/commands/deploy/baremetal.js
+++ b/packages/cli/src/commands/deploy/baremetal.js
@@ -26,6 +26,7 @@ export const DEFAULT_SERVER_CONFIG = {
   monitorCommand: 'pm2',
   sides: ['api', 'web'],
   keepReleases: 5,
+  freeSpaceRequired: 2048,
 }
 
 export const command = 'baremetal [environment]'
@@ -172,7 +173,7 @@ export const verifyServerConfig = (config) => {
     throwMissingConfig('repo')
   }
 
-  if (config.freeSpaceRequired && !/^\d+$/.test(config.freeSpaceRequired)) {
+  if (!/^\d+$/.test(config.freeSpaceRequired)) {
     throw new Error('"freeSpaceRequired" must be an integer >= 0')
   }
 
@@ -415,18 +416,10 @@ export const deployTasks = (yargs, ssh, serverConfig, serverLifecycle) => {
           )
 
           if (dfMb < freeSpaceRequired) {
-            if (typeof serverConfig.freeSpaceRequired === 'undefined') {
-              return task.skip(
-                c.warning(
-                  'Warning: Your server is running low on disk space. (' +
-                    `${Math.round(dfMb)}MB available)`,
-                ),
-              )
-            }
-
             throw new Error(
               `Not enough disk space. You need at least ${freeSpaceRequired}` +
-                'MB free space to continue.',
+                `MB free space to continue. (Currently ${Math.round(dfMb)}MB ` +
+                'available)',
             )
           }
         },


### PR DESCRIPTION
Takes what used to only be a warning (introduced in https://github.com/redwoodjs/redwood/pull/11469) and makes it an error. 

The idea/plan here is that existing projects have enough time to first configure their baremetal deployments with a free disk space limit they're comfortable with when they upgrade to the v8 minor that includes https://github.com/redwoodjs/redwood/pull/11469. And then when this PR is included in the next major release of RW they don't need to make any further changes, only thing different will be that they get an error when their servers eventually (if ever) run low on disk space. Just like it will work for any new projects that deploy to baremetal.

So, kind of like first getting a deprecation warning, and then finally having to make the switch. Only here we go from first only getting a free disk space warning, and then later having the deploy fail (with a clear and helpful error message)