### PR TITLE
fix(exec): only pass script args to script

### DIFF
--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -1,14 +1,27 @@
 import path from 'node:path'
 
+import { fs as memfs, vol } from 'memfs'
 import { vi, afterEach, beforeEach, describe, it, expect } from 'vitest'
 
+import { runScriptFunction } from '../../lib/exec'
 import '../../lib/mockTelemetry'
 import { handler } from '../execHandler'
 
+vi.mock('@redwoodjs/babel-config', () => ({
+  getWebSideDefaultBabelConfig: () => ({
+    presets: [],
+    plugins: [],
+  }),
+  registerApiSideBabelHook: () => {},
+}))
+
 vi.mock('@redwoodjs/project-config', () => ({
   getPaths: () => ({
+    api: { base: '', src: '' },
+    web: { base: '', src: '' },
     scripts: path.join('redwood-app', 'scripts'),
   }),
+  getConfig: () => ({}),
   resolveFile: (path: string) => path,
 }))
 
@@ -26,12 +39,55 @@ vi.mock('@redwoodjs/internal/dist/files', () => ({
   },
 }))
 
+vi.mock('../../lib/exec', () => ({
+  runScriptFunction: vi.fn(),
+}))
+
+vi.mock('fs', () => ({ ...memfs, default: { ...memfs } }))
+vi.mock('node:fs', () => ({ ...memfs, default: { ...memfs } }))
+
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {})
 })
 
 afterEach(() => {
   vi.mocked(console).log.mockRestore()
+})
+
+describe('yarn rw exec', () => {
+  it('passes args on to the script', async () => {
+    vol.fromJSON({
+      'redwood.toml': '# redwood.toml',
+      [path.join('redwood-app', 'scripts', 'normalScript.ts')]: '// script',
+    })
+
+    // Running:
+    // `yarn rw exec normalScript positional1 --no-prisma positional2 --arg1=foo --arg2 bar`
+    const args = {
+      _: ['exec', 'positional1', 'positional2'],
+      prisma: false,
+      arg1: 'foo',
+      arg2: 'bar',
+      list: false,
+      l: false,
+      silent: false,
+      s: false,
+      $0: 'rw',
+      name: 'normalScript',
+    }
+    await handler(args)
+    expect(runScriptFunction).toHaveBeenCalledWith({
+      args: {
+        args: {
+          _: ['positional1', 'positional2'],
+          arg1: 'foo',
+          arg2: 'bar',
+        },
+      },
+      functionName: 'default',
+      path: path.join('redwood-app', 'scripts', 'normalScript.ts'),
+    })
+  })
 })
 
 describe('yarn rw exec --list', () => {

--- a/packages/cli/src/commands/execHandler.js
+++ b/packages/cli/src/commands/execHandler.js
@@ -59,6 +59,34 @@ export const handler = async (args) => {
     return
   }
 
+  // The command the user is running is something like this:
+  //
+  // yarn rw exec scriptName arg1 arg2 --positional1=foo --positional2=bar
+  //
+  // Further up in the command chain we've parsed this with yargs. We asked
+  // yargs to parse the command `exec [name]`. So it plucked `scriptName` from
+  // the command and placed that in a named variable called `name`.
+  // And even further up the chain yargs has already eaten the `yarn` part and
+  // assigned 'rw' to `$0`
+  // So what yargs has left in args._ is ['exec', 'arg1', 'arg2'] (and it has
+  // also assigned 'foo' to `args.positional1` and 'bar' to `args.positional2`).
+  // 'exec', 'arg1' and 'arg2' are in `args._` because those are positional
+  // arguments we haven't given a name.
+  // `'exec'` is of no interest to the user, as its not meant to be an argument
+  // to their script. And so we remove it from the array.
+  scriptArgs._ = scriptArgs._.slice(1)
+
+  // 'rw' is not meant for the script's args, so delete that
+  delete scriptArgs.$0
+
+  // Other arguments that yargs adds are `prisma`, `list`, `l`, `silent` and
+  // `s`.
+  // We eat `prisma` and `list` above. So that leaves us with `l`, `s` and
+  // `silent` that we need to delete as well
+  delete scriptArgs.l
+  delete scriptArgs.s
+  delete scriptArgs.silent
+
   const {
     overrides: _overrides,
     plugins: webPlugins,


### PR DESCRIPTION
Let's say you run this command:
`yarn rw exec normalScript positional1 --no-prisma positional2 --arg1=foo --arg2 bar -s`

What Redwood will do is run your scrip named `normalScript`. It will also pass it the two positional arguments `'positional1'` and `'positional2'`. Plus the two named arguments `arg1` and `arg2` with the values `'foo'` and `'bar'` respectively. It will also read `--no-prisma` and skip generating a prisma client, and `-s` to run the script in silent mode.

What it would also do however is pass a bunch of extra stuff to the script, including the `'exec'` word. This PR cleans all that up to only pass the actual script arguments to the script.

This is breaking because people might have counting on those extra arguments to be passed to the script. Especially `'exec'`because it gets passed to the script as part of the `_` array. It was the first element, and (in this example) `'positional1'` and `'positional2'` would have come after it. So if people were expecting their first positional argument to be at `args._[1]` their script will now break. 