### PR TITLE
chore: upgrade TSTyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "prettier-plugin-sh": "0.14.0",
     "prompts": "2.4.2",
     "rimraf": "6.0.1",
-    "tstyche": "2.1.1",
+    "tstyche": "3.0.0",
     "tsx": "4.19.1",
     "typescript": "5.6.2",
     "vitest": "2.0.5",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -112,7 +112,7 @@
     "@types/react-dom": "^18.2.19",
     "concurrently": "8.2.2",
     "publint": "0.2.11",
-    "tstyche": "2.1.1",
+    "tstyche": "3.0.0",
     "tsx": "4.19.1",
     "typescript": "5.6.2",
     "vitest": "2.0.5"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -65,7 +65,7 @@
     "concurrently": "8.2.2",
     "esbuild": "0.24.0",
     "publint": "0.2.11",
-    "tstyche": "2.1.1",
+    "tstyche": "3.0.0",
     "tsx": "4.19.1",
     "typescript": "5.6.2",
     "vitest": "2.0.5"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -176,7 +176,7 @@
     "publint": "0.2.11",
     "react": "19.0.0-rc-f2df5694-20240916",
     "react-dom": "19.0.0-rc-f2df5694-20240916",
-    "tstyche": "2.1.1",
+    "tstyche": "3.0.0",
     "tsx": "4.19.1",
     "typescript": "5.6.2",
     "vitest": "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8752,7 +8752,7 @@ __metadata:
     react: "npm:19.0.0-rc-f2df5694-20240916"
     react-dom: "npm:19.0.0-rc-f2df5694-20240916"
     react-server-dom-webpack: "npm:19.0.0-rc-f2df5694-20240916"
-    tstyche: "npm:2.1.1"
+    tstyche: "npm:3.0.0"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
     vitest: "npm:2.0.5"
@@ -8791,7 +8791,7 @@ __metadata:
     esbuild: "npm:0.24.0"
     mime-types: "npm:2.1.35"
     publint: "npm:0.2.11"
-    tstyche: "npm:2.1.1"
+    tstyche: "npm:3.0.0"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
     ulid: "npm:2.3.0"
@@ -9029,7 +9029,7 @@ __metadata:
     react-hot-toast: "npm:2.4.1"
     stacktracey: "npm:2.1.8"
     ts-toolbelt: "npm:9.6.0"
-    tstyche: "npm:2.1.1"
+    tstyche: "npm:3.0.0"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
     vitest: "npm:2.0.5"
@@ -26960,7 +26960,7 @@ __metadata:
     prettier-plugin-sh: "npm:0.14.0"
     prompts: "npm:2.4.2"
     rimraf: "npm:6.0.1"
-    tstyche: "npm:2.1.1"
+    tstyche: "npm:3.0.0"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
     vitest: "npm:2.0.5"
@@ -29004,9 +29004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:2.1.1":
-  version: 2.1.1
-  resolution: "tstyche@npm:2.1.1"
+"tstyche@npm:3.0.0":
+  version: 3.0.0
+  resolution: "tstyche@npm:3.0.0"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
@@ -29014,7 +29014,7 @@ __metadata:
       optional: true
   bin:
     tstyche: ./build/bin.js
-  checksum: 10c0/f634f8593344c43623160a4728f433a5c91fb9b00cbd0ac491501c05979fc8dd825b0fd6d6249d8c95207ed365b5c2d7292fdef71f0341c7c2854b9bf5ab09b0
+  checksum: 10c0/dede68ed73dd1a3bab7cc68cc227e32120882c1995c50439fcb250ddf66ce0b79da4b7957999b57ffbc1e6da49814c2334c3b4fed54d07d5cc81c561a62eb2a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR simply upgrades TSTyche to the new major version. Release notes can be found here: https://tstyche.org/releases/tstyche-3

I was trying out the release candidate on this repo before publishing the stable version. All what I have noticed was included in #11716. So, this is very straight forward upgrade (;