### PR TITLE
chore(deps): Bump systeminformation from 5.23.5 to 5.23.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,7 @@
     "semver": "7.6.3",
     "smol-toml": "1.3.1",
     "string-env-interpolation": "1.0.1",
-    "systeminformation": "5.23.5",
+    "systeminformation": "5.23.8",
     "terminal-link": "2.1.1",
     "title-case": "3.0.3",
     "uuid": "10.0.0",

--- a/packages/create-redwood-app/package.json
+++ b/packages/create-redwood-app/package.json
@@ -42,7 +42,7 @@
     "fs-extra": "11.2.0",
     "klaw-sync": "6.0.0",
     "semver": "7.6.3",
-    "systeminformation": "5.23.5",
+    "systeminformation": "5.23.8",
     "terminal-link": "2.1.1",
     "tsx": "4.19.1",
     "untildify": "4.0.0",

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -109,7 +109,7 @@
     "rimraf": "6.0.1",
     "source-map": "0.7.4",
     "string-env-interpolation": "1.0.1",
-    "systeminformation": "5.23.5",
+    "systeminformation": "5.23.8",
     "terminal-link": "2.1.1",
     "ts-node": "10.9.2",
     "typescript": "5.6.2"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -26,7 +26,7 @@
     "@whatwg-node/fetch": "0.9.21",
     "ci-info": "4.0.0",
     "envinfo": "7.14.0",
-    "systeminformation": "5.23.5",
+    "systeminformation": "5.23.8",
     "uuid": "10.0.0",
     "yargs": "17.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,7 +8496,7 @@ __metadata:
     rimraf: "npm:6.0.1"
     source-map: "npm:0.7.4"
     string-env-interpolation: "npm:1.0.1"
-    systeminformation: "npm:5.23.5"
+    systeminformation: "npm:5.23.8"
     terminal-link: "npm:2.1.1"
     ts-node: "npm:10.9.2"
     tsx: "npm:4.19.1"
@@ -8850,7 +8850,7 @@ __metadata:
     "@whatwg-node/fetch": "npm:0.9.21"
     ci-info: "npm:4.0.0"
     envinfo: "npm:7.14.0"
-    systeminformation: "npm:5.23.5"
+    systeminformation: "npm:5.23.8"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
     uuid: "npm:10.0.0"
@@ -14898,7 +14898,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     klaw-sync: "npm:6.0.0"
     semver: "npm:7.6.3"
-    systeminformation: "npm:5.23.5"
+    systeminformation: "npm:5.23.8"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.19.1"
     untildify: "npm:4.0.0"
@@ -28371,16 +28371,6 @@ __metadata:
     "@pkgr/core": "npm:^0.1.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/d8b89e1bf30ba3ffb469d8418c836ad9c0c062bf47028406b4d06548bc66af97155ea2303b96c93bf5c7c0f0d66153a6fbd6924c76521b434e6a9898982abc2e
-  languageName: node
-  linkType: hard
-
-"systeminformation@npm:5.23.5":
-  version: 5.23.5
-  resolution: "systeminformation@npm:5.23.5"
-  bin:
-    systeminformation: lib/cli.js
-  checksum: 10c0/849283b2886c46ff5e79594e939c87202b5283b8aa16cd0d665c595781dba51913060728bae95b94837b78c3a515a0f00ab0a0471604990c5c778f555bd075ea
-  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8171,7 +8171,7 @@ __metadata:
     semver: "npm:7.6.3"
     smol-toml: "npm:1.3.1"
     string-env-interpolation: "npm:1.0.1"
-    systeminformation: "npm:5.23.5"
+    systeminformation: "npm:5.23.8"
     terminal-link: "npm:2.1.1"
     title-case: "npm:3.0.3"
     tsx: "npm:4.19.1"
@@ -28380,6 +28380,16 @@ __metadata:
   bin:
     systeminformation: lib/cli.js
   checksum: 10c0/849283b2886c46ff5e79594e939c87202b5283b8aa16cd0d665c595781dba51913060728bae95b94837b78c3a515a0f00ab0a0471604990c5c778f555bd075ea
+  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
+  languageName: node
+  linkType: hard
+
+"systeminformation@npm:5.23.8":
+  version: 5.23.8
+  resolution: "systeminformation@npm:5.23.8"
+  bin:
+    systeminformation: lib/cli.js
+  checksum: 10c0/d4d750d82345081a6a12200ec8f559ff65a8c28d9797d4368c246682ee02131ee08a4227e4401b6680839f0f0e1a72758071fd84eae2f0584a89e948d583703f
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Changes between 5.23.5 and 5.23.8

<ul>
<li><a href="https://github.com/sebhildebrandt/systeminformation/commit/5a1bdd7e83e27e2d5f16cee2640355dc91bbed79"><code>5a1bdd7</code></a> 5.23.8</li>
<li><a href="https://github.com/sebhildebrandt/systeminformation/commit/dc6474fe846a59fd2d1b67360237229b6072fe5c"><code>dc6474f</code></a> system() added Raspberry 500 detection</li>
<li><a href="https://github.com/sebhildebrandt/systeminformation/commit/efcb478420c3336944690d2f2cffd8ad8270e416"><code>efcb478</code></a> 5.23.7</li>
<li><a href="https://github.com/sebhildebrandt/systeminformation/commit/f7af0a67b78e7894335a6cad510566a25e06ae41"><code>f7af0a6</code></a> networkInterfaces() sanitizing SSID names (windows)</li>
<li><a href="https://github.com/sebhildebrandt/systeminformation/commit/51c7698b91789e00d2308c9f95249ca3bb27a176"><code>51c7698</code></a> 5.23.6</li>
<li><a href="https://github.com/sebhildebrandt/systeminformation/commit/56032602df58d4b34d1b7743eae2a77fe2979bba"><code>5603260</code></a> system() added Raspberry CM5 detection</li>
<li>See full diff in <a href="https://github.com/sebhildebrandt/systeminformation/compare/v5.23.5...v5.23.8">compare view</a></li>
</ul>