### PR TITLE
Revert yarn 4.6.0 upgrade

### DIFF
--- a/.github/actions/check_changesets/package.json
+++ b/.github/actions/check_changesets/package.json
@@ -6,5 +6,5 @@
     "@actions/exec": "1.1.1",
     "@actions/github": "6.0.0"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.4.0"
 }

--- a/.github/actions/check_create_redwood_app/package.json
+++ b/.github/actions/check_create_redwood_app/package.json
@@ -5,5 +5,5 @@
     "@actions/core": "1.11.1",
     "@actions/exec": "1.1.1"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.4.0"
 }

--- a/.github/actions/detect-changes/package.json
+++ b/.github/actions/detect-changes/package.json
@@ -5,5 +5,5 @@
     "@actions/core": "1.11.1",
     "@actions/exec": "1.1.1"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.4.0"
 }

--- a/__fixtures__/fragment-test-project/package.json
+++ b/__fixtures__/fragment-test-project/package.json
@@ -20,5 +20,5 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.1.1"
 }

--- a/__fixtures__/rsc-caching/package.json
+++ b/__fixtures__/rsc-caching/package.json
@@ -20,7 +20,7 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
     "react-is": "19.0.0-rc-f2df5694-20240916"

--- a/__fixtures__/test-project-rsa/package.json
+++ b/__fixtures__/test-project-rsa/package.json
@@ -19,7 +19,7 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
     "react-is": "19.0.0-rc-f2df5694-20240916"

--- a/__fixtures__/test-project-rsc-kitchen-sink/package.json
+++ b/__fixtures__/test-project-rsc-kitchen-sink/package.json
@@ -20,7 +20,7 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.1.1",
   "resolutions": {
     "@apollo/client-react-streaming/superjson": "^1.12.2",
     "react-is": "19.0.0-rc-f2df5694-20240916"

--- a/__fixtures__/test-project/package.json
+++ b/__fixtures__/test-project/package.json
@@ -20,7 +20,7 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
     "react-is": "19.0.0-rc-f2df5694-20240916"

--- a/docs/package.json
+++ b/docs/package.json
@@ -41,5 +41,5 @@
     "@types/react": "^18.2.55",
     "typescript": "5.6.2"
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.4.0"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -13611,11 +13611,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>":
   version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=74658d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
+  checksum: 10c0/e6c1662e4852e22fe4bbdca471dca3e3edc74f6f1df043135c44a18a7902037023ccb0abdfb754595ca9028df8920f2f8492c00fc3cbb4309079aae8b7de71cd
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -134,6 +134,6 @@
     "yargs": "17.7.2",
     "zx": "8.1.9"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.4.0",
   "npmClient": "yarn"
 }

--- a/packages/cli/src/commands/upgrade.js
+++ b/packages/cli/src/commands/upgrade.js
@@ -532,7 +532,7 @@ const dedupeDeps = async (task, { verbose }) => {
       await execa('yarn', ['dedupe'], baseExecaArgsForDedupe)
     } else {
       // Redwood projects should not be using yarn 1.x as we specify a version of yarn in the package.json
-      // with "packageManager": "yarn@4.6.0" or similar.
+      // with "packageManager": "yarn@4.1.1" or similar.
       // Although we could (and previous did) automatically run `npx yarn-deduplicate` here, that would require
       // the user to have `npx` installed, which is not guaranteed and we do not wish to enforce that.
       task.skip(
@@ -542,7 +542,7 @@ const dedupeDeps = async (task, { verbose }) => {
   } catch (e) {
     console.log(c.error(e.message))
     throw new Error(
-      'Could not finish de-duplication. For yarn 1.x, please run `npx yarn-deduplicate`, or for yarn >= 3 run `yarn dedupe` before continuing',
+      'Could not finish de-duplication. For yarn 1.x, please run `npx yarn-deduplicate`, or for yarn 3 run `yarn dedupe` before continuing',
     )
   }
   await yarnInstall({ verbose })

--- a/packages/create-redwood-app/templates/js/package.json
+++ b/packages/create-redwood-app/templates/js/package.json
@@ -20,7 +20,7 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
     "react-is": "19.0.0-rc-f2df5694-20240916"

--- a/packages/create-redwood-app/templates/ts/package.json
+++ b/packages/create-redwood-app/templates/ts/package.json
@@ -20,7 +20,7 @@
   "prisma": {
     "seed": "yarn rw exec seed"
   },
-  "packageManager": "yarn@4.6.0",
+  "packageManager": "yarn@4.4.0",
   "resolutions": {
     "@storybook/react-dom-shim@npm:7.6.17": "https://verdaccio.tobbe.dev/@storybook/react-dom-shim/-/react-dom-shim-8.0.8.tgz",
     "react-is": "19.0.0-rc-f2df5694-20240916"

--- a/packages/create-redwood-rsc-app/yarn.lock
+++ b/packages/create-redwood-rsc-app/yarn.lock
@@ -4115,11 +4115,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.5.3#optional!builtin<compat/typescript>":
   version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=74658d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
+  checksum: 10c0/e6c1662e4852e22fe4bbdca471dca3e3edc74f6f1df043135c44a18a7902037023ccb0abdfb754595ca9028df8920f2f8492c00fc3cbb4309079aae8b7de71cd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29295,21 +29295,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.6.1-rc#optional!builtin<compat/typescript>":
   version: 5.6.1-rc
-  resolution: "typescript@patch:typescript@npm%3A5.6.1-rc#optional!builtin<compat/typescript>::version=5.6.1-rc&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.6.1-rc#optional!builtin<compat/typescript>::version=5.6.1-rc&hash=74658d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/9c6f8d864bc2efc964d1bfc94bf2e14f35cd2ad3df5e92d5304c8759674ba77ae927078a5fc06a527c087953615465dd5decc2d4d28ca8e13c11f9b29e068d93
+  checksum: 10c0/7849a6f82731f33d05dc9401252eeed78cec227aa9b23c316638c12c15ff7ec0903d62aa8718ea0ab5aad2e155a74edcd0c8053b8fdf8020bd1652720d89db7c
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A>=3 < 6#optional!builtin<compat/typescript>":
   version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=74658d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
+  checksum: 10c0/e6c1662e4852e22fe4bbdca471dca3e3edc74f6f1df043135c44a18a7902037023ccb0abdfb754595ca9028df8920f2f8492c00fc3cbb4309079aae8b7de71cd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This reverts #11874 and #11891 to see if that was what caused the versioning issues I had when releasing RW 8.4.3