### PR TITLE
[TS/chore] Migrate deprecated apollo `QueryReference` type in cellTypes.ts

### DIFF
--- a/packages/web/src/components/cell/cellTypes.ts
+++ b/packages/web/src/components/cell/cellTypes.ts
@@ -4,7 +4,7 @@ import type {
   ApolloClient,
   NetworkStatus,
   OperationVariables,
-  QueryReference,
+  QueryRef,
   UseBackgroundQueryResult,
 } from '@apollo/client'
 import type { DocumentNode } from 'graphql'
@@ -200,7 +200,7 @@ export interface CreateCellProps<CellProps, CellVariables> {
 export type SuspendingSuccessProps = React.PropsWithChildren<
   Record<string, unknown>
 > & {
-  queryRef: QueryReference<DataObject> // from useBackgroundQuery
+  queryRef: QueryRef<DataObject> // from useBackgroundQuery
   suspenseQueryResult: SuspenseCellQueryResult<DataObject, any>
   userProps: Record<string, any> // we don't really care about the types here, we are just forwarding on
 }


### PR DESCRIPTION
Just a tiny PR to get rid of a tiny deprecation warning :smiley: 

![grafik](https://github.com/user-attachments/assets/53823b35-c661-43cc-802a-b991b0a6e132)
