### PR TITLE
fix: :bug: add custom headers to subscription in apollo client

### DIFF
--- a/.changesets/11744.md
+++ b/.changesets/11744.md
@@ -1,0 +1,3 @@
+- fix: :bug: add custom headers to subscription in apollo client (#11744) by @dennemark
+
+Allow passing custom headers to `sseLink`, which is used by the Apollo client for subscriptions.

--- a/packages/web/src/apollo/sseLink.ts
+++ b/packages/web/src/apollo/sseLink.ts
@@ -95,7 +95,7 @@ class SSELink extends ApolloLink {
     super()
 
     const { url, auth, headers, httpLinkConfig } = options
-    const { credentials, referrer, referrerPolicy } =
+    const { credentials, referrer, referrerPolicy, ...customHeaders } =
       httpLinkConfig?.headers || {}
 
     this.client = createClient({
@@ -105,12 +105,13 @@ class SSELink extends ApolloLink {
 
         // Only add auth headers when there's a token. `token` is `null` when `!isAuthenticated`.
         if (!token) {
-          return { ...headers }
+          return { ...headers, ...customHeaders }
         }
         return {
           Authorization: `Bearer ${token}`,
           'auth-provider': auth.authProviderType,
           ...headers,
+          ...customHeaders
         }
       },
       credentials: mapCredentialsHeader(credentials),

--- a/packages/web/src/apollo/sseLink.ts
+++ b/packages/web/src/apollo/sseLink.ts
@@ -103,15 +103,13 @@ class SSELink extends ApolloLink {
       headers: async () => {
         const token = await auth.tokenFn()
 
-        // Only add auth headers when there's a token. `token` is `null` when `!isAuthenticated`.
-        if (!token) {
-          return { ...headers, ...customHeaders }
-        }
+        // Only add auth headers when there's a token. `token` is `null` when
+        // `!isAuthenticated`.
         return {
-          Authorization: `Bearer ${token}`,
-          'auth-provider': auth.authProviderType,
+          ...(token && { Authorization: `Bearer ${token}` }),
+          ...(token && { 'auth-provider': auth.authProviderType }),
           ...headers,
-          ...customHeaders
+          ...customHeaders,
         }
       },
       credentials: mapCredentialsHeader(credentials),


### PR DESCRIPTION
Add custom headers to apollo client. 

Fixes https://github.com/redwoodjs/redwood/issues/11732