### PR TITLE
fix(babel-config): react compiler target should be a string

### DIFF
--- a/packages/babel-config/src/web.ts
+++ b/packages/babel-config/src/web.ts
@@ -43,7 +43,7 @@ export const getWebSideBabelPlugins = (
 
   const plugins = [
     // It is important that this plugin run first, as noted here: https://react.dev/learn/react-compiler
-    useReactCompiler && ['babel-plugin-react-compiler', { target: 19 }],
+    useReactCompiler && ['babel-plugin-react-compiler', { target: '19' }],
     // === Import path handling
     [
       'babel-plugin-module-resolver',


### PR DESCRIPTION
The `target` setting should be a string, as clearly shown in https://react.dev/learn/react-compiler#using-react-compiler-with-react-17-or-18

Fixes #11934