### PR TITLE
chore(router): Fix spelling/grammar and type import in tests

### DIFF
--- a/packages/router/src/__tests__/route-validators.test.tsx
+++ b/packages/router/src/__tests__/route-validators.test.tsx
@@ -42,7 +42,7 @@ describe('isValidRoute', () => {
     )
   })
 
-  it("throws if notFoundPage doesn't have page prop", () => {
+  it("throws if NotFoundPage doesn't have page prop", () => {
     // @ts-expect-error Its ok mate, we're checking the validator
     const RouteToCheck = <Route notfound name="bazinga" />
 
@@ -51,7 +51,7 @@ describe('isValidRoute', () => {
     )
   })
 
-  it("does not throws if notFoundPage doesn't have a path", () => {
+  it("does not throw if NotFoundPage doesn't have a path", () => {
     // @ts-expect-error Its ok mate, we're checking the validator
     const RouteToCheck = <Route name="bazinga" notfound page={() => <></>} />
 

--- a/packages/router/src/__tests__/router.test.tsx
+++ b/packages/router/src/__tests__/router.test.tsx
@@ -13,6 +13,7 @@ import {
 
 import type { AuthContextInterface, UseAuth } from '@redwoodjs/auth'
 
+import type { GeneratedRoutesMap } from '../analyzeRoutes.js'
 import {
   back,
   routes as generatedRoutes,
@@ -26,7 +27,6 @@ import {
 } from '../index.js'
 import { useParams } from '../params.js'
 import { Set } from '../Set.js'
-import type { GeneratedRoutesMap } from '../util.js'
 
 type UnknownAuthContextInterface = AuthContextInterface<
   unknown,


### PR DESCRIPTION
The `GeneratedRoutesMap` export had moved to a new file. So updated the test to correct the import.
And found a few naming/grammar things I wanted to change

Noticed these when reviewing https://github.com/redwoodjs/redwood/pull/11894