### PR TITLE
Fix build with TS alias without basePath

### DIFF
--- a/.changesets/11693.md
+++ b/.changesets/11693.md
@@ -1,0 +1,3 @@
+- Fix build with TS alias without basePath (#11693) by @callingmedic911
+
+It fixes the build process for a project with TypeScript path alias. It uses root directory as the fallback if there's no baseUrl in `tsconfig.json`.

--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -140,16 +140,21 @@ export const getPathsFromTypeScriptConfig = (
     return {}
   }
 
-  if (!config.compilerOptions?.baseUrl || !config.compilerOptions?.paths) {
+  if (!config.compilerOptions?.paths) {
     return {}
   }
 
   const { baseUrl, paths } = config.compilerOptions
 
-  // Convert it to absolute path - on windows the baseUrl is already absolute
-  const absoluteBase = path.isAbsolute(baseUrl)
-    ? baseUrl
-    : path.join(rootDir, baseUrl)
+  let absoluteBase: string
+  if (baseUrl) {
+    // Convert it to absolute path - on windows the baseUrl is already absolute
+    absoluteBase = path.isAbsolute(baseUrl)
+      ? baseUrl
+      : path.join(rootDir, baseUrl)
+  } else {
+    absoluteBase = rootDir
+  }
 
   const pathsObj: Record<string, string> = {}
   for (const [key, value] of Object.entries(paths)) {


### PR DESCRIPTION
Closes https://github.com/redwoodjs/redwood/issues/11686.

I think this was accidentally introduced when [we removed `baseUrl` ](https://github.com/redwoodjs/redwood/pull/9944). The change assumes rootDir as the fallback if there's no baseUrl (default TS behaviour).