### PR TITLE
chore(dataMigrate): Switch from jest to vitest

### DIFF
--- a/packages/cli-packages/dataMigrate/dist.test.ts
+++ b/packages/cli-packages/dataMigrate/dist.test.ts
@@ -1,5 +1,7 @@
-import fs from 'fs'
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
 
 const distPath = path.join(__dirname, 'dist')
 

--- a/packages/cli-packages/dataMigrate/package.json
+++ b/packages/cli-packages/dataMigrate/package.json
@@ -21,8 +21,8 @@
     "build:types": "tsc --build --verbose",
     "prepublishOnly": "NODE_ENV=production yarn build",
     "test": "yarn test:unit && yarn test:dist",
-    "test:dist": "yarn jest ./dist.test.ts",
-    "test:unit": "yarn jest src"
+    "test:dist": "yarn vitest run ./dist.test.ts",
+    "test:unit": "yarn vitest run src/"
   },
   "dependencies": {
     "@redwoodjs/babel-config": "workspace:*",
@@ -40,10 +40,10 @@
     "@redwoodjs/framework-tools": "workspace:*",
     "@types/fs-extra": "11.0.4",
     "@types/yargs": "17.0.33",
-    "jest": "29.7.0",
     "memfs": "4.15.1",
     "tsx": "4.19.2",
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "vitest": "2.0.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/install.test.ts
@@ -1,15 +1,12 @@
-import type yargs from 'yargs'
+import { vi, describe, expect, it } from 'vitest'
+import type { Argv } from 'yargs'
 
 import * as installCommand from '../commands/install'
 import { handler as dataMigrateInstallHandler } from '../commands/installHandler.js'
 
-jest.mock(
-  '../commands/installHandler.js',
-  () => ({
-    handler: jest.fn(),
-  }),
-  { virtual: true },
-)
+vi.mock('../commands/installHandler.js', () => ({
+  handler: vi.fn(),
+}))
 
 describe('install', () => {
   it('exports `command`, `description`, `builder`, and `handler`', () => {
@@ -28,7 +25,7 @@ describe('install', () => {
   it('`builder` has an epilogue', () => {
     // The typecasting here is to make TS happy when calling `builder(yargs)`
     // further down. We know that only `epilogue` will be called.
-    const yargs = { epilogue: jest.fn() } as unknown as yargs.Argv
+    const yargs = { epilogue: vi.fn() } as unknown as Argv
 
     installCommand.builder(yargs)
 

--- a/packages/cli-packages/dataMigrate/src/__tests__/up.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/up.test.ts
@@ -1,19 +1,16 @@
-import { vol } from 'memfs'
-import yargs from 'yargs/yargs'
+import { fs as memfs, vol } from 'memfs'
+import { vi, describe, expect, it } from 'vitest'
+import yargs from 'yargs'
 
 import { getPaths } from '@redwoodjs/project-config'
 
 import * as upCommand from '../commands/up'
 import { handler as dataMigrateUpHandler } from '../commands/upHandler.js'
 
-jest.mock('fs', () => require('memfs').fs)
-jest.mock(
-  '../commands/upHandler.js',
-  () => ({
-    handler: jest.fn(),
-  }),
-  { virtual: true },
-)
+vi.mock('fs', () => ({ default: memfs }))
+vi.mock('../commands/upHandler.js', () => ({
+  handler: vi.fn(),
+}))
 
 describe('up', () => {
   it('exports `command`, `description`, `builder`, and `handler`', () => {
@@ -39,14 +36,17 @@ describe('up', () => {
 
     process.env.RWJS_CWD = '/redwood-app'
 
-    const { argv } = upCommand.builder(yargs)
+    const { argv } = upCommand.builder(yargs())
 
     expect(argv).toHaveProperty('import-db-client-from-dist', false)
     expect(argv).toHaveProperty('dist-path', getPaths().api.dist)
   })
 
   it('`handler` proxies to `./upHandler.js`', async () => {
-    await upCommand.handler({})
+    await upCommand.handler({
+      importDbClientFromDist: false,
+      distPath: '',
+    })
     expect(dataMigrateUpHandler).toHaveBeenCalled()
   })
 })

--- a/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import { fs as memfs, vol } from 'memfs'
 import {
   afterAll,
@@ -14,7 +12,6 @@ import {
 import type { MockInstance } from 'vitest'
 
 import { getPaths } from '@redwoodjs/project-config'
-import type * as ProjectConfig from '@redwoodjs/project-config'
 
 import { handler, NO_PENDING_MIGRATIONS_MESSAGE } from '../commands/upHandler'
 
@@ -43,32 +40,6 @@ afterEach(() => {
 
 vi.mock('fs', () => ({ ...memfs, default: { ...memfs } }))
 vi.mock('node:fs', () => ({ default: memfs }))
-
-// TODO: See if we can remove this mock
-vi.mock('@redwoodjs/project-config', async (importOriginal) => {
-  const originalProjectConfig = await importOriginal<typeof ProjectConfig>()
-
-  return {
-    ...originalProjectConfig,
-    getPaths: () => {
-      // TODO: use the same variable as the tests use (`redwoodProjectPath`)
-      const BASE_PATH = '/redwood-app'
-
-      return {
-        base: BASE_PATH,
-        api: {
-          base: BASE_PATH,
-          lib: path.join(BASE_PATH, 'api', 'src', 'lib'),
-          dataMigrations: path.join(BASE_PATH, 'api', 'db', 'dataMigrations'),
-          dist: path.join(BASE_PATH, 'api', 'dist'),
-        },
-        web: {
-          base: path.join(BASE_PATH, 'web'),
-        },
-      }
-    },
-  }
-})
 
 const mockDataMigrations: { current: any[] } = { current: [] }
 

--- a/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
+++ b/packages/cli-packages/dataMigrate/src/__tests__/upHandler.test.ts
@@ -1,6 +1,20 @@
-import { vol } from 'memfs'
+import path from 'node:path'
+
+import { fs as memfs, vol } from 'memfs'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  vi,
+  describe,
+  expect,
+  it,
+} from 'vitest'
+import type { MockInstance } from 'vitest'
 
 import { getPaths } from '@redwoodjs/project-config'
+import type * as ProjectConfig from '@redwoodjs/project-config'
 
 import { handler, NO_PENDING_MIGRATIONS_MESSAGE } from '../commands/upHandler'
 
@@ -8,16 +22,16 @@ import { handler, NO_PENDING_MIGRATIONS_MESSAGE } from '../commands/upHandler'
 
 const redwoodProjectPath = '/redwood-app'
 
-let consoleLogMock: jest.SpyInstance
-let consoleInfoMock: jest.SpyInstance
-let consoleErrorMock: jest.SpyInstance
-let consoleWarnMock: jest.SpyInstance
+let consoleLogMock: MockInstance
+let consoleInfoMock: MockInstance
+let consoleErrorMock: MockInstance
+let consoleWarnMock: MockInstance
 
 beforeEach(() => {
-  consoleLogMock = jest.spyOn(console, 'log').mockImplementation()
-  consoleInfoMock = jest.spyOn(console, 'info').mockImplementation()
-  consoleErrorMock = jest.spyOn(console, 'error').mockImplementation()
-  consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation()
+  consoleLogMock = vi.spyOn(console, 'log').mockImplementation(() => {})
+  consoleInfoMock = vi.spyOn(console, 'info').mockImplementation(() => {})
+  consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {})
+  consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {})
 })
 
 afterEach(() => {
@@ -27,117 +41,107 @@ afterEach(() => {
   consoleWarnMock.mockRestore()
 })
 
-jest.mock('fs', () => require('memfs').fs)
+vi.mock('fs', () => ({ ...memfs, default: { ...memfs } }))
+vi.mock('node:fs', () => ({ default: memfs }))
+
+// TODO: See if we can remove this mock
+vi.mock('@redwoodjs/project-config', async (importOriginal) => {
+  const originalProjectConfig = await importOriginal<typeof ProjectConfig>()
+
+  return {
+    ...originalProjectConfig,
+    getPaths: () => {
+      // TODO: use the same variable as the tests use (`redwoodProjectPath`)
+      const BASE_PATH = '/redwood-app'
+
+      return {
+        base: BASE_PATH,
+        api: {
+          base: BASE_PATH,
+          lib: path.join(BASE_PATH, 'api', 'src', 'lib'),
+          dataMigrations: path.join(BASE_PATH, 'api', 'db', 'dataMigrations'),
+          dist: path.join(BASE_PATH, 'api', 'dist'),
+        },
+        web: {
+          base: path.join(BASE_PATH, 'web'),
+        },
+      }
+    },
+  }
+})
 
 const mockDataMigrations: { current: any[] } = { current: [] }
 
-jest.mock(
-  '/redwood-app/api/dist/lib/db.js',
-  () => {
-    return {
-      db: {
-        rW_DataMigration: {
-          create(dataMigration) {
-            mockDataMigrations.current.push(dataMigration)
-          },
-          findMany() {
-            return mockDataMigrations.current
-          },
+interface DataMigrationRow {
+  version: string
+  name: string
+  startedAt: Date | string
+  finishedAt: Date | string
+}
+
+vi.mock('/redwood-app/api/dist/lib/db.js', () => {
+  return {
+    db: {
+      rW_DataMigration: {
+        create(dataMigration: { data: DataMigrationRow }) {
+          mockDataMigrations.current.push(dataMigration)
         },
-        $disconnect: () => {},
-      },
-    }
-  },
-  { virtual: true },
-)
-
-jest.mock(
-  `\\redwood-app\\api\\dist\\lib\\db.js`,
-  () => {
-    return {
-      db: {
-        rW_DataMigration: {
-          create(dataMigration) {
-            mockDataMigrations.current.push(dataMigration)
-          },
-          findMany() {
-            return mockDataMigrations.current
-          },
+        findMany() {
+          return mockDataMigrations.current
         },
-        $disconnect: () => {},
       },
-    }
-  },
-  { virtual: true },
-)
+      $disconnect: () => {},
+    },
+  }
+})
 
-jest.mock(
-  '/redwood-app/api/db/dataMigrations/20230822075442-wip.ts',
-  () => {
-    return { default: () => {} }
-  },
-  {
-    virtual: true,
-  },
-)
-
-jest.mock(
-  '\\redwood-app\\api\\db\\dataMigrations\\20230822075442-wip.ts',
-  () => {
-    return { default: () => {} }
-  },
-  {
-    virtual: true,
-  },
-)
-
-jest.mock(
-  '/redwood-app/api/db/dataMigrations/20230822075443-wip.ts',
-  () => {
-    return {
-      default: () => {
-        throw new Error('oops')
+vi.mock(`\\redwood-app\\api\\dist\\lib\\db.js`, () => {
+  return {
+    db: {
+      rW_DataMigration: {
+        create(dataMigration: { data: DataMigrationRow }) {
+          mockDataMigrations.current.push(dataMigration)
+        },
+        findMany() {
+          return mockDataMigrations.current
+        },
       },
-    }
-  },
-  {
-    virtual: true,
-  },
-)
+      $disconnect: () => {},
+    },
+  }
+})
 
-jest.mock(
-  '\\redwood-app\\api\\db\\dataMigrations\\20230822075443-wip.ts',
-  () => {
-    return {
-      default: () => {
-        throw new Error('oops')
-      },
-    }
-  },
-  {
-    virtual: true,
-  },
-)
+vi.mock('/redwood-app/api/db/dataMigrations/20230822075442-wip.ts', () => {
+  return { default: () => {} }
+})
 
-jest.mock(
-  '/redwood-app/api/db/dataMigrations/20230822075444-wip.ts',
-  () => {
-    return { default: () => {} }
-  },
-  {
-    virtual: true,
-  },
-)
+vi.mock('\\redwood-app\\api\\db\\dataMigrations\\20230822075442-wip.ts', () => {
+  return { default: () => {} }
+})
 
-jest.mock(
-  '\\redwood-app\\api\\db\\dataMigrations\\20230822075444-wip.ts',
-  () => {
-    return { default: () => {} }
-  },
-  {
-    virtual: true,
-  },
-)
+vi.mock('/redwood-app/api/db/dataMigrations/20230822075443-wip.ts', () => {
+  return {
+    default: () => {
+      throw new Error('oops')
+    },
+  }
+})
+
+vi.mock('\\redwood-app\\api\\db\\dataMigrations\\20230822075443-wip.ts', () => {
+  return {
+    default: () => {
+      throw new Error('oops')
+    },
+  }
+})
+
+vi.mock('/redwood-app/api/db/dataMigrations/20230822075444-wip.ts', () => {
+  return { default: () => {} }
+})
+
+vi.mock('\\redwood-app\\api\\db\\dataMigrations\\20230822075444-wip.ts', () => {
+  return { default: () => {} }
+})
 
 const RWJS_CWD = process.env.RWJS_CWD
 
@@ -238,24 +242,14 @@ describe('upHandler', () => {
       },
     ]
 
-    vol.fromNestedJSON(
+    vol.fromJSON(
       {
         'redwood.toml': '',
-        api: {
-          'package.json': '{}',
-          dist: {
-            lib: {
-              'db.js': '',
-            },
-          },
-          db: {
-            dataMigrations: {
-              '20230822075442-wip.ts': '',
-              '20230822075443-wip.ts': '',
-              '20230822075444-wip.ts': '',
-            },
-          },
-        },
+        'api/package.json': '{}',
+        'api/dist/lib/db.js': '',
+        'api/db/dataMigrations/20230822075442-wip.ts': '',
+        'api/db/dataMigrations/20230822075443-wip.ts': '',
+        'api/db/dataMigrations/20230822075444-wip.ts': '',
       },
       redwoodProjectPath,
     )

--- a/packages/cli-packages/dataMigrate/src/commands/installHandler.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/installHandler.ts
@@ -1,7 +1,7 @@
-import path from 'path'
+import fs from 'node:fs'
+import path from 'node:path'
 
 import execa from 'execa'
-import fs from 'fs-extra'
 import { Listr } from 'listr2'
 
 import { getPaths } from '@redwoodjs/project-config'
@@ -16,7 +16,10 @@ export async function handler() {
       {
         title: 'Creating the dataMigrations directory...',
         task() {
-          fs.outputFileSync(
+          fs.mkdirSync(redwoodProjectPaths.api.dataMigrations, {
+            recursive: true,
+          })
+          fs.writeFileSync(
             path.join(redwoodProjectPaths.api.dataMigrations, '.keep'),
             '',
           )

--- a/packages/cli-packages/dataMigrate/src/commands/upHandler.ts
+++ b/packages/cli-packages/dataMigrate/src/commands/upHandler.ts
@@ -187,7 +187,7 @@ function sortDataMigrationsByVersion(
 }
 
 async function runDataMigration(db: PrismaClient, dataMigrationPath: string) {
-  const dataMigration = require(dataMigrationPath)
+  const dataMigration = await import(dataMigrationPath)
 
   const startedAt = new Date()
   await dataMigration.default({ db })

--- a/packages/cli-packages/dataMigrate/vitest.config.mts
+++ b/packages/cli-packages/dataMigrate/vitest.config.mts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // TODO: Remove this when we've made babel-config ESM+CJS dual build
+    // https://stackoverflow.com/a/77439684/88106
+    alias: {
+      '@redwoodjs/babel-config': path.resolve(
+        __dirname,
+        '../../babel-config/src',
+      ),
+    },
+  },
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8079,12 +8079,12 @@ __metadata:
     dotenv-defaults: "npm:5.0.2"
     execa: "npm:5.1.1"
     fs-extra: "npm:11.2.0"
-    jest: "npm:29.7.0"
     listr2: "npm:7.0.2"
     memfs: "npm:4.15.1"
     terminal-link: "npm:2.1.1"
     tsx: "npm:4.19.2"
     typescript: "npm:5.6.2"
+    vitest: "npm:2.0.5"
     yargs: "npm:17.7.2"
   bin:
     up: ./dist/bin.js


### PR DESCRIPTION
As a step towards ESM support we're switching from Jest to Vitest.
This PR takes care of switching our `@redwoodjs/cli-data-migrate` over.

One technique I used here is to alias an import of a CJS package to the package's source directory, which is using ESM syntax (no `require()`) so it works with Vitest. (The package's ESM source is then converted to CJS with `require()` instead of `import` when building) 