### PR TITLE
Remove extraneous `i18n` dependency from i18n setup

### DIFF
--- a/packages/cli/src/commands/setup/i18n/i18nHandler.js
+++ b/packages/cli/src/commands/setup/i18n/i18nHandler.js
@@ -54,7 +54,6 @@ export const handler = async ({ force }) => {
                     'workspace',
                     'web',
                     'add',
-                    'i18n',
                     'i18next',
                     'react-i18next',
                     'i18next-browser-languagedetector',


### PR DESCRIPTION
I upgraded the i18n-next stack in our Redwood application today and dug a little through the transitive dependencies.

It appears that [`i18n`](https://www.npmjs.com/package/i18n) is not a very actively maintained package that is still in pre-v1.

Neither `i18next`, nor `react-i18next` or `i18next-browser-languagedetector` depend on it.

Hence it can be safely removed tidying up your dependency tree a bit.