### PR TITLE
chore(dbAuth): Switch to vitest for /setup

### DIFF
--- a/packages/auth-providers/dbAuth/setup/jest.config.js
+++ b/packages/auth-providers/dbAuth/setup/jest.config.js
@@ -1,5 +1,0 @@
-/** @type {import('@jest/types').Config.InitialOptions} */
-module.exports = {
-  testEnvironment: 'jest-environment-node',
-  testPathIgnorePatterns: ['fixtures', 'dist'],
-}

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -19,7 +19,7 @@
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",
     "prepublishOnly": "NODE_ENV=production yarn build",
-    "test": "jest src",
+    "test": "yarn vitest run src",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
@@ -38,7 +38,8 @@
     "@types/yargs": "17.0.33",
     "jest": "29.7.0",
     "jest-environment-node": "29.7.0",
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "vitest": "2.0.5"
   },
   "gitHead": "3905ed045508b861b495f8d5630d76c7a157d8f1"
 }

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/__snapshots__/setup.test.ts.snap
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/__snapshots__/setup.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`dbAuth setup command does not duplicate authDecoder creation 1`] = `
+exports[`dbAuth setup command > does not duplicate authDecoder creation 1`] = `
 "
 import { createGraphQLHandler } from '@redwoodjs/graphql-server'
 

--- a/packages/auth-providers/dbAuth/setup/src/__tests__/setupData.test.ts
+++ b/packages/auth-providers/dbAuth/setup/src/__tests__/setupData.test.ts
@@ -1,13 +1,22 @@
+import { vi, beforeAll, afterAll, describe, it, expect } from 'vitest'
+
 import { createUserModelTask } from '../setupData'
 
 const RWJS_CWD = process.env.RWJS_CWD
-const redwoodProjectPath = '../../../../__fixtures__/test-project'
+const { redwoodProjectPath, dbSchemaPath, libPath, functionsPath } = vi.hoisted(
+  () => {
+    const redwoodProjectPath = '../../../../__fixtures__/test-project'
 
-const dbSchemaPath = redwoodProjectPath + '/api/db/schema.prisma'
-const libPath = redwoodProjectPath + '/api/src/lib'
-const functionsPath = redwoodProjectPath + '/api/src/functions'
+    return {
+      redwoodProjectPath,
+      dbSchemaPath: redwoodProjectPath + '/api/db/schema.prisma',
+      libPath: redwoodProjectPath + '/api/src/lib',
+      functionsPath: redwoodProjectPath + '/api/src/functions',
+    }
+  },
+)
 
-jest.mock('@redwoodjs/cli-helpers', () => {
+vi.mock('@redwoodjs/cli-helpers', () => {
   return {
     getGraphqlPath: () => {
       return redwoodProjectPath + '/api/src/functions/graphql.ts'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7659,6 +7659,7 @@ __metadata:
     prompts: "npm:2.4.2"
     terminal-link: "npm:2.1.1"
     typescript: "npm:5.6.2"
+    vitest: "npm:2.0.5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Part of our continuous work of moving from jest to vitest in preparation for CJS/ESM dual building