### PR TITLE
Revert "[Router][TS] Auto-complete route names for unauthenticated prop (#11756)"

### DIFF
--- a/.changesets/11756.md
+++ b/.changesets/11756.md
@@ -1,8 +1,0 @@
-- [Router][TS] Auto-complete route names for unauthenticated prop (#11756) by @Philzen
-
-- auto-suggests available route names
-- will highlight invalid values
-
-This depends on type generation, so either you'll have to run `yarn rw g types` manually, or you'll have to have the dev server running (which regenerates types when required).
-
-This PR is a little breaking, b/c the `<Set>`s generic typing has changed and also the `WrapperType<P>` type has been removed.

--- a/packages/router/src/Set.tsx
+++ b/packages/router/src/Set.tsx
@@ -1,14 +1,20 @@
 import type { ReactElement, ReactNode } from 'react'
 import React from 'react'
 
-import type { routes } from '@redwoodjs/router'
+export type WrapperType<WTProps> = (
+  props: Omit<WTProps, 'wrap' | 'children'> & {
+    children: ReactNode
+  },
+) => ReactElement | null
 
-type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
+type SetProps<P> = P & {
   /**
-   * A react component that the children of the Set will be wrapped
-   * in (typically a Layout component)
+   * P is the interface for the props that are forwarded to the wrapper
+   * components. TypeScript will most likely infer this for you, but if you
+   * need to you can specify it yourself in your JSX like so:
+   *   <Set<{theme: string}> wrap={ThemableLayout} theme="dark">
    */
-  wrap?: P | P[]
+  wrap?: WrapperType<P> | WrapperType<P>[]
   /**
    *`Routes` nested in a `<Set>` with `private` specified require
    * authentication. When a user is not authenticated and attempts to visit
@@ -22,7 +28,7 @@ type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
    *
    * @deprecated Please use `<PrivateSet>` instead and specify this prop there
    */
-  unauthenticated?: keyof typeof routes
+  unauthenticated?: string
   /**
    * Route is permitted when authenticated and user has any of the provided
    * roles such as "admin" or ["admin", "editor"]
@@ -37,7 +43,10 @@ type SetProps<P> = (P extends React.FC ? React.ComponentProps<P> : unknown) & {
 }
 
 /**
- * A set containing public `<Route />`s
+ * TypeScript will often infer the type of the props you can forward to the
+ * wrappers for you, but if you need to you can specify it yourself in your
+ * JSX like so:
+ *   <Set<{theme: string}> wrap={ThemeableLayout} theme="dark">
  */
 export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   // @MARK: Virtual Component, this is actually never rendered
@@ -45,10 +54,11 @@ export function Set<WrapperProps>(props: SetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
-type PrivateSetProps<P> = Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
-  /** The page name where a user will be redirected when not authenticated */
-  unauthenticated: keyof typeof routes
-}
+type PrivateSetProps<P> = P &
+  Omit<SetProps<P>, 'private' | 'unauthenticated'> & {
+    /** The page name where a user will be redirected when not authenticated */
+    unauthenticated: string
+  }
 
 /** @deprecated Please use `<PrivateSet>` instead */
 export function Private<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
@@ -57,9 +67,6 @@ export function Private<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   return <>{props.children}</>
 }
 
-/**
- * A set containing private `<Route />`s that require authentication to access
- */
 export function PrivateSet<WrapperProps>(props: PrivateSetProps<WrapperProps>) {
   // @MARK Virtual Component, this is actually never rendered
   // See analyzeRoutes in utils.tsx, inside the isSetNode block


### PR DESCRIPTION
This reverts commit 6cfc992c35a06307bc703c402296b86ae58873f4.

I'm reverting these PRs:

https://github.com/redwoodjs/redwood/pull/11769
https://github.com/redwoodjs/redwood/pull/11768
https://github.com/redwoodjs/redwood/pull/11767
https://github.com/redwoodjs/redwood/pull/11756