### PR TITLE
fix(dbAuth): Don't include .snap files in the built package

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -145,6 +145,9 @@ module.exports = {
     },
   ],
   // Ignore test directories when we're not testing
+  // Note, no matter what you try to do here, babel will still include
+  // snapshot files in the dist output.
+  // See https://github.com/babel/babel/issues/11394
   ignore:
     process.env.NODE_ENV === 'test'
       ? []

--- a/babel.config.js
+++ b/babel.config.js
@@ -145,7 +145,7 @@ module.exports = {
     },
   ],
   // Ignore test directories when we're not testing
-  // Note, no matter what you try to do here, babel will still include
+  // Note: No matter what you try to do here, babel will still include
   // snapshot files in the dist output.
   // See https://github.com/babel/babel/issues/11394
   ignore:

--- a/packages/auth-providers/dbAuth/setup/package.json
+++ b/packages/auth-providers/dbAuth/setup/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "build": "yarn build:js && yarn build:types",
-    "build:js": "babel src -d dist --extensions \".js,.jsx,.ts,.tsx\" --copy-files --no-copy-ignored",
+    "build //": "Including .snap in extensions because of https://github.com/babel/babel/issues/11394",
+    "build:js": "babel src -d dist --extensions \".js,.ts,.snap\" --copy-files --no-copy-ignored",
     "build:pack": "yarn pack -o redwoodjs-auth-dbauth-setup.tgz",
     "build:types": "tsc --build --verbose",
     "build:watch": "nodemon --watch src --ext \"js,jsx,ts,tsx,template\" --ignore dist --exec \"yarn build\"",


### PR DESCRIPTION
Adding `.snap` to the list of extensions babel should include because of this bug: https://github.com/babel/babel/issues/11394 otherwise the `dist/` folder would include our test snapshot files