### PR TITLE
[TS] Include query parameters in typed Cell component props

### DIFF
--- a/.changesets/11737.md
+++ b/.changesets/11737.md
@@ -1,0 +1,5 @@
+- [TS] Include query parameters in typed Cell component props (#11737) by @Philzen
+
+If you have a Cell that for example takes an `id` prop, to be used as a query
+parameter, it'd also be passed to the individual cell components. This is now
+properly reflected in the types.

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -517,7 +517,6 @@ export const Success = ({ article, id, rand }) => {
 ```tsx
 interface Props
   extends CellSuccessProps<FindArticleQuery, FindArticleQueryVariables> {
-  id: number
   rand: number
 }
 

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -114,7 +114,9 @@ export type CellSuccessProps<
     | NonSuspenseCellQueryResult<TVariables, TData>
     | SuspenseCellQueryResult
   updating?: boolean
-} & TVariables & A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
+} & TVariables &
+  // pre-computing makes the types more readable on hover
+  A.Compute<CellSuccessData<TData>>
 
 /**
  * A coarse type for the `data` prop returned by `useQuery`.

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -55,7 +55,7 @@ export type CellLoadingProps<TVariables extends OperationVariables = any> = {
   queryResult?:
     | NonSuspenseCellQueryResult<TVariables, any>
     | SuspenseCellQueryResult
-}
+} & TVariables
 
 export type CellFailureProps<TVariables extends OperationVariables = any> = {
   queryResult?:
@@ -68,7 +68,7 @@ export type CellFailureProps<TVariables extends OperationVariables = any> = {
    */
   errorCode?: string
   updating?: boolean
-}
+} & TVariables
 
 // aka guarantee that all properties in T exist
 type Guaranteed<T> = {
@@ -114,7 +114,7 @@ export type CellSuccessProps<
     | NonSuspenseCellQueryResult<TVariables, TData>
     | SuspenseCellQueryResult
   updating?: boolean
-} & A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
+} & TVariables & A.Compute<CellSuccessData<TData>> // pre-computing makes the types more readable on hover
 
 /**
  * A coarse type for the `data` prop returned by `useQuery`.


### PR DESCRIPTION
When i generate any cell that needs an input for its GQL query, the generated redwood types make those inputs available as props on the `<…Cell>` component. So far, so good, yer good 'ole Redwood magic.

While authoring the cell component code however, one needs to manually extend the interfaces to get around typescript errors when accessing those props. This PR changes that.

I'd also suggest improving createCell so all components (not only `<Success>`) get full type annotations & generics – so one will get best autocompletion on all components out-of-the-box – but that'd probably be a separate PR.