### PR TITLE
fix(cli): Fix Cell test generation for list cells

### DIFF
--- a/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPostsCell/BlogPostsCell.test.tsx
@@ -24,7 +24,7 @@ describe('BlogPostsCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure id={42} error={new Error('Oh no')} />)
+      render(<Failure error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -36,7 +36,7 @@ describe('BlogPostsCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success id={42} blogPosts={standard().blogPosts} />)
+      render(<Success blogPosts={standard().blogPosts} />)
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
+++ b/packages/cli/src/commands/generate/cell/__tests__/__snapshots__/cell.test.js.snap
@@ -166,7 +166,7 @@ describe('CustomIdFieldsCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure uuid={'42'} error={new Error('Oh no')} />)
+      render(<Failure error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -178,7 +178,7 @@ describe('CustomIdFieldsCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success uuid={'42'} customIdFields={standard().customIdFields} />)
+      render(<Success customIdFields={standard().customIdFields} />)
     }).not.toThrow()
   })
 })
@@ -1232,7 +1232,7 @@ describe('AddressesCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure id={'42'} error={new Error('Oh no')} />)
+      render(<Failure error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -1244,7 +1244,7 @@ describe('AddressesCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success id={'42'} addresses={standard().addresses} />)
+      render(<Success addresses={standard().addresses} />)
     }).not.toThrow()
   })
 })
@@ -1365,7 +1365,7 @@ describe('MembersCell', () => {
 
   it('renders Failure successfully', async () => {
     expect(() => {
-      render(<Failure id={42} error={new Error('Oh no')} />)
+      render(<Failure error={new Error('Oh no')} />)
     }).not.toThrow()
   })
 
@@ -1377,7 +1377,7 @@ describe('MembersCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success id={42} members={standard().members} />)
+      render(<Success members={standard().members} />)
     }).not.toThrow()
   })
 })

--- a/packages/cli/src/commands/generate/cell/cell.js
+++ b/packages/cli/src/commands/generate/cell/cell.js
@@ -101,8 +101,8 @@ export const files = async ({ name, typescript, ...options }) => {
     generator: 'cell',
     templatePath: 'test.js.template',
     templateVars: {
-      idName,
-      mockIdValues,
+      idName: shouldGenerateList ? undefined : idName,
+      mockIdValues: shouldGenerateList ? undefined : mockIdValues,
     },
   })
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/redwoodjs/redwood/pull/11749

Only tests for cells that fetches a unique item should have an `id` field, not cells that fetches all the things