### PR TITLE
chore(babel-config): Remove unused jest config file

### DIFF
--- a/packages/babel-config/jest.config.js
+++ b/packages/babel-config/jest.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  testPathIgnorePatterns: ['fixtures', 'dist/*'],
-}


### PR DESCRIPTION
As I'm going through our packages to get rid of jest and move to vitest I found this old file laying around that we don't use anymore.