### PR TITLE
chore(set): Use the existing AvailableRoutes type

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import React from 'react'
 
-import type { routes } from '@redwoodjs/router'
+import type { AvailableRoutes } from '@redwoodjs/router'
 
 type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
   /**
@@ -22,7 +22,7 @@ type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
    *
    * @deprecated Please use `<PrivateSet>` instead and specify this prop there
    */
-  unauthenticated?: keyof typeof routes
+  unauthenticated?: keyof AvailableRoutes
   /**
    * Route is permitted when authenticated and user has any of the provided
    * roles such as "admin" or ["admin", "editor"]
@@ -47,7 +47,7 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
 
 type PrivateSetProps<P> = Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
   /** The page name where a user will be redirected when not authenticated */
-  unauthenticated: keyof typeof routes
+  unauthenticated: keyof AvailableRoutes
 }
 
 /** @deprecated Please use `<PrivateSet>` instead */


### PR DESCRIPTION
This PR depends on [https://github.com/redwoodjs/redwood/pull/11756](https://github.com/redwoodjs/redwood/pull/11756) so can't release it until that PR is released