### PR TITLE
chore(deps): @babel/cli 7.26.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@actions/core": "1.11.1",
     "@actions/exec": "1.1.1",
     "@actions/glob": "0.5.0",
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@babel/generator": "7.25.7",
     "@babel/node": "7.25.7",

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -32,7 +32,7 @@
     "terminal-link": "2.1.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@simplewebauthn/typescript-types": "7.4.0",
     "@types/yargs": "17.0.33",

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -30,7 +30,7 @@
     "core-js": "3.38.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@simplewebauthn/typescript-types": "7.4.0",
     "@types/react": "^18.2.55",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -85,7 +85,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@types/archiver": "^6",
     "memfs": "4.15.1",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -24,7 +24,7 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@babel/parser": "^7.22.16",
     "@babel/plugin-transform-typescript": "^7.22.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "NODE_ENV=production yarn build"
   },
   "dependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@redwoodjs/api-server": "workspace:*",
     "@redwoodjs/cli": "workspace:*",
     "@redwoodjs/eslint-config": "workspace:*",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,7 @@
     "prettier": "3.4.2"
   },
   "devDependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "typescript": "5.6.2"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"

--- a/packages/graphql-server/package.json
+++ b/packages/graphql-server/package.json
@@ -45,7 +45,7 @@
     "uuid": "10.0.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@envelop/testing": "7.0.0",
     "@envelop/types": "5.0.0",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -104,7 +104,7 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.16.4",
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@redwoodjs/framework-tools": "workspace:*",
     "@testing-library/jest-dom": "6.5.0",

--- a/packages/structure/package.json
+++ b/packages/structure/package.json
@@ -51,7 +51,7 @@
     "yargs-parser": "21.1.1"
   },
   "devDependencies": {
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@types/fs-extra": "11.0.4",
     "@types/lodash": "4.17.15",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -160,7 +160,7 @@
   "devDependencies": {
     "@apollo/client-react-streaming": "0.10.0",
     "@arethetypeswrong/cli": "0.16.4",
-    "@babel/cli": "7.25.7",
+    "@babel/cli": "7.26.4",
     "@babel/core": "^7.22.20",
     "@babel/plugin-transform-runtime": "7.25.7",
     "@babel/runtime": "7.25.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,9 +430,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/cli@npm:7.25.7":
-  version: 7.25.7
-  resolution: "@babel/cli@npm:7.25.7"
+"@babel/cli@npm:7.26.4":
+  version: 7.26.4
+  resolution: "@babel/cli@npm:7.26.4"
   dependencies:
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     "@nicolo-ribaudo/chokidar-2": "npm:2.1.8-no-fsevents.3"
@@ -453,7 +453,7 @@ __metadata:
   bin:
     babel: ./bin/babel.js
     babel-external-helpers: ./bin/babel-external-helpers.js
-  checksum: 10c0/bbbc53eef15844b0bfb737d7d134f979d42c51a269e2aee994b02eb9216a22e8dd3d790d5ae9f5b5c003e01eccfc164c14aaa1ad989695e0154f66a588f77d42
+  checksum: 10c0/f2d4fc3c4a34dd3001e3bd7084b78b38211003c36afaf2dc8fedf4565c0442bd59b1c64a9f91a0b7b2450e089123f197e09577ae50dc994307c3348b310ce34c
   languageName: node
   linkType: hard
 
@@ -7737,7 +7737,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/auth-dbauth-setup@workspace:packages/auth-providers/dbAuth/setup"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.25.7"
     "@prisma/internals": "npm:5.20.0"
@@ -7758,7 +7758,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/auth-dbauth-web@workspace:packages/auth-providers/dbAuth/web"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.25.7"
     "@redwoodjs/auth": "workspace:*"
@@ -8150,7 +8150,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/cli@workspace:packages/cli"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.25.7"
     "@listr2/prompt-adapter-enquirer": "npm:2.0.12"
@@ -8224,7 +8224,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/codemods@workspace:packages/codemods"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/parser": "npm:^7.22.16"
     "@babel/plugin-transform-typescript": "npm:^7.22.15"
@@ -8295,7 +8295,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/core@workspace:packages/core"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@redwoodjs/api-server": "workspace:*"
     "@redwoodjs/cli": "workspace:*"
     "@redwoodjs/eslint-config": "workspace:*"
@@ -8338,7 +8338,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/eslint-config@workspace:packages/eslint-config"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/eslint-parser": "npm:7.25.7"
     "@babel/eslint-plugin": "npm:7.25.7"
@@ -8446,7 +8446,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/graphql-server@workspace:packages/graphql-server"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.25.7"
     "@envelop/core": "npm:5.0.2"
@@ -8772,7 +8772,7 @@ __metadata:
   resolution: "@redwoodjs/router@workspace:packages/router"
   dependencies:
     "@arethetypeswrong/cli": "npm:0.16.4"
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.25.7"
     "@redwoodjs/auth": "workspace:*"
@@ -8838,7 +8838,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs/structure@workspace:packages/structure"
   dependencies:
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/runtime-corejs3": "npm:7.25.7"
     "@prisma/internals": "npm:5.20.0"
@@ -9033,7 +9033,7 @@ __metadata:
     "@apollo/client": "npm:3.11.1"
     "@apollo/client-react-streaming": "npm:0.10.0"
     "@arethetypeswrong/cli": "npm:0.16.4"
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/plugin-transform-runtime": "npm:7.25.7"
     "@babel/runtime": "npm:7.25.7"
@@ -26946,7 +26946,7 @@ __metadata:
     "@actions/core": "npm:1.11.1"
     "@actions/exec": "npm:1.1.1"
     "@actions/glob": "npm:0.5.0"
-    "@babel/cli": "npm:7.25.7"
+    "@babel/cli": "npm:7.26.4"
     "@babel/core": "npm:^7.22.20"
     "@babel/generator": "npm:7.25.7"
     "@babel/node": "npm:7.25.7"


### PR DESCRIPTION
Upgrade @babel/cli from 7.25.7 to 7.26.4
Changes since the previous version:
https://github.com/babel/babel/pull/16495

`@babel/cli` is just a dev dependency, so this is a chore relase