### PR TITLE
fix(dbAuth): Don't use Multi Value Headers on Vercel

### DIFF
--- a/.changesets/11718.md
+++ b/.changesets/11718.md
@@ -1,0 +1,3 @@
+- fix(dbAuth): Don't use Multi Value Headers on Vercel (#11718) by @Tobbe
+
+Fixes a regression regarding dbAuth on Vercel introduced in RW 8

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -296,10 +296,11 @@ export function getDbAuthResponseBuilder(
 
     if (setCookieHeaders.length > 0) {
       if ('multiValueHeaders' in event) {
+        delete headers['set-cookie']
+        delete headers['Set-Cookie']
         dbAuthResponse.multiValueHeaders = {
           'Set-Cookie': setCookieHeaders,
         }
-        delete headers['set-cookie']
       } else {
         headers['set-cookie'] = setCookieHeaders
       }

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -298,10 +298,7 @@ export function getDbAuthResponseBuilder(
       delete headers['set-cookie']
       delete headers['Set-Cookie']
 
-      // `'multiValueHeaders' in event` is true for both Netlify and Vercel
-      // but only Netlify actually supports it. Vercel will just ignore it
-      // https://github.com/vercel/vercel/issues/7820
-      if ('multiValueHeaders' in event && !('x-vercel-id' in headers)) {
+      if (supportsMultiValueHeaders(event)) {
         dbAuthResponse.multiValueHeaders = {
           // Netlify wants 'Set-Cookie' headers to be capitalized
           // https://github.com/redwoodjs/redwood/pull/10889
@@ -316,6 +313,13 @@ export function getDbAuthResponseBuilder(
 
     return dbAuthResponse
   }
+}
+
+// `'multiValueHeaders' in event` is true for both Netlify and Vercel
+// but only Netlify actually supports it. Vercel will just ignore it
+// https://github.com/vercel/vercel/issues/7820
+function supportsMultiValueHeaders(event: APIGatewayProxyEvent | Request) {
+  return 'multiValueHeaders' in event && !('x-vercel-id' in event.headers)
 }
 
 export const extractHashingOptions = (text: string): ScryptOptions => {

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -299,7 +299,7 @@ export function getDbAuthResponseBuilder(
         delete headers['set-cookie']
         delete headers['Set-Cookie']
         dbAuthResponse.multiValueHeaders = {
-          'Set-Cookie': setCookieHeaders,
+          'set-cookie': setCookieHeaders,
         }
       } else {
         headers['set-cookie'] = setCookieHeaders

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -295,13 +295,21 @@ export function getDbAuthResponseBuilder(
     const setCookieHeaders = response.headers?.getSetCookie() || []
 
     if (setCookieHeaders.length > 0) {
-      if ('multiValueHeaders' in event) {
-        delete headers['set-cookie']
-        delete headers['Set-Cookie']
+      delete headers['set-cookie']
+      delete headers['Set-Cookie']
+
+      // `'multiValueHeaders' in event` is true for both Netlify and Vercel
+      // but only Netlify actually supports it. Vercel will just ignore it
+      // https://github.com/vercel/vercel/issues/7820
+      if ('multiValueHeaders' in event && !('x-vercel-id' in headers)) {
         dbAuthResponse.multiValueHeaders = {
-          'set-cookie': setCookieHeaders,
+          // Netlify wants 'Set-Cookie' headers to be capitalized
+          // https://github.com/redwoodjs/redwood/pull/10889
+          'Set-Cookie': setCookieHeaders,
         }
       } else {
+        // If we do this for Netlify the lambda function will throw an error
+        // https://github.com/redwoodjs/redwood/pull/10889
         headers['set-cookie'] = setCookieHeaders
       }
     }

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -319,7 +319,10 @@ export function getDbAuthResponseBuilder(
 // but only Netlify actually supports it. Vercel will just ignore it
 // https://github.com/vercel/vercel/issues/7820
 function supportsMultiValueHeaders(event: APIGatewayProxyEvent | Request) {
-  return 'multiValueHeaders' in event && !('x-vercel-id' in event.headers)
+  return (
+    'multiValueHeaders' in event &&
+    (!event.headers || !('x-vercel-id' in event.headers))
+  )
 }
 
 export const extractHashingOptions = (text: string): ScryptOptions => {


### PR DESCRIPTION
Vercel doesn't support `multiValueHeaders`. See https://github.com/vercel/vercel/issues/7820
Netlify only supports `multiValueHeaders` for how we set our auth cookies: https://github.com/redwoodjs/redwood/pull/10889

So this PR tries to solve for both by adding a check for a Vercel-specific header. 

I worry this will break (they might change what headers they set). But it's the best solution I could come up with for now