### PR TITLE
fix(jobs): Fixes creating worker with deleteSuccessfulJobs config setting in JobManager

### DIFF
--- a/.changesets/11653.md
+++ b/.changesets/11653.md
@@ -1,0 +1,9 @@
+- fix(jobs): Fixes creating worker with deleteSuccessfulJobs config setting in JobManager (#11653) by @dthyresson
+
+According to the Job documentation, the JobManager's `deleteSuccessfulJobs ` can be used to decide if one wants successfully completed jobs from being deleted from the `BackgroundJobs` table.
+
+Keeping job run history around is useful for reporting purposes, such s hoe many jobs run over time, how many fails, how many successes, etc.
+
+However, the `deleteSuccessfulJobs` was not being correctly passed to the worker in `createWorker` so the worker always used the default value -- true -- and always deleted the job run record regardless of configuration.
+
+This PR fixes this issue by setting the config value when creating the worker.

--- a/packages/jobs/src/core/JobManager.ts
+++ b/packages/jobs/src/core/JobManager.ts
@@ -90,6 +90,7 @@ export class JobManager<
       maxRuntime: config.maxRuntime,
       sleepDelay: config.sleepDelay,
       deleteFailedJobs: config.deleteFailedJobs,
+      deleteSuccessfulJobs: config.deleteSuccessfulJobs,
       processName,
       queues: [config.queue].flat(),
       workoff,


### PR DESCRIPTION
According to the Job documentation, the JobManager's `deleteSuccessfulJobs ` can be used to decide if one wants successfully completed jobs from being deleted from the `BackgroundJobs` table.

Keeping job run history around is useful for reporting purposes, such s hoe many jobs run over time, how many fails, how many successes, etc.

However, the `deleteSuccessfulJobs` was not being correctly passed to the worker in `createWorker` so the worker always used the default value -- true -- and always deleted the job run record regardless of configuration.

This PR fixes this issue by setting the config value when creating the worker.