### PR TITLE
[Storybook] Improve typing, add doc links & remove redundant JSDoc in preview.tsx

### DIFF
--- a/.changesets/11745.md
+++ b/.changesets/11745.md
@@ -1,0 +1,4 @@
+- [Storybook] Improve typing, add doc links & remove redundant JSDoc in preview.tsx (#11745) by @Philzen
+
+Better types for storybook preview config
+Better IntelliSense hints for storybook

--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { I18nextProvider } from 'react-i18next'
 import type { GlobalTypes } from '@storybook/csf'
-import type { StoryFn, StoryContext } from '@storybook/react'
+import type { Preview, StoryFn, StoryContext } from '@storybook/react'
 import i18n from 'web/src/i18n'
 
-/** @type { import("@storybook/csf").GlobalTypes } */
+/** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#global-types-and-the-toolbar-annotation | Global types and the toolbar annotation}  */
 export const globalTypes: GlobalTypes = {
   locale: {
     name: 'Locale',
@@ -25,8 +25,8 @@ export const globalTypes: GlobalTypes = {
  * https://github.com/storybookjs/addon-kit/blob/main/src/withGlobals.ts
  * Unfortunately that will make eslint complain, so we have to disable it when
  * using a hook below
- * @param { import("@storybook/react").StoryFn} StoryFn
- * @param { import("@storybook/react").StoryContext} context
+ *
+ * @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} 
  */
 const withI18n = (StoryFn: StoryFn, context: StoryContext) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -41,4 +41,9 @@ const withI18n = (StoryFn: StoryFn, context: StoryContext) => {
   )
 }
 
-export const decorators = [withI18n]
+const preview: Preview =
+{ 
+  decorators: [withI18n]
+}
+
+export default preview

--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { I18nextProvider } from 'react-i18next'
+
 import type { GlobalTypes } from '@storybook/csf'
-import type { Preview, StoryFn, StoryContext } from '@storybook/react'
+import type { Preview, StoryContext, StoryFn } from '@storybook/react'
+import { I18nextProvider } from 'react-i18next'
 import i18n from 'web/src/i18n'
 
 /** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#global-types-and-the-toolbar-annotation | Global types and the toolbar annotation}  */

--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
@@ -30,7 +30,7 @@ export const globalTypes: GlobalTypes = {
  */
 const withI18n = (StoryFn: StoryFn, context: StoryContext) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  React.useEffect(() => {
+  useEffect(() => {
     i18n.changeLanguage(context.globals.locale)
   }, [context.globals.locale])
 
@@ -41,8 +41,7 @@ const withI18n = (StoryFn: StoryFn, context: StoryContext) => {
   )
 }
 
-const preview: Preview =
-{ 
+const preview: Preview = { 
   decorators: [withI18n]
 }
 

--- a/packages/cli/src/commands/setup/ui/templates/chakra.storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/ui/templates/chakra.storybook.preview.tsx.template
@@ -1,20 +1,20 @@
 import * as React from 'react'
 
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
-import type { StoryFn } from '@storybook/react'
+import type { Preview, StoryFn } from '@storybook/react'
 import theme from 'config/chakra.config'
 
 const extendedTheme = extendTheme(theme)
 
-/**
- * @param { import("@storybook/react").StoryFn} StoryFn
- */
-const withChakra = (StoryFn: StoryFn) => {
-  return (
-    <ChakraProvider theme={extendedTheme}>
-      <StoryFn />
-    </ChakraProvider>
-  )
+/** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} */
+const withChakra = (Story: StoryFn) => (
+  <ChakraProvider theme={extendedTheme}>
+    <Story />
+  </ChakraProvider>
+)
+
+const preview: Preview = {
+  decorators: [withChakra]
 }
 
-export const decorators = [withChakra]
+export default preview

--- a/packages/cli/src/commands/setup/ui/templates/mantine.storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/ui/templates/mantine.storybook.preview.tsx.template
@@ -1,14 +1,12 @@
 import * as React from 'react'
 
 import { MantineProvider } from '@mantine/core'
-import type { StoryFn } from '@storybook/react'
+import type { Preview, StoryFn } from '@storybook/react'
 import theme from 'config/mantine.config'
 
 import '@mantine/core/styles.css'
 
-/**
- * @param { import("@storybook/react").StoryFn} StoryFn
- */
+/** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} */
 const withMantine = (StoryFn: StoryFn) => {
   return (
     <MantineProvider theme={theme}>
@@ -17,4 +15,6 @@ const withMantine = (StoryFn: StoryFn) => {
   )
 }
 
-export const decorators = [withMantine]
+const preview: Preview = {
+  decorators: [withMantine]
+}

--- a/packages/cli/src/commands/setup/ui/templates/mantine.storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/ui/templates/mantine.storybook.preview.tsx.template
@@ -7,13 +7,11 @@ import theme from 'config/mantine.config'
 import '@mantine/core/styles.css'
 
 /** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} */
-const withMantine = (StoryFn: StoryFn) => {
-  return (
-    <MantineProvider theme={theme}>
-      <StoryFn />
-    </MantineProvider>
-  )
-}
+const withMantine = (Story: StoryFn) => (
+  <MantineProvider theme={theme}>
+    <Story />
+  </MantineProvider>
+)
 
 const preview: Preview = {
   decorators: [withMantine]

--- a/packages/cli/src/lib/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/lib/templates/storybook.preview.tsx.template
@@ -10,10 +10,12 @@ export const globalTypes: GlobalTypes = {}
  * An example, no-op storybook decorator. Use a function like this to create decorators.
  * @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} 
  */
-const _exampleDecorator = (StoryFn: StoryFn, _context: StoryContext) => {
-  return <StoryFn />
-}
+const _exampleDecorator = (StoryFn: StoryFn, _context: StoryContext) => (
+  <StoryFn />
+)
 
-const preview: Preview = {}
+const preview: Preview = {
+  decorators: [],
+}
 
 export default preview

--- a/packages/cli/src/lib/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/lib/templates/storybook.preview.tsx.template
@@ -1,18 +1,19 @@
 import * as React from 'react'
 
 import type { GlobalTypes } from '@storybook/csf'
-import type { StoryFn, StoryContext } from '@storybook/react'
+import type { Preview, StoryFn, StoryContext } from '@storybook/react'
 
-/** @type { import("@storybook/csf").GlobalTypes } */
+/** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#global-types-and-the-toolbar-annotation | Global types and the toolbar annotation}  */
 export const globalTypes: GlobalTypes = {}
 
 /**
  * An example, no-op storybook decorator. Use a function like this to create decorators.
- * @param { import("@storybook/react").StoryFn} StoryFn
- * @param { import("@storybook/react").StoryContext} context
-*/
+ * @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} 
+ */
 const _exampleDecorator = (StoryFn: StoryFn, _context: StoryContext) => {
   return <StoryFn />
 }
 
-export const decorators = []
+const preview: Preview = {}
+
+export default preview

--- a/packages/cli/src/lib/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/lib/templates/storybook.preview.tsx.template
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import type { GlobalTypes } from '@storybook/csf'
-import type { Preview, StoryFn, StoryContext } from '@storybook/react'
+import type { Preview, StoryContext, StoryFn } from '@storybook/react'
 
 /** @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#global-types-and-the-toolbar-annotation | Global types and the toolbar annotation}  */
 export const globalTypes: GlobalTypes = {}


### PR DESCRIPTION
- Migrate v6-style export to Storybook 7 default export (as per https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#default-export-in-previewjs)
- Remove redundant JS-style type import
- add typing for preview config object
- add doc link for globalTypes config