### PR TITLE
chore(prettier): Ignore a few docs pages because of prettier issue

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,10 @@
 /docs/build
 /docs/versioned_docs
 /docs/versioned_sidebars
+# https://github.com/prettier/prettier/issues/16952
+/docs/docs/how-to/pagination.md
+/docs/docs/tutorial/chapter2/routing-params.md
+/docs/docs/tutorial/chapter6/comment-form.md
 
 # Ignore the .nx directory
 /.nx


### PR DESCRIPTION
Prettier would mess these files up when applying its formatting, leading to broken code samples in our documentation.

I think this might be a prettier issue, so I filed a report: https://github.com/prettier/prettier/issues/16952