### PR TITLE
fix(crwa): Add missing quotes to seed example

### DIFF
--- a/.changesets/11651.md
+++ b/.changesets/11651.md
@@ -1,0 +1,3 @@
+- fix(crwa): Add missing quotes to seed example (#11651) by @Tobbe
+
+Just un-commenting the example seed code now gives you valid code to seed your database with

--- a/__fixtures__/test-project/scripts/seed.ts
+++ b/__fixtures__/test-project/scripts/seed.ts
@@ -73,8 +73,8 @@ export default async () => {
     // Create your database records here! For example, seed some users:
     //
     // const users = [
-    //   { name: 'Alice', email: 'alice@redwoodjs.com },
-    //   { name: 'Bob', email: 'bob@redwoodjs.com },
+    //   { name: 'Alice', email: 'alice@redwoodjs.com' },
+    //   { name: 'Bob', email: 'bob@redwoodjs.com' },
     // ]
     //
     // await db.user.createMany({ data: users })

--- a/packages/create-redwood-app/templates/js/scripts/seed.js
+++ b/packages/create-redwood-app/templates/js/scripts/seed.js
@@ -12,8 +12,8 @@ export default async () => {
     // Create your database records here! For example, seed some users:
     //
     // const users = [
-    //   { name: 'Alice', email: 'alice@redwoodjs.com },
-    //   { name: 'Bob', email: 'bob@redwoodjs.com },
+    //   { name: 'Alice', email: 'alice@redwoodjs.com' },
+    //   { name: 'Bob', email: 'bob@redwoodjs.com' },
     // ]
     //
     // await db.user.createMany({ data: users })

--- a/packages/create-redwood-app/templates/ts/scripts/seed.ts
+++ b/packages/create-redwood-app/templates/ts/scripts/seed.ts
@@ -12,8 +12,8 @@ export default async () => {
     // Create your database records here! For example, seed some users:
     //
     // const users = [
-    //   { name: 'Alice', email: 'alice@redwoodjs.com },
-    //   { name: 'Bob', email: 'bob@redwoodjs.com },
+    //   { name: 'Alice', email: 'alice@redwoodjs.com' },
+    //   { name: 'Bob', email: 'bob@redwoodjs.com' },
     // ]
     //
     // await db.user.createMany({ data: users })


### PR DESCRIPTION
The commented out example seed code was invalid because it was missing a closing single quote around the email addresses