### PR TITLE
chore(vite): Rename 'vite' to more descriptive 'viteSsrDevServer'

### DIFF
--- a/packages/ogimage-gen/src/OgImageMiddleware.test.ts
+++ b/packages/ogimage-gen/src/OgImageMiddleware.test.ts
@@ -183,7 +183,7 @@ describe('OgImageMiddleware', () => {
   test('importComponent should import the component using viteDevServer', async () => {
     const filePath = '/path/to/component.js'
     const invokeOptions = {
-      viteDevServer: {
+      viteSsrDevServer: {
         ssrLoadModule: vi.fn().mockResolvedValue({
           data: 'some data',
           output: 'Component output',
@@ -198,7 +198,7 @@ describe('OgImageMiddleware', () => {
       Component: 'Component output',
     })
 
-    expect(invokeOptions.viteDevServer.ssrLoadModule).toHaveBeenCalledWith(
+    expect(invokeOptions.viteSsrDevServer.ssrLoadModule).toHaveBeenCalledWith(
       filePath,
     )
   })

--- a/packages/ogimage-gen/src/OgImageMiddleware.ts
+++ b/packages/ogimage-gen/src/OgImageMiddleware.ts
@@ -304,9 +304,9 @@ export default class OgImageMiddleware {
     invokeOptions: MiddlewareInvokeOptions,
   ) {
     try {
-      if (invokeOptions.viteDevServer) {
+      if (invokeOptions.viteSsrDevServer) {
         const { data, output } =
-          await invokeOptions.viteDevServer.ssrLoadModule(filePath)
+          await invokeOptions.viteSsrDevServer.ssrLoadModule(filePath)
         return { data, Component: output }
       } else {
         const { data, output } = await import(filePath)

--- a/packages/vite/src/rsc/rscRequestHandler.ts
+++ b/packages/vite/src/rsc/rscRequestHandler.ts
@@ -24,7 +24,7 @@ const BASE_PATH = '/rw-rsc/'
 
 interface CreateRscRequestHandlerOptions {
   getMiddlewareRouter: () => Promise<Router.Instance<any>>
-  viteDevServer?: ViteDevServer
+  viteSsrDevServer?: ViteDevServer
 }
 
 export async function createRscRequestHandler(
@@ -59,7 +59,7 @@ export async function createRscRequestHandler(
         matchedMw?.handler as Middleware | undefined,
         {
           params: matchedMw?.params,
-          viteDevServer: options.viteDevServer,
+          viteSsrDevServer: options.viteSsrDevServer,
         },
       )
 

--- a/packages/vite/src/streaming/createReactStreamingHandler.ts
+++ b/packages/vite/src/streaming/createReactStreamingHandler.ts
@@ -41,11 +41,11 @@ export const createReactStreamingHandler = async (
     getStylesheetLinks,
     getMiddlewareRouter,
   }: CreateReactStreamingHandlerOptions,
-  viteDevServer?: ViteDevServer,
+  viteSsrDevServer?: ViteDevServer,
 ) => {
   const rwPaths = getPaths()
   const rwConfig = getConfig()
-  const isProd = !viteDevServer
+  const isProd = !viteSsrDevServer
   const middlewareRouter: Router.Instance<any> = await getMiddlewareRouter()
   let entryServerImport: EntryServer
   let fallbackDocumentImport: Record<string, any>
@@ -115,7 +115,7 @@ export const createReactStreamingHandler = async (
           route: currentRoute,
           cssPaths: cssLinks,
           params: matchedMw?.params,
-          viteDevServer,
+          viteSsrDevServer,
         },
       )
 
@@ -144,8 +144,8 @@ export const createReactStreamingHandler = async (
     // Do this inside the handler for **dev-only**.
     // This makes sure that changes to entry-server are picked up on refresh
     if (!isProd) {
-      entryServerImport = await ssrLoadEntryServer(viteDevServer)
-      fallbackDocumentImport = await viteDevServer.ssrLoadModule(
+      entryServerImport = await ssrLoadEntryServer(viteSsrDevServer)
+      fallbackDocumentImport = await viteSsrDevServer.ssrLoadModule(
         rwPaths.web.document,
       )
     }
@@ -173,13 +173,15 @@ export const createReactStreamingHandler = async (
         req,
         parsedParams,
       },
-      viteDevServer,
+      viteSsrDevServer,
     })
 
     metaTags = routeHookOutput.meta
 
     // On dev, we don't need to add the slash (for windows support) any more
-    const jsBundles = [viteDevServer ? clientEntryPath : '/' + clientEntryPath]
+    const jsBundles = [
+      viteSsrDevServer ? clientEntryPath : '/' + clientEntryPath,
+    ]
     if (currentRoute.bundle) {
       jsBundles.push('/' + currentRoute.bundle)
     }
@@ -201,14 +203,14 @@ export const createReactStreamingHandler = async (
       {
         waitForAllReady: isSeoCrawler,
         onError: (err) => {
-          if (!isProd && viteDevServer) {
-            viteDevServer.ssrFixStacktrace(err)
+          if (!isProd && viteSsrDevServer) {
+            viteSsrDevServer.ssrFixStacktrace(err)
           }
 
           console.error(err)
         },
       },
-      viteDevServer,
+      viteSsrDevServer,
     )
 
     return reactResponse

--- a/packages/vite/src/streaming/triggerRouteHooks.ts
+++ b/packages/vite/src/streaming/triggerRouteHooks.ts
@@ -60,7 +60,7 @@ interface LoadAndRunRouteHooks {
     req: Request
     parsedParams?: Record<string, any>
   }
-  viteDevServer?: ViteDevServer
+  viteSsrDevServer?: ViteDevServer
   previousOutput?: RouteHookOutput
 }
 
@@ -71,12 +71,14 @@ const defaultRouteHookOutput = {
 export const loadAndRunRouteHooks = async ({
   paths = [],
   reqMeta,
-  viteDevServer,
+  viteSsrDevServer,
   previousOutput = defaultRouteHookOutput,
 }: LoadAndRunRouteHooks): Promise<RouteHookOutput> => {
   // Step 1, load the route hooks
   const loadModule = async (path: string) => {
-    return viteDevServer ? viteDevServer.ssrLoadModule(path) : import(path)
+    return viteSsrDevServer
+      ? viteSsrDevServer.ssrLoadModule(path)
+      : import(path)
   }
 
   let currentRouteHooks: RouteHooks
@@ -105,7 +107,7 @@ export const loadAndRunRouteHooks = async ({
         paths,
         reqMeta,
         previousOutput: rhOutput,
-        viteDevServer,
+        viteSsrDevServer,
       })
     } else {
       return rhOutput

--- a/packages/web/src/server/middleware.ts
+++ b/packages/web/src/server/middleware.ts
@@ -14,7 +14,7 @@ export type MiddlewareInvokeOptions = {
   route?: RWRouteManifestItem
   cssPaths?: string[]
   params?: Record<string, unknown>
-  viteDevServer?: ViteDevServer
+  viteSsrDevServer?: ViteDevServer
 }
 
 export type Middleware = (


### PR DESCRIPTION
Using the generic 'vite' name made more difficult than it had to be to understand what vite dev server was used for what purpose