### PR TITLE
fix(ogimage): Corrected package.json exports

### DIFF
--- a/.changesets/11724.md
+++ b/.changesets/11724.md
@@ -1,0 +1,3 @@
+- fix(ogimage): Corrected package.json exports (#11724) by @Tobbe
+
+Fix publish warnings in our ogImage package. Making TS types available for anyone using this package

--- a/packages/ogimage-gen/package.json
+++ b/packages/ogimage-gen/package.json
@@ -7,27 +7,29 @@
     "directory": "packages/ogimage-gen"
   },
   "license": "MIT",
+  "type": "commonjs",
   "exports": {
     "./plugin": {
+      "types": "./dist/vite-plugin-ogimage-gen.d.ts",
       "import": "./dist/vite-plugin-ogimage-gen.js",
-      "default": "./cjsWrappers/plugin.js",
-      "types": "./dist/vite-plugin-ogimage-gen.d.ts"
+      "default": "./cjsWrappers/plugin.js"
     },
     "./middleware": {
+      "types": "./dist/OgImageMiddleware.d.ts",
       "import": "./dist/OgImageMiddleware.js",
-      "default": "./cjsWrappers/middleware.js",
       "react-server": "./empty.js",
-      "types": "./dist/OgImageMiddleware.d.ts"
+      "default": "./cjsWrappers/middleware.js"
     },
     "./hooks": {
+      "types": "./dist/hooks.d.ts",
       "import": "./dist/hooks.js",
-      "default": "./cjsWrappers/hooks.js",
-      "types": "./dist/hooks.d.ts"
+      "default": "./cjsWrappers/hooks.js"
     }
   },
   "files": [
     "dist",
-    "cjsWrappers"
+    "cjsWrappers",
+    "empty.js"
   ],
   "scripts": {
     "build": "tsx ./build.mts && yarn build:types",


### PR DESCRIPTION
publint (https://github.com/bluwy/publint) was complaining about some fields in ogimage's `package.json`. This PR fixes that.