### PR TITLE
chore(ci): Fix broken storybook smoke tests

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: ⬢ Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 20.18.3
 
     # We have to enable Corepack again for Windows. 🤷
     # In general, we're waiting on [this issue](https://github.com/actions/setup-node/issues/531)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      NODE_OPTIONS: --no-experimental-require-module
 
     steps:
       - name: Checkout the framework code
@@ -306,7 +305,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      NODE_OPTIONS: --no-experimental-require-module
 
     steps:
       - name: Checkout the framework code
@@ -416,7 +414,6 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
-      NODE_OPTIONS: --no-experimental-require-module
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
+      NODE_OPTIONS: --no-experimental-require-module
 
     steps:
       - name: Checkout the framework code
@@ -305,6 +306,7 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
+      NODE_OPTIONS: --no-experimental-require-module
 
     steps:
       - name: Checkout the framework code
@@ -414,6 +416,7 @@ jobs:
     env:
       REDWOOD_CI: 1
       REDWOOD_VERBOSE_TELEMETRY: 1
+      NODE_OPTIONS: --no-experimental-require-module
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Node 20.19.0 broke our storybook integration

See https://github.com/nodejs/node/issues/57555

![image](https://github.com/user-attachments/assets/fa54e658-978b-4732-9817-9073a2deda05)

Apparently wasn't allowed to set the node flag, so trying to pin the node version to 20.18.3 for now instead.
