### PR TITLE
chore(cookie-jar): Add test script and a few more tests

### DIFF
--- a/packages/cookie-jar/package.json
+++ b/packages/cookie-jar/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "build": "tsx ./build.mts && run build:types",
     "build:pack": "yarn pack -o redwoodjs-cookie-jar.tgz",
-    "build:types": "tsc --build --verbose"
+    "build:types": "tsc --build --verbose",
+    "test": "vitest run"
   },
   "dependencies": {
     "cookie": "0.7.2",
@@ -31,7 +32,8 @@
     "@redwoodjs/framework-tools": "workspace:*",
     "@types/fs-extra": "11.0.4",
     "tsx": "4.19.2",
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "vitest": "2.0.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cookie-jar/src/CookieJar.test.ts
+++ b/packages/cookie-jar/src/CookieJar.test.ts
@@ -24,6 +24,27 @@ describe('CookieJar', () => {
     expect(cookieJar.get('tz')).toStrictEqual('Asia/Bangkok')
   })
 
+  test('instatiation behavior with invalid string', () => {
+    expect(new CookieJar('; session').get('foo')).toBeUndefined()
+    expect(new CookieJar('; session').get('session')).toBeUndefined()
+    expect(new CookieJar('session').get('session')).toBeUndefined()
+    expect(new CookieJar('; session=woof-1234').get('session')).toEqual(
+      'woof-1234',
+    )
+    expect(new CookieJar('kittens; session=woof-1234').get('session')).toEqual(
+      'woof-1234',
+    )
+    expect(
+      new CookieJar('kittens; session=woof-1234').get('kittens'),
+    ).toBeUndefined()
+    expect(
+      new CookieJar('kittens; session=woof-1234; foo').get('foo'),
+    ).toBeUndefined()
+    expect(
+      new CookieJar('kittens; session=woof-1234; foo=').get('foo'),
+    ).toEqual('')
+  })
+
   test('getWithOptions', () => {
     const jar = new CookieJar()
     jar.set('kittens', 'soft', { path: '/bazinga' })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8345,6 +8345,7 @@ __metadata:
     fs-extra: "npm:11.2.0"
     tsx: "npm:4.19.2"
     typescript: "npm:5.6.2"
+    vitest: "npm:2.0.5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The `@redwoodjs/cookie-jar` package was missing a "test" script (i.e. `"test": "vitest run"` in its `package.json`)

I also added a few more tests for the CookieJar constructor