### PR TITLE
fix(cli): Support passing numeric args to prisma

### DIFF
--- a/packages/cli/src/commands/prismaHandler.js
+++ b/packages/cli/src/commands/prismaHandler.js
@@ -55,10 +55,12 @@ export const handler = async ({ _, $0, commands = [], ...options }) => {
   for (const [name, value] of Object.entries(options)) {
     // Allow both long and short form commands, e.g. --name and -n
     args.push(name.length > 1 ? `--${name}` : `-${name}`)
-    if (typeof value !== 'boolean') {
+    if (typeof value === 'string') {
       // Make sure options that take multiple quoted words
       // like `-n "create user"` are passed to prisma with quotes.
       value.split(' ').length > 1 ? args.push(`"${value}"`) : args.push(value)
+    } else if (typeof value === 'number') {
+      args.push(value)
     }
   }
 


### PR DESCRIPTION
Without this fix you couldn't set a custom port for prisma studio

```
yarn rw prisma studio --port 8917
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TypeError: value.split is not a function
    at handler (/Users/tobbe/tmp/rw-prisma-studio-port/node_modules/@redwoodjs/cli/dist/commands/prismaHandler.js:76:13)
    at Object.handler (/Users/tobbe/tmp/rw-prisma-studio-port/node_modules/@redwoodjs/cli/dist/commands/prisma.js:46:10)
    at async runYargs (/Users/tobbe/tmp/rw-prisma-studio-port/node_modules/@redwoodjs/cli/dist/index.js:153:3)
    at async /Users/tobbe/tmp/rw-prisma-studio-port/node_modules/@redwoodjs/cli/dist/index.js:105:7
    at async main (/Users/tobbe/tmp/rw-prisma-studio-port/node_modules/@redwoodjs/cli/dist/index.js:94:3)
```