### PR TITLE
chore(deps): Bump vite-plugin-node-polyfills to v0.23.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -87,7 +87,7 @@
     "rimraf": "6.0.1",
     "vite": "5.4.15",
     "vite-plugin-cjs-interop": "2.1.4",
-    "vite-plugin-node-polyfills": "0.22.0",
+    "vite-plugin-node-polyfills": "0.23.0",
     "ws": "8.18.0",
     "yargs-parser": "21.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8902,7 +8902,7 @@ __metadata:
     typescript: "npm:5.6.2"
     vite: "npm:5.4.15"
     vite-plugin-cjs-interop: "npm:2.1.4"
-    vite-plugin-node-polyfills: "npm:0.22.0"
+    vite-plugin-node-polyfills: "npm:0.23.0"
     vitest: "npm:2.1.9"
     ws: "npm:8.18.0"
     yargs-parser: "npm:21.1.1"
@@ -29824,15 +29824,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-node-polyfills@npm:0.22.0":
-  version: 0.22.0
-  resolution: "vite-plugin-node-polyfills@npm:0.22.0"
+"vite-plugin-node-polyfills@npm:0.23.0":
+  version: 0.23.0
+  resolution: "vite-plugin-node-polyfills@npm:0.23.0"
   dependencies:
     "@rollup/plugin-inject": "npm:^5.0.5"
     node-stdlib-browser: "npm:^1.2.0"
   peerDependencies:
-    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
-  checksum: 10c0/f8ddc452eb6fba280977d037f8a6406aa522e69590641ce72ce5bb31c3498856a9f63ab3671bc6a822dcd1ff9ba5cac02cacef4a0e170fd8500cdeeb38c81675
+    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+  checksum: 10c0/439088aa71852737433f360fe5e99f246884885afb11715106b2e4c3c4f0dfc162037831b6b5a2ab4be30faafe5db6a3af37bbdf7eda5788dae2fdb9a44e029e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
From the changelog:

- Improve performance when not using globals
- Support Vite v6