### PR TITLE
breaking(dbAuth): rename cookieName() -> generateCookieName()

### DIFF
--- a/.changesets/11771.md
+++ b/.changesets/11771.md
@@ -1,0 +1,3 @@
+- breaking(dbAuth): rename cookieName() -> generateCookieName() (#11771) by @Tobbe
+
+If you were importing `cookieName` from `@redwoodjs/auth-dbauth-api` you will need to update your imports to `generateCookieName`.

--- a/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
+++ b/packages/auth-providers/dbAuth/api/src/DbAuthHandler.ts
@@ -25,11 +25,11 @@ import {
 
 import * as DbAuthError from './errors'
 import {
-  cookieName,
   decryptSession,
   encryptSession,
   extractCookie,
   extractHashingOptions,
+  generateCookieName,
   getDbAuthResponseBuilder,
   getSession,
   hashPassword,
@@ -414,7 +414,7 @@ export class DbAuthHandler<
     deleteHeaders.append(
       'set-cookie',
       [
-        `${cookieName(this.options.cookie?.name)}=`,
+        `${generateCookieName(this.options.cookie?.name)}=`,
         ...this._cookieAttributes({ expires: 'now' }),
       ].join(';'),
     )
@@ -1245,7 +1245,7 @@ export class DbAuthHandler<
     const session = JSON.stringify(data) + ';' + csrfToken
     const encrypted = encryptSession(session)
     const sessionCookieString = [
-      `${cookieName(this.options.cookie?.name)}=${encrypted}`,
+      `${generateCookieName(this.options.cookie?.name)}=${encrypted}`,
       ...this._cookieAttributes({ expires: this.sessionExpiresDate }),
     ].join(';')
 

--- a/packages/auth-providers/dbAuth/api/src/__tests__/shared.test.ts
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/shared.test.ts
@@ -8,7 +8,7 @@ import * as error from '../errors'
 import {
   extractCookie,
   getSession,
-  cookieName,
+  generateCookieName,
   hashPassword,
   isLegacySession,
   legacyHashPassword,
@@ -79,17 +79,19 @@ describe('getSession()', () => {
   })
 })
 
-describe('cookieName()', () => {
+describe('generateCookieName()', () => {
   it('returns the default cookie name', () => {
-    expect(cookieName(undefined)).toEqual('session')
+    expect(generateCookieName(undefined)).toEqual('session')
   })
 
   it('allows you to pass a cookie name to use', () => {
-    expect(cookieName('my_cookie_name')).toEqual('my_cookie_name')
+    expect(generateCookieName('my_cookie_name')).toEqual('my_cookie_name')
   })
 
   it('replaces %port% with a port number', () => {
-    expect(cookieName('session_%port%_my_app')).toEqual('session_8911_my_app')
+    expect(generateCookieName('session_%port%_my_app')).toEqual(
+      'session_8911_my_app',
+    )
   })
 })
 

--- a/packages/auth-providers/dbAuth/api/src/decoder.ts
+++ b/packages/auth-providers/dbAuth/api/src/decoder.ts
@@ -4,13 +4,13 @@ import type { Decoder } from '@redwoodjs/api'
 
 import { dbAuthSession } from './shared'
 
-export const createAuthDecoder = (cookieNameOption: string): Decoder => {
+export const createAuthDecoder = (cookieNameTemplate: string): Decoder => {
   return async (_token, type, req) => {
     if (type !== 'dbAuth') {
       return null
     }
 
-    const session = dbAuthSession(req.event, cookieNameOption)
+    const session = dbAuthSession(req.event, cookieNameTemplate)
 
     // We no longer compare the session id with the bearer token
     return session

--- a/packages/auth-providers/dbAuth/api/src/shared.ts
+++ b/packages/auth-providers/dbAuth/api/src/shared.ts
@@ -160,22 +160,24 @@ export const encryptSession = (dataString: string) => {
 // returns the actual value of the session cookie
 export const getSession = (
   text: string | undefined,
-  cookieNameOption: string | undefined,
+  cookieNameTemplate: string | undefined,
 ) => {
   if (typeof text === 'undefined' || text === null) {
     return null
   }
 
+  const cookieName = generateCookieName(cookieNameTemplate)
+
   const cookies = text.split(';')
   const sessionCookie = cookies.find((cookie) => {
-    return cookie.split('=')[0].trim() === cookieName(cookieNameOption)
+    return cookie.split('=')[0].trim() === cookieName
   })
 
-  if (!sessionCookie || sessionCookie === `${cookieName(cookieNameOption)}=`) {
+  if (!sessionCookie || sessionCookie === `${cookieName}=`) {
     return null
   }
 
-  return sessionCookie.replace(`${cookieName(cookieNameOption)}=`, '').trim()
+  return sessionCookie.replace(`${cookieName}=`, '').trim()
 }
 
 // Convenience function to get session, decrypt, and return session data all
@@ -183,7 +185,7 @@ export const getSession = (
 // name of the dbAuth session cookie
 export const dbAuthSession = (
   event: APIGatewayProxyEvent | Request,
-  cookieNameOption: string | undefined,
+  cookieNameTemplate: string | undefined,
 ) => {
   const sessionCookie = extractCookie(event)
 
@@ -193,7 +195,7 @@ export const dbAuthSession = (
 
   // This is a browser making a request
   const [session, _csrfToken] = decryptSession(
-    getSession(sessionCookie, cookieNameOption),
+    getSession(sessionCookie, cookieNameTemplate),
   )
   return session
 }
@@ -252,9 +254,9 @@ export const legacyHashPassword = (text: string, salt?: string) => {
   ]
 }
 
-export const cookieName = (name: string | undefined) => {
+export function generateCookieName(template: string | undefined) {
   const port = getPort()
-  const cookieName = name?.replace('%port%', '' + port) ?? 'session'
+  const cookieName = template?.replace('%port%', '' + port) ?? 'session'
 
   return cookieName
 }

--- a/packages/auth-providers/dbAuth/middleware/src/index.ts
+++ b/packages/auth-providers/dbAuth/middleware/src/index.ts
@@ -3,7 +3,7 @@ import type { APIGatewayProxyEvent, Context } from 'aws-lambda'
 import type { DbAuthResponse } from '@redwoodjs/auth-dbauth-api'
 import dbAuthApi from '@redwoodjs/auth-dbauth-api'
 // ^^ above package is still CJS, and named exports aren't supported in import statements
-const { dbAuthSession, cookieName: cookieNameCreator } = dbAuthApi
+const { dbAuthSession, generateCookieName } = dbAuthApi
 import type { GetCurrentUser } from '@redwoodjs/graphql-server'
 import { MiddlewareResponse } from '@redwoodjs/web/middleware'
 import type { Middleware, MiddlewareRequest } from '@redwoodjs/web/middleware'
@@ -117,7 +117,7 @@ export const initDbAuthMiddleware = ({
 
       // Note we have to use ".unset" and not ".clear"
       // because we want to remove these cookies from the browser
-      res.cookies.unset(cookieNameCreator(cookieName))
+      res.cookies.unset(generateCookieName(cookieName))
       res.cookies.unset('auth-provider')
     }
 
@@ -148,7 +148,7 @@ async function validateSession({
     // be thrown
     decryptedSession = dbAuthSession(
       req as Request,
-      cookieNameCreator(cookieName),
+      generateCookieName(cookieName),
     )
   } catch (e) {
     if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Having both the variable named `cookieName` and the function  named `cookieName` when they're supposed to be used together was very unergonomic

Unfortunately the `cookieName()` function was exported, so it is possible that someone was using it in their project. And if so, they'd need to update their code to use the new `generateCookieName()` name.