### PR TITLE
[setup i18n storybook] Use function with capitalized name to comply with eslint-rule

### DIFF
--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
@@ -22,9 +22,9 @@ export const globalTypes: GlobalTypes = {
 }
 
 /**
- * @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} 
+ * @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator}
  */
-const withI18n = function WithI18n (Story: StoryFn, context: StoryContext) {
+const withI18n = function WithI18n(Story: StoryFn, context: StoryContext) {
   React.useEffect(() => {
     i18n.changeLanguage(context.globals.locale)
   }, [context.globals.locale])
@@ -36,8 +36,8 @@ const withI18n = function WithI18n (Story: StoryFn, context: StoryContext) {
   )
 }
 
-const preview: Preview = { 
-  decorators: [withI18n]
+const preview: Preview = {
+  decorators: [withI18n],
 }
 
 export default preview

--- a/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
+++ b/packages/cli/src/commands/setup/i18n/templates/storybook.preview.tsx.template
@@ -22,22 +22,16 @@ export const globalTypes: GlobalTypes = {
 }
 
 /**
- * We're following Storybook's naming convention here. See for example
- * https://github.com/storybookjs/addon-kit/blob/main/src/withGlobals.ts
- * Unfortunately that will make eslint complain, so we have to disable it when
- * using a hook below
- *
  * @see {@link https://storybook.js.org/docs/7/essentials/toolbars-and-globals#create-a-decorator | Create a decorator} 
  */
-const withI18n = (StoryFn: StoryFn, context: StoryContext) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+const withI18n = function WithI18n (Story: StoryFn, context: StoryContext) {
   React.useEffect(() => {
     i18n.changeLanguage(context.globals.locale)
   }, [context.globals.locale])
 
   return (
     <I18nextProvider i18n={i18n}>
-      <StoryFn />
+      <Story />
     </I18nextProvider>
   )
 }


### PR DESCRIPTION
Much nicer and shorter, as it doesn't require to disable an `eslint-disable-*`-annotation (for a rule that is actually not broken here).

Using a named function is a common pattern in storybook to comply with `react-hooks/rules-of-hooks`, for instance also when [using hooks in a render method](https://storybook.js.org/docs/writing-stories/args#setting-args-from-within-a-story): 

> To avoid linting issues, it is recommended to use a function with a capitalized name.
> If you are not concerned with linting, you may use an arrow function.

