### PR TITLE
fix(cli): Await files() when generating scripts

### DIFF
--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -87,7 +87,9 @@ export const handler = async ({ force, ...args }) => {
     [
       {
         title: 'Generating script file...',
-        task: writeFilesTask(await files(args), { overwriteExisting: force }),
+        task: async () => {
+          return writeFilesTask(await files(args), { overwriteExisting: force })
+        },
       },
       {
         title: 'Next steps...',

--- a/packages/cli/src/commands/generate/script/script.js
+++ b/packages/cli/src/commands/generate/script/script.js
@@ -87,9 +87,7 @@ export const handler = async ({ force, ...args }) => {
     [
       {
         title: 'Generating script file...',
-        task: () => {
-          return writeFilesTask(files(args), { overwriteExisting: force })
-        },
+        task: writeFilesTask(await files(args), { overwriteExisting: force }),
       },
       {
         title: 'Next steps...',


### PR DESCRIPTION
Fixes a regression introduced with #11946

`files()` is now async and needs to be awaited

I wish our CLI was written in TypeScript, because then this regression wouldn't have slipped through

Marking this for `next-release` (instead of `next-release-patch` because #11946 is scheduled for `next-release`)