### PR TITLE
feat(cli): Support generating sdls for models with only an id and relation

### DIFF
--- a/.changesets/11931.md
+++ b/.changesets/11931.md
@@ -1,0 +1,11 @@
+- feat(cli): Support generating sdls for models with only an id and relation (#11931) by @Tobbe
+
+It's now possible to generate SDL files for models that look like this
+
+```prisma
+// This would be seeded with available car brands
+model CarBrand {
+  brand String @id
+  cars  Car[]
+}
+```

--- a/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.js.snap
+++ b/packages/cli/src/commands/generate/sdl/__tests__/__snapshots__/sdl.test.js.snap
@@ -1572,6 +1572,66 @@ exports[`with graphql documentations > in typescript mode > creates a single wor
 "
 `;
 
+exports[`without graphql documentations > in javascript mode > create an sdl file for model with only id and relation 1`] = `
+"export const schema = gql\`
+  type Car {
+    id: Int!
+    brand: String!
+    carBrand: CarBrand!
+  }
+
+  type Query {
+    cars: [Car!]! @requireAuth
+    car(id: Int!): Car @requireAuth
+  }
+
+  input CreateCarInput {
+    brand: String!
+  }
+
+  input UpdateCarInput {
+    brand: String
+  }
+
+  type Mutation {
+    createCar(input: CreateCarInput!): Car! @requireAuth
+    updateCar(id: Int!, input: UpdateCarInput!): Car! @requireAuth
+    deleteCar(id: Int!): Car! @requireAuth
+  }
+\`
+"
+`;
+
+exports[`without graphql documentations > in javascript mode > create an sdl file for model with only id and relation 2`] = `
+"export const schema = gql\`
+  type CarBrand {
+    brand: String!
+    cars: [Car]!
+  }
+
+  type Query {
+    carBrands: [CarBrand!]! @requireAuth
+    carBrand(brand: String!): CarBrand @requireAuth
+  }
+
+  input CreateCarBrandInput {
+    brand: String!
+  }
+
+  input UpdateCarBrandInput {
+    brand: String!
+  }
+
+  type Mutation {
+    createCarBrand(input: CreateCarBrandInput!): CarBrand! @requireAuth
+    updateCarBrand(brand: String!, input: UpdateCarBrandInput!): CarBrand!
+      @requireAuth
+    deleteCarBrand(brand: String!): CarBrand! @requireAuth
+  }
+\`
+"
+`;
+
 exports[`without graphql documentations > in javascript mode > creates a multi word sdl file 1`] = `
 "export const schema = gql\`
   type UserProfile {
@@ -1804,6 +1864,66 @@ exports[`without graphql documentations > in javascript mode > creates a single 
     createPost(input: CreatePostInput!): Post! @requireAuth
     updatePost(id: Int!, input: UpdatePostInput!): Post! @requireAuth
     deletePost(id: Int!): Post! @requireAuth
+  }
+\`
+"
+`;
+
+exports[`without graphql documentations > in typescript mode > create an sdl file for model with only id and relation 1`] = `
+"export const schema = gql\`
+  type Car {
+    id: Int!
+    brand: String!
+    carBrand: CarBrand!
+  }
+
+  type Query {
+    cars: [Car!]! @requireAuth
+    car(id: Int!): Car @requireAuth
+  }
+
+  input CreateCarInput {
+    brand: String!
+  }
+
+  input UpdateCarInput {
+    brand: String
+  }
+
+  type Mutation {
+    createCar(input: CreateCarInput!): Car! @requireAuth
+    updateCar(id: Int!, input: UpdateCarInput!): Car! @requireAuth
+    deleteCar(id: Int!): Car! @requireAuth
+  }
+\`
+"
+`;
+
+exports[`without graphql documentations > in typescript mode > create an sdl file for model with only id and relation 2`] = `
+"export const schema = gql\`
+  type CarBrand {
+    brand: String!
+    cars: [Car]!
+  }
+
+  type Query {
+    carBrands: [CarBrand!]! @requireAuth
+    carBrand(brand: String!): CarBrand @requireAuth
+  }
+
+  input CreateCarBrandInput {
+    brand: String!
+  }
+
+  input UpdateCarBrandInput {
+    brand: String!
+  }
+
+  type Mutation {
+    createCarBrand(input: CreateCarBrandInput!): CarBrand! @requireAuth
+    updateCarBrand(brand: String!, input: UpdateCarBrandInput!): CarBrand!
+      @requireAuth
+    deleteCarBrand(brand: String!): CarBrand! @requireAuth
   }
 \`
 "

--- a/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
+++ b/packages/cli/src/commands/generate/sdl/__tests__/fixtures/schema.prisma
@@ -66,6 +66,18 @@ enum Color {
 }
 
 model CustomData {
-  id       Int    @id @default(autoincrement())
-  data     String
+  id   Int    @id @default(autoincrement())
+  data String
+}
+
+// This would be seeded with available car brands
+model CarBrand {
+  brand String @id
+  cars  Car[]
+}
+
+model Car {
+  id       Int      @id @default(autoincrement())
+  brand    String
+  carBrand CarBrand @relation(fields: [brand], references: [brand])
 }

--- a/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.js
+++ b/packages/cli/src/commands/generate/sdl/__tests__/sdl.test.js
@@ -236,6 +236,37 @@ const itCreatesAnSDLFileWithByteDefinitions = (baseArgs = {}) => {
   })
 }
 
+const itCreatesAnSslFileForModelWithOnlyIdAndRelation = (baseArgs = {}) => {
+  test('create an sdl file for model with only id and relation', async () => {
+    const files = {
+      ...(await sdl.files({
+        ...baseArgs,
+        name: 'Car',
+        crud: true,
+      })),
+      ...(await sdl.files({
+        ...baseArgs,
+        name: 'CarBrand',
+        crud: true,
+      })),
+    }
+    const extension = extensionForBaseArgs(baseArgs)
+
+    expect(
+      files[
+        path.normalize(`/path/to/project/api/src/graphql/cars.sdl.${extension}`)
+      ],
+    ).toMatchSnapshot()
+    expect(
+      files[
+        path.normalize(
+          `/path/to/project/api/src/graphql/carBrands.sdl.${extension}`,
+        )
+      ],
+    ).toMatchSnapshot()
+  })
+}
+
 describe('without graphql documentations', () => {
   describe('in javascript mode', () => {
     const baseArgs = { ...getDefaultArgs(sdl.defaults), tests: true }
@@ -249,6 +280,7 @@ describe('without graphql documentations', () => {
     itCreatesAnSDLFileWithEnumDefinitions(baseArgs)
     itCreatesAnSDLFileWithJsonDefinitions(baseArgs)
     itCreatesAnSDLFileWithByteDefinitions(baseArgs)
+    itCreatesAnSslFileForModelWithOnlyIdAndRelation(baseArgs)
   })
 
   describe('in typescript mode', () => {
@@ -267,6 +299,7 @@ describe('without graphql documentations', () => {
     itCreatesAnSDLFileWithEnumDefinitions(baseArgs)
     itCreatesAnSDLFileWithJsonDefinitions(baseArgs)
     itCreatesAnSDLFileWithByteDefinitions(baseArgs)
+    itCreatesAnSslFileForModelWithOnlyIdAndRelation(baseArgs)
   })
 })
 


### PR DESCRIPTION
It's now possible to generate sdl files for models that look like this

```prisma
// This would be seeded with available car brands
model CarBrand {
  brand String @id
  cars  Car[]
}
```