### PR TITLE
fix(cli): derive API debug port from api port to avoid conflicts

### DIFF
--- a/packages/cli/src/commands/__tests__/dev.test.js
+++ b/packages/cli/src/commands/__tests__/dev.test.js
@@ -89,7 +89,6 @@ describe('yarn rw dev', () => {
       },
       api: {
         port: 8911,
-        debugPort: 18911,
       },
       experimental: {
         streamingSsr: {
@@ -136,7 +135,6 @@ describe('yarn rw dev', () => {
       },
       api: {
         port: 8911,
-        debugPort: 18911,
       },
       experimental: {
         streamingSsr: {
@@ -231,5 +229,34 @@ describe('yarn rw dev', () => {
     const apiCommand = find(concurrentlyArgs, { name: 'api' })
 
     expect(apiCommand.command).not.toContain('--debug-port')
+  })
+
+  it('Derives debug port from api port when not explicitly configured', async () => {
+    getConfig.mockReturnValue({
+      web: {
+        port: 8912,
+      },
+      api: {
+        port: 8913,
+        // debugPort intentionally omitted — should be derived
+      },
+      experimental: {
+        streamingSsr: {
+          enabled: false,
+        },
+      },
+    })
+
+    await handler({
+      side: ['api'],
+    })
+
+    const concurrentlyArgs = concurrently.mock.lastCall[0]
+    const apiCommand = find(concurrentlyArgs, { name: 'api' })
+
+    // 8913 → 18913 (prepend "1")
+    expect(apiCommand.command.replace(/\s+/g, ' ')).toContain(
+      'yarn rw-api-server-watch --port 8913 --debug-port 18913',
+    )
   })
 })

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -32,7 +32,7 @@ export const builder = (yargs) => {
     .option('apiDebugPort', {
       type: 'number',
       description:
-        'Port on which to expose API server debugger. If you supply the flag with no value it defaults to 18911.',
+        'Port on which to expose API server debugger. If you supply the flag with no value it defaults to 1 prepended to the api port (e.g. api port 8913 → debug port 18913).',
     })
     .middleware(() => {
       const check = checkNodeVersion()

--- a/packages/cli/src/commands/devHandler.js
+++ b/packages/cli/src/commands/devHandler.js
@@ -15,8 +15,6 @@ import { generatePrismaClient } from '../lib/generatePrismaClient'
 import { getFreePort } from '../lib/ports'
 import { serverFileExists } from '../lib/project'
 
-const defaultApiDebugPort = 18911
-
 export const handler = async ({
   side = ['api', 'web'],
   forward = '',
@@ -143,16 +141,24 @@ export const handler = async ({
     if (apiDebugPort) {
       return `--debug-port ${apiDebugPort}`
     } else if (argv.includes('--apiDebugPort')) {
-      return `--debug-port ${defaultApiDebugPort}`
+      // No value supplied — derive from api port to avoid collisions when
+      // running multiple RW apps simultaneously (issue #10937)
+      return `--debug-port ${parseInt('1' + String(apiAvailablePort))}`
     }
 
     const apiDebugPortInToml = getConfig().api.debugPort
-    if (apiDebugPortInToml) {
+    if (apiDebugPortInToml !== undefined && apiDebugPortInToml !== false) {
       return `--debug-port ${apiDebugPortInToml}`
     }
+    if (apiDebugPortInToml === false) {
+      // Explicitly disabled in TOML
+      return ''
+    }
 
-    // Don't pass in debug port flag, unless configured
-    return ''
+    // Default: derive debug port from api port (e.g. 8911 → 18911, 8913 → 18913)
+    // This ensures multiple RW apps running on different ports don't share the
+    // same debug port.
+    return `--debug-port ${parseInt('1' + String(apiAvailablePort))}`
   }
 
   const redwoodConfigPath = getConfigPath()

--- a/packages/project-config/src/__tests__/config.test.ts
+++ b/packages/project-config/src/__tests__/config.test.ts
@@ -32,7 +32,6 @@ describe('getConfig', () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "api": {
-          "debugPort": 18911,
           "path": "./api",
           "port": 8911,
           "schemaPath": "./api/db/schema.prisma",

--- a/packages/project-config/src/config.ts
+++ b/packages/project-config/src/config.ts
@@ -146,7 +146,6 @@ const DEFAULT_CONFIG: Config = {
     target: TargetEnum.NODE,
     schemaPath: './api/db/schema.prisma',
     serverConfig: './api/server.config.js',
-    debugPort: 18911,
   },
   graphql: {
     fragments: false,


### PR DESCRIPTION
## Summary

Fixes #10937

When multiple Redwood apps run simultaneously on different ports (e.g. one on `8911`, another on `8913`), they previously both launched with the same hardcoded `--debug-port 18911`, causing the second app's debugger to fail silently.

## Changes

**`packages/project-config/src/config.ts`**
- Removed the hardcoded `debugPort: 18911` from `DEFAULT_CONFIG`. The debug port is no longer a config default — it's now derived at dev-server launch time.

**`packages/cli/src/commands/devHandler.js`**
- `getApiDebugFlag()` now derives the default debug port by prepending `'1'` to the api port:
  - api port `8911` → debug port `18911` ✅ (same as before, no breaking change)
  - api port `8913` → debug port `18913` ✅ (no more collision)
- Explicit `--apiDebugPort` CLI flag and `api.debugPort` TOML setting still take full precedence.
- `debugPort = false` in TOML still disables the debugger entirely.

**`packages/cli/src/commands/dev.js`**
- Updated the `--apiDebugPort` option description to reflect the new derivation behavior.

**Tests**
- Updated existing tests to remove the hardcoded `debugPort: 18911` from mocked configs.
- Added a new test case: running with api port `8913` produces debug port `18913`.

## Before / After

```
# Before (both apps use port 18911):
App 1 (api :8911): rw-api-server-watch --port 8911 --debug-port 18911
App 2 (api :8913): rw-api-server-watch --port 8913 --debug-port 18911  ← conflict!

# After:
App 1 (api :8911): rw-api-server-watch --port 8911 --debug-port 18911
App 2 (api :8913): rw-api-server-watch --port 8913 --debug-port 18913  ✅
```