### PR TITLE
chore(project-config): Associate JSDoc with method. Remove `as`

### DIFF
--- a/packages/project-config/src/configPath.ts
+++ b/packages/project-config/src/configPath.ts
@@ -2,22 +2,29 @@ import { findUp } from './findUp.js'
 
 const CONFIG_FILE_NAME = 'redwood.toml'
 
+const getConfigPathCache = new Map<string, string>()
+
 /**
  * Search the parent directories for the Redwood configuration file.
  */
-const getConfigPathCache = new Map<string, string>()
 export const getConfigPath = (
   cwd: string = process.env.RWJS_CWD ?? process.cwd(),
 ): string => {
-  if (getConfigPathCache.has(cwd)) {
-    return getConfigPathCache.get(cwd) as string
+  const cachedPath = getConfigPathCache.get(cwd)
+
+  if (cachedPath) {
+    return cachedPath
   }
+
   const configPath = findUp(CONFIG_FILE_NAME, cwd)
+
   if (!configPath) {
     throw new Error(
       `Could not find a "${CONFIG_FILE_NAME}" file, are you sure you're in a Redwood project?`,
     )
   }
+
   getConfigPathCache.set(cwd, configPath)
+
   return configPath
 }


### PR DESCRIPTION
Put the JSDoc comment right next to the method so that editors pick up on it. Also remove a TS type cast by restructuring the code