### PR TITLE
chore(codemods): Try `pool: 'forks'` instead of 'vmForks'

### DIFF
--- a/packages/codemods/vite.config.mts
+++ b/packages/codemods/vite.config.mts
@@ -11,6 +11,6 @@ export default defineConfig({
       '.d.ts',
     ],
     setupFiles: ['./vite.setup.mts'],
-    pool: 'vmForks',
+    pool: 'forks',
   },
 })


### PR DESCRIPTION
Trying to fix this 
![image](https://github.com/user-attachments/assets/df838586-e64a-4090-ab62-b5cbebb19afb)

More context here: https://github.com/vitest-dev/vitest/discussions/6285
And here: https://github.com/nodejs/node/issues/54735