### PR TITLE
[CLI] Refactor & simplify schema helpers

### DIFF
--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -35,8 +35,8 @@ const getExistingModelName = async (name) => {
     }
   }
 
-  const schema = await getSchemaDefinitions()
-  for (let model of schema.datamodel.models) {
+  const schema = (await getSchemaDefinitions()).datamodel
+  for (let model of schema.models) {
     if (model.name.toLowerCase() === modelName) {
       return model.name
     }
@@ -51,8 +51,9 @@ const getExistingModelName = async (name) => {
  * entire schema is returned.
  */
 export const getSchema = async (name) => {
+  const schema = (await getSchemaDefinitions()).datamodel
   if (!name) {
-    return (await getSchemaDefinitions()).datamodel
+    return schema
   }
 
   const modelName = await getExistingModelName(name)
@@ -66,10 +67,7 @@ export const getSchema = async (name) => {
     return schemaMemo[modelName]
   }
 
-  const schema = await getSchemaDefinitions()
-  const model = schema.datamodel.models.find(
-    (model) => model.name === modelName,
-  )
+  const model = schema.models.find((model) => model.name === modelName)
   if (!model) {
     return undefined // can this happen, and if yes, should we prefer throwing an error?
   }
@@ -77,7 +75,7 @@ export const getSchema = async (name) => {
   // look for any fields that are enums and attach the possible enum values
   // so we can put them in generated test files
   model.fields.forEach((field) => {
-    const fieldEnum = schema.datamodel.enums.find((e) => field.type === e.name)
+    const fieldEnum = schema.enums.find((e) => field.type === e.name)
     if (fieldEnum) {
       field.enumValues = fieldEnum.values
     }

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -67,9 +67,9 @@ export const getSchema = async (name) => {
   }
 
   const schema = await getSchemaDefinitions()
-  const model = schema.datamodel.models.find((model) => {
-    return model.name === modelName
-  })
+  const model = schema.datamodel.models.find(
+    (model) => model.name === modelName,
+  )
 
   if (!model) {
     return undefined // can this happen, and if yes, should we prefer throwing an error?
@@ -78,9 +78,7 @@ export const getSchema = async (name) => {
   // look for any fields that are enums and attach the possible enum values
   // so we can put them in generated test files
   model.fields.forEach((field) => {
-    const fieldEnum = schema.datamodel.enums.find((e) => {
-      return field.type === e.name
-    })
+    const fieldEnum = schema.datamodel.enums.find((e) => field.type === e.name)
     if (fieldEnum) {
       field.enumValues = fieldEnum.values
     }
@@ -101,10 +99,7 @@ export const getEnum = async (name) => {
     return schema.metadata.datamodel.enums
   }
 
-  const model = schema.datamodel.enums.find((model) => {
-    return model.name === name
-  })
-
+  const model = schema.datamodel.enums.find((model) => model.name === name)
   if (!model) {
     throw new Error(
       `No enum schema definition found for \`${name}\` in schema.prisma file`,
@@ -131,11 +126,10 @@ export const getSchemaDefinitions = () => {
 /*
  * Returns the config info defined in `schema.prisma` (provider, datasource, etc.)
  */
-export const getSchemaConfig = () => {
-  return getConfig({
+export const getSchemaConfig = () =>
+  getConfig({
     datamodel: getDataModel(),
   })
-}
 
 export async function verifyModelName(options) {
   const modelName =

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -10,14 +10,14 @@ import { singularize, isPlural } from './rwPluralize'
 import { getPaths } from './'
 
 /**
- * Used to memoize results from `getSchema` so we don't have to go through
- * the work of open the file and parsing it from scratch each time getSchema()
+ * Used to memoize results from `getSchema()` so we don't have to go through
+ * the work of opening and parsing the file from scratch each time `getSchema()`
  * is called with the same model name.
  */
 const schemaMemo = {}
 
 /**
- * Searches for the given model (ignoring case) in schema.prisma
+ * Searches for the given model (ignoring case) in `schema.prisma`
  * and returns the name as it is written by the user, or
  * `undefined` if no model could be found
  */
@@ -70,7 +70,6 @@ export const getSchema = async (name) => {
   const model = schema.datamodel.models.find(
     (model) => model.name === modelName,
   )
-
   if (!model) {
     return undefined // can this happen, and if yes, should we prefer throwing an error?
   }
@@ -89,9 +88,9 @@ export const getSchema = async (name) => {
 }
 
 /**
- * Returns the enum defined with the given `name` parsed from
- * the schema.prisma of the target application. If no `name` is given then the
- * all enum definitions are returned
+ * Returns the enum defined with the given `name` parsed from the
+ * `schema.prisma` of the target application. If no `name` is given
+ * then all enum definitions are returned
  */
 export const getEnum = async (name) => {
   const schema = await getSchemaDefinitions()

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -25,10 +25,10 @@ const getExistingModelName = async (name) => {
   if (!name) {
     return undefined
   }
-  // Support PascalCase, camelCase, kebab-case, UPPER_CASE, and lowercase model
-  // names
-  const modelName = name.replace(/[_-]/g, '').toLowerCase()
 
+  // Support PascalCase, camelCase, kebab-case, UPPER_CASE,
+  // and lowercase model names
+  const modelName = name.replace(/[_-]/g, '').toLowerCase()
   for (let model of Object.values(schemaMemo)) {
     if (model.name.toLowerCase() === modelName) {
       return model.name
@@ -36,12 +36,12 @@ const getExistingModelName = async (name) => {
   }
 
   const schema = await getSchemaDefinitions()
-
   for (let model of schema.datamodel.models) {
     if (model.name.toLowerCase() === modelName) {
       return model.name
     }
   }
+
   return undefined
 }
 

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -62,30 +62,32 @@ export const getSchema = async (name) => {
     )
   }
 
-  if (!schemaMemo[modelName]) {
-    const schema = await getSchemaDefinitions()
-    const model = schema.datamodel.models.find((model) => {
-      return model.name === modelName
-    })
-
-    if (model) {
-      // look for any fields that are enums and attach the possible enum values
-      // so we can put them in generated test files
-      model.fields.forEach((field) => {
-        const fieldEnum = schema.datamodel.enums.find((e) => {
-          return field.type === e.name
-        })
-        if (fieldEnum) {
-          field.enumValues = fieldEnum.values
-        }
-      })
-
-      // memoize based on the model name
-      schemaMemo[modelName] = model
-    }
+  if (schemaMemo[modelName]) {
+    return schemaMemo[modelName]
   }
 
-  return schemaMemo[modelName]
+  const schema = await getSchemaDefinitions()
+  const model = schema.datamodel.models.find((model) => {
+    return model.name === modelName
+  })
+
+  if (!model) {
+    return undefined // can this happen, and if yes, should we prefer throwing an error?
+  }
+
+  // look for any fields that are enums and attach the possible enum values
+  // so we can put them in generated test files
+  model.fields.forEach((field) => {
+    const fieldEnum = schema.datamodel.enums.find((e) => {
+      return field.type === e.name
+    })
+    if (fieldEnum) {
+      field.enumValues = fieldEnum.values
+    }
+  })
+
+  // memoize based on the model name
+  return (schemaMemo[modelName] = model)
 }
 
 /**

--- a/packages/cli/src/lib/schemaHelpers.js
+++ b/packages/cli/src/lib/schemaHelpers.js
@@ -52,6 +52,7 @@ const getExistingModelName = async (name) => {
  */
 export const getSchema = async (name) => {
   const schema = (await getSchemaDefinitions()).datamodel
+
   if (!name) {
     return schema
   }
@@ -69,10 +70,11 @@ export const getSchema = async (name) => {
 
   const model = schema.models.find((model) => model.name === modelName)
   if (!model) {
-    return undefined // can this happen, and if yes, should we prefer throwing an error?
+    // TODO: Can this happen, and if yes, should we prefer throwing an error?
+    return undefined
   }
 
-  // look for any fields that are enums and attach the possible enum values
+  // Look for any fields that are enums and attach the possible enum values
   // so we can put them in generated test files
   model.fields.forEach((field) => {
     const fieldEnum = schema.enums.find((e) => field.type === e.name)
@@ -81,8 +83,10 @@ export const getSchema = async (name) => {
     }
   })
 
-  // memoize based on the model name
-  return (schemaMemo[modelName] = model)
+  // Memoize based on the model name
+  schemaMemo[modelName] = model
+
+  return model
 }
 
 /**


### PR DESCRIPTION
While working on another PR i skimmed through this file and recognized some code block that could be written simpler and with less indentation by applying the [early return pattern](https://dev.to/shameel/-clean-coding-tip-early-return-principle-47kj), thus reducing the cognitive complexity required to mentally process the code.

The iterative process of simplifying the code then uncovered a potential `undefined` return value (→ ec50ab8dbd1b2665371801b82e93c1ae14edbc16) in the `getSchema()` method, which i marked with a TODO comment for further consideration.