### PR TITLE
fix(babel-config): Specify 'target' for the react compiler plugin

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -43,12 +43,7 @@ export const getWebSideBabelPlugins = (
 
   const plugins = [
     // It is important that this plugin run first, as noted here: https://react.dev/learn/react-compiler
-    useReactCompiler && [
-      'babel-plugin-react-compiler',
-      {
-        // No specific config at this time...
-      },
-    ],
+    useReactCompiler && ['babel-plugin-react-compiler', { target: 19 }],
     // === Import path handling
     [
       'babel-plugin-module-resolver',


### PR DESCRIPTION
The docs (https://react.dev/learn/react-compiler) have `target` specified. And the Vite react plugin we're using also mention the `target` config in their [changelog for v4.3.3](https://github.com/vitejs/vite-plugin-react/blob/HEAD/packages/plugin-react/CHANGELOG.md#433-2024-10-19), so I figured we better add it