### PR TITLE
fix(api-server): prevent race condition in server restart process

### DIFF
--- a/.changesets/11731.md
+++ b/.changesets/11731.md
@@ -1,0 +1,1 @@
+- fix(api-server): prevent race condition in server restart process (#11731) by @o0charlie0o

--- a/packages/api-server/src/serverManager.ts
+++ b/packages/api-server/src/serverManager.ts
@@ -102,7 +102,7 @@ export class ServerManager {
         clearTimeout(forceKillTimeout)
       }
 
-      this.httpServerProcess!.on('exit', () => {
+      this.httpServerProcess?.on('exit', () => {
         console.log(chalk.yellow('API server exited.'))
         cleanup()
         resolve()
@@ -115,11 +115,11 @@ export class ServerManager {
           ),
         )
         cleanup()
-        this.httpServerProcess!.kill('SIGKILL')
+        this.httpServerProcess?.kill('SIGKILL')
         resolve()
       }, 2000)
 
-      this.httpServerProcess!.kill()
+      this.httpServerProcess?.kill()
     })
   }
 }


### PR DESCRIPTION
### Description
Fixes a race condition in the API server restart process where the newly started server could be killed by a lingering timeout handler from the previous shutdown sequence.

### Changes
- Refactored `killApiServer` to use a single promise with proper cleanup
- Added cleanup function to remove exit listeners and clear timeouts
- Ensured exit listeners are set up before sending kill signal to prevent missing exit events
- Added proper logging for server shutdown states

### Background
Previously, using `Promise.race` allowed both promises to continue executing even after one resolved, which could lead to the force-kill timeout executing after a new server had started. This fix ensures that only one shutdown path (graceful or force) can execute, and all listeners and timeouts are properly cleaned up.

### Testing
To verify the fix:
1. Start the dev server
2. Make a change to trigger a server restart
3. Confirm that the server successfully restarts and remains running
4. Verify that multiple restarts work consistently

Fixes #11719 