### PR TITLE
Fix absolute & component folder imports in Storybook config folder

### DIFF
--- a/.changesets/11746.md
+++ b/.changesets/11746.md
@@ -1,0 +1,3 @@
+- Fix absolute & component folder imports in Storybook config folder (#11746) by @Philzen
+
+Include the storybook config folder in the includes in `{ts,js}config.json`

--- a/__fixtures__/test-project/web/tsconfig.json
+++ b/__fixtures__/test-project/web/tsconfig.json
@@ -35,6 +35,7 @@
   "include": [
     "src",
     "config",
+    ".storybook/**/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",
     "../types",

--- a/packages/create-redwood-app/templates/js/web/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/web/jsconfig.json
@@ -43,7 +43,7 @@
   },
   "include": [
     "src",
-    "config",
+    ".storybook/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",
     "../types",

--- a/packages/create-redwood-app/templates/js/web/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/web/jsconfig.json
@@ -43,6 +43,7 @@
   },
   "include": [
     "src",
+    "config",
     ".storybook/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",

--- a/packages/create-redwood-app/templates/js/web/jsconfig.json
+++ b/packages/create-redwood-app/templates/js/web/jsconfig.json
@@ -44,7 +44,7 @@
   "include": [
     "src",
     "config",
-    ".storybook/*",
+    ".storybook/**/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",
     "../types",

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -34,7 +34,7 @@
   },
   "include": [
     "src",
-    "config",
+    ".storybook/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",
     "../types",

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -34,6 +34,7 @@
   },
   "include": [
     "src",
+    "config",
     ".storybook/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",

--- a/packages/create-redwood-app/templates/ts/web/tsconfig.json
+++ b/packages/create-redwood-app/templates/ts/web/tsconfig.json
@@ -35,7 +35,7 @@
   "include": [
     "src",
     "config",
-    ".storybook/*",
+    ".storybook/**/*",
     "../.redwood/types/includes/all-*",
     "../.redwood/types/includes/web-*",
     "../types",


### PR DESCRIPTION
Resolves #11741. Thanks @irg1008 for [pointing out](https://github.com/redwoodjs/redwood/issues/11741#issuecomment-2518865958) the obvious fix.

This should have been updated in the move from webpack to vite, as storybook config files were moved from `web/config` to `web/.storybook` then.

This completes the update.