### PR TITLE
chore(dbAuth): Switch to vitest for /web

### DIFF
--- a/packages/auth-providers/dbAuth/web/__mocks__/@simplewebauthn/browser.js
+++ b/packages/auth-providers/dbAuth/web/__mocks__/@simplewebauthn/browser.js
@@ -1,7 +1,0 @@
-const webAuthn = {
-  platformAuthenticatorIsAvailable: () => {},
-  startRegistration: () => {},
-  startAuthentication: () => {},
-}
-
-module.exports = webAuthn

--- a/packages/auth-providers/dbAuth/web/jest.config.js
+++ b/packages/auth-providers/dbAuth/web/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('@jest/types').Config.InitialOptions} */
-module.exports = {
-  testEnvironment: 'jest-environment-jsdom',
-  testPathIgnorePatterns: ['fixtures', 'dist'],
-}

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -34,10 +34,9 @@
     "@babel/core": "^7.26.10",
     "@simplewebauthn/typescript-types": "7.4.0",
     "@types/react": "^18.2.55",
-    "jest": "29.7.0",
-    "jest-environment-jsdom": "29.7.0",
     "react": "19.0.0-rc-f2df5694-20240916",
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "vitest": "2.0.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/dbAuth/web/package.json
+++ b/packages/auth-providers/dbAuth/web/package.json
@@ -20,7 +20,7 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
+    "test": "yarn vitest run src",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.middleware.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.middleware.test.ts
@@ -1,6 +1,9 @@
 import { act, renderHook } from '@testing-library/react'
+import { vi, beforeAll, afterAll, describe, it, expect } from 'vitest'
 
-import type { CustomProviderHooks, DbAuthClientArgs } from '../dbAuth'
+import type { CustomProviderHooks } from '@redwoodjs/auth'
+
+import type { DbAuthClientArgs } from '../dbAuth'
 import { createDbAuthClient, createAuth } from '../dbAuth'
 
 import { fetchMock } from './dbAuth.test'
@@ -30,7 +33,7 @@ export function getMwDbAuth(
 // They test the middleware specific things about the dbAuth client
 
 describe('dbAuth web ~ cookie/middleware auth', () => {
-  let originalEnv
+  let originalEnv: string
 
   // This tells the dbAuth client to setup in middleware mode
   beforeAll(() => {
@@ -50,10 +53,7 @@ describe('dbAuth web ~ cookie/middleware auth', () => {
     // Middleware auth clients should not return tokens
     expect(await dbAuthInstance.getToken()).toBeNull()
 
-    let currentUser
-    await act(async () => {
-      currentUser = await dbAuthInstance.getCurrentUser()
-    })
+    const currentUser = await dbAuthInstance.getCurrentUser()
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       // Doesn't speak to graphql!
@@ -71,7 +71,7 @@ describe('dbAuth web ~ cookie/middleware auth', () => {
   })
 
   it('can still override getCurrentUser', async () => {
-    const mockedCustomCurrentUser = jest.fn()
+    const mockedCustomCurrentUser = vi.fn()
     const { current: dbAuthInstance } = getMwDbAuth({
       useCurrentUser: mockedCustomCurrentUser,
     })

--- a/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/dbAuth.test.ts
@@ -1,14 +1,15 @@
 import { renderHook, act } from '@testing-library/react'
+import { vi, beforeAll, beforeEach, describe, it, expect } from 'vitest'
 
-import type { CurrentUser } from '@redwoodjs/auth'
+import type { CustomProviderHooks, CurrentUser } from '@redwoodjs/auth'
 
-import type { CustomProviderHooks, DbAuthClientArgs } from '../dbAuth'
+import type { DbAuthClientArgs } from '../dbAuth'
 import { createDbAuthClient, createAuth } from '../dbAuth'
 
 globalThis.RWJS_API_URL = '/.redwood/functions'
 globalThis.RWJS_API_GRAPHQL_URL = '/.redwood/functions/graphql'
 
-jest.mock('@whatwg-node/fetch', () => {
+vi.mock('@whatwg-node/fetch', () => {
   return
 })
 
@@ -20,7 +21,7 @@ interface User {
 
 let loggedInUser: User | undefined
 
-export const fetchMock = jest.fn()
+export const fetchMock = vi.fn()
 fetchMock.mockImplementation(async (url, options) => {
   const body = options?.body ? JSON.parse(options.body) : {}
 

--- a/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
+++ b/packages/auth-providers/dbAuth/web/src/__tests__/webAuthn.test.ts
@@ -1,26 +1,36 @@
+import { vi, beforeEach, describe, it, expect } from 'vitest'
+
 import WebAuthnClient from '../webAuthn'
 
 globalThis.RWJS_API_URL = '/.redwood/functions'
 
-jest.mock('@whatwg-node/fetch', () => {
+vi.mock('@simplewebauthn/browser', () => {
+  return {
+    platformAuthenticatorIsAvailable: () => {},
+    startRegistration: () => {},
+    startAuthentication: () => {},
+  }
+})
+
+vi.mock('@whatwg-node/fetch', () => {
   return
 })
 
-const mockOpen = jest.fn()
-const mockSend = jest.fn()
+const mockOpen = vi.fn()
+const mockSend = vi.fn()
 
 const xhrMock: Partial<XMLHttpRequest> = {
   open: mockOpen,
   send: mockSend,
-  setRequestHeader: jest.fn(),
+  setRequestHeader: vi.fn(),
   readyState: 4,
   status: 200,
   responseText: '{}',
 }
 
-jest
-  .spyOn(global, 'XMLHttpRequest')
-  .mockImplementation(() => xhrMock as XMLHttpRequest)
+vi.spyOn(global, 'XMLHttpRequest').mockImplementation(
+  () => xhrMock as XMLHttpRequest,
+)
 
 function clearCookies() {
   document.cookie.split(';').forEach(function (c) {

--- a/packages/auth-providers/dbAuth/web/vitest.config.mts
+++ b/packages/auth-providers/dbAuth/web/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['vitest.setup.mts'],
+  },
+})

--- a/packages/auth-providers/dbAuth/web/vitest.setup.mts
+++ b/packages/auth-providers/dbAuth/web/vitest.setup.mts
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  // If vitest globals are enabled testing-library will clean up after each
+  // test automatically, but we don't enable globals, so we have to manually
+  // clean up here
+  // https://testing-library.com/docs/react-testing-library/api/#cleanup
+  cleanup()
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7674,10 +7674,9 @@ __metadata:
     "@simplewebauthn/typescript-types": "npm:7.4.0"
     "@types/react": "npm:^18.2.55"
     core-js: "npm:3.38.1"
-    jest: "npm:29.7.0"
-    jest-environment-jsdom: "npm:29.7.0"
     react: "npm:19.0.0-rc-f2df5694-20240916"
     typescript: "npm:5.6.2"
+    vitest: "npm:2.0.5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Part of our continuous work of moving from jest to vitest in preparation for CJS/ESM dual building