### PR TITLE
[Router][TS] Auto-complete route names for unauthenticated prop

### DIFF
--- a/.changesets/11756.md
+++ b/.changesets/11756.md
@@ -1,0 +1,8 @@
+- [Router][TS] Auto-complete route names for unauthenticated prop (#11756) by @Philzen
+
+- auto-suggests available route names
+- will highlight invalid values
+
+This depends on type generation, so either you'll have to run `yarn rw g types` manually, or you'll have to have the dev server running (which regenerates types when required).
+
+This PR is a little breaking, b/c the `<Set>`s generic typing has changed and also the `WrapperType<P>` type has been removed.

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -9,7 +9,7 @@ export type WrapperType<WTProps> = (
   },
 ) => ReactElement | null
 
-type SetProps<P> = P & {
+type SetProps<P> = (P extends WrapperType<P> ? P : {}) & {
   /**
    * P is the interface for the props that are forwarded to the wrapper
    * components. TypeScript will most likely infer this for you, but if you

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -9,14 +9,14 @@ export type WrapperType<WTProps> = (
   },
 ) => ReactElement | null
 
-type SetProps<P> = (P extends WrapperType<P> ? P : {}) & {
+type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
   /**
    * P is the interface for the props that are forwarded to the wrapper
    * components. TypeScript will most likely infer this for you, but if you
    * need to you can specify it yourself in your JSX like so:
    *   <Set<{theme: string}> wrap={ThemableLayout} theme="dark">
    */
-  wrap?: WrapperType<P> | WrapperType<P>[]
+  wrap?: P | P[]
   /**
    *`Routes` nested in a `<Set>` with `private` specified require
    * authentication. When a user is not authenticated and attempts to visit
@@ -56,8 +56,7 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
-type PrivateSetProps<P> = (P extends WrapperType<P> ? P : {}) &
-  Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
+type PrivateSetProps<P> = Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
     /** The page name where a user will be redirected when not authenticated */
     unauthenticated: keyof typeof routes
   }

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -56,7 +56,7 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
-type PrivateSetProps<P> = P &
+type PrivateSetProps<P> = (P extends WrapperType<P> ? P : {}) &
   Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
     /** The page name where a user will be redirected when not authenticated */
     unauthenticated: keyof typeof routes

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -3,12 +3,6 @@ import React from 'react'
 
 import type { routes } from '@redwoodjs/router'
 
-export type WrapperType<WTProps> = (
-  props: Omit<WTProps, 'wrap' | 'children'> & {
-    children: ReactNode
-  },
-) => ReactElement | null
-
 type SetProps<P extends React.FC> = React.ComponentProps<P> & {
   /**
    * A react component that the children of the Set will be wrapped

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement, ReactNode } from 'react'
 import React from 'react'
 
+import type { routes } from '@redwoodjs/router'
+
 export type WrapperType<WTProps> = (
   props: Omit<WTProps, 'wrap' | 'children'> & {
     children: ReactNode
@@ -28,7 +30,7 @@ type SetProps<P> = P & {
    *
    * @deprecated Please use `<PrivateSet>` instead and specify this prop there
    */
-  unauthenticated?: string
+  unauthenticated?: keyof typeof routes
   /**
    * Route is permitted when authenticated and user has any of the provided
    * roles such as "admin" or ["admin", "editor"]
@@ -57,7 +59,7 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
 type PrivateSetProps<P> = P &
   Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
     /** The page name where a user will be redirected when not authenticated */
-    unauthenticated: string
+    unauthenticated: keyof typeof routes
   }
 
 /** @deprecated Please use `<PrivateSet>` instead */

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -9,7 +9,7 @@ export type WrapperType<WTProps> = (
   },
 ) => ReactElement | null
 
-type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
+type SetProps<P extends React.FC> = React.ComponentProps<P> & {
   /**
    * P is the interface for the props that are forwarded to the wrapper
    * components. TypeScript will most likely infer this for you, but if you

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -11,10 +11,8 @@ export type WrapperType<WTProps> = (
 
 type SetProps<P extends React.FC> = React.ComponentProps<P> & {
   /**
-   * P is the interface for the props that are forwarded to the wrapper
-   * components. TypeScript will most likely infer this for you, but if you
-   * need to you can specify it yourself in your JSX like so:
-   *   <Set<{theme: string}> wrap={ThemableLayout} theme="dark">
+   * A react component that the children of the Set will be wrapped
+   * in (typically a Layout component)
    */
   wrap?: P | P[]
   /**
@@ -45,10 +43,7 @@ type SetProps<P extends React.FC> = React.ComponentProps<P> & {
 }
 
 /**
- * TypeScript will often infer the type of the props you can forward to the
- * wrappers for you, but if you need to you can specify it yourself in your
- * JSX like so:
- *   <Set<{theme: string}> wrap={ThemeableLayout} theme="dark">
+ * A set containing public `<Route />`s
  */
 export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   // @MARK: Virtual Component, this is actually never rendered
@@ -68,6 +63,9 @@ export function Private<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
+/**
+ * A set containing private `<Route />`s that require authentication to access
+ */
 export function PrivateSet<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   // @MARK Virtual Component, this is actually never rendered
   // See analyzeRoutes in utils.tsx, inside the isSetNode block

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import type { routes } from '@redwoodjs/router'
 
-type SetProps<P extends React.FC> = React.ComponentProps<P> & {
+type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
   /**
    * A react component that the children of the Set will be wrapped
    * in (typically a Layout component)
@@ -46,9 +46,9 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
 }
 
 type PrivateSetProps<P> = Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
-    /** The page name where a user will be redirected when not authenticated */
-    unauthenticated: keyof typeof routes
-  }
+  /** The page name where a user will be redirected when not authenticated */
+  unauthenticated: keyof typeof routes
+}
 
 /** @deprecated Please use `<PrivateSet>` instead */
 export function Private<WrapperProps>(props: PrivateSetProps<WrapperProps>) {


### PR DESCRIPTION
Before:

![grafik](https://github.com/user-attachments/assets/21e2e1ef-ef10-4ff2-a08f-11246b496609)

- no auto-completion (any string is allowed)
- no highlight of invalid route names (i.e. when you have a typo)

After:

![grafik](https://github.com/user-attachments/assets/60ea531f-478c-4033-a405-3224f060aba3)

- auto-suggests available route names (coming from `.redwood/types/includes/web-routerRoutes.d.ts` → `AvailableRoutes`)
- will highlight invalid values

Of course, this depends on type generation, so either you'll have `yarn rw g types` executed manually after introducing new route names, or you'll have the dev server running (which regenerates types when required).

--- 

Full credits to @Tobbe for inspiring this [while discussing a different issue](https://github.com/redwoodjs/redwood/pull/11739#issuecomment-2518732853).