### PR TITLE
[chore] Use framer-motion @^11 instead of @^9 for Chakra UI setup

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
+++ b/packages/cli/src/commands/setup/ui/libraries/chakra-ui.js
@@ -48,7 +48,7 @@ export async function handler({ force, install }) {
     '@chakra-ui/react@^2',
     '@emotion/react@^11',
     '@emotion/styled@^11',
-    'framer-motion@^9',
+    'framer-motion@^11',
   ]
 
   const tasks = new Listr(


### PR DESCRIPTION
This is actually the version that the install command at https://v2.chakra-ui.com/getting-started will resolve to … and i can confirm it works like a charm with chakra ui version 2 in our own project.