### PR TITLE
fix(cli): Pin TailwindCSS to v3

### DIFF
--- a/.changesets/11920.md
+++ b/.changesets/11920.md
@@ -1,0 +1,4 @@
+- fix(cli): Pin TailwindCSS to v3 (#11920) by @Tobbe
+
+Pinning TW to v3 for our `yarn rw setup ui tailwind` command until we've added
+support for TW v4

--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -121,7 +121,7 @@ export const handler = async ({ force, install }) => {
   const webWorkspacePackages = [
     'postcss',
     'postcss-loader',
-    'tailwindcss',
+    'tailwindcss@^3.4.17',
     'autoprefixer',
   ]
 


### PR DESCRIPTION
Now that TailwindCSS v4 is out [1] we need to pin the version we install to v3 until we've added support for TW v4.

[1] https://tailwindcss.com/blog/tailwindcss-v4