### PR TITLE
chore(ci): Don't pin the Node version. Storybook issue fixed

### DIFF
--- a/.github/actions/set-up-job/action.yml
+++ b/.github/actions/set-up-job/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: ⬢ Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 20.18.3
+        node-version: 20
 
     # We have to enable Corepack again for Windows. 🤷
     # In general, we're waiting on [this issue](https://github.com/actions/setup-node/issues/531)


### PR DESCRIPTION
With https://github.com/redwoodjs/redwood/pull/12003 merged I should be able to restore our CI tests again. (Reverting https://github.com/redwoodjs/redwood/pull/12001)