### PR TITLE
Revert "chore(set): Use the existing AvailableRoutes type (#11767)"

### DIFF
--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react'
 import React from 'react'
 
-import type { AvailableRoutes } from '@redwoodjs/router'
+import type { routes } from '@redwoodjs/router'
 
 type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
   /**
@@ -22,7 +22,7 @@ type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
    *
    * @deprecated Please use `<PrivateSet>` instead and specify this prop there
    */
-  unauthenticated?: keyof AvailableRoutes
+  unauthenticated?: keyof typeof routes
   /**
    * Route is permitted when authenticated and user has any of the provided
    * roles such as "admin" or ["admin", "editor"]
@@ -47,7 +47,7 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
 
 type PrivateSetProps<P> = Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
   /** The page name where a user will be redirected when not authenticated */
-  unauthenticated: keyof AvailableRoutes
+  unauthenticated: keyof typeof routes
 }
 
 /** @deprecated Please use `<PrivateSet>` instead */


### PR DESCRIPTION
This reverts commit f208c8b97012950b89156e914e01544a6ed1f6f3.

I'm reverting these PRs:

https://github.com/redwoodjs/redwood/pull/11769
https://github.com/redwoodjs/redwood/pull/11768
https://github.com/redwoodjs/redwood/pull/11767
https://github.com/redwoodjs/redwood/pull/11756