### PR TITLE
chore(deps): Bump memfs from 4.13.0 to 4.15.1

### DIFF
--- a/packages/auth-providers/supertokens/setup/package.json
+++ b/packages/auth-providers/supertokens/setup/package.json
@@ -46,7 +46,7 @@
     "@redwoodjs/framework-tools": "workspace:*",
     "@types/yargs": "17.0.33",
     "concurrently": "8.2.2",
-    "memfs": "4.13.0",
+    "memfs": "4.15.1",
     "publint": "0.2.11",
     "tsx": "4.19.1",
     "typescript": "5.6.2",

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -41,7 +41,7 @@
     "@types/fs-extra": "11.0.4",
     "@types/yargs": "17.0.33",
     "jest": "29.7.0",
-    "memfs": "4.13.0",
+    "memfs": "4.15.1",
     "tsx": "4.19.1",
     "typescript": "5.6.2"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,7 +86,7 @@
     "@babel/cli": "7.25.7",
     "@babel/core": "^7.22.20",
     "@types/archiver": "^6",
-    "memfs": "4.13.0",
+    "memfs": "4.15.1",
     "tsx": "4.19.1",
     "typescript": "5.6.2",
     "vitest": "2.0.5"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -103,7 +103,7 @@
     "@types/yargs-parser": "21.0.3",
     "concurrently": "8.2.2",
     "glob": "11.0.0",
-    "memfs": "4.13.0",
+    "memfs": "4.15.1",
     "publint": "0.2.11",
     "rollup": "4.24.0",
     "tsx": "4.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7951,7 +7951,7 @@ __metadata:
     "@redwoodjs/framework-tools": "workspace:*"
     "@types/yargs": "npm:17.0.33"
     concurrently: "npm:8.2.2"
-    memfs: "npm:4.13.0"
+    memfs: "npm:4.15.1"
     publint: "npm:0.2.11"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
@@ -8049,7 +8049,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     jest: "npm:29.7.0"
     listr2: "npm:6.6.1"
-    memfs: "npm:4.13.0"
+    memfs: "npm:4.15.1"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.19.1"
     typescript: "npm:5.6.2"
@@ -8160,7 +8160,7 @@ __metadata:
     latest-version: "npm:5.1.0"
     listr2: "npm:6.6.1"
     lodash: "npm:4.17.21"
-    memfs: "npm:4.13.0"
+    memfs: "npm:4.15.1"
     pascalcase: "npm:1.0.0"
     pluralize: "npm:8.0.0"
     portfinder: "npm:1.0.32"
@@ -8950,7 +8950,7 @@ __metadata:
     glob: "npm:11.0.0"
     http-proxy-middleware: "npm:3.0.3"
     isbot: "npm:5.1.17"
-    memfs: "npm:4.13.0"
+    memfs: "npm:4.15.1"
     publint: "npm:0.2.11"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     react-server-dom-webpack: "npm:19.0.0-rc-f2df5694-20240916"
@@ -22498,15 +22498,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memfs@npm:4.13.0":
-  version: 4.13.0
-  resolution: "memfs@npm:4.13.0"
+"memfs@npm:4.15.1":
+  version: 4.15.1
+  resolution: "memfs@npm:4.15.1"
   dependencies:
     "@jsonjoy.com/json-pack": "npm:^1.0.3"
     "@jsonjoy.com/util": "npm:^1.3.0"
     tree-dump: "npm:^1.0.1"
     tslib: "npm:^2.0.0"
-  checksum: 10c0/b0cb47cefdafc8e84ced864a24654dc83d57b4019a2cef3fe8f0cb0f841da95d5f46bf5149d88fa41b8af05841c392776def801e1d293ecc4cbaf087244cbd12
+  checksum: 10c0/9afcf2c491374ffcd12f57aaf4773d40b0372806824eed260280db2404987d949ce81887ec2ae1346b8e11b613f6553ceef57ef2f5eaf91f0762670ec43ee0de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Commits since 4.13.0

* support stream as source in promises version of writeFile (https://github.com/streamich/memfs/issues/1069) ([11f8a36](https://github.com/streamich/memfs/commit/11f8a36d3a8daefe16ac8e7912743a60c47158a6))
* accept passing a FileHandle to createReadStream and createWriteStream (https://github.com/streamich/memfs/issues/1077) ([af163dc](https://github.com/streamich/memfs/commit/af163dc4fa198b022c631b02fca10445c37ca82e))
* implement createReadStream and createWriteStream on FileHandle (https://github.com/streamich/memfs/issues/1076) ([c413df5](https://github.com/streamich/memfs/commit/c413df5e3e151e446a944a8fba5cc02db46937a0)), closes https://github.com/streamich/memfs/issues/1063
* resolve relative symlinks to the current directory (https://github.com/streamich/memfs/issues/1079) ([63e3873](https://github.com/streamich/memfs/commit/63e38735fe08b728da02b9328d16be4d132b9327)), closes https://github.com/streamich/memfs/issues/725