### PR TITLE
[Router] Fix TS error when passing WrapperProps to `<PrivateSet>`s

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -54,7 +54,7 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
-type PrivateSetProps<P> = Omit<
+type PrivateSetProps<P> = P & Omit<
   SetProps<P>,
   'private' | 'unauthenticated' | 'wrap'
 > & {


### PR DESCRIPTION
Redwood v6.4 deprecated the `unauthorized` prop on `<Set>`s so during that upgrade we migrated to `<PrivateSet>` as [per the release notes](https://github.com/redwoodjs/redwood/releases/tag/v6.4.0).

Since then any props passed to the `wrap={…}` component show up as TypeScript errors.

I'm a bit surprised to see that TypeScript's `Omit` drops the props derived via the generic from `Set` here :exploding_head: here … could not find anything explaining that behavior in the [docs](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys), so would be glad to learn why that happens (otherwise feels a bit like a typescript bug?).

Simply adding them again as an intersection types does the job and gets rid of the typescript error here (e738350c829b9607d6deea6b694beb65b81284fa)