### PR TITLE
Revert "fix(set): Correctly infer generic (#11768)"

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -8,7 +8,7 @@ type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
    * A react component that the children of the Set will be wrapped
    * in (typically a Layout component)
    */
-  wrap?: P
+  wrap?: P | P[]
   /**
    *`Routes` nested in a `<Set>` with `private` specified require
    * authentication. When a user is not authenticated and attempts to visit


### PR DESCRIPTION
This reverts commit 8e1644acfeafc57ed2ebcd0f97597773282408cd.

I'm reverting these PRs:

https://github.com/redwoodjs/redwood/pull/11769
https://github.com/redwoodjs/redwood/pull/11768
https://github.com/redwoodjs/redwood/pull/11767
https://github.com/redwoodjs/redwood/pull/11756