### PR TITLE
fix(dev): Remove redundant whitespace in cli output

### DIFF
--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -186,7 +186,9 @@ export const handler = async ({
         `    --port ${apiAvailablePort}`,
         `    ${getApiDebugFlag()}`,
         '    | rw-log-formatter"',
-      ].join(' '),
+      ]
+        .join(' ')
+        .replace(/\s+/g, ' '),
       env: {
         NODE_ENV: 'development',
         NODE_OPTIONS: getDevNodeOptions(),


### PR DESCRIPTION
Alternative implementation of https://github.com/redwoodjs/redwood/pull/11875

Remove redundant whitespace in cli cmd output

Before: 
<img width="982" alt="image" src="https://github.com/user-attachments/assets/3a4c644d-bab7-4ea7-8196-57f71b670a5a" />

After:
<img width="986" alt="image" src="https://github.com/user-attachments/assets/6478088e-6aae-4ff4-971d-b1f963d58469" />
