### PR TITLE
chore(deps): Bump path-to-regexp to v1.9.0

### DIFF
--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -9014,11 +9014,11 @@ __metadata:
   linkType: hard
 
 "path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
+  version: 1.9.0
+  resolution: "path-to-regexp@npm:1.9.0"
   dependencies:
     isarray: "npm:0.0.1"
-  checksum: 10c0/7b25d6f27a8de03f49406d16195450f5ced694398adea1510b0f949d9660600d1769c5c6c83668583b7e6b503f3caf1ede8ffc08135dbe3e982f034f356fbb5c
+  checksum: 10c0/de9ddb01b84d9c2c8e2bed18630d8d039e2d6f60a6538595750fa08c7a6482512257464c8da50616f266ab2cdd2428387e85f3b089e4c3f25d0c537e898a0751
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumping path-to-regexp to v1.9.0 closes a high severity dependabot security alert

<img width="1274" height="560" alt="image" src="https://github.com/user-attachments/assets/8df271f7-910a-4271-b3c2-5b327f63665b" />
