### PR TITLE
fix: close leaked stdio file descriptors after detaching child process

### DIFF
--- a/packages/cli/src/lib/background.js
+++ b/packages/cli/src/lib/background.js
@@ -65,6 +65,14 @@ export function spawnBackgroundProcess(name, cmd, args) {
   // Close the parent's copies of the stdio file descriptors.
   // The child process inherited its own copies via spawn(), so
   // leaving these open in the parent leaks fds until process exit.
-  fs.closeSync(stdout)
-  fs.closeSync(stderr)
+  try {
+    fs.closeSync(stdout)
+  } catch {
+    // fd may already be closed or invalid — ignore
+  }
+  try {
+    fs.closeSync(stderr)
+  } catch {
+    // fd may already be closed or invalid — ignore
+  }
 }

--- a/packages/cli/src/lib/background.js
+++ b/packages/cli/src/lib/background.js
@@ -61,4 +61,10 @@ export function spawnBackgroundProcess(name, cmd, args) {
   // Spawn and detach the process
   const child = spawn(cmd, args, spawnOptions)
   child.unref()
+
+  // Close the parent's copies of the stdio file descriptors.
+  // The child process inherited its own copies via spawn(), so
+  // leaving these open in the parent leaks fds until process exit.
+  fs.closeSync(stdout)
+  fs.closeSync(stderr)
 }


### PR DESCRIPTION
## Summary

`packages/cli/src/lib/background.js` opens two file descriptors via `fs.openSync()` for stdout/stderr log files, passes them to `spawn()` as stdio options, then calls `child.unref()` without closing the parent's copies of the fds.

The child process inherits its own copies of the file descriptors via `spawn()`, so the parent's copies serve no purpose after spawning. They leak until the parent process exits.

This matters when the CLI spawns multiple background processes (e.g. dev server + watcher) -- each invocation leaks two fds.

## Fix

Added `fs.closeSync(stdout)` and `fs.closeSync(stderr)` after `child.unref()`.

## Test

Manual: run `yarn rw dev` and check open file descriptors with `lsof -p <pid>` -- the log file fds should no longer appear in the parent process.