### PR TITLE
fix(forms): Re-export InputFieldProps

### DIFF
--- a/.changesets/11879.md
+++ b/.changesets/11879.md
@@ -1,0 +1,3 @@
+- fix(forms): Re-export InputFieldProps (#11879) by @Tobbe
+
+Makes it possible to import the `InputFieldProps` type from `@redwoodjs/forms`

--- a/packages/forms/src/index.tsx
+++ b/packages/forms/src/index.tsx
@@ -78,6 +78,7 @@ export {
   UrlField,
   WeekField,
 } from './InputComponents'
+export type { InputFieldProps } from './InputComponents'
 export { Label } from './Label'
 export { SelectField } from './SelectField'
 export { ServerErrorsContext } from './ServerErrorsContext'


### PR DESCRIPTION
The `InputFieldProps` type used to be accessible to RW Apps by doing a `dist/` import. But when we switched how we build the forms package for the RW v8 release we forgot to re-export it

Reported here https://community.redwoodjs.com/t/redwood-v8-0-0-upgrade-guide/7250/74?u=tobbe