### PR TITLE
Add fetch example with use of apiUrl env variable

### DIFF
--- a/docs/docs/how-to/custom-function.md
+++ b/docs/docs/how-to/custom-function.md
@@ -60,7 +60,11 @@ from the web side would give you an error like:
 Access to fetch at 'http://localhost:8911/serverTime' from origin 'http://localhost:8910' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 ```
 
-We could set the headers for `serverTime` to allow requests from any origin... but maybe a better idea would be to never request `8911` from `8910` in the first place. Hence the `apiUrl`! We're making a request to `8910/.redwood/functions/serverTime`&mdash;still the same domain&mdash;but [Vite](https://github.com/redwoodjs/redwood/blob/main/packages/vite/src/index.ts#L119) proxies them to `localhost:8911/serverTime` for us.
+We could set the headers for `serverTime` to allow requests from any origin... but maybe a better idea would be to never request `8911` from `8910` in the first place. Hence the `apiUrl`! We're making a request to `8910/.redwood/functions/serverTime`&mdash;still the same domain&mdash;but [Vite](https://github.com/redwoodjs/redwood/blob/main/packages/vite/src/index.ts#L119) proxies them to `localhost:8911/serverTime` for us. Since we can access the `apiUrl` on the frontend via [environment variables](environment-variables/#accessing-api-urls), we can now change above fetch to work in development as well as production environment:
+
+```javascript
+const serverTime = await fetch(window.RWJS_API_URL+'/serverTime')
+```
 
 ## Getting the Time
 


### PR DESCRIPTION
The docs were missing an explanation on how to use environment variables to fetch a custom function from frontend.