### PR TITLE
feat(dbAuth): Lax SameSite cookie policy

### DIFF
--- a/.changesets/11889.md
+++ b/.changesets/11889.md
@@ -1,0 +1,4 @@
+- feat(dbAuth): Lax SameSite cookie policy (#11889) by @Tobbe
+
+Setting the `SameSite` cookie policy to `Lax` allows users to be immediately
+authenticated when arriving from external domains.

--- a/__fixtures__/fragment-test-project/api/src/functions/auth.ts
+++ b/__fixtures__/fragment-test-project/api/src/functions/auth.ts
@@ -182,7 +182,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development',
 
         // If you need to allow other domains (besides the api side) access to

--- a/__fixtures__/test-project-rsc-kitchen-sink/api/src/functions/auth.ts
+++ b/__fixtures__/test-project-rsc-kitchen-sink/api/src/functions/auth.ts
@@ -187,7 +187,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development',
 
         // If you need to allow other domains (besides the api side) access to

--- a/__fixtures__/test-project/api/src/functions/auth.ts
+++ b/__fixtures__/test-project/api/src/functions/auth.ts
@@ -182,7 +182,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development',
 
         // If you need to allow other domains (besides the api side) access to

--- a/docs/docs/auth/dbauth.md
+++ b/docs/docs/auth/dbauth.md
@@ -319,7 +319,7 @@ cookie: {
   attributes: {
     HttpOnly: true,
     Path: '/',
-    SameSite: 'Strict',
+    SameSite: 'Lax',
     Secure: true,
     // Domain: 'example.com',
   },
@@ -360,7 +360,7 @@ cookie: {
   attributes: {
     HttpOnly: true,
     Path: '/',
-    SameSite: 'Strict',
+    SameSite: 'Lax',
     Secure: process.env.NODE_ENV !== 'development' ? true : false,
     // highlight-next-line
     Domain: 'example.com'
@@ -564,7 +564,7 @@ export const handler = async (event, context) => {
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development' ? true : false,
       },
     },

--- a/docs/docs/cors.md
+++ b/docs/docs/cors.md
@@ -109,7 +109,7 @@ const authHandler = new DbAuthHandler(event, context, {
   cookie: {
     HttpOnly: true,
     Path: '/',
-    SameSite: 'Strict',
+    SameSite: 'Lax',
     Secure: true,
   },
   forgotPassword: forgotPasswordOptions,

--- a/docs/docs/how-to/oauth.md
+++ b/docs/docs/how-to/oauth.md
@@ -636,7 +636,7 @@ const secureCookie = (user) => {
     `Expires=${expires.toUTCString()}`,
     'HttpOnly=true',
     'Path=/',
-    'SameSite=Strict',
+    'SameSite=Lax',
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })
@@ -731,7 +731,7 @@ const secureCookie = (user) => {
     `Expires=${expires.toUTCString()}`,
     'HttpOnly=true',
     'Path=/',
-    'SameSite=Strict',
+    'SameSite=Lax',
     `Secure=${process.env.NODE_ENV !== 'development'}`,
   ]
   const data = JSON.stringify({ id: user.id })

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
@@ -2568,7 +2568,7 @@ describe('dbAuth', () => {
             attributes: {
               Path: '/',
               HttpOnly: true,
-              SameSite: 'Strict',
+              SameSite: 'Lax',
               Secure: true,
               Domain: 'example.com',
             },

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.fetch.test.js
@@ -2580,7 +2580,7 @@ describe('dbAuth', () => {
       expect(attributes.length).toEqual(6)
       expect(attributes[0]).toEqual('Path=/')
       expect(attributes[1]).toEqual('HttpOnly')
-      expect(attributes[2]).toEqual('SameSite=Strict')
+      expect(attributes[2]).toEqual('SameSite=Lax')
       expect(attributes[3]).toEqual('Secure')
       expect(attributes[4]).toEqual('Domain=example.com')
       expect(attributes[5]).toMatch(`Expires=`)

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -2380,7 +2380,7 @@ describe('dbAuth', () => {
       expect(attributes.length).toEqual(6)
       expect(attributes[0]).toEqual('Path=/')
       expect(attributes[1]).toEqual('HttpOnly')
-      expect(attributes[2]).toEqual('SameSite=Strict')
+      expect(attributes[2]).toEqual('SameSite=Lax')
       expect(attributes[3]).toEqual('Secure')
       expect(attributes[4]).toEqual('Domain=example.com')
       expect(attributes[5]).toMatch(`Expires=`)

--- a/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
+++ b/packages/auth-providers/dbAuth/api/src/__tests__/DbAuthHandler.test.js
@@ -2367,7 +2367,7 @@ describe('dbAuth', () => {
             attributes: {
               Path: '/',
               HttpOnly: true,
-              SameSite: 'Strict',
+              SameSite: 'Lax',
               Secure: true,
               Domain: 'example.com',
             },

--- a/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.ts.template
@@ -187,7 +187,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development',
 
         // If you need to allow other domains (besides the api side) access to

--- a/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/auth-providers/dbAuth/setup/src/templates/api/functions/auth.webAuthn.ts.template
@@ -177,7 +177,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development' ? true : false,
 
         // If you need to allow other domains (besides the api side) access to

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.ts.template
@@ -172,7 +172,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development' ? true : false,
 
         // If you need to allow other domains (besides the api side) access to

--- a/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
+++ b/packages/cli-helpers/src/auth/__tests__/fixtures/dbAuthSetup/templates/api/functions/auth.webAuthn.ts.template
@@ -177,7 +177,7 @@ export const handler = async (
       attributes: {
         HttpOnly: true,
         Path: '/',
-        SameSite: 'Strict',
+        SameSite: 'Lax',
         Secure: process.env.NODE_ENV !== 'development' ? true : false,
 
         // If you need to allow other domains (besides the api side) access to

--- a/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
+++ b/tasks/smoke-tests/rsc-kitchen-sink/tests/rsc-kitchen-sink.spec.ts
@@ -268,7 +268,7 @@ test('Retrieving request details in a', async ({ page }) => {
       expires: Math.floor(Date.now() / 1000) + 300, // 5 minutes from now in seconds
       secure: true,
       httpOnly: true,
-      sameSite: 'Strict',
+      sameSite: 'Lax',
     },
   ])
 


### PR DESCRIPTION
Setting the `SameSite` cookie policy to `Lax` allows users to be immediately authenticated when arriving from external domains. 

This is also what Djang and Ruby on Rails has by default.

Here are the Django docs saying it's Lax by default:
https://docs.djangoproject.com/en/5.1/ref/settings/#session-cookie-samesite
Here's the Rails test that asserts that it's Lax by default:
https://github.com/rails/rails/blob/da32425a0864f6da7bdd2a8d3a43027fbfb2a504/railties/test/application/configuration_test.rb#L3352
 