### PR TITLE
fix(cli): Update cell test template to include `id`

### DIFF
--- a/__fixtures__/test-project/web/src/components/AuthorCell/AuthorCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/AuthorCell/AuthorCell.test.tsx
@@ -24,7 +24,7 @@ describe('AuthorCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -36,7 +36,7 @@ describe('AuthorCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success author={standard().author} />)
+      render(<Success id={42} author={standard().author} />)
     }).not.toThrow()
   })
 })

--- a/__fixtures__/test-project/web/src/components/BlogPostCell/BlogPostCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPostCell/BlogPostCell.test.tsx
@@ -24,7 +24,7 @@ describe('BlogPostCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -36,7 +36,7 @@ describe('BlogPostCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success blogPost={standard().blogPost} />)
+      render(<Success id={42} blogPost={standard().blogPost} />)
     }).not.toThrow()
   })
 })

--- a/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
@@ -24,7 +24,7 @@ describe('BlogPostsCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -36,7 +36,7 @@ describe('BlogPostsCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success blogPosts={standard().blogPosts} />)
+      render(<Success id={42} blogPosts={standard().blogPosts} />)
     }).not.toThrow()
   })
 })

--- a/__fixtures__/test-project/web/src/components/WaterfallBlogPostCell/WaterfallBlogPostCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/WaterfallBlogPostCell/WaterfallBlogPostCell.test.tsx
@@ -24,7 +24,7 @@ describe('WaterfallBlogPostCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -36,7 +36,9 @@ describe('WaterfallBlogPostCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success waterfallBlogPost={standard().waterfallBlogPost} />)
+      render(
+        <Success id={42} waterfallBlogPost={standard().waterfallBlogPost} />
+      )
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -166,7 +166,7 @@ describe('CustomIdFieldsCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure uuid={'42'} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -178,7 +178,7 @@ describe('CustomIdFieldsCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success customIdFields={standard().customIdFields} />)
+      render(<Success uuid={'42'} customIdFields={standard().customIdFields} />)
     }).not.toThrow()
   })
 })
@@ -283,7 +283,7 @@ describe('CustomIdFieldCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure uuid={'42'} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -295,7 +295,7 @@ describe('CustomIdFieldCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success customIdField={standard().customIdField} />)
+      render(<Success uuid={'42'} customIdField={standard().customIdField} />)
     }).not.toThrow()
   })
 })
@@ -400,7 +400,7 @@ describe('UserProfileCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -412,7 +412,7 @@ describe('UserProfileCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success userProfile={standard().userProfile} />)
+      render(<Success id={42} userProfile={standard().userProfile} />)
     }).not.toThrow()
   })
 })
@@ -517,7 +517,7 @@ describe('UserProfileCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -529,7 +529,7 @@ describe('UserProfileCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success userProfile={standard().userProfile} />)
+      render(<Success id={42} userProfile={standard().userProfile} />)
     }).not.toThrow()
   })
 })
@@ -634,7 +634,7 @@ describe('UserCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -646,7 +646,7 @@ describe('UserCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success user={standard().user} />)
+      render(<Success id={42} user={standard().user} />)
     }).not.toThrow()
   })
 })
@@ -751,7 +751,7 @@ describe('UserProfileCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -763,7 +763,7 @@ describe('UserProfileCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success userProfile={standard().userProfile} />)
+      render(<Success id={42} userProfile={standard().userProfile} />)
     }).not.toThrow()
   })
 })
@@ -835,7 +835,7 @@ describe('BazingaCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -847,7 +847,7 @@ describe('BazingaCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success bazinga={standard().bazinga} />)
+      render(<Success id={42} bazinga={standard().bazinga} />)
     }).not.toThrow()
   })
 })
@@ -1040,7 +1040,7 @@ describe('UserProfileCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -1052,7 +1052,7 @@ describe('UserProfileCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success userProfile={standard().userProfile} />)
+      render(<Success id={42} userProfile={standard().userProfile} />)
     }).not.toThrow()
   })
 })
@@ -1109,7 +1109,7 @@ describe('AddressCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={'42'} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -1121,7 +1121,7 @@ describe('AddressCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success address={standard().address} />)
+      render(<Success id={'42'} address={standard().address} />)
     }).not.toThrow()
   })
 })
@@ -1232,7 +1232,7 @@ describe('AddressesCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={'42'} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -1244,7 +1244,7 @@ describe('AddressesCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success addresses={standard().addresses} />)
+      render(<Success id={'42'} addresses={standard().addresses} />)
     }).not.toThrow()
   })
 })
@@ -1365,7 +1365,7 @@ describe('MembersCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure id={42} error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -1377,7 +1377,7 @@ describe('MembersCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success members={standard().members} />)
+      render(<Success id={42} members={standard().members} />)
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -100,6 +100,10 @@ export const files = async ({ name, typescript, ...options }) => {
     webPathSection: REDWOOD_WEB_PATH_NAME,
     generator: 'cell',
     templatePath: 'test.js.template',
+    templateVars: {
+      idName,
+      mockIdValues,
+    },
   })
 
   const storiesFile = await templateForComponentFile({

--- a/packages/cli/src/commands/generate/cell/templates/test.js.template
+++ b/packages/cli/src/commands/generate/cell/templates/test.js.template
@@ -24,7 +24,7 @@ describe('${pascalName}Cell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure error={new Error('Oh no')} />)
+      render(<Failure <% if (idName) { %>${idName}={${mockIdValues[0]}} <% } %>error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -36,7 +36,7 @@ describe('${pascalName}Cell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success ${camelName}={standard().${camelName}} />)
+      render(<Success <% if (idName) { %>${idName}={${mockIdValues[0]}} <% } %>${camelName}={standard().${camelName}} />)
     }).not.toThrow()
   })
 })


### PR DESCRIPTION
Fix regression introduced in https://github.com/redwoodjs/redwood/pull/11737

`<Success>` and `<Failure>` components had extra types added that require the id to be passed to the components. The tests that we generate did not do this, so we got a type error like this

![image](https://github.com/user-attachments/assets/acf2dcc1-72f3-4939-9136-ad9e059c9e98)

This PR updates the cell test template to include the id when needed