### PR TITLE
Revert "feat(router): Better autocomplete for `<Set>`s (#11769)"

### DIFF
--- a/.changesets/11769.md
+++ b/.changesets/11769.md
@@ -1,3 +1,0 @@
-- feat(router): Better autocomplete for `<Set>`s (#11769) by @Tobbe
-
-There's a limit to 10 wrapper components. After that additional props will not be included. To work around this you can either make sure to put wrapper components that doesn't require any props last, or just split your wrappers between multiple `<Set>`s

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -3,7 +3,12 @@ import React from 'react'
 
 import type { AvailableRoutes } from '@redwoodjs/router'
 
-type RegularSetProps = {
+type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
+  /**
+   * A react component that the children of the Set will be wrapped
+   * in (typically a Layout component)
+   */
+  wrap?: P
   /**
    *`Routes` nested in a `<Set>` with `private` specified require
    * authentication. When a user is not authenticated and attempts to visit
@@ -18,38 +23,6 @@ type RegularSetProps = {
    * @deprecated Please use `<PrivateSet>` instead and specify this prop there
    */
   unauthenticated?: keyof AvailableRoutes
-}
-
-/**
- * A set containing public `<Route />`s
- */
-export function Set<WrapperProps>(
-  props: CommonSetProps<WrapperProps> & RegularSetProps,
-) {
-  // @MARK: Virtual Component, this is actually never rendered
-  // See analyzeRoutes in utils.tsx, inside the isSetNode block
-  return <>{props.children}</>
-}
-
-type CommonSetProps<P> = (P extends React.FC<any>
-  ? React.ComponentProps<P>
-  : P extends React.FC<any>[]
-    ? React.ComponentProps<P[0]> &
-        React.ComponentProps<P[1]> &
-        React.ComponentProps<P[2]> &
-        React.ComponentProps<P[3]> &
-        React.ComponentProps<P[4]> &
-        React.ComponentProps<P[5]> &
-        React.ComponentProps<P[6]> &
-        React.ComponentProps<P[7]> &
-        React.ComponentProps<P[8]> &
-        React.ComponentProps<P[9]>
-    : unknown) & {
-  /**
-   * A React component, or an array of React components, that the children of
-   * the Set will be wrapped in (typically a Layout component and/or a context)
-   */
-  wrap?: P
   /**
    * Route is permitted when authenticated and user has any of the provided
    * roles such as "admin" or ["admin", "editor"]
@@ -63,13 +36,22 @@ type CommonSetProps<P> = (P extends React.FC<any>
   whileLoadingPage?: () => ReactElement | null
 }
 
+/**
+ * A set containing public `<Route />`s
+ */
+export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
+  // @MARK: Virtual Component, this is actually never rendered
+  // See analyzeRoutes in utils.tsx, inside the isSetNode block
+  return <>{props.children}</>
+}
+
+type PrivateSetProps<P> = Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
+  /** The page name where a user will be redirected when not authenticated */
+  unauthenticated: keyof AvailableRoutes
+}
+
 /** @deprecated Please use `<PrivateSet>` instead */
-export function Private<WrapperProps>(
-  props: CommonSetProps<WrapperProps> & {
-    /** The page name where a user will be redirected when not authenticated */
-    unauthenticated: keyof AvailableRoutes
-  },
-) {
+export function Private<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   // @MARK Virtual Component, this is actually never rendered
   // See analyzeRoutes in utils.tsx, inside the isSetNode block
   return <>{props.children}</>
@@ -78,12 +60,7 @@ export function Private<WrapperProps>(
 /**
  * A set containing private `<Route />`s that require authentication to access
  */
-export function PrivateSet<WrapperProps>(
-  props: CommonSetProps<WrapperProps> & {
-    /** The page name where a user will be redirected when not authenticated */
-    unauthenticated: keyof AvailableRoutes
-  },
-) {
+export function PrivateSet<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   // @MARK Virtual Component, this is actually never rendered
   // See analyzeRoutes in utils.tsx, inside the isSetNode block
   return <>{props.children}</>
@@ -91,7 +68,7 @@ export function PrivateSet<WrapperProps>(
 
 export const isSetNode = (
   node: ReactNode,
-): node is ReactElement<CommonSetProps<any> & RegularSetProps> => {
+): node is ReactElement<SetProps<any>> => {
   return (
     React.isValidElement(node) &&
     (node.type === Set || node.type === PrivateSet || node.type === Private) &&
@@ -102,15 +79,13 @@ export const isSetNode = (
 
 export const isPrivateSetNode = (
   node: ReactNode,
-): node is ReactElement<
-  CommonSetProps<unknown> & { unauthenticated: keyof AvailableRoutes }
-> => {
+): node is ReactElement<PrivateSetProps<unknown>> => {
   return React.isValidElement(node) && node.type === PrivateSet
 }
 
 // Only identifies <Private> nodes, not <Set private> nodes
 export const isPrivateNode = (
   node: ReactNode,
-): node is ReactElement<CommonSetProps<any> & RegularSetProps> => {
+): node is ReactElement<SetProps<any>> => {
   return React.isValidElement(node) && node.type === Private
 }


### PR DESCRIPTION
This reverts commit 9e6b769fb770c1f2fb01910d72c65431c3197b62.

I'm reverting these PRs:

https://github.com/redwoodjs/redwood/pull/11769
https://github.com/redwoodjs/redwood/pull/11768
https://github.com/redwoodjs/redwood/pull/11767
https://github.com/redwoodjs/redwood/pull/11756