### PR TITLE
fix(set): Correctly infer generic

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -8,7 +8,7 @@ type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
    * A react component that the children of the Set will be wrapped
    * in (typically a Layout component)
    */
-  wrap?: P | P[]
+  wrap?: P
   /**
    *`Routes` nested in a `<Set>` with `private` specified require
    * authentication. When a user is not authenticated and attempts to visit


### PR DESCRIPTION
This PR depends on https://github.com/redwoodjs/redwood/pull/11756, so they have to be released together