### PR TITLE
feat(cli): Add support for RWJS_CWD and --cwd to TW setup

### DIFF
--- a/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
+++ b/packages/cli/src/commands/setup/ui/libraries/tailwindcss.js
@@ -138,12 +138,18 @@ export const handler = async ({ force, install }) => {
                 task: async () => {
                   const yarnVersion = await execa('yarn', ['--version'])
                   const isYarnV1 = yarnVersion.stdout.trim().startsWith('1')
-                  await execa('yarn', [
-                    'add',
-                    '-D',
-                    ...(isYarnV1 ? ['-W'] : []),
-                    ...projectPackages,
-                  ])
+                  await execa(
+                    'yarn',
+                    [
+                      'add',
+                      '-D',
+                      ...(isYarnV1 ? ['-W'] : []),
+                      ...projectPackages,
+                    ],
+                    {
+                      cwd: rwPaths.base,
+                    },
+                  )
                 },
               },
             ],
@@ -160,13 +166,13 @@ export const handler = async ({ force, install }) => {
               {
                 title: `Install ${webWorkspacePackages.join(', ')}`,
                 task: async () => {
-                  await execa('yarn', [
-                    'workspace',
-                    'web',
-                    'add',
-                    '-D',
-                    ...webWorkspacePackages,
-                  ])
+                  await execa(
+                    'yarn',
+                    ['workspace', 'web', 'add', '-D', ...webWorkspacePackages],
+                    {
+                      cwd: rwPaths.base,
+                    },
+                  )
                 },
               },
             ],


### PR DESCRIPTION
Makes it possible to run `yarn rw --cwd /some/path/to/a/rw/project setup ui tw`
(mostly used for testing purposes)