### PR TITLE
feat(cells): Optimize default afterQuery by avoiding memcopy

### DIFF
--- a/.changesets/11758.md
+++ b/.changesets/11758.md
@@ -1,0 +1,3 @@
+- feat(cells): Optimize default afterQuery by avoiding memcopy (#11758) by @Philzen
+
+Directly return `data` without fist making a 1:1 copy of it

--- a/packages/web/src/components/cell/createCell.tsx
+++ b/packages/web/src/components/cell/createCell.tsx
@@ -37,7 +37,7 @@ function createNonSuspendingCell<
     fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
   }),
-  afterQuery = (data) => ({ ...data }),
+  afterQuery = (data) => data,
   isEmpty = isDataEmpty,
   Loading = () => <>Loading...</>,
   Failure,


### PR DESCRIPTION
Just stumbled over this. Not sure how much the browser engines are optimized for this kinds of operations nowadays, but at the end of the day it cannot JIT it completely away and i guess it would still need to create a full copy in memory. Some of the "literature" seems to confirm this at least as best practice consideration:

- https://stackoverflow.com/a/58569057/1246547
- https://thinhdanggroup.github.io/spreading-operator-nodejs/  
  > Using the spread operator in performance-critical loops or with large objects can negatively impact performance due to the creation of shallow copies.

At the end of the day one may consider this a neglectable micro-optimization, but as the redwood cell is the "work horse" for data piped to the frontend (which *may* potentially include large amounts of data) this may be worth it – at least it won't hurt :wink: 