### PR TITLE
fix(web) type NonSuspenseCellQueryResult...

### DIFF
--- a/.changesets/11639.md
+++ b/.changesets/11639.md
@@ -1,0 +1,5 @@
+- fix(web) type NonSuspenseCallQueryResult... (#11639) by @richard-stafflink
+
+The result you get back as `queryResult` is now properly typed. Typically the
+type will be something like `FindPostById`, i.e. the first type that is passed
+to `CellSuccessProps` (instead of just being `any`).

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -52,11 +52,15 @@ export type CellProps<
 >
 
 export type CellLoadingProps<TVariables extends OperationVariables = any> = {
-  queryResult?: NonSuspenseCellQueryResult<TVariables> | SuspenseCellQueryResult
+  queryResult?:
+    | NonSuspenseCellQueryResult<TVariables, any>
+    | SuspenseCellQueryResult
 }
 
 export type CellFailureProps<TVariables extends OperationVariables = any> = {
-  queryResult?: NonSuspenseCellQueryResult<TVariables> | SuspenseCellQueryResult
+  queryResult?:
+    | NonSuspenseCellQueryResult<TVariables, any>
+    | SuspenseCellQueryResult
   error?: QueryOperationResult['error'] | Error // for tests and storybook
 
   /**
@@ -106,7 +110,9 @@ export type CellSuccessProps<
   TData = any,
   TVariables extends OperationVariables = any,
 > = {
-  queryResult?: NonSuspenseCellQueryResult<TVariables> | SuspenseCellQueryResult
+  queryResult?:
+    | NonSuspenseCellQueryResult<TVariables, TData>
+    | SuspenseCellQueryResult
   updating?: boolean
 } & A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
 
@@ -199,8 +205,9 @@ export type SuspendingSuccessProps = React.PropsWithChildren<
 
 export type NonSuspenseCellQueryResult<
   TVariables extends OperationVariables = any,
+  TData = any,
 > = Partial<
-  Omit<QueryOperationResult<any, TVariables>, 'loading' | 'error' | 'data'>
+  Omit<QueryOperationResult<TData, TVariables>, 'loading' | 'error' | 'data'>
 >
 
 // We call this queryResult in createCell, sadly a very overloaded term


### PR DESCRIPTION
## Description:
As of RW 7:

**Issue:**
When using `CellSuccessProps`:
`queryResult` lost the typings for `TData` it used to have in RW 6, namely `queryResult.fetchMore.data` had the `TData` type (from `CellSuccessProps<TData, OperationVariables>`).
This also affects `queryResult.previousData`

**Cause:**
`NonSuspenseCellQueryResult` no longer accepted the `TData` generic type, and hard-coded `TData` for `QueryOperationResult` to **any**.

**Fix:**
Pass through `TData`, instead of `any` to `QueryOperationResult` and ensure all other inherited types also pass down `TData`. Cell Props for Loading and Failure could default to `any`.

Before the fix:
![image](https://github.com/user-attachments/assets/6a5aff33-5611-4dcc-a0e7-9259afd435f5)

After the fix:
![image](https://github.com/user-attachments/assets/03985ebb-af32-482c-8d1f-cad382f36977)
