### PR TITLE
chore: use self references in type tests

### DIFF
--- a/packages/router/src/__typetests__/routeParamsTypes.test.ts
+++ b/packages/router/src/__typetests__/routeParamsTypes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'tstyche'
 
-import type { RouteParams, ParamType } from '../routeParamsTypes.js'
+import type { RouteParams, ParamType } from '@redwoodjs/router'
 
 /**
  * FAQ:

--- a/packages/router/src/__typetests__/tsconfig.json
+++ b/packages/router/src/__typetests__/tsconfig.json
@@ -4,5 +4,5 @@
     "types": []
   },
   "include": ["./"],
-  "exclude": [],
+  "exclude": []
 }

--- a/packages/router/src/__typetests__/tsconfig.json
+++ b/packages/router/src/__typetests__/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "incremental": true,
-    "declarationMap": false,
-    "emitDeclarationOnly": false,
     "types": []
   },
   "include": ["./"],
   "exclude": [],
-  "references": [{ "path": "../../" }]
 }

--- a/packages/router/src/__typetests__/useLocation.test.ts
+++ b/packages/router/src/__typetests__/useLocation.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'tstyche'
 
-import { useLocation } from '../location.js'
+import { useLocation } from '@redwoodjs/router'
 
 test('useLocation types', () => {
   const location = useLocation()

--- a/packages/storage/src/__typetests__/tsconfig.json
+++ b/packages/storage/src/__typetests__/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": []
   },
-  "exclude": [],
+  "exclude": []
 }

--- a/packages/storage/src/__typetests__/tsconfig.json
+++ b/packages/storage/src/__typetests__/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": [],
+}

--- a/packages/storage/src/__typetests__/types.test.ts
+++ b/packages/storage/src/__typetests__/types.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from 'tstyche'
 
-import { createUploadsConfig, setupStorage } from 'src/index.js'
+import { createUploadsConfig, setupStorage } from '@redwoodjs/storage'
 
 import { MemoryStorage } from '../adapters/MemoryStorage/MemoryStorage.js'
 import { type UploadsConfig } from '../prismaExtension.js'
 
-// Use the createUplodsConfig helper here....
+// Use the createUploadsConfig helper here....
 // otherwise the types won't be accurate
 const uploadsConfig = createUploadsConfig({
   dummy: {
@@ -25,7 +25,7 @@ const { saveFiles } = setupStorage({
 
 // const prismaClient = new PrismaClient().$extends(storagePrismaExtension)
 
-test('only configured models have savers', async () => {
+test('only configured models have savers', () => {
   expect(saveFiles).type.toHaveProperty('forDummy')
   expect(saveFiles).type.toHaveProperty('forDumbo')
 
@@ -52,7 +52,7 @@ test('inline config for save files is OK!', () => {
   expect(saveFiles).type.not.toHaveProperty('forDumbo')
 })
 
-test('UploadsConfig accepts all available models with their fields', async () => {
+test('UploadsConfig accepts all available models with their fields', () => {
   expect<UploadsConfig>().type.toHaveProperty('dummy')
   expect<UploadsConfig>().type.toHaveProperty('dumbo')
   expect<UploadsConfig>().type.toHaveProperty('book')

--- a/packages/web/src/__typetests__/tsconfig.json
+++ b/packages/web/src/__typetests__/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "incremental": true,
-    "declarationMap": false,
-    "emitDeclarationOnly": false,
-    "sourceMap": true,
     "types": []
   },
   "include": ["./"],


### PR DESCRIPTION
What if all type test would use self references?

---

This was the problem. I was playing with new version of TSTyche (just because I plan to release it in a couple of days) and I have noticed that type tests of `@redwoodjs/router` do not use `./packages/router/src/__typetests__/tsconfig.json`. The file exists, but `./packages/router/tsconfig.json` is loaded instead:

<img width="530" alt="Screenshot 2024-11-04 at 21 46 38" src="https://github.com/user-attachments/assets/b036ef19-9dbd-4f42-8348-6e825dec0e69">

So I took a look at `./packages/router/src/__typetests__/tsconfig.json` and saw this error:


<img width="1054" alt="Screenshot 2024-11-04 at 21 47 58" src="https://github.com/user-attachments/assets/ab1297d2-cab9-478b-a3b6-71a5ded47f71">

Hm.. Might be this is why that TSConfig is ignored. What if `references` would be replaced with self references? Some of the type tests already use self references:

https://github.com/redwoodjs/redwood/blob/457d1c726262a529b2250da5b93f7e83be95eba9/packages/web/src/__typetests__/cellProps.test.tsx#L7

---

This works, because TypeScript handles self references when `"moduleResolution": "nodenext"` or `"moduleResolution": "node16"` is set. Hence, this approach works as expected.
