### PR TITLE
[TS + Docs] Include potential gql input variables in ListCell's Loading and Success component typing & improve TS docs

### DIFF
--- a/.changesets/11773.md
+++ b/.changesets/11773.md
@@ -1,0 +1,1 @@
+- [TS + Docs] Include potential gql input variables in ListCell's Loading and Success component typing & improve TS docs (#11773) by @Philzen

--- a/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.tsx
@@ -28,11 +28,15 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<BlogPostsQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ blogPosts }: CellSuccessProps<BlogPostsQuery>) => (
+export const Success = ({
+  blogPosts,
+}: CellSuccessProps<BlogPostsQuery, BlogPostsQueryVariables>) => (
   <div className="divide-grey-700 divide-y">
     {blogPosts.map((post) => (
       <BlogPost key={post.id} blogPost={post} />

--- a/docs/docs/how-to/pagination.md
+++ b/docs/docs/how-to/pagination.md
@@ -10,6 +10,9 @@ So you have a blog, and probably only a few short posts. But as the blog grows b
 
 We'll begin by updating the SDL. To our `Query` type a new query is added to get just a single page of posts. We'll pass in the page we want, and when returning the result we'll also include the total number of posts as that'll be needed when building our pagination component.
 
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
 ```javascript title="api/src/graphql/posts.sdl.js"
 export const schema = gql`
   # ...
@@ -29,9 +32,37 @@ export const schema = gql`
 `
 ```
 
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```typescript title="api/src/graphql/posts.sdl.ts"
+export const schema = gql`
+  # ...
+
+  type PostPage {
+    posts: [Post!]!
+    count: Int!
+  }
+
+  type Query {
+    postPage(page: Int): PostPage
+    posts: [Post!]!
+    post(id: Int!): Post!
+  }
+
+  # ...
+`
+```
+
+</TabItem>
+</Tabs>
+
 You might have noticed that we made the page optional. That's because we want to be able to default to the first page if no page is provided.
 
 Now we need to add a resolver for this new query to our posts service.
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
 
 ```javascript title="api/src/services/posts/posts.js"
 const POSTS_PER_PAGE = 5
@@ -50,11 +81,37 @@ export const postPage = ({ page = 1 }) => {
 }
 ```
 
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```typescript title="api/src/services/posts/posts.ts"
+const POSTS_PER_PAGE = 5
+
+export const postPage = ({ page = 1 }) => {
+  const offset = (page - 1) * POSTS_PER_PAGE
+
+  return {
+    posts: db.post.findMany({
+      take: POSTS_PER_PAGE,
+      skip: offset,
+      orderBy: { createdAt: 'desc' },
+    }),
+    count: db.post.count(),
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 So now we can make a GraphQL request (using [Apollo](https://www.apollographql.com/)) for a specific page of our blog posts. And the resolver we just updated will use [Prisma](https://www.prisma.io/) to fetch the correct posts from our database.
 
 With these updates to the API side of things done, it's time to move over to the web side. It's the BlogPostsCell component that makes the gql query to display the list of blog posts on the HomePage of the blog, so let's update that query.
 
-```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.js"
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.jsx"
 export const QUERY = gql`
   query BlogPostsQuery($page: Int) {
     postPage(page: $page) {
@@ -70,17 +127,64 @@ export const QUERY = gql`
 `
 ```
 
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
+import type { BlogPostsQuery, BlogPostsQueryVariables } from 'types/graphql'
+
+import type { TypedDocumentNode } from '@redwoodjs/web'
+
+export const QUERY: TypedDocumentNode<BlogPostsQuery, BlogPostsQueryVariables> =
+  gql`
+    query BlogPostsQuery($page: Int) {
+      postPage(page: $page) {
+        posts {
+          id
+          title
+          body
+          createdAt
+        }
+        count
+      }
+    }
+  `
+```
+
+</TabItem>
+</Tabs>
+
 The `Success` component in the same file also needs a bit of an update to handle the new gql query result structure.
 
-```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.js"
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+  
+```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.jsx"
 export const Success = ({ postPage }) => {
   return postPage.posts.map((post) => <BlogPost key={post.id} post={post} />)
 }
 ```
 
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
+export const Success = ({
+  postPage,
+}: CellSuccessProps<BlogPostsQuery, BlogPostsQueryVariables>) => {
+  return postPage.posts.map((post) => <BlogPost key={post.id} post={post} />)
+}
+```
+
+</TabItem>
+</Tabs>
+
 Now we need a way to pass a value for the `page` parameter to the query. To do that we'll take advantage of a little RedwoodJS magic. Remember from the tutorial how you made the post id part of the route path `(<Route path="/blog-post/{id:Int}" page={BlogPostPage} name="blogPost" />)` and that id was then sent as a prop to the BlogPostPage component? We'll do something similar here for the page number, but instead of making it a part of the url path, we'll make it a url query string. These, too, are magically passed as a prop to the relevant page component. And you don't even have to update the route to make it work! Let's update `HomePage.js` to handle the prop.
 
-```jsx title="web/src/pages/HomePage/HomePage.js"
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+  
+```jsx title="web/src/pages/HomePage/HomePage.jsx"
 const HomePage = ({ page = 1 }) => {
   return (
     <BlogLayout>
@@ -90,17 +194,56 @@ const HomePage = ({ page = 1 }) => {
 }
 ```
 
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```tsx title="web/src/pages/HomePage/HomePage.tsx"
+const HomePage = ({ page = 1 }) => {
+  return (
+    <BlogLayout>
+      <BlogPostsCell page={page} />
+    </BlogLayout>
+  )
+}
+```
+
+</TabItem>
+</Tabs>
+
 So now if someone navigates to https://awesomeredwoodjsblog.com?page=2 (and the blog was actually hosted on awesomeredwoodjsblog.com), then `HomePage` would have its `page` prop set to `"2"`, and we then pass that value along to `BlogPostsCell`. If no `?page=` query parameter is provided `page` will default to `1`
 
 Going back to `BlogPostsCell` there is one me thing to add before the query parameter work.
 
-```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.js"
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+  
+```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.jsx"
 export const beforeQuery = ({ page }) => {
   page = page ? parseInt(page, 10) : 1
 
   return { variables: { page } }
 }
 ```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.jsx"
+export const beforeQuery = ({
+  urlName,
+}: FindBlogPostQueryVariables): GraphQLQueryHookOptions<
+  FindBlogPostQuery,
+  FindBlogPostQueryVariables
+> => {
+  urlName = urlName ? parseInt(urlName, 10) : 1
+
+  return { variables: { urlName } }
+}
+
+```
+
+</TabItem>
+</Tabs>
 
 The query parameter is passed to the component as a string, so we need to parse it into a number.
 
@@ -110,7 +253,10 @@ The final thing to add is a page selector, or pagination component, to the end o
 
 Generate a new component with`yarn rw g component Pagination`
 
-```jsx title="web/src/components/Pagination/Pagination.js"
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+  
+```jsx title="web/src/components/Pagination/Pagination.jsx"
 import { Link, routes } from '@redwoodjs/router'
 
 const POSTS_PER_PAGE = 5
@@ -121,9 +267,7 @@ const Pagination = ({ count }) => {
   for (let i = 0; i < Math.ceil(count / POSTS_PER_PAGE); i++) {
     items.push(
       <li key={i}>
-        <Link to={routes.home({ page: i + 1 })}>
-          {i + 1}
-        </Link>
+        <Link to={routes.home({ page: i + 1 })}>{i + 1}</Link>
       </li>
     )
   }
@@ -139,11 +283,49 @@ const Pagination = ({ count }) => {
 export default Pagination
 ```
 
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```tsx title="web/src/components/Pagination/Pagination.tsx"
+import { Link, routes } from '@redwoodjs/router'
+
+const POSTS_PER_PAGE = 5
+
+const Pagination = ({ count }: { count: number }) => {
+  const items = []
+
+  for (let i = 0; i < Math.ceil(count / POSTS_PER_PAGE); i++) {
+    items.push(
+      <li key={i}>
+        <Link to={routes.home({ page: i + 1 })}>{i + 1}</Link>
+      </li>
+    )
+  }
+
+  return (
+    <>
+      <h2>Pagination</h2>
+      <ul>{items}</ul>
+    </>
+  )
+}
+
+export default Pagination
+```
+
+</TabItem>
+</Tabs>
+
 Keeping with the theme of the official RedwoodJS tutorial we're not adding any css, but if you wanted the pagination to look a little nicer it'd be easy to remove the bullets from that list, and make it horizontal instead of vertical.
 
 Finally let's add this new component to the end of `BlogPostsCell`. Don't forget to `import` it at the top as well.
 
-```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.js"
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```jsx title="web/src/components/BlogPostsCell/BlogPostsCell.jsx"
 import Pagination from 'src/components/Pagination'
 
 // ...
@@ -151,13 +333,41 @@ import Pagination from 'src/components/Pagination'
 export const Success = ({ postPage }) => {
   return (
     <>
-      {postPage.posts.map((post) => <BlogPost key={post.id} post={post} />)}
+      {postPage.posts.map((post) => (
+        <BlogPost key={post.id} post={post} />
+      ))}
 
       <Pagination count={postPage.count} />
     </>
   )
 }
 ```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
+import Pagination from 'src/components/Pagination'
+
+// ...
+
+export const Success = ({
+  postPage,
+}: CellSuccessProps<BlogPostsQuery, BlogPostsQueryVariables>) => {
+  return (
+    <>
+      {postPage.posts.map((post) => (
+        <BlogPost key={post.id} post={post} />
+      ))}
+
+      <Pagination count={postPage.count} />
+    </>
+  )
+}
+```
+
+</TabItem>
+</Tabs>
 
 And there you have it! You have now added pagination to your redwood blog. One technical limitation to the current implementation is that it doesn't handle too many pages very gracefully. Just imagine what that list of pages would look like if you had 100 pages! It's left as an exercise to the reader to build a more fully featured Pagination component.
 

--- a/docs/docs/how-to/pagination.md
+++ b/docs/docs/how-to/pagination.md
@@ -230,16 +230,15 @@ export const beforeQuery = ({ page }) => {
 
 ```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
 export const beforeQuery = ({
-  urlName,
+  page,
 }: FindBlogPostQueryVariables): GraphQLQueryHookOptions<
   FindBlogPostQuery,
   FindBlogPostQueryVariables
 > => {
-  urlName = urlName ? parseInt(urlName, 10) : 1
+  page = page ? parseInt(page, 10) : 1
 
-  return { variables: { urlName } }
+  return { variables: { page } }
 }
-
 ```
 
 </TabItem>

--- a/docs/docs/how-to/pagination.md
+++ b/docs/docs/how-to/pagination.md
@@ -228,7 +228,7 @@ export const beforeQuery = ({ page }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.jsx"
+```tsx title="web/src/components/BlogPostsCell/BlogPostsCell.tsx"
 export const beforeQuery = ({
   urlName,
 }: FindBlogPostQueryVariables): GraphQLQueryHookOptions<

--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -48,10 +48,10 @@ import type { FindPosts, FindPostsVariables } from 'types/graphql'
 import type {
   CellFailureProps,
   CellSuccessProps,
-  TypeDocumentNode,
+  TypedDocumentNode,
 } from '@redwoodjs/web'
 
-export const QUERY: TypeDocumentNode<FindPosts, FindPostsVariables> = gql`
+export const QUERY: TypedDocumentNode<FindPosts, FindPostsVariables> = gql`
   query FindPosts {
     posts {
       id
@@ -169,10 +169,10 @@ import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
 import type {
   CellFailureProps,
   CellSuccessProps,
-  TypeDocumentNode,
+  TypedDocumentNode,
 } from '@redwoodjs/web'
 
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       articles {
@@ -244,7 +244,7 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       // highlight-next-line
@@ -305,10 +305,10 @@ import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
 import type {
   CellFailureProps,
   CellSuccessProps,
-  TypeDocumentNode,
+  TypedDocumentNode,
 } from '@redwoodjs/web'
 
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       // highlight-next-line
@@ -441,7 +441,7 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       // highlight-next-line
@@ -475,7 +475,7 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       // highlight-next-line
@@ -550,7 +550,7 @@ export const Success = ({ articles }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       // highlight-next-line
@@ -612,7 +612,7 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       articles: posts {

--- a/docs/docs/tutorial/chapter2/cells.md
+++ b/docs/docs/tutorial/chapter2/cells.md
@@ -43,10 +43,15 @@ export const Success = ({ posts }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx
-import type { FindPosts } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+import type { FindPosts, FindPostsVariables } from 'types/graphql'
 
-export const QUERY = gql`
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
+export const QUERY: TypeDocumentNode<FindPosts, FindPostsVariables> = gql`
   query FindPosts {
     posts {
       id
@@ -61,11 +66,13 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>No posts yet!</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({ error }: CellFailureProps<FindPostsVariables>) => (
   <div>Error loading posts: {error.message}</div>
 )
 
-export const Success = ({ posts }: CellSuccessProps<FindPosts>) => {
+export const Success = ({
+  posts,
+}: CellSuccessProps<FindPosts, FindPostsVariables>) => {
   return posts.map((post) => (
     <article key={post.id}>
       <h2>{post.title}</h2>
@@ -156,27 +163,37 @@ export const Success = ({ articles }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-import type { ArticlesQuery } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
 
-export const QUERY = gql`
-  query ArticlesQuery {
-    articles {
-      id
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      articles {
+        id
+      }
     }
-  }
-`
+  `
 
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<ArticlesQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <ul>
       {articles.map((item) => {
@@ -226,15 +243,16 @@ export const QUERY = gql`
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const QUERY = gql`
-  query ArticlesQuery {
-    // highlight-next-line
-    articles {
-      id
+```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      // highlight-next-line
+      articles {
+        id
+      }
     }
-  }
-`
+  `
 ```
 
 </TabItem>
@@ -281,29 +299,39 @@ export const Success = ({ posts }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-import type { ArticlesQuery } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
 
-export const QUERY = gql`
-  query ArticlesQuery {
-    // highlight-next-line
-    posts {
-      id
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      // highlight-next-line
+      posts {
+        id
+      }
     }
-  }
-`
+  `
 
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<ArticlesQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
 // highlight-next-line
-export const Success = ({ posts }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({
+  posts,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <ul>
       // highlight-next-line
@@ -363,7 +391,7 @@ export default HomePage
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/pages/HomePage/HomePage.tsx"
+```tsx title="web/src/pages/HomePage/HomePage.tsx"
 import { Metadata } from '@redwoodjs/web'
 
 // highlight-next-line
@@ -413,14 +441,15 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-export const QUERY = gql`
-  query ArticlesQuery {
-    // highlight-next-line
-    posts {
-      id
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      // highlight-next-line
+      posts {
+        id
+      }
     }
-  }
-`
+  `
 ```
 
 </TabItem>
@@ -446,13 +475,14 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-export const QUERY = gql`
-  query ArticlesQuery {
-    // highlight-next-line
-    articles: posts {
-      id
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      // highlight-next-line
+      articles: posts {
+        id
+      }
     }
-  }
 `
 ```
 
@@ -472,7 +502,7 @@ export const Success = ({ articles }) => { ... }
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => { ... }
+export const Success = ({ articles }: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => { ... }
 ```
 
 </TabItem>
@@ -519,26 +549,31 @@ export const Success = ({ articles }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const QUERY = gql`
-  query ArticlesQuery {
-    // highlight-next-line
-    articles: posts {
-      id
+```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      // highlight-next-line
+      articles: posts {
+        id
+      }
     }
-  }
-`
+  `
 
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<ArticlesQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-// highlight-next-line
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({
+  // highlight-next-line
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <ul>
       // highlight-next-line
@@ -577,17 +612,18 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const QUERY = gql`
-  query ArticlesQuery {
-    articles: posts {
-      id
-      // highlight-start
-      title
-      body
-      createdAt
-      // highlight-end
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      articles: posts {
+        id
+        // highlight-start
+        title
+        body
+        createdAt
+        // highlight-end
+      }
     }
-  }
 `
 ```
 
@@ -627,7 +663,9 @@ export const Success = ({ articles }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     // highlight-start
     <>

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -355,10 +355,10 @@ import type { FindArticleQuery, FindArticleQueryVariables } from 'types/graphql'
 import type {
   CellFailureProps,
   CellSuccessProps,
-  TypeDocumentNode,
+  TypedDocumentNode,
 } from '@redwoodjs/web'
 
-export const QUERY: TypeDocumentNode<
+export const QUERY: TypedDocumentNode<
   FindArticleQuery,
   FindArticleQueryVariables
 > = gql`
@@ -712,13 +712,13 @@ import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
 import type {
   CellFailureProps,
   CellSuccessProps,
-  TypeDocumentNode,
+  TypedDocumentNode,
 } from '@redwoodjs/web'
 
 // highlight-next-line
 import Article from 'src/components/Article'
 
-export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+export const QUERY: TypedDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
   gql`
     query ArticlesQuery {
       articles: posts {
@@ -798,13 +798,13 @@ import type { FindArticleQuery, FindArticleQueryVariables } from 'types/graphql'
 import type {
   CellFailureProps,
   CellSuccessProps,
-  TypeDocumentNode,
+  TypedDocumentNode,
 } from '@redwoodjs/web'
 
 // highlight-next-line
 import Article from 'src/components/Article'
 
-export const QUERY: TypeDocumentNode<
+export const QUERY: TypedDocumentNode<
   FindArticleQuery,
   FindArticleQueryVariables
 > = gql`

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -740,7 +740,9 @@ export const Failure = ({
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
+export const Success = ({
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <>
       {articles.map((article) => (
@@ -828,7 +830,9 @@ export const Failure = ({
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ article }: CellSuccessProps<FindArticleQuery, FindArticleQueryVariables>) => {
+export const Success = ({
+  article,
+}: CellSuccessProps<FindArticleQuery, FindArticleQueryVariables>) => {
   // highlight-next-line
   return <Article article={article} />
 }

--- a/docs/docs/tutorial/chapter2/routing-params.md
+++ b/docs/docs/tutorial/chapter2/routing-params.md
@@ -46,7 +46,9 @@ import { Link, routes } from '@redwoodjs/router'
 
 // QUERY, Loading, Empty and Failure definitions...
 
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <>
       {articles.map((article) => (
@@ -349,9 +351,17 @@ export const Success = ({ article }) => {
 
 ```tsx title="web/src/components/ArticleCell/ArticleCell.tsx"
 import type { FindArticleQuery, FindArticleQueryVariables } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
 
-export const QUERY = gql`
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
+export const QUERY: TypeDocumentNode<
+  FindArticleQuery,
+  FindArticleQueryVariables
+> = gql`
   query FindArticleQuery($id: Int!) {
     // highlight-next-line
     article: post(id: $id) {
@@ -369,7 +379,9 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<FindArticleQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
@@ -410,7 +422,7 @@ export default ArticlePage
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/pages/ArticlePage/ArticlePage.tsx"
+```tsx title="web/src/pages/ArticlePage/ArticlePage.tsx"
 import { Metadata } from '@redwoodjs/web'
 import ArticleCell from 'src/components/ArticleCell'
 
@@ -470,7 +482,7 @@ What if you could request the conversion right in the route's path? Introducing 
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/Routes.tsx"
+```tsx title="web/src/Routes.tsx"
 <Route path="/article/{id:Int}" page={ArticlePage} name="article" />
 ```
 
@@ -493,7 +505,7 @@ All of the props you give to the cell will be automatically available as props i
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx
+```tsx
 <ArticleCell id={id} rand={Math.random()} />
 ```
 
@@ -561,7 +573,7 @@ export default Article
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/Article/Article.tsx"
+```tsx title="web/src/components/Article/Article.tsx"
 const Article = () => {
   return (
     <div>
@@ -615,7 +627,7 @@ export default Article
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/Article/Article.tsx"
+```tsx title="web/src/components/Article/Article.tsx"
 // highlight-next-line
 import { Link, routes } from '@redwoodjs/router'
 
@@ -694,33 +706,41 @@ export const Success = ({ articles }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
+
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
 // highlight-next-line
 import Article from 'src/components/Article'
 
-import type { ArticlesQuery } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
-
-export const QUERY = gql`
-  query ArticlesQuery {
-    articles: posts {
-      id
-      title
-      body
-      createdAt
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      articles: posts {
+        id
+        title
+        body
+        createdAt
+      }
     }
-  }
-`
+  `
 
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<ArticlesQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({ articles }: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <>
       {articles.map((article) => (
@@ -772,14 +792,22 @@ export const Success = ({ article }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/ArticleCell/ArticleCell.tsx"
+```tsx title="web/src/components/ArticleCell/ArticleCell.tsx"
+import type { FindArticleQuery, FindArticleQueryVariables } from 'types/graphql'
+
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
 // highlight-next-line
 import Article from 'src/components/Article'
 
-import type { FindArticleQuery, FindArticleQueryVariables } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
-
-export const QUERY = gql`
+export const QUERY: TypeDocumentNode<
+  FindArticleQuery,
+  FindArticleQueryVariables
+> = gql`
   query FindArticleQuery($id: Int!) {
     article: post(id: $id) {
       id
@@ -794,7 +822,9 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<FindArticleQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 

--- a/docs/docs/tutorial/chapter5/first-story.md
+++ b/docs/docs/tutorial/chapter5/first-story.md
@@ -192,31 +192,41 @@ export const Success = ({ articles }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/ArticlesCell/ArticlesCell.tsx"
+import type { ArticlesQuery, ArticlesQueryVariables } from 'types/graphql'
+
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypeDocumentNode,
+} from '@redwoodjs/web'
+
 import Article from 'src/components/Article'
 
-import type { ArticlesQuery } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
-
-export const QUERY = gql`
-  query ArticlesQuery {
-    articles: posts {
-      id
-      title
-      body
-      createdAt
+export const QUERY: TypeDocumentNode<ArticlesQuery, ArticlesQueryVariables> =
+  gql`
+    query ArticlesQuery {
+      articles: posts {
+        id
+        title
+        body
+        createdAt
+      }
     }
-  }
-`
+  `
 
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<ArticlesQueryVariables>) => (
   <div>Error: {error.message}</div>
 )
 
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
+export const Success = ({
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
   return (
     <div className="space-y-10">
       {articles.map((article) => (

--- a/docs/docs/tutorial/chapter5/first-test.md
+++ b/docs/docs/tutorial/chapter5/first-test.md
@@ -316,7 +316,6 @@ export const Success = ({
     articles.map((article) => <Article article={article} />)
   }
 }
-
 ```
 
 </TabItem>

--- a/docs/docs/tutorial/chapter5/first-test.md
+++ b/docs/docs/tutorial/chapter5/first-test.md
@@ -307,12 +307,16 @@ export const Success = ({ articles }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx
-// highlight-next-line
-export const Success = ({ articles }: CellSuccessProps<ArticlesQuery>) => {
-  return (
-    { articles.map((article) => <Article article={article} />) }
-  )
+export const Success = ({
+  // highlight-next-line
+  articles,
+}: CellSuccessProps<ArticlesQuery, ArticlesQueryVariables>) => {
+  return
+  {
+    articles.map((article) => <Article article={article} />)
+  }
 }
+
 ```
 
 </TabItem>

--- a/docs/docs/tutorial/chapter6/comment-form.md
+++ b/docs/docs/tutorial/chapter6/comment-form.md
@@ -287,6 +287,7 @@ const CommentForm = () => {
           wrapperClassName="bg-red-100 text-red-900 text-sm p-3 rounded"
         />
         // highlight-end
+
         <Label
           name="name"
           className="block text-xs font-semibold text-gray-500 uppercase"

--- a/docs/docs/tutorial/chapter6/comment-form.md
+++ b/docs/docs/tutorial/chapter6/comment-form.md
@@ -1642,18 +1642,19 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```graphql title="web/src/components/CommentsCell/CommentsCell.tsx"
-export const QUERY = gql`
-  // highlight-start
-  query CommentsQuery($postId: Int!) {
-    comments(postId: $postId) {
-    // highlight-end
-      id
-      name
-      body
-      createdAt
+export const QUERY: TypedDocumentNode<CommentsQuery, CommentsQueryVariables> =
+  gql`
+    // highlight-start
+    query CommentsQuery($postId: Int!) {
+      comments(postId: $postId) {
+      // highlight-end
+        id
+        name
+        body
+        createdAt
+      }
     }
-  }
-`
+  `
 ```
 
 </TabItem>

--- a/docs/docs/tutorial/chapter6/comment-form.md
+++ b/docs/docs/tutorial/chapter6/comment-form.md
@@ -238,8 +238,10 @@ import {
   // highlight-next-line
   SubmitHandler,
 } from '@redwoodjs/forms'
-// highlight-next-line
-import { useMutation, TypedDocumentNode } from '@redwoodjs/web'
+// highlight-start
+import type { TypedDocumentNode } from '@redwoodjs/web'
+import { useMutation } from '@redwoodjs/web'
+// highlight-end
 
 // highlight-start
 const CREATE: TypedDocumentNode<
@@ -848,9 +850,14 @@ export default CommentForm
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/CommentForm/CommentForm.tsx"
+```tsx title="web/src/components/CommentForm/CommentForm.tsx"
 // highlight-next-line
 import { useState } from 'react'
+
+import type {
+  CreateCommentMutation,
+  CreateCommentMutationVariables,
+} from 'types/graphql'
 
 import {
   Form,
@@ -860,13 +867,17 @@ import {
   TextAreaField,
   Submit,
 } from '@redwoodjs/forms'
+import type { TypedDocumentNode } from '@redwoodjs/web'
 import { useMutation } from '@redwoodjs/web'
 // highlight-next-line
 import { toast } from '@redwoodjs/web/toast'
 
 import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
 
-const CREATE = gql`
+const CREATE: TypedDocumentNode<
+  CreateCommentMutation,
+  CreateCommentMutationVariables
+> = gql`
   mutation CreateCommentMutation($input: CreateCommentInput!) {
     createComment(input: $input) {
       id
@@ -1037,7 +1048,7 @@ export default BlogLayout
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/layouts/BlogLayout/BlogLayout.tsx"
+```tsx title="web/src/layouts/BlogLayout/BlogLayout.tsx"
 import { Link, routes } from '@redwoodjs/router'
 // highlight-next-line
 import { Toaster } from '@redwoodjs/web/toast'
@@ -1599,7 +1610,7 @@ const Article = ({ article, summary = false }) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/Article/Article.tsx"
+```tsx title="web/src/components/Article/Article.tsx"
 const Article = ({ article, summary = false }) => {
   return (
     <article>

--- a/docs/docs/tutorial/chapter6/comment-form.md
+++ b/docs/docs/tutorial/chapter6/comment-form.md
@@ -219,7 +219,14 @@ export default CommentForm
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```jsx title="web/src/components/CommentForm/CommentForm.tsx"
+```tsx title="web/src/components/CommentForm/CommentForm.tsx"
+// highlight-start
+import type {
+  CreateCommentMutation,
+  CreateCommentMutationVariables,
+} from 'types/graphql'
+// highlight-end
+
 import {
   Form,
   // highlight-next-line
@@ -232,10 +239,13 @@ import {
   SubmitHandler,
 } from '@redwoodjs/forms'
 // highlight-next-line
-import { useMutation } from '@redwoodjs/web'
+import { useMutation, TypedDocumentNode } from '@redwoodjs/web'
 
 // highlight-start
-const CREATE = gql`
+const CREATE: TypedDocumentNode<
+  CreateCommentMutation,
+  CreateCommentMutationVariables
+> = gql`
   mutation CreateCommentMutation($input: CreateCommentInput!) {
     createComment(input: $input) {
       id

--- a/docs/docs/tutorial/chapter6/multiple-comments.md
+++ b/docs/docs/tutorial/chapter6/multiple-comments.md
@@ -83,34 +83,44 @@ export const Success = ({ comments }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/CommentsCell/CommentsCell.tsx"
+import type { CommentsQuery, CommentsQueryVariables } from 'types/graphql'
+
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypedDocumentNode,
+} from '@redwoodjs/web'
+
 // highlight-next-line
 import Comment from 'src/components/Comment'
 
-import type { CommentsQuery } from 'types/graphql'
-import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
-
-export const QUERY = gql`
-  query CommentsQuery {
-    comments {
-      id
-      // highlight-start
-      name
-      body
-      createdAt
-      // highlight-end
+export const QUERY: TypedDocumentNode<CommentsQuery, CommentsQueryVariables> =
+  gql`
+    query CommentsQuery {
+      comments {
+        id
+        // highlight-start
+        name
+        body
+        createdAt
+        // highlight-end
+      }
     }
-  }
-`
+  `
 
 export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<CommentsQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error.message}</div>
 )
 
-export const Success = ({ comments }: CellSuccessProps<CommentsQuery>) => {
+export const Success = ({
+  comments,
+}: CellSuccessProps<CommentsQuery, CommentsQueryVariables>) => {
   return (
     // highlight-start
     <>
@@ -214,7 +224,9 @@ export const Success = ({ comments }) => {
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/CommentsCell/CommentsCell.tsx"
-export const Success = ({ comments }) => {
+export const Success = ({
+  comments,
+}: CellSuccessProps<CommentsQuery, CommentsQueryVariables>) => {
   return (
     // highlight-next-line
     <div className="space-y-8">

--- a/docs/docs/tutorial/chapter7/rbac.md
+++ b/docs/docs/tutorial/chapter7/rbac.md
@@ -86,7 +86,7 @@ export const getCurrentUser = async (session) => {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```javascript title="api/src/lib/auth.ts"
+```typescript title="api/src/lib/auth.ts"
 export const getCurrentUser = async (session) => {
   return await db.user.findUnique({
     where: { id: session.id },
@@ -494,19 +494,25 @@ export default Comment
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/Comment/Comment.tsx"
-// highlight-next-line
+// highlight-start
+import type {
+  Comment as IComment,
+  DeleteCommentMutation,
+  DeleteCommentMutationVariables,
+} from 'types/graphql'
+
+import type { TypedDocumentNode } from '@redwoodjs/web'
 import { useMutation } from '@redwoodjs/web'
 
+import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
+// highlight-end
 import { useAuth } from 'src/auth'
 
-// highlight-next-line
-import { QUERY as CommentsQuery } from 'src/components/CommentsCell'
-
-// highlight-next-line
-import type { Comment as IComment } from 'types/graphql'
-
 // highlight-start
-const DELETE = gql`
+const DELETE: TypedDocumentNode<
+  DeleteCommentMutation,
+  DeleteCommentMutationVariables
+> = gql`
   mutation DeleteCommentMutation($id: Int!) {
     deleteComment(id: $id) {
       postId
@@ -583,8 +589,6 @@ We'll also need to update the `CommentsQuery` we're importing from `CommentsCell
 <TabItem value="js" label="JavaScript">
 
 ```jsx title="web/src/components/CommentsCell/CommentsCell.jsx"
-import Comment from 'src/components/Comment'
-
 export const QUERY = gql`
   query CommentsQuery($postId: Int!) {
     comments(postId: $postId) {
@@ -603,20 +607,20 @@ export const QUERY = gql`
 <TabItem value="ts" label="TypeScript">
 
 ```tsx title="web/src/components/CommentsCell/CommentsCell.tsx"
-import Comment from 'src/components/Comment'
-
-export const QUERY = gql`
-  query CommentsQuery($postId: Int!) {
-    comments(postId: $postId) {
-      id
-      name
-      body
-      // highlight-next-line
-      postId
-      createdAt
+//
+export const QUERY: TypedDocumentNode<CommentsQuery, CommentsQueryVariables> =
+  gql`
+    query CommentsQuery($postId: Int!) {
+      comments(postId: $postId) {
+        id
+        name
+        body
+        // highlight-next-line
+        postId
+        createdAt
+      }
     }
-  }
-`
+  `
 ```
 
 </TabItem>

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -926,11 +926,13 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({ error }: CellFailureProps<MembersQueryVariables>) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ members }: CellSuccessProps<MembersQuery>) => {
+export const Success = ({
+  members,
+}: CellSuccessProps<MembersQuery, MembersQueryVariables>) => {
   return (
     <ul>
       {members.map((item) => {

--- a/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
+++ b/packages/cli/src/commands/generate/cell/templates/cellList.tsx.template
@@ -21,11 +21,15 @@ export const Loading = () => <div>Loading...</div>
 
 export const Empty = () => <div>Empty</div>
 
-export const Failure = ({ error }: CellFailureProps) => (
+export const Failure = ({
+  error,
+}: CellFailureProps<${operationName}Variables>) => (
   <div style={{ color: 'red' }}>Error: {error?.message}</div>
 )
 
-export const Success = ({ ${camelName} }: CellSuccessProps<${operationName}>) => {
+export const Success = ({
+  ${camelName},
+}: CellSuccessProps<${operationName}, ${operationName}Variables>) => {
   return (
     <ul>
       {${camelName}.map((item) => {

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -51,7 +51,7 @@ export type CellProps<
     CellPropsVariables<CellType, GQLVariables>
 >
 
-type InputVarProps<T> = T extends { [key: string]: never; } ? unknown : T
+type InputVarProps<T> = T extends { [key: string]: never } ? unknown : T
 
 export type CellLoadingProps<TVariables extends OperationVariables = any> = {
   queryResult?:
@@ -175,7 +175,7 @@ export interface CreateCellProps<CellProps, CellVariables> {
     response: DataObject,
     options: {
       isDataEmpty: (data: DataObject) => boolean
-    }
+    },
   ) => boolean
   /**
    * If the query's in flight and there's no stale data, render this.

--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -51,11 +51,13 @@ export type CellProps<
     CellPropsVariables<CellType, GQLVariables>
 >
 
+type InputVarProps<T> = T extends { [key: string]: never; } ? unknown : T
+
 export type CellLoadingProps<TVariables extends OperationVariables = any> = {
   queryResult?:
     | NonSuspenseCellQueryResult<TVariables, any>
     | SuspenseCellQueryResult
-} & TVariables
+} & InputVarProps<TVariables>
 
 export type CellFailureProps<TVariables extends OperationVariables = any> = {
   queryResult?:
@@ -68,7 +70,7 @@ export type CellFailureProps<TVariables extends OperationVariables = any> = {
    */
   errorCode?: string
   updating?: boolean
-} & TVariables
+} & InputVarProps<TVariables>
 
 // aka guarantee that all properties in T exist
 type Guaranteed<T> = {
@@ -114,7 +116,7 @@ export type CellSuccessProps<
     | NonSuspenseCellQueryResult<TVariables, TData>
     | SuspenseCellQueryResult
   updating?: boolean
-} & TVariables &
+} & InputVarProps<TVariables> &
   // pre-computing makes the types more readable on hover
   A.Compute<CellSuccessData<TData>>
 
@@ -173,7 +175,7 @@ export interface CreateCellProps<CellProps, CellVariables> {
     response: DataObject,
     options: {
       isDataEmpty: (data: DataObject) => boolean
-    },
+    }
   ) => boolean
   /**
    * If the query's in flight and there's no stale data, render this.


### PR DESCRIPTION
Although list cells in the simpler examples don't have input variables, they *will* very well have them in more advanced apps (i.e. only selecting the items that belong to a certain user or given other constraints), so it good to have these input vars available for autocompletion out of the box.

- Adds to #5343 (updating all docs to reflect QUERY annotation with `TypedDocumentNode`)
- adds to in https://github.com/redwoodjs/redwood/pull/11737, as i realized these now have to be passed in order for the types to still work.
- Updated documentation for new generated …QueryVariables generic on Failure and Success components
- docs: fixed some tsx highlighting blocks
- docs: fixed import order to reflect Eslint rules since RW 2  
