### PR TITLE
chore(babel-config): Use only one fs import, and use node: specifier

### DIFF
--- a/packages/babel-config/src/api.ts
+++ b/packages/babel-config/src/api.ts
@@ -1,6 +1,5 @@
-import { existsSync } from 'fs'
-import fs from 'fs/promises'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 
 import type { PluginOptions, PluginTarget, TransformOptions } from '@babel/core'
 import { transformAsync } from '@babel/core'
@@ -150,7 +149,7 @@ export const getApiSideBabelPlugins = ({
 
 export const getApiSideBabelConfigPath = () => {
   const p = path.join(getPaths().api.base, 'babel.config.js')
-  if (existsSync(p)) {
+  if (fs.existsSync(p)) {
     return p
   } else {
     return
@@ -225,7 +224,7 @@ export const transformWithBabel = async (
   srcPath: string,
   plugins: TransformOptions['plugins'],
 ) => {
-  const code = await fs.readFile(srcPath, 'utf-8')
+  const code = await fs.promises.readFile(srcPath, 'utf-8')
   const defaultOptions = getApiSideDefaultBabelConfig({
     projectIsEsm: projectSideIsEsm('api'),
   })


### PR DESCRIPTION
Use only a single `node:fs` import. 

The point of this PR is to make it easier to mock out fs access when unit testing