### PR TITLE
Add full typing OOTB for all cell components

### DIFF
--- a/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cell.tsx.template
@@ -1,8 +1,9 @@
 import type { ${operationName}, ${operationName}Variables } from 'types/graphql'
 
 import type {
-  CellSuccessProps,
   CellFailureProps,
+  CellLoadingProps,
+  CellSuccessProps,
   TypedDocumentNode,
 } from '@redwoodjs/web'
 
@@ -17,18 +18,22 @@ export const QUERY: TypedDocumentNode<
   }
 `
 
-export const Loading = () => <div>Loading...</div>
+export const Loading: React.FC<
+  CellLoadingProps<<${operationName}Variables>
+> = () => <div>Loading...</div>
 
-export const Empty = () => <div>Empty</div>
+export const Empty: React.FC<
+  CellSuccessProps<${operationName}Variables>
+> = () => <div>Empty</div>
 
-export const Failure = ({
-  error,
-}: CellFailureProps<${operationName}Variables>) => (
+export const Failure: React.FC<
+  CellFailureProps<${operationName}Variables>
+> = ({ error }) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({
-  ${camelName},
-}: CellSuccessProps<${operationName}, ${operationName}Variables>) => {
+export const Success: React.FC<
+  CellSuccessProps<${operationName}, ${operationName}Variables>
+> = ({ ${camelName} }) => {
   return <div>{JSON.stringify(${camelName})}</div>
 }


### PR DESCRIPTION
As contemplated over at https://github.com/redwoodjs/redwood/pull/11737#issue-2703599810 this PR also adds full typing to the generated `<Loading />` and `<Empty />` components.
