### PR TITLE
[dev server] Remove extraneous whitespace in dev server's nodemon command

### DIFF
--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -184,7 +184,7 @@ export const handler = async ({
         `--watch "${redwoodConfigPath}"`,
         '--exec "yarn rw-api-server-watch',
         `--port ${apiAvailablePort}`,
-        `${getApiDebugFlag()}`,
+        getApiDebugFlag(),
         '| rw-log-formatter"',
       ].join(' '),
       env: {

--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -180,12 +180,12 @@ export const handler = async ({
       name: 'api',
       command: [
         'yarn nodemon',
-        '  --quiet',
-        `  --watch "${redwoodConfigPath}"`,
-        '  --exec "yarn rw-api-server-watch',
-        `    --port ${apiAvailablePort}`,
-        `    ${getApiDebugFlag()}`,
-        '    | rw-log-formatter"',
+        '--quiet',
+        `--watch "${redwoodConfigPath}"`,
+        '--exec "yarn rw-api-server-watch',
+        `--port ${apiAvailablePort}`,
+        `${getApiDebugFlag()}`,
+        '| rw-log-formatter"',
       ].join(' '),
       env: {
         NODE_ENV: 'development',


### PR DESCRIPTION
Just a little thing that had been bugging my eye ever since when stopping the dev server:

![grafik](https://github.com/user-attachments/assets/47318f69-4413-44c4-bcfd-b4aa16356085)

With this PR applied it looks proper:

![grafik](https://github.com/user-attachments/assets/c6de7383-1fca-40c4-b6a4-be11c1e5013e)

