### PR TITLE
Fix AuthProviderProps export missing from `@redwood/auth`

### DIFF
--- a/.changesets/11766.md
+++ b/.changesets/11766.md
@@ -1,0 +1,3 @@
+- Fix AuthProviderProps export missing from `@redwood/auth` (#11766) by @Philzen
+
+`AuthProviderProps` is now exported from `@redwood/auth`

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,5 @@
 export type { AuthContextInterface, CurrentUser } from './AuthContext.js'
+export type { AuthProviderProps } from './AuthProvider/AuthProvider.js';
 export { useNoAuth } from './useAuth.js'
 export type { UseAuth } from './useAuth.js'
 export { createAuthentication } from './authFactory.js'


### PR DESCRIPTION
May resolve #11765 

In that case patchreleaseworthy. :wink: 