### PR TITLE
Fix `useEffect is not defined` in i18n template

### DIFF
--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
@@ -31,7 +31,7 @@ export const globalTypes: GlobalTypes = {
  */
 const withI18n = (StoryFn: StoryFn, context: StoryContext) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  useEffect(() => {
+  React.useEffect(() => {
     i18n.changeLanguage(context.globals.locale)
   }, [context.globals.locale])
 


### PR DESCRIPTION
Just realized there was an out-of-scope change in https://github.com/redwoodjs/redwood/commit/455bae82e9040ee5dcdde0209ba183abe6dd146b#diff-7bf7fd2335d6beea7dfeeca1b8d1898bdbd26324d5576d05b61d77e87b6a8439R34 (#11745) that broke this template:

![grafik](https://github.com/user-attachments/assets/f28cac75-8ba9-4b80-b3db-7de980b67093)

![grafik](https://github.com/user-attachments/assets/004d3c06-9172-4a2a-94eb-d578dd490f88)

This PR fixes the mess ;)

Hence, no changeset needed i guess.