### PR TITLE
fix(templates+docs) Make Storybook links link to correct versions

### DIFF
--- a/__fixtures__/fragment-test-project/web/src/components/Author/Author.stories.tsx
+++ b/__fixtures__/fragment-test-project/web/src/components/Author/Author.stories.tsx
@@ -8,7 +8,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/__fixtures__/fragment-test-project/web/src/components/BlogPost/BlogPost.stories.tsx
+++ b/__fixtures__/fragment-test-project/web/src/components/BlogPost/BlogPost.stories.tsx
@@ -8,7 +8,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/__fixtures__/test-project/web/src/components/Author/Author.stories.tsx
+++ b/__fixtures__/test-project/web/src/components/Author/Author.stories.tsx
@@ -8,7 +8,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/__fixtures__/test-project/web/src/components/BlogPost/BlogPost.stories.tsx
+++ b/__fixtures__/test-project/web/src/components/BlogPost/BlogPost.stories.tsx
@@ -8,7 +8,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/docs/docs/cli-commands.md
+++ b/docs/docs/cli-commands.md
@@ -2126,7 +2126,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/docs/storybook.md
+++ b/docs/docs/storybook.md
@@ -50,4 +50,4 @@ If you've been using Storybook for a while, you might need to take some manual s
 
 If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/7.x/storybook/#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
-If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators
+If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/7/writing-stories/decorators#global-decorators

--- a/docs/versioned_docs/version-1.x/cli-commands.md
+++ b/docs/versioned_docs/version-1.x/cli-commands.md
@@ -1823,7 +1823,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-1.x/storybook.md
+++ b/docs/versioned_docs/version-1.x/storybook.md
@@ -46,7 +46,7 @@ All of these files get merged with Redwood's default configurations, which you c
 
 > Since `storybook.config.js` configures Storybook's server, note that any changes you make require restarting Storybook.
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/6/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -77,7 +77,7 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/6/configure#configure-story-rendering).
 
 ### Configuring the UI with `storybook.manager.js`
 
@@ -88,7 +88,7 @@ For more, see the Storybook docs on [configuring how stories render](https://sto
 > yarn rw storybook --no-manager-cache
 > ```
 
-You can [theme Storybook's UI](https://storybook.js.org/docs/react/configure/theming) by installing two packages and making a few changes to Redwood's initial configuration.
+You can [theme Storybook's UI](https://storybook.js.org/docs/6/configure/user-interface/theming) by installing two packages and making a few changes to Redwood's initial configuration.
 
 From the root of your RedwoodJS project:
 
@@ -107,4 +107,4 @@ addons.setConfig({
 })
 ```
 
-Check out [Storybook's theming quickstart](https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/react/configure/theming#theming-docs).
+Check out [Storybook's theming quickstart](https://storybook.js.org/docs/6/configure/user-interface/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/6/configure/user-interface/theming#theming-docs).

--- a/docs/versioned_docs/version-2.x/cli-commands.md
+++ b/docs/versioned_docs/version-2.x/cli-commands.md
@@ -1842,7 +1842,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-2.x/storybook.md
+++ b/docs/versioned_docs/version-2.x/storybook.md
@@ -46,7 +46,7 @@ All of these files get merged with Redwood's default configurations, which you c
 
 > Since `storybook.config.js` configures Storybook's server, note that any changes you make require restarting Storybook.
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/6/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -77,7 +77,7 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/6/configure#configure-story-rendering).
 
 ### Configuring the UI with `storybook.manager.js`
 
@@ -88,7 +88,7 @@ For more, see the Storybook docs on [configuring how stories render](https://sto
 > yarn rw storybook --no-manager-cache
 > ```
 
-You can [theme Storybook's UI](https://storybook.js.org/docs/react/configure/theming) by installing two packages and making a few changes to Redwood's initial configuration.
+You can [theme Storybook's UI](https://storybook.js.org/docs/6/configure/user-interface/theming) by installing two packages and making a few changes to Redwood's initial configuration.
 
 From the root of your RedwoodJS project:
 
@@ -107,4 +107,4 @@ addons.setConfig({
 })
 ```
 
-Check out [Storybook's theming quickstart](https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/react/configure/theming#theming-docs).
+Check out [Storybook's theming quickstart](https://storybook.js.org/docs/6/configure/user-interface/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/6/configure/user-interface/theming#theming-docs).

--- a/docs/versioned_docs/version-3.x/cli-commands.md
+++ b/docs/versioned_docs/version-3.x/cli-commands.md
@@ -1910,7 +1910,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-3.x/storybook.md
+++ b/docs/versioned_docs/version-3.x/storybook.md
@@ -46,7 +46,7 @@ All of these files get merged with Redwood's default configurations, which you c
 
 > Since `storybook.config.js` configures Storybook's server, note that any changes you make require restarting Storybook.
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/6/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -77,7 +77,7 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/6/configure#configure-story-rendering).
 
 ### Configuring the UI with `storybook.manager.js`
 
@@ -88,7 +88,7 @@ For more, see the Storybook docs on [configuring how stories render](https://sto
 > yarn rw storybook --no-manager-cache
 > ```
 
-You can [theme Storybook's UI](https://storybook.js.org/docs/react/configure/theming) by installing two packages and making a few changes to Redwood's initial configuration.
+You can [theme Storybook's UI](https://storybook.js.org/docs/6/configure/user-interface/theming) by installing two packages and making a few changes to Redwood's initial configuration.
 
 From the root of your RedwoodJS project:
 
@@ -107,4 +107,4 @@ addons.setConfig({
 })
 ```
 
-Check out [Storybook's theming quickstart](https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/react/configure/theming#theming-docs).
+Check out [Storybook's theming quickstart](https://storybook.js.org/docs/6/configure/user-interface/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/6/configure/user-interface/theming#theming-docs).

--- a/docs/versioned_docs/version-4.x/cli-commands.md
+++ b/docs/versioned_docs/version-4.x/cli-commands.md
@@ -1910,7 +1910,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-4.x/storybook.md
+++ b/docs/versioned_docs/version-4.x/storybook.md
@@ -46,7 +46,7 @@ All of these files get merged with Redwood's default configurations, which you c
 
 > Since `storybook.config.js` configures Storybook's server, note that any changes you make require restarting Storybook.
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/6/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -77,7 +77,7 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/6/configure#configure-story-rendering).
 
 ### Configuring the UI with `storybook.manager.js`
 
@@ -88,7 +88,7 @@ For more, see the Storybook docs on [configuring how stories render](https://sto
 > yarn rw storybook --no-manager-cache
 > ```
 
-You can [theme Storybook's UI](https://storybook.js.org/docs/react/configure/theming) by installing two packages and making a few changes to Redwood's initial configuration.
+You can [theme Storybook's UI](https://storybook.js.org/docs/6/configure/user-interface/theming) by installing two packages and making a few changes to Redwood's initial configuration.
 
 From the root of your RedwoodJS project:
 
@@ -107,4 +107,4 @@ addons.setConfig({
 })
 ```
 
-Check out [Storybook's theming quickstart](https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/react/configure/theming#theming-docs).
+Check out [Storybook's theming quickstart](https://storybook.js.org/docs/6/configure/user-interface/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/6/configure/user-interface/theming#theming-docs).

--- a/docs/versioned_docs/version-5.x/cli-commands.md
+++ b/docs/versioned_docs/version-5.x/cli-commands.md
@@ -1930,7 +1930,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-5.x/storybook.md
+++ b/docs/versioned_docs/version-5.x/storybook.md
@@ -46,7 +46,7 @@ All of these files get merged with Redwood's default configurations, which you c
 
 > Since `storybook.config.js` configures Storybook's server, note that any changes you make require restarting Storybook.
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/6/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -77,7 +77,7 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/6/configure#configure-story-rendering).
 
 ### Configuring the UI with `storybook.manager.js`
 
@@ -88,7 +88,7 @@ For more, see the Storybook docs on [configuring how stories render](https://sto
 > yarn rw storybook --no-manager-cache
 > ```
 
-You can [theme Storybook's UI](https://storybook.js.org/docs/react/configure/theming) by installing two packages and making a few changes to Redwood's initial configuration.
+You can [theme Storybook's UI](https://storybook.js.org/docs/6/configure/user-interface/theming) by installing two packages and making a few changes to Redwood's initial configuration.
 
 From the root of your RedwoodJS project:
 
@@ -107,4 +107,4 @@ addons.setConfig({
 })
 ```
 
-Check out [Storybook's theming quickstart](https://storybook.js.org/docs/react/configure/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/react/configure/theming#theming-docs).
+Check out [Storybook's theming quickstart](https://storybook.js.org/docs/6/configure/user-interface/theming#create-a-theme-quickstart) for a guide on creating your own theme. You may also want to export your theme to [re-use it with Storybook Docs](https://storybook.js.org/docs/6/configure/user-interface/theming#theming-docs).

--- a/docs/versioned_docs/version-6.x/cli-commands.md
+++ b/docs/versioned_docs/version-6.x/cli-commands.md
@@ -1982,7 +1982,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/6/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-6.x/storybook.md
+++ b/docs/versioned_docs/version-6.x/storybook.md
@@ -51,7 +51,7 @@ Since `storybook.config.js` configures Storybook's server, changes you make may 
 
 :::
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/6/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -82,4 +82,4 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/6/configure#configure-story-rendering).

--- a/docs/versioned_docs/version-7.x/cli-commands.md
+++ b/docs/versioned_docs/version-7.x/cli-commands.md
@@ -2105,7 +2105,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/7/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-7.x/storybook.md
+++ b/docs/versioned_docs/version-7.x/storybook.md
@@ -51,7 +51,7 @@ Since `storybook.config.js` configures Storybook's server, changes you make may 
 
 :::
 
-While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/react/configure/overview#configure-your-storybook-project) in `storybook.config.js`, you'll probably only want to configure `addons`:
+While you can configure [any of Storybook server's available options](https://storybook.js.org/docs/7/configure) in `storybook.config.js`, you'll probably only want to configure `addons`:
 
 ```javascript title="web/config/storybook.config.js"
 module.exports = {
@@ -82,4 +82,4 @@ export const decorators = [
 ]
 ```
 
-For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
+For more, see the Storybook docs on [configuring how stories render](https://storybook.js.org/docs/7/configure#configure-story-rendering).

--- a/docs/versioned_docs/version-8.0/cli-commands.md
+++ b/docs/versioned_docs/version-8.0/cli-commands.md
@@ -2126,7 +2126,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/7/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-8.0/storybook.md
+++ b/docs/versioned_docs/version-8.0/storybook.md
@@ -13,7 +13,7 @@ You don't have to start the dev server, login as a user, tab through dropdowns, 
 And say goodbye to rendering a whole page and make six GraphQL calls just to change the color of a modal!
 You can set up every component as a story and tweak it within Storybook. And for any [cells](./cells.md), [mocking GraphQL could not be easier!](./how-to/mocking-graphql-in-storybook.md)
 
-RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/configure/integration/frameworks),
+RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/7/configure/integration/frameworks),
 using Vite as its bundler to align with your production project.
 
 An older version of our Storybook integration used Webpack as its bundler — For more information on the differences, see [this forum post](https://community.redwoodjs.com/t/storybook-in-redwood-is-moving-to-vite/7212).
@@ -32,7 +32,7 @@ If this is your first time running Storybook:
 - The Redwood CLI will install Storybook, the framework package, and all related dependencies.
 - The Redwood CLI will create the following config files for you:
   - `web/.storybook/main.ts`
-    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
+    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/7/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
   - `web/.storybook/preview-body.html`
     - This is required to change the `id` of the root div to `redwood-app`, which is what the entry file used by Vite requires.
 
@@ -40,7 +40,7 @@ Once Storybook is all set up, it'll spin up on localhost port `7910` and open yo
 
 ## Configuring Storybook
 
-To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/configure).
+To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/7/configure).
 
 ## Migrating from Storybook Webpack to Storybook Vite
 
@@ -50,4 +50,4 @@ If you've been using Storybook for a while, you might need to take some manual s
 
 If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/storybook#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
-If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators
+If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/7/writing-stories/decorators#global-decorators

--- a/docs/versioned_docs/version-8.1/cli-commands.md
+++ b/docs/versioned_docs/version-8.1/cli-commands.md
@@ -2126,7 +2126,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/7/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-8.1/storybook.md
+++ b/docs/versioned_docs/version-8.1/storybook.md
@@ -13,7 +13,7 @@ You don't have to start the dev server, login as a user, tab through dropdowns, 
 And say goodbye to rendering a whole page and make six GraphQL calls just to change the color of a modal!
 You can set up every component as a story and tweak it within Storybook. And for any [cells](./cells.md), [mocking GraphQL could not be easier!](./how-to/mocking-graphql-in-storybook.md)
 
-RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/configure/integration/frameworks),
+RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/7/configure/integration/frameworks),
 using Vite as its bundler to align with your production project.
 
 An older version of our Storybook integration used Webpack as its bundler — For more information on the differences, see [this forum post](https://community.redwoodjs.com/t/storybook-in-redwood-is-moving-to-vite/7212).
@@ -32,7 +32,7 @@ If this is your first time running Storybook:
 - The Redwood CLI will install Storybook, the framework package, and all related dependencies.
 - The Redwood CLI will create the following config files for you:
   - `web/.storybook/main.ts`
-    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
+    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/7/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
   - `web/.storybook/preview-body.html`
     - This is required to change the `id` of the root div to `redwood-app`, which is what the entry file used by Vite requires.
 
@@ -40,7 +40,7 @@ Once Storybook is all set up, it'll spin up on localhost port `7910` and open yo
 
 ## Configuring Storybook
 
-To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/configure).
+To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/7/configure).
 
 ## Migrating from Storybook Webpack to Storybook Vite
 
@@ -50,4 +50,4 @@ If you've been using Storybook for a while, you might need to take some manual s
 
 If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/storybook#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
-If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators
+If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/7/writing-stories/decorators#global-decorators

--- a/docs/versioned_docs/version-8.2/cli-commands.md
+++ b/docs/versioned_docs/version-8.2/cli-commands.md
@@ -2126,7 +2126,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/7/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-8.2/storybook.md
+++ b/docs/versioned_docs/version-8.2/storybook.md
@@ -13,7 +13,7 @@ You don't have to start the dev server, login as a user, tab through dropdowns, 
 And say goodbye to rendering a whole page and make six GraphQL calls just to change the color of a modal!
 You can set up every component as a story and tweak it within Storybook. And for any [cells](./cells.md), [mocking GraphQL could not be easier!](./how-to/mocking-graphql-in-storybook.md)
 
-RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/configure/integration/frameworks),
+RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/7/configure/integration/frameworks),
 using Vite as its bundler to align with your production project.
 
 An older version of our Storybook integration used Webpack as its bundler — For more information on the differences, see [this forum post](https://community.redwoodjs.com/t/storybook-in-redwood-is-moving-to-vite/7212).
@@ -32,7 +32,7 @@ If this is your first time running Storybook:
 - The Redwood CLI will install Storybook, the framework package, and all related dependencies.
 - The Redwood CLI will create the following config files for you:
   - `web/.storybook/main.ts`
-    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
+    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/7/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
   - `web/.storybook/preview-body.html`
     - This is required to change the `id` of the root div to `redwood-app`, which is what the entry file used by Vite requires.
 
@@ -40,7 +40,7 @@ Once Storybook is all set up, it'll spin up on localhost port `7910` and open yo
 
 ## Configuring Storybook
 
-To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/configure).
+To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/7/configure).
 
 ## Migrating from Storybook Webpack to Storybook Vite
 
@@ -50,4 +50,4 @@ If you've been using Storybook for a while, you might need to take some manual s
 
 If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/storybook#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
-If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators
+If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/7/writing-stories/decorators#global-decorators

--- a/docs/versioned_docs/version-8.3/cli-commands.md
+++ b/docs/versioned_docs/version-8.3/cli-commands.md
@@ -2126,7 +2126,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/7/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-8.3/storybook.md
+++ b/docs/versioned_docs/version-8.3/storybook.md
@@ -13,7 +13,7 @@ You don't have to start the dev server, login as a user, tab through dropdowns, 
 And say goodbye to rendering a whole page and make six GraphQL calls just to change the color of a modal!
 You can set up every component as a story and tweak it within Storybook. And for any [cells](./cells.md), [mocking GraphQL could not be easier!](./how-to/mocking-graphql-in-storybook.md)
 
-RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/configure/integration/frameworks),
+RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/7/configure/integration/frameworks),
 using Vite as its bundler to align with your production project.
 
 An older version of our Storybook integration used Webpack as its bundler — For more information on the differences, see [this forum post](https://community.redwoodjs.com/t/storybook-in-redwood-is-moving-to-vite/7212).
@@ -32,7 +32,7 @@ If this is your first time running Storybook:
 - The Redwood CLI will install Storybook, the framework package, and all related dependencies.
 - The Redwood CLI will create the following config files for you:
   - `web/.storybook/main.ts`
-    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
+    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/7/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
   - `web/.storybook/preview-body.html`
     - This is required to change the `id` of the root div to `redwood-app`, which is what the entry file used by Vite requires.
 
@@ -40,7 +40,7 @@ Once Storybook is all set up, it'll spin up on localhost port `7910` and open yo
 
 ## Configuring Storybook
 
-To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/configure).
+To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/7/configure).
 
 ## Migrating from Storybook Webpack to Storybook Vite
 
@@ -50,4 +50,4 @@ If you've been using Storybook for a while, you might need to take some manual s
 
 If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/storybook#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
-If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators
+If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/7/writing-stories/decorators#global-decorators

--- a/docs/versioned_docs/version-8.4/cli-commands.md
+++ b/docs/versioned_docs/version-8.4/cli-commands.md
@@ -2126,7 +2126,7 @@ Starts Storybook locally
 yarn redwood storybook
 ```
 
-[Storybook](https://storybook.js.org/docs/react/get-started/introduction) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
+[Storybook](https://storybook.js.org/docs/7/get-started/install) is a tool for UI development that allows you to develop your components in isolation, away from all the conflated cruft of your real app.
 
 > "Props in, views out! Make it simple to reason about."
 

--- a/docs/versioned_docs/version-8.4/storybook.md
+++ b/docs/versioned_docs/version-8.4/storybook.md
@@ -13,7 +13,7 @@ You don't have to start the dev server, login as a user, tab through dropdowns, 
 And say goodbye to rendering a whole page and make six GraphQL calls just to change the color of a modal!
 You can set up every component as a story and tweak it within Storybook. And for any [cells](./cells.md), [mocking GraphQL could not be easier!](./how-to/mocking-graphql-in-storybook.md)
 
-RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/configure/integration/frameworks),
+RedwoodJS offers a Storybook integration leveraging Storybook's [Framework Packages](https://storybook.js.org/docs/7/configure/integration/frameworks),
 using Vite as its bundler to align with your production project.
 
 An older version of our Storybook integration used Webpack as its bundler — For more information on the differences, see [this forum post](https://community.redwoodjs.com/t/storybook-in-redwood-is-moving-to-vite/7212).
@@ -32,7 +32,7 @@ If this is your first time running Storybook:
 - The Redwood CLI will install Storybook, the framework package, and all related dependencies.
 - The Redwood CLI will create the following config files for you:
   - `web/.storybook/main.ts`
-    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
+    - This is the primary [Storybook configuration file](https://storybook.js.org/docs/7/configure). Note that it references our framework package, [`storybook-framework-redwoodjs-vite`](https://www.npmjs.com/package/storybook-framework-redwoodjs-vite).
   - `web/.storybook/preview-body.html`
     - This is required to change the `id` of the root div to `redwood-app`, which is what the entry file used by Vite requires.
 
@@ -40,7 +40,7 @@ Once Storybook is all set up, it'll spin up on localhost port `7910` and open yo
 
 ## Configuring Storybook
 
-To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/configure).
+To configure Storybook, please follow [the official Storybook docs](https://storybook.js.org/docs/7/configure).
 
 ## Migrating from Storybook Webpack to Storybook Vite
 
@@ -50,4 +50,4 @@ If you've been using Storybook for a while, you might need to take some manual s
 
 If you don't have any custom [Storybook configuration](https://redwoodjs.com/docs/storybook#configuring-storybook), you should be good to go - no changes needed. The Out of Box experience should be the same, and please [let us know](https://github.com/redwoodjs/redwood/issues/new?assignees=&labels=bug%2Fneeds-info&projects=&template=bug-report.yml&title=%5BBug%5D%3A+) if you run into any issues.
 
-If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/writing-stories/decorators#global-decorators
+If you do have custom Storybook configuration, then you'll need to manually migrate it over to the new files. For example, if you've got any global decorators, you can now just follow the official Storybook docs on that: https://storybook.js.org/docs/7/writing-stories/decorators#global-decorators

--- a/packages/cli/src/commands/generate/component/__tests__/__snapshots__/component.test.ts.snap
+++ b/packages/cli/src/commands/generate/component/__tests__/__snapshots__/component.test.ts.snap
@@ -59,7 +59,7 @@ exports[`creates a multi word component story 1`] = `
 // }
 // \`\`\`
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import UserProfile from './UserProfile'
 
@@ -112,7 +112,7 @@ exports[`creates a single word component story 1`] = `
 // }
 // \`\`\`
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import User from './User'
 

--- a/packages/cli/src/commands/generate/component/templates/stories.jsx.template
+++ b/packages/cli/src/commands/generate/component/templates/stories.jsx.template
@@ -8,7 +8,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import ${pascalName} from './${pascalName}'
 

--- a/packages/cli/src/commands/generate/component/templates/stories.tsx.template
+++ b/packages/cli/src/commands/generate/component/templates/stories.tsx.template
@@ -8,7 +8,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/components/TestComponent/TestComponent.stories.js
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/input/web/src/components/TestComponent/TestComponent.stories.js
@@ -7,7 +7,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import TestComponent from './TestComponent'
 

--- a/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/components/TestComponent/TestComponent.stories.jsx
+++ b/packages/codemods/src/codemods/v6.x.x/convertJsToJsx/__testfixtures__/example/output/web/src/components/TestComponent/TestComponent.stories.jsx
@@ -7,7 +7,7 @@
 // }
 // ```
 //
-// See https://storybook.js.org/docs/react/writing-stories/args.
+// See https://storybook.js.org/docs/7/writing-stories/args
 
 import TestComponent from './TestComponent'
 


### PR DESCRIPTION
This corrects all links pre-RW7 to link to Storybook 6 docs, and all others to Storybook 7 docs.

That also includes a few occurrences in code generators & codemods.