### PR TITLE
chore(babel-config): Fix TS warning about converting require into import

### DIFF
--- a/packages/babel-config/src/common.ts
+++ b/packages/babel-config/src/common.ts
@@ -6,10 +6,10 @@ import { parseConfigFileTextToJson } from 'typescript'
 
 import { getPaths } from '@redwoodjs/project-config'
 
+import pkgJson from '../package.json'
+
 import { getWebSideBabelPlugins } from './web'
 import type { Flags as WebFlags } from './web'
-
-const pkgJson = require('../package.json')
 
 export interface RegisterHookOptions {
   /**


### PR DESCRIPTION
<img width="483" alt="image" src="https://github.com/user-attachments/assets/19f42ed2-ee90-4e89-a616-bb1bf827f369" />

Fix the warning above by converting the `require()` call to `import`