### PR TITLE
Include `.storybook` folder in Linting

### DIFF
--- a/.changesets/11748.md
+++ b/.changesets/11748.md
@@ -1,0 +1,1 @@
+- Include .storybook folder in Linting (#11748) by @Philzen

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -42,6 +42,9 @@ export const handler = async ({ path, fix }) => {
         fix && '--fix',
         !pathString && fs.existsSync(getPaths().web.src) && 'web/src',
         !pathString && fs.existsSync(getPaths().web.config) && 'web/config',
+        !pathString &&
+          fs.existsSync(getPaths().web.storybook) &&
+          'web/.storybook',
         !pathString && fs.existsSync(getPaths().scripts) && 'scripts',
         !pathString && fs.existsSync(getPaths().api.src) && 'api/src',
         pathString,

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -55,6 +55,8 @@ module.exports = {
     './shared.js',
     config.web.a11y && 'plugin:jsx-a11y/recommended',
   ].filter(Boolean),
+  // This is merged with `ignorePatterns` in shared.js
+  ignorePatterns: ['!.storybook/'],
   parserOptions: {
     requireConfigFile: false,
     babelOptions: getProjectBabelOptions(),

--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -32,7 +32,10 @@ module.exports = {
     'jest-dom',
     '@redwoodjs',
   ],
-  ignorePatterns: ['node_modules', 'dist', "!.storybook/"],
+  // In addition to this, eslint also has some implicit ignore patterns, like
+  // `node_modules`.
+  // See https://eslint.org/docs/latest/use/configure/ignore-deprecated
+  ignorePatterns: ['dist'],
   settings: {
     react: {
       version: 'detect',

--- a/packages/eslint-config/shared.js
+++ b/packages/eslint-config/shared.js
@@ -32,7 +32,7 @@ module.exports = {
     'jest-dom',
     '@redwoodjs',
   ],
-  ignorePatterns: ['node_modules', 'dist'],
+  ignorePatterns: ['node_modules', 'dist', "!.storybook/"],
   settings: {
     react: {
       version: 'detect',


### PR DESCRIPTION
From the [ESLint docs](https://eslint.org/docs/latest/use/configure/ignore-deprecated):

> ESLint always follows a couple of implicit ignore rules even if the --no-ignore flag is passed. The implicit rules are as follows:
> 
>    node_modules/ is ignored.
>    dot-files (except for .eslintrc.*) as well as dot-folders and their contents are ignored.

Since the upgrade to storybook-vite (which now has the config files in `web/.storybook`) its config files have become a blind spot for ESLint … this PR fixes that.

Hence this should also become part of the next patch release as v8 introduced it.